### PR TITLE
Add no-op function to runtime checks code generation

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -310,7 +310,9 @@ const functionMap = {
         console.log('debugger', ...args)
         // eslint-disable-next-line no-debugger
         debugger
-    }
+    },
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    noop: () => { }
 }
 
 /**

--- a/unit-test/script-overload-snapshots/config/3.json
+++ b/unit-test/script-overload-snapshots/config/3.json
@@ -2,5 +2,17 @@
     "fn": {
         "type": "function",
         "functionName": "debug"
+    },
+    "noop": {
+        "type": "function",
+        "functionName": "noop"
+    },
+    "navigator.noop": {
+        "type": "function",
+        "functionName": "noop"
+    },
+    "nonexistent": {
+        "type": "function",
+        "functionName": "nonexistent"
     }
 }

--- a/unit-test/script-overload-snapshots/out/3.js
+++ b/unit-test/script-overload-snapshots/out/3.js
@@ -32,11 +32,25 @@
     // eslint-disable-next-line no-debugger
     debugger
   };
+  let _ddg_s = () => { };
+  let _ddg_b = parentScope?.navigator ? parentScope.navigator : Object.bind(null);
+  let _ddg_t = () => { };
+  let _ddg_a = constructProxy(_ddg_b, {
+    noop: _ddg_t
+  });
+  let navigator = _ddg_a;
+  let _ddg_u = undefined;
   const window = constructProxy(parentScope, {
-    fn: _ddg_r
+    fn: _ddg_r,
+    noop: _ddg_s,
+    navigator: _ddg_a,
+    nonexistent: _ddg_u
   });
   const globalThis = constructProxy(parentScope, {
-    fn: _ddg_r
+    fn: _ddg_r,
+    noop: _ddg_s,
+    navigator: _ddg_a,
+    nonexistent: _ddg_u
   });
   console.log(1)
 })(globalThis)


### PR DESCRIPTION
Allows the config to rewrite a method to a fully empty method.