### PR TITLE
Fix issue to get accurate iframe video src

### DIFF
--- a/src/features/click-to-load.js
+++ b/src/features/click-to-load.js
@@ -523,7 +523,7 @@ function replaceTrackingElement (widget, trackingElement, placeholderElement) {
     // from the DOM after they are collapsed. As a workaround, have the iframe
     // load a benign data URI, so that it's uncollapsed, before removing it from
     // the DOM. See https://crbug.com/1428971
-    const originalSrc = elementToReplace.src
+    const originalSrc = elementToReplace.src || elementToReplace.getAttribute('data-src')
     elementToReplace.src =
         'data:text/plain;charset=utf-8;base64,' + btoa('https://crbug.com/1428971')
 


### PR DESCRIPTION
Sometimes, YT iframes won't have a set `src` attribute, and instead are using `data-src=*`. This caused breakage since we were relying on `src` to store the original video src when replacing it.