### PR TITLE
Add overloading of property descriptors

### DIFF
--- a/unit-test/verify-artifacts.js
+++ b/unit-test/verify-artifacts.js
@@ -6,7 +6,7 @@ import { cwd } from '../scripts/script-utils.js'
 const ROOT = join(cwd(import.meta.url), '..')
 const BUILD = join(ROOT, 'build')
 const APPLE_BUILD = join(ROOT, 'Sources/ContentScopeScripts/dist')
-let CSS_OUTPUT_SIZE = 590_000
+let CSS_OUTPUT_SIZE = 600_000
 const CSS_OUTPUT_SIZE_CHROME = CSS_OUTPUT_SIZE * 1.45 // 45% larger for Chrome MV2 due to base64 encoding
 if (process.platform === 'win32') {
     CSS_OUTPUT_SIZE = CSS_OUTPUT_SIZE * 1.1 // 10% larger for Windows due to line endings


### PR DESCRIPTION
https://app.asana.com/0/569473074191537/1204844629773408/f

- Disable the exception we currently have for xfinity
- Also enable all stack trace checking with `"matchAllStackDomains": "enabled",`
- Also enable this with `"overloadGetOwnPropertyDescriptor": "enabled"`
- Go to xfinity,

Without this patch you see exceptions about illegal invocation, with they should be gone.