### PR TITLE
Performance monitoring

### DIFF
--- a/integration-test/test-performance.js
+++ b/integration-test/test-performance.js
@@ -1,0 +1,55 @@
+/**
+ *  Tests for basic performance
+ */
+import { setup } from './helpers/harness.js'
+
+describe('Runtime checks: should check basic performance', () => {
+    let browser
+    let server
+    let teardown
+    let setupServer
+    let gotoAndWait
+    beforeAll(async () => {
+        ({ browser, setupServer, teardown, gotoAndWait } = await setup({ withExtension: true }))
+        server = setupServer()
+    })
+    afterAll(async () => {
+        await server?.close()
+        await teardown()
+    })
+
+    it('Should perform within a resonable timeframe', async () => {
+        const port = server.address().port
+        const page = await browser.newPage()
+        await gotoAndWait(page, `http://localhost:${port}/blank.html`, {
+            debug: true,
+            site: {
+                enabledFeatures: ['runtimeChecks', 'fingerprintingCanvas']
+            },
+            featureSettings: {
+                runtimeChecks: {
+                    taintCheck: 'enabled',
+                    matchAllDomains: 'enabled',
+                    matchAllStackDomains: 'disabled',
+                    overloadInstanceOf: 'enabled',
+                    stackDomains: [
+                        {
+                            domain: 'localhost'
+                        }
+                    ]
+                }
+            }
+        })
+        const perfResult = await page.evaluate(
+            () => {
+                return {
+                    load: performance.getEntriesByName('load')[0].duration,
+                    init: performance.getEntriesByName('init')[0].duration,
+                    runtimeChecks: performance.getEntriesByName('runtimeChecksCallInit')[0].duration
+                }
+            })
+        expect(perfResult.runtimeChecks).toBeLessThan(2)
+        expect(perfResult.load).toBeLessThan(3)
+        expect(perfResult.init).toBeLessThan(15)
+    })
+})

--- a/src/content-feature.js
+++ b/src/content-feature.js
@@ -1,10 +1,12 @@
 import { camelcase, matchHostname, processAttr } from './utils.js'
 import { immutableJSONPatch } from 'immutable-json-patch'
+import { PerformanceMonitor } from './performance.js'
 
 export default class ContentFeature {
     constructor (featureName) {
         this.name = featureName
         this._args = null
+        this.monitor = new PerformanceMonitor()
     }
 
     /**
@@ -85,16 +87,12 @@ export default class ContentFeature {
     init (args) {
     }
 
-    createPerformanceMarker (name) {
-        performance.mark(this.name + name)
-    }
-
     callInit (args) {
-        this.createPerformanceMarker('CallInitStart')
+        const mark = this.monitor.mark(this.name + 'CallInit')
         this._args = args
         this.platform = args.platform
         this.init(args)
-        this.createPerformanceMarker('CallInitEnd')
+        mark.end()
         this.measure()
     }
 
@@ -102,17 +100,16 @@ export default class ContentFeature {
     }
 
     callLoad (args) {
-        this.createPerformanceMarker('CallLoadStart')
+        const mark = this.monitor.mark(this.name + 'CallLoad')
         this._args = args
         this.platform = args.platform
         this.load(args)
-        this.createPerformanceMarker('CallLoadEnd')
+        mark.end()
     }
 
     measure () {
         if (this._args.debug) {
-            performance.measure(this.name + 'Init', this.name + 'CallInitStart', this.name + 'CallInitEnd')
-            performance.measure(this.name + 'Load', this.name + 'CallLoadStart', this.name + 'CallLoadEnd')
+            this.monitor.measure()
         }
     }
 

--- a/src/content-feature.js
+++ b/src/content-feature.js
@@ -109,7 +109,7 @@ export default class ContentFeature {
 
     measure () {
         if (this._args.debug) {
-            this.monitor.measure()
+            this.monitor.measureAll()
         }
     }
 

--- a/src/content-feature.js
+++ b/src/content-feature.js
@@ -85,19 +85,35 @@ export default class ContentFeature {
     init (args) {
     }
 
+    createPerformanceMarker (name) {
+        performance.mark(this.name + name)
+    }
+
     callInit (args) {
+        this.createPerformanceMarker('CallInitStart')
         this._args = args
         this.platform = args.platform
         this.init(args)
+        this.createPerformanceMarker('CallInitEnd')
+        this.measure()
     }
 
     load (args) {
     }
 
     callLoad (args) {
+        this.createPerformanceMarker('CallLoadStart')
         this._args = args
         this.platform = args.platform
         this.load(args)
+        this.createPerformanceMarker('CallLoadEnd')
+    }
+
+    measure () {
+        if (this._args.debug) {
+            performance.measure(this.name + 'Init', this.name + 'CallInitStart', this.name + 'CallInitEnd')
+            performance.measure(this.name + 'Load', this.name + 'CallLoadStart', this.name + 'CallLoadEnd')
+        }
     }
 
     update () {

--- a/src/content-scope-features.js
+++ b/src/content-scope-features.js
@@ -1,6 +1,7 @@
 /* global mozProxies */
 import { initStringExemptionLists, isFeatureBroken, registerMessageSecret, getInjectionElement } from './utils'
 import { featureNames } from './features'
+import PerformanceMonitor from './performance'
 // @ts-expect-error Special glob import for injected features see scripts/utils/build.js
 import injectedFeaturesCode from 'ddg:runtimeInjects'
 
@@ -20,6 +21,7 @@ let initArgs = null
 const updates = []
 const features = []
 const alwaysInitFeatures = new Set(['cookie'])
+const performanceMonitor = new PerformanceMonitor()
 
 /**
  * @typedef {object} LoadArgs
@@ -34,6 +36,7 @@ const alwaysInitFeatures = new Set(['cookie'])
  * @param {LoadArgs} args
  */
 export async function load (args) {
+    performanceMonitor.mark('loadStart')
     if (!shouldRun()) {
         return
     }
@@ -52,6 +55,7 @@ export async function load (args) {
         })
         features.push(feature)
     }
+    performanceMonitor.mark('loadEnd')
 }
 
 /**
@@ -105,6 +109,7 @@ function supportsInjectedFeatures () {
 }
 
 export async function init (args) {
+    performanceMonitor.mark('initStart')
     initArgs = args
     if (!shouldRun()) {
         return
@@ -124,6 +129,10 @@ export async function init (args) {
     while (updates.length) {
         const update = updates.pop()
         await updateFeaturesInner(update)
+    }
+    performanceMonitor.mark('initEnd')
+    if (args.debug) {
+        performanceMonitor.measure()
     }
 }
 

--- a/src/content-scope-features.js
+++ b/src/content-scope-features.js
@@ -1,7 +1,7 @@
 /* global mozProxies */
 import { initStringExemptionLists, isFeatureBroken, registerMessageSecret, getInjectionElement } from './utils'
 import { featureNames } from './features'
-import PerformanceMonitor from './performance'
+import { PerformanceMonitor } from './performance'
 // @ts-expect-error Special glob import for injected features see scripts/utils/build.js
 import injectedFeaturesCode from 'ddg:runtimeInjects'
 
@@ -36,7 +36,7 @@ const performanceMonitor = new PerformanceMonitor()
  * @param {LoadArgs} args
  */
 export async function load (args) {
-    performanceMonitor.mark('loadStart')
+    const mark = performanceMonitor.mark('load')
     if (!shouldRun()) {
         return
     }
@@ -55,7 +55,7 @@ export async function load (args) {
         })
         features.push(feature)
     }
-    performanceMonitor.mark('loadEnd')
+    mark.end()
 }
 
 /**
@@ -109,7 +109,7 @@ function supportsInjectedFeatures () {
 }
 
 export async function init (args) {
-    performanceMonitor.mark('initStart')
+    const mark = performanceMonitor.mark('init')
     initArgs = args
     if (!shouldRun()) {
         return
@@ -130,7 +130,7 @@ export async function init (args) {
         const update = updates.pop()
         await updateFeaturesInner(update)
     }
-    performanceMonitor.mark('initEnd')
+    mark.end()
     if (args.debug) {
         performanceMonitor.measure()
     }

--- a/src/content-scope-features.js
+++ b/src/content-scope-features.js
@@ -132,7 +132,7 @@ export async function init (args) {
     }
     mark.end()
     if (args.debug) {
-        performanceMonitor.measure()
+        performanceMonitor.measureAll()
     }
 }
 

--- a/src/performance.js
+++ b/src/performance.js
@@ -20,7 +20,7 @@ export class PerformanceMonitor {
     /**
      * Measure all performance markers
      */
-    measure () {
+    measureAll () {
         this.marks.forEach((mark) => {
             mark.measure()
         })

--- a/src/performance.js
+++ b/src/performance.js
@@ -1,14 +1,49 @@
-export default class PerformanceMonitor {
+/**
+ * Performance monitor, holds reference to PerformanceMark instances.
+ */
+export class PerformanceMonitor {
+    constructor () {
+        this.marks = []
+    }
+
     /**
      * Create performance marker
      * @param {string} name
+     * @returns {PerformanceMark}
      */
     mark (name) {
-        performance.mark(name)
+        const mark = new PerformanceMark(name)
+        this.marks.push(mark)
+        return mark
+    }
+
+    /**
+     * Measure all performance markers
+     */
+    measure () {
+        this.marks.forEach((mark) => {
+            mark.measure()
+        })
+    }
+}
+
+/**
+ * Tiny wrapper around performance.mark and performance.measure
+ */
+export class PerformanceMark {
+    /**
+     * @param {string} name
+     */
+    constructor (name) {
+        this.name = name
+        performance.mark(this.name + 'Start')
+    }
+
+    end () {
+        performance.mark(this.name + 'End')
     }
 
     measure () {
-        performance.measure('load', 'loadStart', 'loadEnd')
-        performance.measure('init', 'initStart', 'initEnd')
+        performance.measure(this.name, this.name + 'Start', this.name + 'End')
     }
 }

--- a/src/performance.js
+++ b/src/performance.js
@@ -1,0 +1,14 @@
+export default class PerformanceMonitor {
+    /**
+     * Create performance marker
+     * @param {string} name
+     */
+    mark (name) {
+        performance.mark(name)
+    }
+
+    measure () {
+        performance.measure('load', 'loadStart', 'loadEnd')
+        performance.measure('init', 'initStart', 'initEnd')
+    }
+}

--- a/unit-test/verify-artifacts.js
+++ b/unit-test/verify-artifacts.js
@@ -6,7 +6,7 @@ import { cwd } from '../scripts/script-utils.js'
 const ROOT = join(cwd(import.meta.url), '..')
 const BUILD = join(ROOT, 'build')
 const APPLE_BUILD = join(ROOT, 'Sources/ContentScopeScripts/dist')
-const CSS_OUTPUT_SIZE = 530000
+const CSS_OUTPUT_SIZE = 550000
 const CSS_OUTPUT_SIZE_CHROME = CSS_OUTPUT_SIZE * 1.45 // 45% larger for Chrome MV2 due to base64 encoding
 
 const checks = {


### PR DESCRIPTION
Adds some very basic performance monitoring.

To use this in the extension, you need to use the devtools-panel.html flow to get debug: true set on the tab.
This sets marks by default but never will monitor unless the debug flag is set.

Opening the performance monitor in the browser, you can zoom in and see each part of the code:
<img width="302" alt="image" src="https://user-images.githubusercontent.com/338988/230873136-bf07a101-2a4c-41fe-a649-04ce38b49cb9.png">
