### PR TITLE
Avoid showing placeholders for the same element multiple times

### DIFF
--- a/src/features/click-to-load.js
+++ b/src/features/click-to-load.js
@@ -21,6 +21,9 @@ let sharedStrings = null
 const entities = []
 const entityData = {}
 
+// Used to avoid displaying placeholders for the same tracking element twice.
+const knownTrackingElements = new WeakSet()
+
 let readyResolver
 const ready = new Promise(resolve => { readyResolver = resolve })
 
@@ -509,6 +512,12 @@ async function replaceClickToLoadElements (targetElement) {
             }
 
             await Promise.all(trackingElements.map(trackingElement => {
+                if (knownTrackingElements.has(trackingElement)) {
+                    return Promise.resolve()
+                }
+
+                knownTrackingElements.add(trackingElement)
+
                 const widget = new DuckWidget(widgetData, trackingElement, entity)
                 return createPlaceholderElementAndReplace(widget, trackingElement)
             }))


### PR DESCRIPTION
Even without the hideTrackingElement code path, there are some
situations that can lead to duplicate placeholders from being shown
for an element. Let's explicitly prevent that from happening.