### PR TITLE
Dispatch Click to Load ready event again when necessary

### DIFF
--- a/src/features/click-to-load.js
+++ b/src/features/click-to-load.js
@@ -1702,6 +1702,16 @@ export default class ClickToLoad extends ContentFeature {
         }
         await afterPageLoad
 
+        // On some websites, the "ddg-ctp-ready" event is occasionally
+        // dispatched too early, before the listener is ready to receive it.
+        // To counter that, catch "ddg-ctp-surrogate-load" events dispatched
+        // _after_ page, so the "ddg-ctp-ready" event can be dispatched again.
+        window.addEventListener(
+            'ddg-ctp-surrogate-load', () => {
+                originalWindowDispatchEvent(createCustomEvent('ddg-ctp-ready'))
+            }
+        )
+
         // Then wait for any in-progress element replacements, before letting
         // the surrogate scripts know to start.
         window.setTimeout(() => {


### PR DESCRIPTION
The "ddg-ctp-ready" event is dispatched by the Click to Load
content-scope-script, to let the surrogate scripts know when the
feature is ready. Very occasionally that event is dispatched too
early, and so the surrogate script misses it. Workaround that by
dispatching the event again, if we see that a surrogate script
finished loading _after_ page load has finished.