### PR TITLE
Rename HTMLDocument to Document as the former is legacy naming

### DIFF
--- a/src/content-scope-features.js
+++ b/src/content-scope-features.js
@@ -7,7 +7,7 @@ import injectedFeaturesCode from 'ddg:runtimeInjects'
 function shouldRun () {
     // don't inject into non-HTML documents (such as XML documents)
     // but do inject into XHTML documents
-    if (document instanceof HTMLDocument === false && (
+    if (document instanceof Document === false && (
         document instanceof XMLDocument === false ||
         document.createElement('div') instanceof HTMLDivElement === false
     )) {


### PR DESCRIPTION
Makes no real difference in code, the browser aliases the former but it's considered deprecated.