### PR TITLE
Prevent debugging serialization to cause page to break

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -403,12 +403,17 @@ export function hasTaintedMethod (scope, shouldStackCheck = false) {
  * @returns {string}
  */
 function debugSerialize (argsArray) {
+    const maxSerializedSize = 1000
     const serializedArgs = argsArray.map((arg) => {
         try {
-            return JSON.stringify(arg)
+            const serializableOut = JSON.stringify(arg)
+            if (serializableOut.length > maxSerializedSize) {
+                return `<truncated, length: ${serializableOut.length}, value: ${serializableOut.substring(0, maxSerializedSize)}...>`
+            }
+            return serializableOut
         } catch (e) {
             // Sometimes this happens when we can't serialize an object to string but we still wish to log it and make other args readable
-            return '[unserializable]'
+            return '<unserializable>'
         }
     })
     return JSON.stringify(serializedArgs)

--- a/src/utils.js
+++ b/src/utils.js
@@ -399,6 +399,22 @@ export function hasTaintedMethod (scope, shouldStackCheck = false) {
 }
 
 /**
+ * @param {*[]} argsArray
+ * @returns {string}
+ */
+function debugSerialize (argsArray) {
+    const serializedArgs = argsArray.map((arg) => {
+        try {
+            return JSON.stringify(arg)
+        } catch (e) {
+            // Sometimes this happens when we can't serialize an object to string but we still wish to log it and make other args readable
+            return '[unserializable]'
+        }
+    })
+    return JSON.stringify(serializedArgs)
+}
+
+/**
  * @template {object} P
  * @typedef {object} ProxyObject<P>
  * @property {(target?: object, thisArg?: P, args?: object) => void} apply
@@ -440,7 +456,7 @@ export class DDGProxy {
                     kind: this.property,
                     documentUrl: document.location.href,
                     stack: getStack(),
-                    args: JSON.stringify(args[2])
+                    args: debugSerialize(args[2])
                 })
             }
             // The normal return value


### PR DESCRIPTION
Fixes page load issues on Amazon, https://www.citi.com/ and many others where we're serializing symbols that aren't serializable.

This appears to be any page with react so makes debugging very annoying.