### PR TITLE
Improve element hiding empty check to avoid potentially hiding visible content

### DIFF
--- a/src/features/element-hiding.js
+++ b/src/features/element-hiding.js
@@ -5,6 +5,7 @@ const parser = new DOMParser()
 let hiddenElements = new WeakMap()
 let appliedRules = new Set()
 let shouldInjectStyleTag = false
+let mediaAndFormSelectors = 'video,canvas,embed,object,audio,map,form,input,textarea,select,option,button'
 
 /**
  * Hide DOM element if rule conditions met
@@ -137,8 +138,7 @@ function isDomNodeEmpty (node) {
     })
 
     const visibleText = parsedNode.innerText.trim().toLocaleLowerCase().replace(/:$/, '')
-    const mediaContent = parsedNode.querySelector('video,canvas,embed,object,audio,map')
-    const formContent = parsedNode.querySelector('form,input,textarea,select,option,button')
+    const mediaAndFormContent = parsedNode.querySelector(mediaAndFormSelectors)
     const frameElements = [...parsedNode.querySelectorAll('iframe')]
     // query original node instead of parsedNode for img elements since heuristic relies
     // on size of image elements
@@ -156,8 +156,7 @@ function isDomNodeEmpty (node) {
     })
 
     if ((visibleText === '' || adLabelStrings.includes(visibleText)) &&
-        mediaContent === null && formContent === null &&
-        noFramesWithContent && !visibleImages) {
+        mediaAndFormContent === null && noFramesWithContent && !visibleImages) {
         return true
     }
     return false
@@ -297,6 +296,7 @@ export function init (args) {
     const styleTagExceptions = getFeatureSetting(featureName, args, 'styleTagExceptions')
     adLabelStrings = getFeatureSetting(featureName, args, 'adLabelStrings')
     shouldInjectStyleTag = getFeatureSetting(featureName, args, 'useStrictHideStyleTag')
+    mediaAndFormSelectors = getFeatureSetting(featureName, args, 'mediaAndFormSelectors') || mediaAndFormSelectors
 
     // determine whether strict hide rules should be injected as a style tag
     if (shouldInjectStyleTag) {

--- a/unit-test/dirSize.js
+++ b/unit-test/dirSize.js
@@ -4,7 +4,7 @@ import fastFolderSizeSync from 'fast-folder-size/sync.js'
 const buildDirs = ['android', 'chrome', 'chrome-mv3', 'firefox', 'integration', 'windows']
 // Lets sanity check build sizes, picking 512KB as a rather arbitrary limit
 // Higher for Chrome MV2 due to base64 encoding
-const quotas = [512000, 680960, 512000, 512000, 512000, 512000]
+const quotas = [512000, 716800, 512000, 512000, 512000, 512000]
 const rootDir = 'build'
 
 describe('Expect build size of', () => {


### PR DESCRIPTION
Asana link: https://app.asana.com/0/1203557590179903/1204090946699947/f
Corresponding privacy test page update: https://github.com/duckduckgo/privacy-test-pages/pull/130

While we try to be precise in the selector rules we use for element hiding, we've run into a few cases now where we accidentally hid visible content that matched an ad selector. This PR adds several guardrails to prevent hiding visible content even when elements match common ad selectors.

Specifically, this PR:
- avoids hiding elements that contain various media tags such as `<embed>`, `<object>`, `<audio>`, and `<map>`
- avoids hiding elements that contain form tags such as `<form>`, `<input>`, `<textarea>`, `<select>`, `<option>`, and `<button>`
- avoids hiding elements that contain real images - we previously weren't counting images as visible content since ad containers frequently include tracking pixels and small ad logos (like adchoices). Now we the size of contained images and don't hide when they're > 20px width or height.