### PR TITLE
Avoid Click to Load placeholders overflowing small containers

### DIFF
--- a/src/features/click-to-load.js
+++ b/src/features/click-to-load.js
@@ -446,6 +446,13 @@ async function createPlaceholderElementAndReplace (widget, trackingElement) {
         if (parseInt(placeholderHeight, 10) <= 200 || parseInt(parentHeight, 10) <= 200) {
             const titleRowTextButton = shadowRoot.querySelector(`#${titleID + 'TextButton'}`)
             titleRowTextButton.style.display = 'block'
+
+            // Avoid the placeholder being taller than the containing element
+            // and overflowing.
+            const innerDiv = shadowRoot.querySelector('.DuckDuckGoSocialContainer')
+            innerDiv.style.minHeight = ''
+            innerDiv.style.maxHeight = parentHeight
+            innerDiv.style.overflow = 'hidden'
         }
     }
 


### PR DESCRIPTION
There are some situations where the containing element of a Click to
Load placeholder is smaller than the placeholder. It can look kind of
broken when the placeholder overflows the parent element. Let's try to
work around that here.