### PR TITLE
Fix CTL clicks propagation

### DIFF
--- a/src/features/click-to-load.js
+++ b/src/features/click-to-load.js
@@ -369,6 +369,7 @@ class DuckWidget {
         const handleClick = e => {
             // Ensure that the click is created by a user event & prevent double clicks from adding more animations
             if (e.isTrusted && !clicked) {
+                e.stopPropagation()
                 this.isUnblocked = true
                 clicked = true
                 let isLogin = false


### PR DESCRIPTION
Stop event propagation for CTL clicks, to avoid conflict with the page trying to handle the video instead of us during unblocking content.