### PR TITLE
use processedConfig.platform instead of the baked in value

### DIFF
--- a/build/windows/contentScope.js
+++ b/build/windows/contentScope.js
@@ -7190,9 +7190,7 @@
       }
 
       contentScopeFeatures.load({
-          platform: {
-              name: 'windows'
-          }
+          platform: processedConfig.platform
       });
 
       contentScopeFeatures.init(processedConfig);

--- a/inject/windows.js
+++ b/inject/windows.js
@@ -9,9 +9,7 @@ function init () {
     }
 
     contentScopeFeatures.load({
-        platform: {
-            name: 'windows'
-        }
+        platform: processedConfig.platform
     })
 
     contentScopeFeatures.init(processedConfig)


### PR DESCRIPTION
Asana link: https://app.asana.com/0/1201048563534612/1203086567720768
CC: @RendijsSmukulis @q71114

Description:

Instead of setting the platform to 'windows' in the windows-specific code, let clients specify the platform parameters. Other features (e.g. navigator interface) require that anyway and with the current solution, some features can't be enabled.