### PR TITLE
Check build dir always has a clean git tree

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,6 +20,8 @@ jobs:
       - run: npm install
       - run: npm run lint
       - run: npm run test-unit
+      - name: "Clean tree"
+        run: "npm run test-clean-tree"
   integration:
     runs-on: ubuntu-20.04
     timeout-minutes: 10

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "test-unit": "jasmine --config=unit-test/config.json",
     "test-int": "npm run build-integration && jasmine --config=integration-test/config.js",
     "test-int-x": "xvfb-run --server-args='-screen 0 1024x768x24' npm run test-int",
+    "test-clean-tree": "npm run build && sh scripts/check-for-changes.sh",
     "test": "npm run lint && npm run test-unit && npm run test-int"
   },
   "type": "module",

--- a/scripts/check-for-changes.sh
+++ b/scripts/check-for-changes.sh
@@ -1,0 +1,2 @@
+git update-index --refresh 
+git diff-index --quiet HEAD --


### PR DESCRIPTION
Same test I added for autofill, builds in ci but doesn't locally.

I kept the run script naming convention here but happy to change to ':'