### PR TITLE
Fix firefox build

### DIFF
--- a/scripts/inject.js
+++ b/scripts/inject.js
@@ -40,7 +40,8 @@ const builds = {
 }
 
 async function initOther (injectScriptPath, platformName) {
-    const injectScript = await rollupScript(injectScriptPath, `inject${platformName}`)
+    const supportsMozProxies = platformName === 'firefox'
+    const injectScript = await rollupScript(injectScriptPath, `inject${platformName}`, supportsMozProxies)
     const outputScript = injectScript
     return outputScript
 }
@@ -73,7 +74,7 @@ async function init () {
     if (args.platform === 'chrome') {
         output = await initChrome(build.input)
     } else {
-        output = await initOther(build.input)
+        output = await initOther(build.input, args.platform)
     }
 
     // bundle and write the output

--- a/scripts/inject.js
+++ b/scripts/inject.js
@@ -1,5 +1,6 @@
 import { rollupScript } from './utils/build.js'
 import { parseArgs, write } from './script-utils.js'
+import { camelcase } from '../src/utils.js'
 
 const contentScopePath = 'src/content-scope-features.js'
 const contentScopeName = 'contentScopeFeatures'
@@ -41,7 +42,8 @@ const builds = {
 
 async function initOther (injectScriptPath, platformName) {
     const supportsMozProxies = platformName === 'firefox'
-    const injectScript = await rollupScript(injectScriptPath, `inject${platformName}`, supportsMozProxies)
+    const identName = `inject${camelcase(platformName)}`
+    const injectScript = await rollupScript(injectScriptPath, identName, supportsMozProxies)
     const outputScript = injectScript
     return outputScript
 }

--- a/scripts/utils/build.js
+++ b/scripts/utils/build.js
@@ -43,10 +43,10 @@ function runtimeInjections () {
     }
 }
 
-export async function rollupScript (scriptPath, name, supportsMozProxies = true) {
+export async function rollupScript (scriptPath, name, supportsMozProxies = false) {
     let mozProxies = false
     // The code is using a global, that we define here which means once tree shaken we get a browser specific output.
-    if (process.argv[2] === 'firefox' && supportsMozProxies) {
+    if (supportsMozProxies) {
         mozProxies = true
     }
     const inputOptions = {

--- a/scripts/utils/build.js
+++ b/scripts/utils/build.js
@@ -44,11 +44,9 @@ function runtimeInjections () {
 }
 
 export async function rollupScript (scriptPath, name, supportsMozProxies = false) {
-    let mozProxies = false
     // The code is using a global, that we define here which means once tree shaken we get a browser specific output.
-    if (supportsMozProxies) {
-        mozProxies = true
-    }
+    const mozProxies = supportsMozProxies
+
     const inputOptions = {
         input: scriptPath,
         plugins: [

--- a/unit-test/verify-artifacts.js
+++ b/unit-test/verify-artifacts.js
@@ -1,12 +1,12 @@
 import { join, relative } from 'node:path'
-import { statSync } from 'node:fs'
+import { readFileSync, statSync } from 'node:fs'
 import { cwd } from '../scripts/script-utils.js'
 
 // path helpers
 const ROOT = join(cwd(import.meta.url), '..')
 const BUILD = join(ROOT, 'build')
 const APPLE_BUILD = join(ROOT, 'Sources/ContentScopeScripts/dist')
-const CSS_OUTPUT_SIZE = 512000
+const CSS_OUTPUT_SIZE = 530000
 const CSS_OUTPUT_SIZE_CHROME = CSS_OUTPUT_SIZE * 1.45 // 45% larger for Chrome MV2 due to base64 encoding
 
 const checks = {
@@ -17,10 +17,12 @@ const checks = {
         { kind: 'maxFileSize', value: CSS_OUTPUT_SIZE_CHROME, path: join(BUILD, 'chrome/inject.js') }
     ],
     'chrome-mv3': [
-        { kind: 'maxFileSize', value: CSS_OUTPUT_SIZE, path: join(BUILD, 'chrome-mv3/inject.js') }
+        { kind: 'maxFileSize', value: CSS_OUTPUT_SIZE, path: join(BUILD, 'chrome-mv3/inject.js') },
+        { kind: 'containsString', text: 'cloneInto(', path: join(BUILD, 'chrome-mv3/inject.js'), includes: false }
     ],
     firefox: [
-        { kind: 'maxFileSize', value: CSS_OUTPUT_SIZE, path: join(BUILD, 'firefox/inject.js') }
+        { kind: 'maxFileSize', value: CSS_OUTPUT_SIZE, path: join(BUILD, 'firefox/inject.js') },
+        { kind: 'containsString', text: 'cloneInto(', path: join(BUILD, 'firefox/inject.js'), includes: true }
     ],
     integration: [
         { kind: 'maxFileSize', value: CSS_OUTPUT_SIZE, path: join(BUILD, 'integration/contentScope.js') }
@@ -36,11 +38,22 @@ const checks = {
 describe('checks', () => {
     for (const [platformName, platformChecks] of Object.entries(checks)) {
         for (const check of platformChecks) {
+            const localPath = relative(ROOT, check.path)
             if (check.kind === 'maxFileSize') {
-                const localPath = relative(ROOT, check.path)
                 it(`${platformName}: '${localPath}' is smaller than ${check.value}`, () => {
                     const stats = statSync(check.path)
                     expect(stats.size).toBeLessThan(check.value)
+                })
+            }
+            if (check.kind === 'containsString') {
+                it(`${platformName}: '${localPath}' contains ${check.text}`, () => {
+                    const fileContents = readFileSync(localPath).toString()
+                    const includes = fileContents.includes(check.text)
+                    if (check.includes) {
+                        expect(includes).toBeTrue()
+                    } else {
+                        expect(includes).toBeFalse()
+                    }
                 })
             }
         }


### PR DESCRIPTION
Fixes up an issue of the missing arg into the build file, we should do all the arg processing in inject and pass through any processing into build.js

I've added some basic sanity checking of the files to the unit tests due to the lack of Firefox integration testing here or on the Extension side. With the Playwright migration of both repos we can address that properly.

Additionally this fixes up the broken platform name argument which has been missing for quite some time. (I don't think we actually need this in rollup given changes to iife)