### PR TITLE
Update styletag injection to use <style> for platforms other than firefox

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -23,16 +23,26 @@ export function getInjectionElement () {
     return document.head || document.documentElement
 }
 
+
+// Tests don't define this variable so fallback to behave like chrome
+const hasMozProxies = typeof mozProxies !== 'undefined' ? mozProxies : false
+
 /**
  * Creates a script element with the given code to avoid Firefox CSP restrictions.
  * @param {string} css
  * @returns {HTMLLinkElement}
  */
 export function createStyleElement (css) {
-    const style = document.createElement('link')
-    style.href = 'data:text/css,' + encodeURIComponent(css)
-    style.setAttribute('rel', 'stylesheet')
-    style.setAttribute('type', 'text/css')
+    let style
+    if (!!hasMozProxies) {
+        const style = document.createElement('link')
+        style.href = 'data:text/css,' + encodeURIComponent(css)
+        style.setAttribute('rel', 'stylesheet')
+        style.setAttribute('type', 'text/css')
+    } else {
+        style = document.createElement('style')
+        style.innerText = css
+    }
     return style
 }
 
@@ -52,9 +62,6 @@ export function setGlobal (globalObjIn) {
     globalObj = globalObjIn
     Error = globalObj.Error
 }
-
-// Tests don't define this variable so fallback to behave like chrome
-const hasMozProxies = typeof mozProxies !== 'undefined' ? mozProxies : false
 
 // linear feedback shift register to find a random approximation
 export function nextRandom (v) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -29,7 +29,7 @@ const hasMozProxies = typeof mozProxies !== 'undefined' ? mozProxies : false
 /**
  * Creates a script element with the given code to avoid Firefox CSP restrictions.
  * @param {string} css
- * @returns {HTMLLinkElement}
+ * @returns {HTMLLinkElement | HTMLStyleElement}
  */
 export function createStyleElement (css) {
     let style

--- a/src/utils.js
+++ b/src/utils.js
@@ -23,7 +23,6 @@ export function getInjectionElement () {
     return document.head || document.documentElement
 }
 
-
 // Tests don't define this variable so fallback to behave like chrome
 const hasMozProxies = typeof mozProxies !== 'undefined' ? mozProxies : false
 
@@ -34,7 +33,7 @@ const hasMozProxies = typeof mozProxies !== 'undefined' ? mozProxies : false
  */
 export function createStyleElement (css) {
     let style
-    if (!!hasMozProxies) {
+    if (hasMozProxies) {
         const style = document.createElement('link')
         style.href = 'data:text/css,' + encodeURIComponent(css)
         style.setAttribute('rel', 'stylesheet')

--- a/src/utils.js
+++ b/src/utils.js
@@ -34,7 +34,7 @@ const hasMozProxies = typeof mozProxies !== 'undefined' ? mozProxies : false
 export function createStyleElement (css) {
     let style
     if (hasMozProxies) {
-        const style = document.createElement('link')
+        style = document.createElement('link')
         style.href = 'data:text/css,' + encodeURIComponent(css)
         style.setAttribute('rel', 'stylesheet')
         style.setAttribute('type', 'text/css')


### PR DESCRIPTION
In order to bypass `style-src` CSP restrictions in Firefox, we use a link element. However this creates a CSP issue on other platforms on websites that have `style-src 'unsafe-inline'` in their CSP, which is relatively common: we're not able to inject a link element. This PR updates our injection technique to only use link elements in Firefox, and normal style elements elsewhere.