### PR TITLE
Make duck player page more resilient to race conditions on macOS

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -69,9 +69,15 @@ jobs:
       if: always()
       with:
         name: playwright-report
-        path: playwright-report/
+        path: test-results
         retention-days: 5
     - run: npm run test-int-x
+    - uses: actions/upload-artifact@v2
+      if: always()
+      with:
+        name: playwright-report-pages
+        path: packages/special-pages/test-results
+        retention-days: 5
     - name: Build docs
       run: npm run docs
 

--- a/packages/special-pages/.gitignore
+++ b/packages/special-pages/.gitignore
@@ -1,1 +1,2 @@
 test-results
+playwright-report

--- a/packages/special-pages/package.json
+++ b/packages/special-pages/package.json
@@ -6,7 +6,7 @@
   "main": "index.js",
   "scripts": {
     "build": "node index.mjs",
-    "build.dev": "node index.mjs --debug",
+    "build.dev": "node index.mjs --env development",
     "test": "playwright test",
     "test.windows": "npm run test -- --project duckplayer-windows",
     "test.apple": "npm run test -- --project duckplayer-apple",
@@ -14,8 +14,8 @@
     "test.ui": "npm run test -- --ui",
     "pretest": "npm run build.dev",
     "pretest.headed": "npm run build.dev",
-    "test-int-x": "playwright test",
-    "test-int": "playwright test",
+    "test-int-x": "npm run test",
+    "test-int": "npm run test",
     "serve": "http-server -c-1 --port 3210 ../../"
   },
   "license": "ISC",

--- a/packages/special-pages/pages/duckplayer/src/js/messages.js
+++ b/packages/special-pages/pages/duckplayer/src/js/messages.js
@@ -159,3 +159,40 @@ export function createDuckPlayerPageMessaging (opts) {
     }
     throw new Error('unreachable - platform not supported')
 }
+
+/**
+ * This will return either { value: awaited value },
+ *                         { error: error message }
+ *
+ * It will execute the given function in uniform intervals
+ * until either:
+ *   1: the given function stops throwing errors
+ *   2: the maxAttempts limit is reached
+ *
+ * This is useful for situations where you don't want to continue
+ * until a result is found - normally to work around race-conditions
+ *
+ * @template {(...args: any[]) => any} FN
+ * @param {FN} fn
+ * @param {{maxAttempts?: number, intervalMs?: number}} params
+ * @returns {Promise<{ value: Awaited<ReturnType<FN>>, attempt: number } | { error: string }>}
+ */
+export async function callWithRetry (fn, params = {}) {
+    const { maxAttempts = 10, intervalMs = 300 } = params
+    let attempt = 1
+
+    while (attempt <= maxAttempts) {
+        try {
+            return { value: await fn(), attempt }
+        } catch (error) {
+            if (attempt === maxAttempts) {
+                return { error: `Max attempts reached: ${error}` }
+            }
+
+            await new Promise((resolve) => setTimeout(resolve, intervalMs))
+            attempt++
+        }
+    }
+
+    return { error: 'Unreachable: value not retrieved' }
+}

--- a/packages/special-pages/playwright.config.js
+++ b/packages/special-pages/playwright.config.js
@@ -14,11 +14,20 @@ export default defineConfig({
         }
     ],
     fullyParallel: !process.env.CI,
+    /* Retry on CI only */
+    retries: process.env.CI ? 2 : 0,
+    /* Opt out of parallel tests on CI. */
+    workers: process.env.CI ? 1 : undefined,
+    reporter: process.env.CI ? 'github' : [['html', { open: 'never' }]],
     // @ts-expect-error - Type 'undefined' is not assignable to type 'string'. process.env
     webServer: {
         command: 'npm run serve',
         port: 3210,
         reuseExistingServer: true,
         env: process.env
+    },
+    use: {
+        actionTimeout: 1000,
+        trace: 'on-first-retry'
     }
 })

--- a/packages/special-pages/tests/duckplayer.spec.js
+++ b/packages/special-pages/tests/duckplayer.spec.js
@@ -82,7 +82,7 @@ test.describe('duckplayer toolbar', () => {
 })
 
 test.describe('duckplayer settings', () => {
-    test.skip('always open setting', async ({ page }, workerInfo) => {
+    test('always open setting', async ({ page }, workerInfo) => {
         const duckplayer = DuckPlayerPage.create(page, workerInfo)
         // load as normal
         await duckplayer.openWithVideoID()
@@ -98,7 +98,7 @@ test.describe('duckplayer settings', () => {
         await duckplayer.toggleAlwaysOpenSetting()
         await duckplayer.sentUpdatedSettings()
     })
-    test.skip('when a new value arrives via subscription', async ({ page }, workerInfo) => {
+    test('when a new value arrives via subscription', async ({ page }, workerInfo) => {
         const duckplayer = DuckPlayerPage.create(page, workerInfo)
         // load as normal
         await duckplayer.openWithVideoID()

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -41,6 +41,7 @@ export default defineConfig({
     retries: process.env.CI ? 2 : 0,
     /* Opt out of parallel tests on CI. */
     workers: process.env.CI ? 1 : undefined,
+    reporter: process.env.CI ? 'github' : [['html', { open: 'never' }]],
     /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
     webServer: {
         reuseExistingServer: true,


### PR DESCRIPTION
When implementing Duck Player on macOS - I encountered a race-condition where our script in the page is calling for a request/response before the special page has been marked as 'safe to receive messages' by the native side.

I looked into fixing it on their end, but it's heavily related to the fact that user-scripts are global and cannot be directly tied to a particular hostname.

So, I'm fixing it here by attempting (10 times) to make an 'initial connection' - once that's established we continue as normal.

This is a nice way of ensuring we can proceed across all platforms. So whilst it's technically a macOS only fix right now, it really helps everywhere by not giving up on first error.