### PR TITLE
Fix CSP for element hiding in Firefox

### DIFF
--- a/src/features/element-hiding.js
+++ b/src/features/element-hiding.js
@@ -224,7 +224,9 @@ function extractTimeoutRules (rules) {
  * @param {string} rules[].type
  */
 function injectStyleTag (rules) {
-    const styleTag = document.createElement('style')
+    const styleTag = document.createElement('link')
+    styleTag.setAttribute('rel', 'stylesheet')
+    styleTag.setAttribute('type', 'text/css')
     let styleTagContents = ''
 
     rules.forEach((rule, i) => {
@@ -236,7 +238,7 @@ function injectStyleTag (rules) {
     })
 
     styleTagContents = styleTagContents.concat('{display:none!important;min-height:0!important;height:0!important;}')
-    styleTag.innerText = styleTagContents
+    styleTag.href = 'data:text/css,' + encodeURIComponent(styleTagContents)
 
     document.head.appendChild(styleTag)
 }


### PR DESCRIPTION
As reported here: https://github.com/duckduckgo/duckduckgo-privacy-extension/issues/367#issuecomment-1465535802 we're getting blocked by page CSP.

This shouldn't happen as we're acting on the users behalf, see: https://bugzilla.mozilla.org/show_bug.cgi?id=1415352#c48

Using a link and data attribute should circumvent the blocking but doesn't prevent the error as mentioned in the Bugzilla issue. (in fact in my testing it now nolonger points to our code so having a useful comment in the code doesn't help us even 😢)

@dharb are you able to test this out in Firefox, perhaps we could create a test page with a CSP like the following:
```
<html>
    <head>
        <title>Content Security Policy</title>
        <meta http-equiv="Content-Security-Policy" content="script-src 'self' https: http:; object-src 'none'; base-uri 'none'; style-src 'self' ; font-src 'self'">
    </head>
    <body>
        <h1>Boop</h1>
        <iframe id="google_ads_iframe" ></iframe>
        <div id="taboola-sd">sss</div>
        <div class="taboolaHeight">seeeess</div>
    </body>
</html>
```