### PR TITLE
relative imports for messaging

### DIFF
--- a/src/content-feature.js
+++ b/src/content-feature.js
@@ -1,7 +1,7 @@
 import { camelcase, matchHostname, processAttr, computeEnabledFeatures, parseFeatureSettings } from './utils.js'
 import { immutableJSONPatch } from 'immutable-json-patch'
 import { PerformanceMonitor } from './performance.js'
-import { MessagingContext } from '@duckduckgo/messaging'
+import { MessagingContext } from '../packages/messaging/index.js'
 
 /**
  * @typedef {object} AssetConfig

--- a/src/create-messaging.js
+++ b/src/create-messaging.js
@@ -1,4 +1,4 @@
-import { Messaging, MessagingContext, WebkitMessagingConfig, WindowsMessagingConfig } from '@duckduckgo/messaging'
+import { Messaging, MessagingContext, WebkitMessagingConfig, WindowsMessagingConfig } from '../packages/messaging/index.js'
 
 /**
  * Extracted so we can iterate on the best way to bring this to all platforms

--- a/src/features/click-to-load.js
+++ b/src/features/click-to-load.js
@@ -1,4 +1,4 @@
-import { Messaging, TestTransportConfig, WebkitMessagingConfig } from '@duckduckgo/messaging'
+import { Messaging, TestTransportConfig, WebkitMessagingConfig } from '../../packages/messaging/index.js'
 import { createCustomEvent, originalWindowDispatchEvent } from '../utils.js'
 import { logoImg, loadingImages, closeIcon } from './click-to-load/ctl-assets.js'
 import { getStyles, getConfig } from './click-to-load/ctl-config.js'


### PR DESCRIPTION
## Description 
use relative imports for the code paths used in production builds or code that might get imported from consumers (like the extension)

There's probably a better long-term fix than this, but it solves our immediate problem 

Related to https://app.asana.com/0/312629933896096/1204853511976567/f