### PR TITLE
Take care to set hasMozProxies for Firefox builds again

### DIFF
--- a/scripts/utils/build.js
+++ b/scripts/utils/build.js
@@ -4,6 +4,7 @@ import replace from '@rollup/plugin-replace'
 import resolve from '@rollup/plugin-node-resolve'
 import dynamicImportVariables from 'rollup-plugin-dynamic-import-variables'
 import { runtimeInjected } from '../../src/features.js'
+import { parseArgs } from '../script-utils.js'
 
 /**
  * This is a helper function to require all files in a directory
@@ -46,7 +47,8 @@ function runtimeInjections () {
 export async function rollupScript (scriptPath, name, supportsMozProxies = true) {
     let mozProxies = false
     // The code is using a global, that we define here which means once tree shaken we get a browser specific output.
-    if (process.argv[2] === 'firefox' && supportsMozProxies) {
+    const args = parseArgs(process.argv.slice(2), ['platform'])
+    if (args.platform === 'firefox' && supportsMozProxies) {
         mozProxies = true
     }
     const inputOptions = {


### PR DESCRIPTION
The build script was checking if one of the command line arguments
were "firefox", before setting a variable. Unfortunately, the command
line arguments were moved around[1] which broke this check. Let's fix
that, copying the parsing logic used elsewhere.

1 - https://github.com/duckduckgo/content-scope-scripts/commit/03751df2274120e7e007cf64bcffcc19363977bc