### PR TITLE
Ignore monitoring for DOM0 event listeners as they're already handled

### DIFF
--- a/src/features/runtime-checks.js
+++ b/src/features/runtime-checks.js
@@ -106,6 +106,8 @@ class DDGRuntimeChecks extends HTMLElement {
                     },
                     set (value) {
                         if (shouldFilterKey(this.#tagName, 'property', prop)) return
+                        // Ignore any properties that start with 'on' as they are only relevant once and already handled
+                        if (prop.startsWith('on')) return
                         el[prop] = value
                     }
                 })

--- a/src/features/runtime-checks.js
+++ b/src/features/runtime-checks.js
@@ -10,6 +10,9 @@ let initialCreateElement
 let tagModifiers = {}
 let shadowDomEnabled = false
 let scriptOverload = {}
+// Ignore monitoring properties that are only relevant once and already handled
+const defaultIgnoreMonitorList = ['onerror', 'onload']
+let ignoreMonitorList = defaultIgnoreMonitorList
 
 /**
  * @param {string} tagName
@@ -106,8 +109,7 @@ class DDGRuntimeChecks extends HTMLElement {
                     },
                     set (value) {
                         if (shouldFilterKey(this.#tagName, 'property', prop)) return
-                        // Ignore any properties that start with 'on' as they are only relevant once and already handled
-                        if (prop.startsWith('on')) return
+                        if (ignoreMonitorList.includes(prop)) return
                         el[prop] = value
                     }
                 })
@@ -470,6 +472,7 @@ export default class RuntimeChecks extends ContentFeature {
         tagModifiers = this.getFeatureSetting('tagModifiers') || {}
         shadowDomEnabled = this.getFeatureSettingEnabled('shadowDom') || false
         scriptOverload = this.getFeatureSetting('scriptOverload') || {}
+        ignoreMonitorList = this.getFeatureSetting('ignoreMonitorList') || defaultIgnoreMonitorList
 
         overrideCreateElement()
 


### PR DESCRIPTION
We can't really test for this as it creates a crash in Chrome.
The following is the test I as using:
https://github.com/duckduckgo/duckduckgo-privacy-extension/commit/dc3efa29676cc5daca02d13bb32877b74e63d254