### PR TITLE
Allow pausing/resuming geolocation streaming in Windows app and disable protocol handler / pan-tilt-zoom

### DIFF
--- a/src/features/windows-permission-usage.js
+++ b/src/features/windows-permission-usage.js
@@ -312,6 +312,12 @@ export function init () {
 
                 const videoRequested = args[0]?.video
                 const audioRequested = args[0]?.audio
+
+                if (videoRequested && (videoRequested.pan || videoRequested.tilt || videoRequested.zoom)) {
+                    // WebView2 doesn't support acquiring pan-tilt-zoom from its API at the moment
+                    return Promise.reject(new DOMException('Pan-tilt-zoom is not supported'))
+                }
+
                 return DDGReflect.apply(target, thisArg, args).then(function (stream) {
                     console.debug(`User stream ${stream.id} has been acquired`)
                     userMediaStreams.add(stream)
@@ -365,7 +371,8 @@ export function init () {
         { name: 'Bluetooth', prototype: Bluetooth.prototype, method: 'requestDevice' },
         { name: 'USB', prototype: USB.prototype, method: 'requestDevice' },
         { name: 'Serial', prototype: Serial.prototype, method: 'requestPort' },
-        { name: 'HID', prototype: HID.prototype, method: 'requestDevice' }
+        { name: 'HID', prototype: HID.prototype, method: 'requestDevice' },
+        { name: 'Protocol handler', prototype: Navigator.prototype, method: 'registerProtocolHandler' }
     ]
     for (const { name, prototype, method } of permissionsToDisable) {
         try {

--- a/src/features/windows-permission-usage.js
+++ b/src/features/windows-permission-usage.js
@@ -106,12 +106,13 @@ export function init () {
     function pause (permission) {
         switch (permission) {
         case Permission.Camera:
-        case Permission.Microphone:
+        case Permission.Microphone: {
             const streamTracks = getTracks(permission)
             streamTracks?.forEach(track => {
                 track.enabled = false
             })
             break
+        }
         case Permission.Geolocation:
             pauseWatchedPositions = true
             signalPermissionStatus(Permission.Geolocation, Status.Paused)
@@ -122,12 +123,13 @@ export function init () {
     function resume (permission) {
         switch (permission) {
         case Permission.Camera:
-        case Permission.Microphone:
+        case Permission.Microphone: {
             const streamTracks = getTracks(permission)
             streamTracks?.forEach(track => {
                 track.enabled = true
             })
             break
+        }
         case Permission.Geolocation:
             pauseWatchedPositions = false
             signalPermissionStatus(Permission.Geolocation, Status.Active)


### PR DESCRIPTION
- Added option to pause / resume geolocation stream.
- Disable access to protocol handler and pan-tilt-zoom camera permissions.

https://app.asana.com/0/0/1203947316990877/f
https://app.asana.com/0/0/1203992606607851/f