### PR TITLE
Tweak Click to Load placeholder button colours to be more consistent

### DIFF
--- a/src/features/click-to-load.js
+++ b/src/features/click-to-load.js
@@ -927,6 +927,7 @@ function makeButton (buttonText, mode = 'lightMode') {
 
 /**
  * Create a toggle button.
+ * @param {displayMode} mode
  * @param {boolean} [isActive=false]
  *   True if the button should be toggled by default.
  * @param {string} [classNames='']
@@ -935,7 +936,7 @@ function makeButton (buttonText, mode = 'lightMode') {
  *   Value to assign to the button's 'data-key' attribute.
  * @returns {HTMLButtonElement}
  */
-function makeToggleButton (isActive = false, classNames = '', dataKey = '') {
+function makeToggleButton (mode, isActive = false, classNames = '', dataKey = '') {
     const toggleButton = document.createElement('button')
     toggleButton.className = classNames
     toggleButton.style.cssText = styles.toggleButton
@@ -943,11 +944,15 @@ function makeToggleButton (isActive = false, classNames = '', dataKey = '') {
     toggleButton.setAttribute('aria-pressed', isActive ? 'true' : 'false')
     toggleButton.setAttribute('data-key', dataKey)
 
+    const activeKey = isActive ? 'active' : 'inactive'
+
     const toggleBg = document.createElement('div')
-    toggleBg.style.cssText = styles.toggleButtonBg + (isActive ? styles.toggleButtonBgState.active : styles.toggleButtonBgState.inactive)
+    toggleBg.style.cssText =
+        styles.toggleButtonBg + styles[mode].toggleButtonBgState[activeKey]
 
     const toggleKnob = document.createElement('div')
-    toggleKnob.style.cssText = styles.toggleButtonKnob + (isActive ? styles.toggleButtonKnobState.active : styles.toggleButtonKnobState.inactive)
+    toggleKnob.style.cssText =
+        styles.toggleButtonKnob + styles.toggleButtonKnobState[activeKey]
 
     toggleButton.appendChild(toggleBg)
     toggleButton.appendChild(toggleKnob)
@@ -975,7 +980,7 @@ function makeToggleButtonWithText (text, mode, isActive = false, toggleClassName
     const wrapper = document.createElement('div')
     wrapper.style.cssText = styles.toggleButtonWrapper
 
-    const toggleButton = makeToggleButton(isActive, toggleClassNames, dataKey)
+    const toggleButton = makeToggleButton(mode, isActive, toggleClassNames, dataKey)
 
     const textDiv = document.createElement('div')
     textDiv.style.cssText = styles.contentText + styles.toggleButtonText + styles[mode].toggleButtonText + textCssStyles
@@ -1529,7 +1534,7 @@ function createYouTubePreview (originalElement, widget) {
     )
     const previewTextLink = previewText.querySelector('a')
     if (previewTextLink) {
-        const newPreviewTextLink = getLearnMoreLink()
+        const newPreviewTextLink = getLearnMoreLink(widget.getMode())
         newPreviewTextLink.innerText = previewTextLink.innerText
         previewTextLink.replaceWith(newPreviewTextLink)
     }

--- a/src/features/click-to-load/ctl-config.js
+++ b/src/features/click-to-load/ctl-config.js
@@ -43,7 +43,15 @@ export const styles = {
         `,
         toggleButtonText: `
             color: #EEEEEE;
-        `
+        `,
+        toggleButtonBgState: {
+            active: `
+                background: #5784FF;
+            `,
+            inactive: `
+                background-color: #666666;
+            `
+        }
     },
     lightMode: {
         background: `
@@ -69,7 +77,15 @@ export const styles = {
         `,
         toggleButtonText: `
             color: #666666;
-        `
+        `,
+        toggleButtonBgState: {
+            active: `
+                background: #3969EF;
+            `,
+            inactive: `
+                background-color: #666666;
+            `
+        }
     },
     loginMode: {
         buttonBackground: `
@@ -459,14 +475,6 @@ export const styles = {
         margin: 0 0 0 7px;
         padding: 0;
     `,
-    toggleButtonBgState: {
-        active: `
-            background: #3969EF;
-        `,
-        inactive: `
-            background-color: #666666;
-        `
-    },
     toggleButtonKnob: `
         position: absolute;
         display: inline-block;


### PR DESCRIPTION
It turns out that there are several slightly different shades of blue
used for the various buttons/links in the Click to Load YouTube
placeholders. Those vary for dark-mode as well. Let's try to get them
to be more consistent for both light and dark modes.