### PR TITLE
Disable all features globally if we have the config before load

### DIFF
--- a/Sources/ContentScopeScripts/dist/contentScope.js
+++ b/Sources/ContentScopeScripts/dist/contentScope.js
@@ -731,6 +731,10 @@
       return preferences
   }
 
+  function isGloballyDisabled (args) {
+      return args.site.allowlisted || args.site.isBroken
+  }
+
   var contentScopeFeatures = (function (exports) {
   'use strict';
 
@@ -4439,7 +4443,7 @@
 
   function init () {
       const processedConfig = processConfig($CONTENT_SCOPE$, $USER_UNPROTECTED_DOMAINS$, $USER_PREFERENCES$);
-      if (processedConfig.site.allowlisted) {
+      if (isGloballyDisabled(processedConfig)) {
           return
       }
 

--- a/build/android/contentScope.js
+++ b/build/android/contentScope.js
@@ -731,6 +731,10 @@
       return preferences
   }
 
+  function isGloballyDisabled (args) {
+      return args.site.allowlisted || args.site.isBroken
+  }
+
   var contentScopeFeatures = (function (exports) {
   'use strict';
 
@@ -4439,7 +4443,7 @@
 
   function init () {
       const processedConfig = processConfig($CONTENT_SCOPE$, $USER_UNPROTECTED_DOMAINS$, $USER_PREFERENCES$);
-      if (processedConfig.site.allowlisted) {
+      if (isGloballyDisabled(processedConfig)) {
           return
       }
 

--- a/build/windows/contentScope.js
+++ b/build/windows/contentScope.js
@@ -731,6 +731,10 @@
       return preferences
   }
 
+  function isGloballyDisabled (args) {
+      return args.site.allowlisted || args.site.isBroken
+  }
+
   const windowsSpecificFeatures = ['windowsPermissionUsage'];
 
   var contentScopeFeatures = (function (exports) {
@@ -4441,6 +4445,9 @@
 
   function init () {
       const processedConfig = processConfig($CONTENT_SCOPE$, $USER_UNPROTECTED_DOMAINS$, $USER_PREFERENCES$, windowsSpecificFeatures);
+      if (isGloballyDisabled(processedConfig)) {
+          return
+      }
 
       contentScopeFeatures.load();
 

--- a/inject/android.js
+++ b/inject/android.js
@@ -1,10 +1,10 @@
 /* global contentScopeFeatures */
 
-import { processConfig } from './../src/utils'
+import { processConfig, isGloballyDisabled } from './../src/utils'
 
 function init () {
     const processedConfig = processConfig($CONTENT_SCOPE$, $USER_UNPROTECTED_DOMAINS$, $USER_PREFERENCES$)
-    if (processedConfig.site.allowlisted) {
+    if (isGloballyDisabled(processedConfig)) {
         return
     }
 

--- a/inject/apple.js
+++ b/inject/apple.js
@@ -1,10 +1,10 @@
 /* global contentScopeFeatures */
 
-import { processConfig } from './../src/utils'
+import { processConfig, isGloballyDisabled } from './../src/utils'
 
 function init () {
     const processedConfig = processConfig($CONTENT_SCOPE$, $USER_UNPROTECTED_DOMAINS$, $USER_PREFERENCES$)
-    if (processedConfig.site.allowlisted) {
+    if (isGloballyDisabled(processedConfig)) {
         return
     }
 

--- a/inject/windows.js
+++ b/inject/windows.js
@@ -1,9 +1,12 @@
 /* global contentScopeFeatures */
 
-import { processConfig, windowsSpecificFeatures } from './../src/utils'
+import { processConfig, isGloballyDisabled, windowsSpecificFeatures } from './../src/utils'
 
 function init () {
     const processedConfig = processConfig($CONTENT_SCOPE$, $USER_UNPROTECTED_DOMAINS$, $USER_PREFERENCES$, windowsSpecificFeatures)
+    if (isGloballyDisabled(processedConfig)) {
+        return
+    }
 
     contentScopeFeatures.load()
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -487,6 +487,10 @@ export function processConfig (data, userList, preferences, platformSpecificFeat
     return preferences
 }
 
+export function isGloballyDisabled (args) {
+    return args.site.allowlisted || args.site.isBroken
+}
+
 export const windowsSpecificFeatures = ['windowsPermissionUsage']
 
 export function isWindowsSpecificFeature (featureName) {


### PR DESCRIPTION
Ensures on platforms that statically have the config that we disable globally for both broken or allowlisted sites to reduce risk of features being enabled (cookies 👀 at you).