### PR TITLE
Partially revert "Tighten linting" changes to Click to Load code

### DIFF
--- a/src/features/click-to-load.js
+++ b/src/features/click-to-load.js
@@ -1,3 +1,7 @@
+// TODO - Remove these comments to enable full linting.
+/* eslint-disable @typescript-eslint/ban-ts-comment, @typescript-eslint/await-thenable, require-await */
+// @ts-nocheck
+
 import { createCustomEvent, sendMessage, OriginalCustomEvent, originalWindowDispatchEvent } from '../utils.js'
 import { logoImg, loadingImages, closeIcon } from './click-to-load/ctl-assets.js'
 import { styles, getConfig } from './click-to-load/ctl-config.js'
@@ -185,11 +189,9 @@ class DuckWidget {
     adjustYouTubeVideoElement (videoElement) {
         let onError = null
 
-        // @ts-expect-error inital fix of click-to-load (please remove)
         if (!videoElement.src) {
             return onError
         }
-        // @ts-expect-error inital fix of click-to-load (please remove)
         const url = new URL(videoElement.src)
         const { hostname: originalHostname } = url
 
@@ -203,7 +205,6 @@ class DuckWidget {
             url.hostname = 'www.youtube-nocookie.com'
             onError = (event) => {
                 url.hostname = originalHostname
-                // @ts-expect-error inital fix of click-to-load (please remove)
                 videoElement.src = url.href
                 event.stopImmediatePropagation()
             }
@@ -213,7 +214,6 @@ class DuckWidget {
         // loaded, otherwise it doesn't allow autoplay.
         let allowString = videoElement.getAttribute('allow') || ''
         const allowed = new Set(allowString.split(';').map(s => s.trim()))
-        // @ts-expect-error inital fix of click-to-load (please remove)
         if (this.autoplay) {
             allowed.add('autoplay')
             url.searchParams.set('autoplay', '1')
@@ -224,19 +224,18 @@ class DuckWidget {
         allowString = Array.from(allowed).join('; ')
         videoElement.setAttribute('allow', allowString)
 
-        // @ts-expect-error inital fix of click-to-load (please remove)
         videoElement.src = url.href
         return onError
     }
 
     /*
-        * Fades out the given element. Returns a promise that resolves when the fade is complete.
-        * @param {Element} element - the element to fade in or out
-        * @param {int} interval - frequency of opacity updates (ms)
-        * @param {bool} fadeIn - true if the element should fade in instead of out
-        */
+     * Fades out the given element. Returns a promise that resolves when the fade is complete.
+     * @param {Element} element - the element to fade in or out
+     * @param {int} interval - frequency of opacity updates (ms)
+     * @param {boolean} fadeIn - true if the element should fade in instead of out
+     */
     fadeElement (element, interval, fadeIn) {
-        return new Promise((resolve, reject) => {
+        return new Promise(resolve => {
             let opacity = fadeIn ? 0 : 1
             const originStyle = element.style.cssText
             const fadeOut = setInterval(function () {
@@ -267,7 +266,6 @@ class DuckWidget {
                 clicked = true
                 let isLogin = false
                 const clickElement = e.srcElement // Object.assign({}, e)
-                // @ts-expect-error inital fix of click-to-load (please remove)
                 if (this.replaceSettings.type === 'loginButton') {
                     isLogin = true
                 }
@@ -276,10 +274,8 @@ class DuckWidget {
 
                     // If we allow everything when this element is clicked,
                     // notify surrogate to enable SDK and replace original element.
-                    // @ts-expect-error inital fix of click-to-load (please remove)
                     if (this.clickAction.type === 'allowFull') {
                         parent.replaceChild(originalElement, replacementElement)
-                        // @ts-expect-error inital fix of click-to-load (please remove)
                         this.dispatchEvent(window, 'ddg-ctp-load-sdk')
                         return
                     }
@@ -291,7 +287,6 @@ class DuckWidget {
 
                     // Loading animation (FB can take some time to load)
                     const loadingImg = document.createElement('img')
-                    // @ts-expect-error inital fix of click-to-load (please remove)
                     loadingImg.setAttribute('src', loadingImages[this.getMode()])
                     loadingImg.setAttribute('height', '14px')
                     loadingImg.style.cssText = styles.loadingImg
@@ -316,14 +311,11 @@ class DuckWidget {
 
                     let fbElement
                     let onError = null
-                    // @ts-expect-error inital fix of click-to-load (please remove)
                     switch (this.clickAction.type) {
                     case 'iFrame':
-                        // @ts-expect-error inital fix of click-to-load (please remove)
                         fbElement = this.createFBIFrame()
                         break
                     case 'youtube-video':
-                        // @ts-expect-error inital fix of click-to-load (please remove)
                         onError = this.adjustYouTubeVideoElement(originalElement)
                         fbElement = originalElement
                         break
@@ -341,14 +333,12 @@ class DuckWidget {
                     fbContainer.appendChild(replacementElement)
                     fadeIn.appendChild(fbElement)
                     fbElement.addEventListener('load', async () => {
-                        // @ts-expect-error inital fix of click-to-load (please remove)
-                        const v = await this.fadeOutElement(replacementElement)
+                        await this.fadeOutElement(replacementElement)
                         fbContainer.replaceWith(fbElement)
-                        // @ts-expect-error inital fix of click-to-load (please remove)
                         this.dispatchEvent(fbElement, 'ddg-ctp-placeholder-clicked')
-                        // @ts-expect-error inital fix of click-to-load (please remove)
                         await this.fadeInElement(fadeIn)
-                        fbElement.focus() // focus on new element for screen readers
+                        // Focus on new element for screen readers.
+                        fbElement.focus()
                     }, { once: true })
                     // Note: This event only fires on Firefox, on Chrome the frame's
                     //       load event will always fire.
@@ -356,9 +346,7 @@ class DuckWidget {
                         fbElement.addEventListener('error', onError, { once: true })
                     }
                 }, { once: true })
-                // @ts-expect-error inital fix of click-to-load (please remove)
                 const action = this.entity === 'Youtube' ? 'block-ctl-yt' : 'block-ctl-fb'
-                // @ts-expect-error inital fix of click-to-load (please remove)
                 unblockClickToLoadContent({ entity: this.entity, action, isLogin })
             }
         }.bind(this)
@@ -391,7 +379,7 @@ function replaceTrackingElement (widget, trackingElement, placeholderElement, cu
  * @param {Element} trackingElement
  *   The tracking element on the page that should be replaced with a placeholder.
  */
-function createPlaceholderElementAndReplace (widget, trackingElement) {
+async function createPlaceholderElementAndReplace (widget, trackingElement) {
     if (widget.replaceSettings.type === 'blank') {
         replaceTrackingElement(widget, trackingElement, document.createElement('div'))
     }
@@ -410,10 +398,9 @@ function createPlaceholderElementAndReplace (widget, trackingElement) {
     /** Facebook CTL */
     if (widget.replaceSettings.type === 'dialog') {
         const icon = widget.replaceSettings.icon
-        // @ts-expect-error inital fix of click-to-load (please remove)
         const button = makeButton(widget.replaceSettings.buttonText, widget.getMode())
         const textButton = makeTextButton(widget.replaceSettings.buttonText, widget.getMode())
-        const { contentBlock, shadowRoot } = createContentBlock(
+        const { contentBlock, shadowRoot } = await createContentBlock(
             widget, button, textButton, icon
         )
         button.addEventListener('click', widget.clickFunction(trackingElement, contentBlock))
@@ -422,18 +409,16 @@ function createPlaceholderElementAndReplace (widget, trackingElement) {
         replaceTrackingElement(
             widget, trackingElement, contentBlock
         )
-        // @ts-expect-error inital fix of click-to-load (please remove)
         showExtraUnblockIfShortPlaceholder(shadowRoot, contentBlock)
     }
 
     /** YouTube CTL */
     if (widget.replaceSettings.type === 'youtube-video') {
         sendMessage('updateYouTubeCTLAddedFlag', true)
-        replaceYouTubeCTL(trackingElement, widget)
+        await replaceYouTubeCTL(trackingElement, widget)
 
         // Subscribe to changes to youtubePreviewsEnabled setting
         // and update the CTL state
-        // @ts-expect-error inital fix of click-to-load (please remove)
         window.addEventListener('ddg-settings-youtubePreviewsEnabled', ({ detail: value }) => {
             isYoutubePreviewsEnabled = value
             replaceYouTubeCTL(trackingElement, widget, true)
@@ -450,7 +435,7 @@ function createPlaceholderElementAndReplace (widget, trackingElement) {
  *   Boolean indicating if this function should toggle between placeholders,
  *   because tracking element has already been replaced
  */
-function replaceYouTubeCTL (trackingElement, widget, togglePlaceholder = false) {
+async function replaceYouTubeCTL (trackingElement, widget, togglePlaceholder = false) {
     // Skip replacing tracking element if it has already been unblocked
     if (widget.isUnblocked) {
         return
@@ -458,7 +443,7 @@ function replaceYouTubeCTL (trackingElement, widget, togglePlaceholder = false) 
 
     // Show YouTube Preview for embedded video
     if (isYoutubePreviewsEnabled === true) {
-        const { youTubePreview, shadowRoot } = createYouTubePreview(trackingElement, widget)
+        const { youTubePreview, shadowRoot } = await createYouTubePreview(trackingElement, widget)
         const currentPlaceholder = togglePlaceholder ? widget.placeholderElement : null
         resizeElementToMatch(currentPlaceholder || trackingElement, youTubePreview)
         replaceTrackingElement(
@@ -468,15 +453,13 @@ function replaceYouTubeCTL (trackingElement, widget, togglePlaceholder = false) 
 
         // Block YouTube embedded video and display blocking dialog
     } else {
-        // @ts-expect-error inital fix of click-to-load (please remove)
         widget.autoplay = false
-        const { blockingDialog, shadowRoot } = createYouTubeBlockingDialog(trackingElement, widget)
+        const { blockingDialog, shadowRoot } = await createYouTubeBlockingDialog(trackingElement, widget)
         const currentPlaceholder = togglePlaceholder ? widget.placeholderElement : null
         resizeElementToMatch(currentPlaceholder || trackingElement, blockingDialog)
         replaceTrackingElement(
             widget, trackingElement, blockingDialog, currentPlaceholder
         )
-        // @ts-expect-error inital fix of click-to-load (please remove)
         showExtraUnblockIfShortPlaceholder(shadowRoot, blockingDialog)
     }
 }
@@ -498,17 +481,13 @@ function showExtraUnblockIfShortPlaceholder (shadowRoot, placeholder) {
     const { height: parentHeight } = window.getComputedStyle(placeholder.parentElement)
     if (parseInt(placeholderHeight, 10) <= 200 || parseInt(parentHeight, 10) <= 200) {
         const titleRowTextButton = shadowRoot.querySelector(`#${titleID + 'TextButton'}`)
-        // @ts-expect-error inital fix of click-to-load (please remove)
         titleRowTextButton.style.display = 'block'
 
         // Avoid the placeholder being taller than the containing element
         // and overflowing.
         const innerDiv = shadowRoot.querySelector('.DuckDuckGoSocialContainer')
-        // @ts-expect-error inital fix of click-to-load (please remove)
         innerDiv.style.minHeight = ''
-        // @ts-expect-error inital fix of click-to-load (please remove)
         innerDiv.style.maxHeight = parentHeight
-        // @ts-expect-error inital fix of click-to-load (please remove)
         innerDiv.style.overflow = 'hidden'
     }
 }
@@ -642,16 +621,13 @@ function resizeElementToMatch (sourceElement, targetElement) {
     //       the source element instead?
     const { height, width } = sourceElement.getBoundingClientRect()
     if (height > 0 && width > 0) {
-        // @ts-expect-error inital fix of click-to-load (please remove)
         targetElement.style.height = height + 'px'
-        // @ts-expect-error inital fix of click-to-load (please remove)
         targetElement.style.width = width + 'px'
     } else {
         stylesToCopy.push('height', 'width')
     }
 
     for (const key of stylesToCopy) {
-        // @ts-expect-error inital fix of click-to-load (please remove)
         targetElement.style[key] = computedStyle[key]
     }
 }
@@ -908,7 +884,7 @@ function makeLoginButton (buttonText, mode, hoverTextBody, icon, originalElement
     }
 }
 
-function makeModal (entity, acceptFunction, ...acceptFunctionParams) {
+async function makeModal (entity, acceptFunction, ...acceptFunctionParams) {
     const icon = entityData[entity].modalIcon
 
     const modalContainer = document.createElement('div')
@@ -1032,7 +1008,7 @@ function createTitleRow (message, textButton, closeBtnFn) {
 }
 
 // Create the content block to replace other divs/iframes with
-function createContentBlock (widget, button, textButton, img, bottomRow) {
+async function createContentBlock (widget, button, textButton, img, bottomRow) {
     const contentBlock = document.createElement('div')
     contentBlock.style.cssText = styles.wrapperDiv
 
@@ -1107,7 +1083,7 @@ function createContentBlock (widget, button, textButton, img, bottomRow) {
 }
 
 // Create the content block to replace embedded youtube videos/iframes with
-function createYouTubeBlockingDialog (trackingElement, widget) {
+async function createYouTubeBlockingDialog (trackingElement, widget) {
     const button = makeButton(widget.replaceSettings.buttonText, widget.getMode())
     const textButton = makeTextButton(widget.replaceSettings.buttonText, widget.getMode())
 
@@ -1127,7 +1103,7 @@ function createYouTubeBlockingDialog (trackingElement, widget) {
     )
     bottomRow.appendChild(previewToggle)
 
-    const { contentBlock, shadowRoot } = createContentBlock(
+    const { contentBlock, shadowRoot } = await createContentBlock(
         widget, button, textButton, null, bottomRow
     )
     contentBlock.id = trackingElement.id
@@ -1153,7 +1129,7 @@ function createYouTubeBlockingDialog (trackingElement, widget) {
  * @returns {{ youTubePreview: Element, shadowRoot: Element }}
  *   Object containing the YouTube Preview element and its shadowRoot.
  */
-function createYouTubePreview (originalElement, widget) {
+async function createYouTubePreview (originalElement, widget) {
     const youTubePreview = document.createElement('div')
     youTubePreview.id = originalElement.id
     youTubePreview.style.cssText = styles.wrapperDiv + styles.placeholderWrapperDiv
@@ -1163,7 +1139,6 @@ function createYouTubePreview (originalElement, widget) {
     // Protect the contents of our placeholder inside a shadowRoot, to avoid
     // it being styled by the website's stylesheets.
     const shadowRoot = youTubePreview.attachShadow({ mode: devMode ? 'open' : 'closed' })
-    // @ts-expect-error inital fix of click-to-load (please remove)
     const { wrapperClass, styleElement } = makeBaseStyleElement(widget.getMode())
     shadowRoot.appendChild(styleElement)
 
@@ -1212,7 +1187,6 @@ function createYouTubePreview (originalElement, widget) {
     const playButtonRow = document.createElement('div')
     playButtonRow.style.cssText = styles.youTubePlayButtonRow
 
-    // @ts-expect-error inital fix of click-to-load (please remove)
     const playButton = makeButton('', widget.getMode())
     playButton.style.cssText += styles.youTubePlayButton
 
@@ -1258,15 +1232,12 @@ function createYouTubePreview (originalElement, widget) {
 
     youTubePreviewDiv.appendChild(innerDiv)
 
-    // @ts-expect-error inital fix of click-to-load (please remove)
     widget.autoplay = false
     // We use .then() instead of await here to show the placeholder right away
     // while the YouTube endpoint takes it time to respond.
-    // @ts-expect-error inital fix of click-to-load (please remove)
     const videoURL = originalElement.src || originalElement.getAttribute('data-src')
     getYouTubeVideoDetails(videoURL)
     window.addEventListener('ddg-ctp-youTubeVideoDetails',
-        // @ts-expect-error inital fix of click-to-load (please remove)
         ({ detail: { videoURL: videoURLResp, status, title, previewImage } }) => {
             if (videoURLResp !== videoURL) { return }
             if (status === 'success') {
@@ -1275,7 +1246,6 @@ function createYouTubePreview (originalElement, widget) {
                 if (previewImage) {
                     previewImageElement.setAttribute('src', previewImage)
                 }
-                // @ts-expect-error inital fix of click-to-load (please remove)
                 widget.autoplay = true
             }
         }
@@ -1285,7 +1255,6 @@ function createYouTubePreview (originalElement, widget) {
     const feedbackRow = makeShareFeedbackRow()
     shadowRoot.appendChild(feedbackRow)
 
-    // @ts-expect-error inital fix of click-to-load (please remove)
     return { youTubePreview, shadowRoot }
 }
 
@@ -1303,7 +1272,6 @@ const messageResponseHandlers = {
 
         // Start Click to Load
         window.addEventListener('ddg-ctp-replace-element', ({ target }) => {
-            // @ts-expect-error inital fix of click-to-load (please remove)
             replaceClickToLoadElements(target)
         }, { capture: true })
 
@@ -1371,21 +1339,16 @@ export default class ClickToLoad extends ContentFeature {
 
         // Listen for events from "surrogate" scripts.
         addEventListener('ddg-ctp', (event) => {
-            // @ts-expect-error inital fix of click-to-load (please remove)
             if (!event.detail) return
-            // @ts-expect-error inital fix of click-to-load (please remove)
             const entity = event.detail.entity
             if (!entities.includes(entity)) {
                 // Unknown entity, reject
                 return
             }
-            // @ts-expect-error inital fix of click-to-load (please remove)
             if (event.detail.appID) {
-                // @ts-expect-error inital fix of click-to-load (please remove)
                 appID = JSON.stringify(event.detail.appID).replace(/"/g, '')
             }
             // Handle login call
-            // @ts-expect-error inital fix of click-to-load (please remove)
             if (event.detail.action === 'login') {
                 if (entityData[entity].shouldShowLoginModal) {
                     makeModal(entity, runLogin, entity)


### PR DESCRIPTION
Recently, we adjusted the linting rules to make them stricter. While
doing that, we made some changes to the Click to Load code to make the
linting pass. Unfortunately, that complicated ongoing (and more
urgent) changes to that code that are about to land.

Let's revert the linting changes to the Click to Load code therefore,
while keeping the linting passing + adding a note to revisit.