### PR TITLE
Fix missing header insertion point

### DIFF
--- a/src/content-scope-features.js
+++ b/src/content-scope-features.js
@@ -1,5 +1,5 @@
 /* global mozProxies */
-import { initStringExemptionLists, isFeatureBroken, registerMessageSecret } from './utils'
+import { initStringExemptionLists, isFeatureBroken, registerMessageSecret, getInjectionElement } from './utils'
 import { featureNames } from './features'
 // @ts-expect-error Special glob import for injected features see scripts/utils/build.js
 import injectedFeaturesCode from 'ddg:runtimeInjects'
@@ -71,7 +71,7 @@ async function injectFeatures (args) {
         ${codeFeatures.join('\n')}
     })()`
     script.src = 'data:text/javascript;base64,' + btoa(code)
-    document.head.appendChild(script)
+    getInjectionElement().appendChild(script)
     script.remove()
 }
 

--- a/src/features/element-hiding.js
+++ b/src/features/element-hiding.js
@@ -1,4 +1,4 @@
-import { isBeingFramed, getFeatureSetting, matchHostname, DDGProxy, DDGReflect } from '../utils'
+import { isBeingFramed, getFeatureSetting, matchHostname, DDGProxy, DDGReflect, getInjectionElement } from '../utils'
 
 let adLabelStrings = []
 const parser = new DOMParser()
@@ -227,7 +227,7 @@ function extractTimeoutRules (rules) {
 }
 
 /**
- * Create styletag for strict hide rules and append it to document head
+ * Create styletag for strict hide rules and append it to the document
  * @param {Object[]} rules
  * @param {string} rules[].selector
  * @param {string} rules[].type
@@ -249,7 +249,7 @@ function injectStyleTag (rules) {
     styleTagContents = styleTagContents.concat('{display:none!important;min-height:0!important;height:0!important;}')
     styleTag.href = 'data:text/css,' + encodeURIComponent(styleTagContents)
 
-    document.head.appendChild(styleTag)
+    getInjectionElement().appendChild(styleTag)
 }
 
 /**

--- a/src/utils.js
+++ b/src/utils.js
@@ -14,6 +14,13 @@ export function registerMessageSecret (secret) {
 }
 
 /**
+ * @returns {HTMLElement} the element to inject the script into
+ */
+export function getInjectionElement () {
+    return document.head || document.documentElement
+}
+
+/**
  * Used for testing to override the globals used within this file.
  * @param {window} globalObjIn
  */


### PR DESCRIPTION
Fixes the cases where sometimes there's no head element; for example srcdoc iframes with no content.