### PR TITLE
Use Reflect for script.src

### DIFF
--- a/integration-test/test-pages/runtime-checks/pages/basic-run.html
+++ b/integration-test/test-pages/runtime-checks/pages/basic-run.html
@@ -137,6 +137,45 @@
             ];
         });
 
+        test('Prevent src overloading', async () => {
+            window.scripty2Ran = false;
+            const scriptElement = document.createElement('script');
+            scriptElement.id = 'scripty2';
+            scriptElement.setAttribute('type', 'application/javascript');
+            scriptElement.src = 'test://url'
+
+            let setCounter = 0
+            // Pretend to be page overloading the src attribute
+            Object.defineProperty(scriptElement, 'src', {
+                get: () => 'invalid',
+                set: () => {
+                    setCounter++
+                }
+            })
+
+            const getAttribute = scriptElement.getAttribute('src');
+            // Should increment setCounter
+            scriptElement.src = 'test://other'
+            // Should NOT increment setCounter
+            scriptElement.setAttribute('src', 'bloop');
+
+            document.body.appendChild(scriptElement);
+            const hadInspectorNode = scriptElement === document.querySelector('ddg-runtime-checks:last-of-type');
+            // Continue to modify the script element after it has been added to the DOM
+            scriptElement.madeUpProp = 'val';
+            const instanceofResult = scriptElement instanceof HTMLScriptElement;
+            const scripty = document.querySelector('#scripty2');
+
+            return [
+                { name: 'hadInspectorNode', result: hadInspectorNode, expected: true },
+                { name: 'expect script to match', result: scripty, expected: scriptElement },
+                { name: 'scripty.getAttribute', result: getAttribute, expected: 'test://url' },
+                { name: 'setAttribute does not loop', result: setCounter, expected: 1 },
+                { name: 'scripty.type', result: scripty.type, expected: 'application/javascript' },
+                { name: 'scripty.id', result: scripty.id, expected: 'scripty2' }
+            ];
+        });
+
         // eslint-disable-next-line no-undef
         renderResults();
     </script>

--- a/src/features/runtime-checks.js
+++ b/src/features/runtime-checks.js
@@ -253,7 +253,8 @@ class DDGRuntimeChecks extends HTMLElement {
     getAttribute (name, value) {
         if (shouldFilterKey(this.#tagName, 'attribute', name)) return
         if (supportedSinks.includes(name)) {
-            return this[name]
+            // Use Reflect to avoid infinite recursion
+            return Reflect.get(DDGRuntimeChecks.prototype, name, this)
         }
         return this._callMethod('getAttribute', name, value)
     }
@@ -261,8 +262,8 @@ class DDGRuntimeChecks extends HTMLElement {
     setAttribute (name, value) {
         if (shouldFilterKey(this.#tagName, 'attribute', name)) return
         if (supportedSinks.includes(name)) {
-            this[name] = value
-            return
+            // Use Reflect to avoid infinite recursion
+            return Reflect.set(DDGRuntimeChecks.prototype, name, value, this)
         }
         return this._callMethod('setAttribute', name, value)
     }


### PR DESCRIPTION
Use reflect for script.src as some scripts bind this to call getAttribute causing a stack overflow.

Follow the steps in: https://github.com/duckduckgo/duckduckgo-privacy-extension/issues/1913

cookielaw is exempted from stack tracing and pandadoc are exceptions; when they're enabled you'll see the stack overflow mentioned in the issue.

When you place a debugger within the class you see cookielaw has overriden us:
```js
Object.getOwnPropertyDescriptor(this, 'src').get.toString()
'function(){return a.getAttribute("src")||""}'
```

```js
Object.getOwnPropertyDescriptor(this, 'src').set.toString()
'function(c){var b="";"string"==typeof c?b=c:c instanceof Object&&(b=c.toString());b=n(b);!b.categoryIds.length&&!b.vsCatIds.length||\n"script"!==d[0].toLowerCase()||p(a)||m(b.categoryIds,b.vsCatIds)||q(a)?!b.categoryIds.length||-1===w.indexOf(d[0].toLowerCase())||p(a)||m(b.categoryIds,b.vsCatIds)||q(a)?f("src",c):(a.removeAttribute("src"),f("data-src",c),c=a.getAttribute("class"),c||(c=B(b.categoryIds,c||"",b.vsCatIds),f("class",c))):(f("type","text/plain"),f("src",c));return!0}'
```

We're doing the reverse wishing to call `this[name]` which in turn calls `getAttribute` creating the infinite loop.