### PR TITLE
Fix Click to Load dark-mode detection

### DIFF
--- a/src/features/click-to-load.js
+++ b/src/features/click-to-load.js
@@ -95,8 +95,7 @@ class DuckWidget {
         if (this.replaceSettings.type === 'loginButton') {
             return 'loginMode'
         }
-        const mode = this.originalElement.getAttribute('data-colorscheme')
-        if (mode === 'dark') {
+        if (window?.matchMedia('(prefers-color-scheme: dark)')?.matches) {
             return 'darkMode'
         }
         return 'lightMode'


### PR DESCRIPTION
The Click to Load placeholders have light and dark themes, let's fix
dark-mode detection so that the correct theme is used.