### PR TITLE
Improve narrow YouTube Click to Load placeholders

### DIFF
--- a/unit-test/verify-artifacts.js
+++ b/unit-test/verify-artifacts.js
@@ -6,7 +6,7 @@ import { cwd } from '../scripts/script-utils.js'
 const ROOT = join(cwd(import.meta.url), '..')
 const BUILD = join(ROOT, 'build')
 const APPLE_BUILD = join(ROOT, 'Sources/ContentScopeScripts/dist')
-const CSS_OUTPUT_SIZE = 551000
+const CSS_OUTPUT_SIZE = 560000
 const CSS_OUTPUT_SIZE_CHROME = CSS_OUTPUT_SIZE * 1.45 // 45% larger for Chrome MV2 due to base64 encoding
 
 const checks = {


### PR DESCRIPTION
When the YouTube Click to Load placeholders are very narrow, the
information text takes up too much space and some of the other
elements are lost. Let's tweak narrow placeholders, to hide that
information text and move the "Learn more" link. This isn't the best
approach (using @container queries[1] might be better), but this code
is going to be refactored shortly anyway.

1 - https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Container_Queries