### PR TITLE
Capture Set for utils

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -5,6 +5,8 @@
 let globalObj = typeof window === 'undefined' ? globalThis : window
 let Error = globalObj.Error
 let messageSecret
+// Capture prototype to prevent overloading
+const Set = globalObj.Set
 
 // save a reference to original CustomEvent amd dispatchEvent so they can't be overriden to forge messages
 export const OriginalCustomEvent = typeof CustomEvent === 'undefined' ? null : CustomEvent


### PR DESCRIPTION
Basic fix for: https://app.asana.com/0/0/1204392417715156/f and https://github.com/duckduckgo/duckduckgo-privacy-extension/issues/1898

I'll fast follow with making this more robust as there's a growing need to capture globals through the codebase to prevent these types of prototype pollution and ultimately breakage.