### PR TITLE
Update Click to Load YouTube (preview-enabled) footer text

### DIFF
--- a/src/features/click-to-load.js
+++ b/src/features/click-to-load.js
@@ -1473,9 +1473,22 @@ function createYouTubePreview (originalElement, widget) {
     /** Preview Info Text */
     const previewText = document.createElement('div')
     previewText.style.cssText = styles.contentText + styles.toggleButtonText + styles.youTubePreviewInfoText
-    previewText.innerText = widget.replaceSettings.placeholder.previewInfoText + ' '
-    // Use darkMode styles because of preview background
-    previewText.appendChild(getLearnMoreLink('darkMode'))
+    // Since this string contains an anchor element, setting innerText won't
+    // work.
+    // Warning: This is not ideal! The translated (and original) strings must be
+    //          checked very carefully! Any HTML they contain will be inserted.
+    //          Ideally, the translation system would allow only certain element
+    //          types to be included, and would avoid the URLs for links being
+    //          included in the translations.
+    previewText.insertAdjacentHTML(
+        'beforeend', widget.replaceSettings.placeholder.previewInfoText
+    )
+    const previewTextLink = previewText.querySelector('a')
+    if (previewTextLink) {
+        const newPreviewTextLink = getLearnMoreLink()
+        newPreviewTextLink.innerText = previewTextLink.innerText
+        previewTextLink.replaceWith(newPreviewTextLink)
+    }
 
     previewToggleRow.appendChild(previewToggle)
     previewToggleRow.appendChild(previewText)

--- a/src/locales/click-to-load/bg/youtube.json
+++ b/src/locales/click-to-load/bg/youtube.json
@@ -45,7 +45,7 @@
     "note" : "Overlay toggle shown when Youtube previews are enabled"
   },
   "infoPreviewInfoText" : {
-    "title" : "Изключете прегледите, за да получите допълнителна поверителност от DuckDuckGo.",
+    "title" : "<a href=\\\"https://help.duckduckgo.com/duckduckgo-help-pages/privacy/embedded-content-protection/\\\">Научете повече</a> за вградената защита от социални медии на DuckDuckGo",
     "note" : "Overlay footer shown when Youtube previews are enabled"
   }
 }

--- a/src/locales/click-to-load/cs/youtube.json
+++ b/src/locales/click-to-load/cs/youtube.json
@@ -45,7 +45,7 @@
     "note" : "Overlay toggle shown when Youtube previews are enabled"
   },
   "infoPreviewInfoText" : {
-    "title" : "Vypnutím náhledů ti DuckDuckGo zajistí víc soukromí.",
+    "title" : "<a href=\\\"https://help.duckduckgo.com/duckduckgo-help-pages/privacy/embedded-content-protection/\\\">Další informace</a> o ochraně DuckDuckGo před sledováním prostřednictvím vloženého obsahu ze sociálních médií",
     "note" : "Overlay footer shown when Youtube previews are enabled"
   }
 }

--- a/src/locales/click-to-load/da/youtube.json
+++ b/src/locales/click-to-load/da/youtube.json
@@ -45,7 +45,7 @@
     "note" : "Overlay toggle shown when Youtube previews are enabled"
   },
   "infoPreviewInfoText" : {
-    "title" : "Slå forhåndsvisninger fra for at få yderligere privatliv fra DuckDuckGo.",
+    "title" : "<a href=\\\"https://help.duckduckgo.com/duckduckgo-help-pages/privacy/embedded-content-protection/\\\">Få mere at vide på</a> om DuckDuckGos indbyggede beskyttelse på sociale medier",
     "note" : "Overlay footer shown when Youtube previews are enabled"
   }
 }

--- a/src/locales/click-to-load/de/youtube.json
+++ b/src/locales/click-to-load/de/youtube.json
@@ -45,7 +45,7 @@
     "note" : "Overlay toggle shown when Youtube previews are enabled"
   },
   "infoPreviewInfoText" : {
-    "title" : "Deaktiviere Vorschauen für zusätzlichen Datenschutz von DuckDuckGo.",
+    "title" : "<a href=\\\"https://help.duckduckgo.com/duckduckgo-help-pages/privacy/embedded-content-protection/\\\">Erfahre mehr</a> über den DuckDuckGo-Schutz vor eingebetteten Social Media-Inhalten",
     "note" : "Overlay footer shown when Youtube previews are enabled"
   }
 }

--- a/src/locales/click-to-load/el/youtube.json
+++ b/src/locales/click-to-load/el/youtube.json
@@ -45,7 +45,7 @@
     "note" : "Overlay toggle shown when Youtube previews are enabled"
   },
   "infoPreviewInfoText" : {
-    "title" : "Απενεργοποιήστε τις προεπισκοπήσεις για πρόσθετη προστασία των προσωπικών δεδομένων από το DuckDuckGo.",
+    "title" : "<a href=\\\"https://help.duckduckgo.com/duckduckgo-help-pages/privacy/embedded-content-protection/\\\">Μάθετε περισσότερα</a> για την ενσωματωμένη προστασία κοινωνικών μέσων DuckDuckGo",
     "note" : "Overlay footer shown when Youtube previews are enabled"
   }
 }

--- a/src/locales/click-to-load/en/youtube.json
+++ b/src/locales/click-to-load/en/youtube.json
@@ -44,7 +44,7 @@
         "note": "Overlay toggle shown when Youtube previews are enabled"
     },
     "infoPreviewInfoText": {
-        "title": "Turn previews off for additional privacy from DuckDuckGo.",
+        "title": "<a href=\\\"https://help.duckduckgo.com/duckduckgo-help-pages/privacy/embedded-content-protection/\\\">Learn more</a> about DuckDuckGo Embedded Social Media Protection",
         "note": "Overlay footer shown when Youtube previews are enabled"
     }
 }

--- a/src/locales/click-to-load/es/youtube.json
+++ b/src/locales/click-to-load/es/youtube.json
@@ -45,7 +45,7 @@
     "note" : "Overlay toggle shown when Youtube previews are enabled"
   },
   "infoPreviewInfoText" : {
-    "title" : "Desactiva las vistas previas para obtener más privacidad de DuckDuckGo.",
+    "title" : "<a href=\\\"https://help.duckduckgo.com/duckduckgo-help-pages/privacy/embedded-content-protection/\\\">Más información</a> sobre la protección integrada de redes sociales DuckDuckGo",
     "note" : "Overlay footer shown when Youtube previews are enabled"
   }
 }

--- a/src/locales/click-to-load/et/youtube.json
+++ b/src/locales/click-to-load/et/youtube.json
@@ -45,7 +45,7 @@
     "note" : "Overlay toggle shown when Youtube previews are enabled"
   },
   "infoPreviewInfoText" : {
-    "title" : "Lülita DuckDuckGo täiendava privaatsuse tagamiseks eelvaated välja.",
+    "title" : "<a href=\\\"https://help.duckduckgo.com/duckduckgo-help-pages/privacy/embedded-content-protection/\\\">Lisateave</a> DuckDuckGo sisseehitatud sotsiaalmeediakaitse kohta",
     "note" : "Overlay footer shown when Youtube previews are enabled"
   }
 }

--- a/src/locales/click-to-load/fi/youtube.json
+++ b/src/locales/click-to-load/fi/youtube.json
@@ -45,7 +45,7 @@
     "note" : "Overlay toggle shown when Youtube previews are enabled"
   },
   "infoPreviewInfoText" : {
-    "title" : "Poista esikatselut käytöstä saadaksesi paremman yksityisyyden DuckDuckGolta.",
+    "title" : "<a href=\\\"https://help.duckduckgo.com/duckduckgo-help-pages/privacy/embedded-content-protection/\\\">Lue lisää</a> DuckDuckGon upotetusta sosiaalisen median suojauksesta",
     "note" : "Overlay footer shown when Youtube previews are enabled"
   }
 }

--- a/src/locales/click-to-load/fr/youtube.json
+++ b/src/locales/click-to-load/fr/youtube.json
@@ -45,7 +45,7 @@
     "note" : "Overlay toggle shown when Youtube previews are enabled"
   },
   "infoPreviewInfoText" : {
-    "title" : "Désactivez les aperçus pour plus de confidentialité grâce à DuckDuckGo.",
+    "title" : "<a href=\\\"https://help.duckduckgo.com/duckduckgo-help-pages/privacy/embedded-content-protection/\\\">En savoir plus</a> sur la protection intégrée DuckDuckGo des réseaux sociaux",
     "note" : "Overlay footer shown when Youtube previews are enabled"
   }
 }

--- a/src/locales/click-to-load/hr/youtube.json
+++ b/src/locales/click-to-load/hr/youtube.json
@@ -45,7 +45,7 @@
     "note" : "Overlay toggle shown when Youtube previews are enabled"
   },
   "infoPreviewInfoText" : {
-    "title" : "Isključivanjem pretpregleda DuckDuckGo ti omogućava dodatnu privatnost.",
+    "title" : "<a href=\\\"https://help.duckduckgo.com/duckduckgo-help-pages/privacy/embedded-content-protection/\\\">Saznaj više</a> o uključenoj DuckDuckGo zaštiti od društvenih medija",
     "note" : "Overlay footer shown when Youtube previews are enabled"
   }
 }

--- a/src/locales/click-to-load/hu/youtube.json
+++ b/src/locales/click-to-load/hu/youtube.json
@@ -45,7 +45,7 @@
     "note" : "Overlay toggle shown when Youtube previews are enabled"
   },
   "infoPreviewInfoText" : {
-    "title" : "A DuckDuckGo fokozott adatvédelme érdekében kapcsold ki az előnézeteket.",
+    "title" : "<a href=\\\"https://help.duckduckgo.com/duckduckgo-help-pages/privacy/embedded-content-protection/\\\">További tudnivalók</a> a DuckDuckGo beágyazott közösségi média elleni védelméről",
     "note" : "Overlay footer shown when Youtube previews are enabled"
   }
 }

--- a/src/locales/click-to-load/it/youtube.json
+++ b/src/locales/click-to-load/it/youtube.json
@@ -45,7 +45,7 @@
     "note" : "Overlay toggle shown when Youtube previews are enabled"
   },
   "infoPreviewInfoText" : {
-    "title" : "Disabilita le anteprime per una maggiore privacy da DuckDuckGo.",
+    "title" : "<a href=\\\"https://help.duckduckgo.com/duckduckgo-help-pages/privacy/embedded-content-protection/\\\">Scopri di più</a> sulla protezione dai social media integrata di DuckDuckGo",
     "note" : "Overlay footer shown when Youtube previews are enabled"
   }
 }

--- a/src/locales/click-to-load/lt/youtube.json
+++ b/src/locales/click-to-load/lt/youtube.json
@@ -45,7 +45,7 @@
     "note" : "Overlay toggle shown when Youtube previews are enabled"
   },
   "infoPreviewInfoText" : {
-    "title" : "Išjunkite peržiūras, kad gautumėte papildomo privatumo iš „DuckDuckGo“.",
+    "title" : "<a href=\\\"https://help.duckduckgo.com/duckduckgo-help-pages/privacy/embedded-content-protection/\\\">Sužinokite daugiau</a> apie „DuckDuckGo“ įdėtąją socialinės žiniasklaidos apsaugą",
     "note" : "Overlay footer shown when Youtube previews are enabled"
   }
 }

--- a/src/locales/click-to-load/lv/youtube.json
+++ b/src/locales/click-to-load/lv/youtube.json
@@ -45,7 +45,7 @@
     "note" : "Overlay toggle shown when Youtube previews are enabled"
   },
   "infoPreviewInfoText" : {
-    "title" : "Izslēdz priekšskatījumus, lai iegūtu papildu konfidencialitāti no DuckDuckGo.",
+    "title" : "<a href=\\\"https://help.duckduckgo.com/duckduckgo-help-pages/privacy/embedded-content-protection/\\\">Uzzini vairāk</a> par DuckDuckGo iegulto sociālo mediju aizsardzību",
     "note" : "Overlay footer shown when Youtube previews are enabled"
   }
 }

--- a/src/locales/click-to-load/nb/youtube.json
+++ b/src/locales/click-to-load/nb/youtube.json
@@ -45,7 +45,7 @@
     "note" : "Overlay toggle shown when Youtube previews are enabled"
   },
   "infoPreviewInfoText" : {
-    "title" : "Slå av forhåndsvisninger for sterkere personvern med DuckDuckGo.",
+    "title" : "<a href=\\\"https://help.duckduckgo.com/duckduckgo-help-pages/privacy/embedded-content-protection/\\\">Finn ut mer</a> om DuckDuckGos innebygde beskyttelse for sosiale medier",
     "note" : "Overlay footer shown when Youtube previews are enabled"
   }
 }

--- a/src/locales/click-to-load/nl/youtube.json
+++ b/src/locales/click-to-load/nl/youtube.json
@@ -45,7 +45,7 @@
     "note" : "Overlay toggle shown when Youtube previews are enabled"
   },
   "infoPreviewInfoText" : {
-    "title" : "Schakel voorbeelden uit voor extra privacy van DuckDuckGo.",
+    "title" : "<a href=\\\"https://help.duckduckgo.com/duckduckgo-help-pages/privacy/embedded-content-protection/\\\">Meer informatie</a> over DuckDuckGo's bescherming tegen ingesloten social media",
     "note" : "Overlay footer shown when Youtube previews are enabled"
   }
 }

--- a/src/locales/click-to-load/pl/youtube.json
+++ b/src/locales/click-to-load/pl/youtube.json
@@ -45,7 +45,7 @@
     "note" : "Overlay toggle shown when Youtube previews are enabled"
   },
   "infoPreviewInfoText" : {
-    "title" : "Wyłącz podglądy, aby uzyskać większą prywatność dzięki DuckDuckGo.",
+    "title" : "<a href=\\\"https://help.duckduckgo.com/duckduckgo-help-pages/privacy/embedded-content-protection/\\\">Dowiedz się więcej</a> o zabezpieczeniu osadzonych treści społecznościowych DuckDuckGo",
     "note" : "Overlay footer shown when Youtube previews are enabled"
   }
 }

--- a/src/locales/click-to-load/pt/youtube.json
+++ b/src/locales/click-to-load/pt/youtube.json
@@ -45,7 +45,7 @@
     "note" : "Overlay toggle shown when Youtube previews are enabled"
   },
   "infoPreviewInfoText" : {
-    "title" : "Desativa as pré-visualizações para obteres privacidade adicional com o DuckDuckGo.",
+    "title" : "<a href=\\\"https://help.duckduckgo.com/duckduckgo-help-pages/privacy/embedded-content-protection/\\\">Saiba mais</a> sobre a Proteção contra conteúdos de redes sociais incorporados do DuckDuckGo",
     "note" : "Overlay footer shown when Youtube previews are enabled"
   }
 }

--- a/src/locales/click-to-load/ro/youtube.json
+++ b/src/locales/click-to-load/ro/youtube.json
@@ -45,7 +45,7 @@
     "note" : "Overlay toggle shown when Youtube previews are enabled"
   },
   "infoPreviewInfoText" : {
-    "title" : "Dezactivează previzualizările pentru o confidențialitate suplimentară de la DuckDuckGo.",
+    "title" : "<a href=\\\"https://help.duckduckgo.com/duckduckgo-help-pages/privacy/embedded-content-protection/\\\">Află mai multe</a> despre Protecția integrată DuckDuckGo pentru rețelele sociale",
     "note" : "Overlay footer shown when Youtube previews are enabled"
   }
 }

--- a/src/locales/click-to-load/ru/youtube.json
+++ b/src/locales/click-to-load/ru/youtube.json
@@ -45,7 +45,7 @@
     "note" : "Overlay toggle shown when Youtube previews are enabled"
   },
   "infoPreviewInfoText" : {
-    "title" : "DuckDuckGo рекомендует отключить предпросмотр для дополнительной защиты конфиденциальности.",
+    "title" : "<a href=\\\"https://help.duckduckgo.com/duckduckgo-help-pages/privacy/embedded-content-protection/\\\">Подробнее</a> о защите DuckDuckGo от внедренного контента соцсетей",
     "note" : "Overlay footer shown when Youtube previews are enabled"
   }
 }

--- a/src/locales/click-to-load/sk/youtube.json
+++ b/src/locales/click-to-load/sk/youtube.json
@@ -45,7 +45,7 @@
     "note" : "Overlay toggle shown when Youtube previews are enabled"
   },
   "infoPreviewInfoText" : {
-    "title" : "Pre zvýšenú ochranu súkromia od DuckDuckGo vypnite ukážky.",
+    "title" : "<a href=\\\"https://help.duckduckgo.com/duckduckgo-help-pages/privacy/embedded-content-protection/\\\">Získajte viac informácií</a> o DuckDuckGo, vloženej ochrane sociálnych médií",
     "note" : "Overlay footer shown when Youtube previews are enabled"
   }
 }

--- a/src/locales/click-to-load/sl/youtube.json
+++ b/src/locales/click-to-load/sl/youtube.json
@@ -45,7 +45,7 @@
     "note" : "Overlay toggle shown when Youtube previews are enabled"
   },
   "infoPreviewInfoText" : {
-    "title" : "Izklopite predoglede za dodatno zasebnost v DuckDuckGo.",
+    "title" : "<a href=\\\"https://help.duckduckgo.com/duckduckgo-help-pages/privacy/embedded-content-protection/\\\">Več</a> o vgrajeni zaščiti družbenih medijev DuckDuckGo",
     "note" : "Overlay footer shown when Youtube previews are enabled"
   }
 }

--- a/src/locales/click-to-load/sv/youtube.json
+++ b/src/locales/click-to-load/sv/youtube.json
@@ -45,7 +45,7 @@
     "note" : "Overlay toggle shown when Youtube previews are enabled"
   },
   "infoPreviewInfoText" : {
-    "title" : "Inaktivera förhandsvisningar för ytterligare integritet med DuckDuckGo.",
+    "title" : "<a href=\\\"https://help.duckduckgo.com/duckduckgo-help-pages/privacy/embedded-content-protection/\\\">Läs mer</a> om DuckDuckGos skydd mot inbäddade sociala medier",
     "note" : "Overlay footer shown when Youtube previews are enabled"
   }
 }

--- a/src/locales/click-to-load/tr/youtube.json
+++ b/src/locales/click-to-load/tr/youtube.json
@@ -45,7 +45,7 @@
     "note" : "Overlay toggle shown when Youtube previews are enabled"
   },
   "infoPreviewInfoText" : {
-    "title" : "DuckDuckGo'dan daha fazla gizlilik için önizlemeleri kapatın.",
+    "title" : "DuckDuckGo Yerleşik Sosyal Medya Koruması hakkında <a href=\\\"https://help.duckduckgo.com/duckduckgo-help-pages/privacy/embedded-content-protection/\\\">daha fazla bilgi edinin</a>",
     "note" : "Overlay footer shown when Youtube previews are enabled"
   }
 }

--- a/unit-test/verify-artifacts.js
+++ b/unit-test/verify-artifacts.js
@@ -6,7 +6,7 @@ import { cwd } from '../scripts/script-utils.js'
 const ROOT = join(cwd(import.meta.url), '..')
 const BUILD = join(ROOT, 'build')
 const APPLE_BUILD = join(ROOT, 'Sources/ContentScopeScripts/dist')
-const CSS_OUTPUT_SIZE = 551000
+const CSS_OUTPUT_SIZE = 560000
 const CSS_OUTPUT_SIZE_CHROME = CSS_OUTPUT_SIZE * 1.45 // 45% larger for Chrome MV2 due to base64 encoding
 
 const checks = {


### PR DESCRIPTION
During internal review, it was requested that we change the
footer-text for Click to Load YouTube placeholders.