### PR TITLE
Workaround declarativeNetRequest element collapsing bug

### DIFF
--- a/src/features/click-to-load.js
+++ b/src/features/click-to-load.js
@@ -485,6 +485,16 @@ function replaceTrackingElement (widget, trackingElement, placeholderElement) {
     ]
     elementToReplace.style.setProperty('display', 'none', 'important')
 
+    // When iframes are blocked by the declarativeNetRequest API, they are
+    // collapsed (hidden) automatically. Unfortunately however, there's a bug
+    // that stops them from being uncollapsed (shown again) if they are removed
+    // from the DOM after they are collapsed. As a workaround, have the iframe
+    // load a benign data URI, so that it's uncollapsed, before removing it from
+    // the DOM. See https://crbug.com/1428971
+    const originalSrc = elementToReplace.src
+    elementToReplace.src =
+        'data:text/plain;charset=utf-8;base64,' + btoa('https://crbug.com/1428971')
+
     // Add the placeholder element to the page.
     elementToReplace.parentElement.insertBefore(
         placeholderElement, elementToReplace
@@ -504,6 +514,7 @@ function replaceTrackingElement (widget, trackingElement, placeholderElement) {
         // placeholder) can finally be removed from the DOM.
         elementToReplace.remove()
         elementToReplace.style.setProperty('display', ...originalDisplay)
+        elementToReplace.src = originalSrc
     })
 }
 


### PR DESCRIPTION
There's a bug[1] with the declarativeNetRequest API that means that
after blocked iframes are collapsed (hidden) they sometimes can't be
uncollapsed (shown again) after they load successfully. That causes
Click to Load to get messed up for Chrome MV3 builds of the extension,
as the content is sometimes not shown to the user again after it has
been unblocked. The bug is triggered when the collapsed iframe is
removed from the DOM.

As a workaround, let's load a benign data URI in blocked iframes
before removing them from the DOM. That way they are uncollapsed, and
so if they are added back to the page they will be visible to the
user.

1 - https://crbug.com/1428971