### PR TITLE
Fix MV3 secret generation in insecure contexts

### DIFF
--- a/build/chrome-mv3/inject.js
+++ b/build/chrome-mv3/inject.js
@@ -5454,7 +5454,7 @@
 })({});
 
 
-    const secret = window.crypto.randomUUID();
+    const secret = (crypto.getRandomValues(new Uint32Array(1))[0] / 2 ** 32).toString().replace('0.', '');
 
     contentScopeFeatures.load({
         platform: {

--- a/inject/chrome-mv3.js
+++ b/inject/chrome-mv3.js
@@ -1,6 +1,6 @@
 /* global contentScopeFeatures */
 
-const secret = window.crypto.randomUUID()
+const secret = (crypto.getRandomValues(new Uint32Array(1))[0] / 2 ** 32).toString().replace('0.', '')
 
 contentScopeFeatures.load({
     platform: {


### PR DESCRIPTION
`window.crypto.randomUUID` is not available in insecure contexts. Instead we can use `crypto.getRandomValues` as we do on Chrome MV2.