### PR TITLE
Fix duplicating customElement definition

### DIFF
--- a/src/features/click-to-load/components/ctl-placeholder-blocked.js
+++ b/src/features/click-to-load/components/ctl-placeholder-blocked.js
@@ -299,4 +299,6 @@ export class DDGCtlPlaceholderBlockedElement extends HTMLElement {
     }
 }
 
-customElements.define(DDGCtlPlaceholderBlockedElement.CUSTOM_TAG_NAME, DDGCtlPlaceholderBlockedElement)
+if (!customElements.get(DDGCtlPlaceholderBlockedElement.CUSTOM_TAG_NAME)) {
+    customElements.define(DDGCtlPlaceholderBlockedElement.CUSTOM_TAG_NAME, DDGCtlPlaceholderBlockedElement)
+}


### PR DESCRIPTION
Fix duplicating customElement definition by first checking if it was previously defined.