### PR TITLE
Enable unused var lint check as an error

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -20,7 +20,8 @@
         "indent": ["error", 4],
         "require-await": ["error"],
         "promise/prefer-await-to-then": ["error"],
-        "@typescript-eslint/await-thenable": "error"
+        "@typescript-eslint/await-thenable": "error",
+        "@typescript-eslint/no-unused-vars": "error"
     },
     "env": {
         "webextensions": true,

--- a/inject/integration.js
+++ b/inject/integration.js
@@ -14,7 +14,7 @@ function getTopLevelURL () {
     }
 }
 
-function generateConfig (data, userList) {
+function generateConfig () {
     const topLevelUrl = getTopLevelURL()
     const trackerLookup = import.meta.trackerLookup
     return {

--- a/integration-test/pages/runtimeChecks/script.js
+++ b/integration-test/pages/runtimeChecks/script.js
@@ -7,6 +7,6 @@ function init () {
     document.body.appendChild(script)
 }
 // Wait for setup
-window.addEventListener('initialize', (e) => {
+window.addEventListener('initialize', () => {
     init()
 })

--- a/integration-test/test-pages/shared/utils.js
+++ b/integration-test/test-pages/shared/utils.js
@@ -61,20 +61,20 @@ const isReadyPromise = new Promise((resolve) => {
 const url = new URL(window.location.href)
 if (url.searchParams.get('automation')) {
     isInAutomation = true
-    window.addEventListener('content-scope-init-complete', (e) => {
+    window.addEventListener('content-scope-init-complete', () => {
         isReadyPromiseResolve()
     })
 }
 
 // @ts-expect-error - ongoingTests is not defined in the type definition
 window.ongoingTests = []
-// eslint-disable-next-line no-unused-vars
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 function test (name, test) {
     // @ts-expect-error - ongoingTests is not defined in the type definition
     window.ongoingTests.push({ name, test })
 }
 
-// eslint-disable-next-line no-unused-vars
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 async function renderResults () {
     const results = {}
     if (isInAutomation) {

--- a/packages/special-pages/tests/page-objects/mocks.js
+++ b/packages/special-pages/tests/page-objects/mocks.js
@@ -1,5 +1,4 @@
 import {
-    mockResponses,
     mockWindowsMessaging,
     readOutgoingMessages,
     simulateSubscriptionMessage,

--- a/snapshots/script-overload-snapshots/out/1.js
+++ b/snapshots/script-overload-snapshots/out/1.js
@@ -13,7 +13,7 @@
       return scope
     }
     return new Proxy(scope, {
-      get (target, property, receiver) {
+      get (target, property) {
         const targetObj = target[property]
         let targetOut = target
         if (typeof property === 'string' && property in outputs) {

--- a/snapshots/script-overload-snapshots/out/2.js
+++ b/snapshots/script-overload-snapshots/out/2.js
@@ -13,7 +13,7 @@
       return scope
     }
     return new Proxy(scope, {
-      get (target, property, receiver) {
+      get (target, property) {
         const targetObj = target[property]
         let targetOut = target
         if (typeof property === 'string' && property in outputs) {

--- a/snapshots/script-overload-snapshots/out/3.js
+++ b/snapshots/script-overload-snapshots/out/3.js
@@ -13,7 +13,7 @@
       return scope
     }
     return new Proxy(scope, {
-      get (target, property, receiver) {
+      get (target, property) {
         const targetObj = target[property]
         let targetOut = target
         if (typeof property === 'string' && property in outputs) {

--- a/src/content-feature.js
+++ b/src/content-feature.js
@@ -1,4 +1,4 @@
-import { camelcase, getTabHostname, matchHostname, processAttr, computeEnabledFeatures, parseFeatureSettings } from './utils.js'
+import { camelcase, matchHostname, processAttr, computeEnabledFeatures, parseFeatureSettings } from './utils.js'
 import { immutableJSONPatch } from 'immutable-json-patch'
 import { PerformanceMonitor } from './performance.js'
 
@@ -156,7 +156,7 @@ export default class ContentFeature {
         })
     }
 
-    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars, @typescript-eslint/no-empty-function
     init (args) {
     }
 
@@ -169,7 +169,7 @@ export default class ContentFeature {
         this.measure()
     }
 
-    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars, @typescript-eslint/no-empty-function
     load (args) {
     }
 

--- a/src/features/element-hiding.js
+++ b/src/features/element-hiding.js
@@ -54,9 +54,8 @@ function collapseDomNode (element, rule, previousElement) {
  * Unhide previously hidden DOM element if content loaded into it
  * @param {HTMLElement} element
  * @param {Object} rule
- * @param {HTMLElement} [previousElement]
  */
-function expandNonEmptyDomNode (element, rule, previousElement) {
+function expandNonEmptyDomNode (element, rule) {
     if (!element) {
         return
     }
@@ -76,7 +75,7 @@ function expandNonEmptyDomNode (element, rule, previousElement) {
             // iterate upwards from matching DOM elements until we arrive at previously
             // hidden element. Unhide element if it contains visible content.
             // @ts-expect-error https://app.asana.com/0/1201614831475344/1203979574128023/f
-            expandNonEmptyDomNode(element.parentNode, rule, element)
+            expandNonEmptyDomNode(element.parentNode, rule)
         }
         break
     default:
@@ -215,7 +214,7 @@ function extractTimeoutRules (rules) {
     const strictHideRules = []
     const timeoutRules = []
 
-    rules.forEach((rule, i) => {
+    rules.forEach((rule) => {
         if (rule.type === 'hide') {
             strictHideRules.push(rule)
         } else {
@@ -315,7 +314,7 @@ export default class ElementHiding extends ContentFeature {
 
         // now have the final list of rules to apply, so we apply them when document is loaded
         if (document.readyState === 'loading') {
-            window.addEventListener('DOMContentLoaded', (event) => {
+            window.addEventListener('DOMContentLoaded', () => {
                 applyRules(activeRules)
             })
         } else {
@@ -331,7 +330,7 @@ export default class ElementHiding extends ContentFeature {
         })
         historyMethodProxy.overload()
         // listen for popstate events in order to run on back/forward navigations
-        window.addEventListener('popstate', (event) => {
+        window.addEventListener('popstate', () => {
             applyRules(activeRules)
         })
     }

--- a/src/features/runtime-checks.js
+++ b/src/features/runtime-checks.js
@@ -471,6 +471,7 @@ function overrideCreateElement () {
     initialCreateElement = proxy._native
 }
 
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 function getTaintFromScope (scope, args) {
     try {
         scope = args.callee.caller

--- a/src/features/runtime-checks/script-overload.js
+++ b/src/features/runtime-checks/script-overload.js
@@ -1,5 +1,6 @@
 import { processAttr, getContextId } from '../../utils.js'
 
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 const globalStates = new Set()
 
 function generateUniqueID () {
@@ -123,7 +124,7 @@ function constructProxy (scope, outputs) {
         return scope
     }
     return new Proxy(scope, {
-        get (target, property, receiver) {
+        get (target, property) {
             const targetObj = target[property]
             let targetOut = target
             if (typeof property === 'string' && property in outputs) {
@@ -213,7 +214,7 @@ export function wrapScriptCodeOverload (code, config) {
         currentScope = aggregatedLookup
         const pathOut = path[path.length - 1]
         // Traverse the path and create the nested objects
-        path.slice(0, -1).forEach((pathPart, index) => {
+        path.slice(0, -1).forEach((pathPart) => {
             if (!currentScope.has(pathPart)) {
                 currentScope.set(pathPart, new Map())
             }

--- a/src/features/web-compat.js
+++ b/src/features/web-compat.js
@@ -68,7 +68,7 @@ function safariObjectFix () {
         }
         // @ts-expect-error https://app.asana.com/0/1201614831475344/1203979574128023/f
         defineProperty(window.safari.pushNotification, 'permission', {
-            value: (name) => {
+            value: () => {
                 return new SafariRemoteNotificationPermission()
             },
             configurable: true,

--- a/src/features/windows-permission-usage.js
+++ b/src/features/windows-permission-usage.js
@@ -271,7 +271,7 @@ export default class WindowsPermissionUsage extends ContentFeature {
                 // @ts-expect-error - trackEnabledPropertyDescriptor is possibly undefined
                 return trackEnabledPropertyDescriptor.get.bind(this)()
             },
-            set: function (value) {
+            set: function () {
                 // @ts-expect-error - trackEnabledPropertyDescriptor is possibly undefined
                 const result = trackEnabledPropertyDescriptor.set.bind(this)(...arguments)
                 if (videoTracks.has(this)) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -591,8 +591,6 @@ export function processConfig (data, userList, preferences, platformSpecificFeat
     const topLevelHostname = getTabHostname()
     const site = computeLimitedSiteObject()
     const allowlisted = userList.filter(domain => domain === topLevelHostname).length > 0
-    const remoteFeatureNames = Object.keys(data.features)
-    const platformSpecificFeaturesNotInRemoteConfig = platformSpecificFeatures.filter((featureName) => !remoteFeatureNames.includes(featureName))
     /** @type {Record<string, any>} */
     const output = { ...preferences }
     if (output.platform) {


### PR DESCRIPTION
Fixes linting errors that are drowning every PR.  I've not really checked but `@typescript-eslint/no-unused-vars` I think replaces the default `no-unused-vars` which is why we've had the slow creep of this code.

I've accepted some of them as there's some follow up PR with my code but the rest I've fixed.