### PR TITLE
fix(web-compat): run web-compat first in webkit environments

### DIFF
--- a/src/features.js
+++ b/src/features.js
@@ -27,8 +27,8 @@ const otherFeatures = /** @type {const} */([
 /** @type {Record<string, FeatureName[]>} */
 export const platformSupport = {
     apple: [
-        ...baseFeatures,
-        'webCompat'
+        'webCompat',
+        ...baseFeatures
     ],
     'apple-isolated': [
         'duckPlayer'

--- a/unit-test/features.js
+++ b/unit-test/features.js
@@ -1,0 +1,24 @@
+import { platformSupport } from '../src/features.js'
+
+describe('Features definition', () => {
+    fit('calls `webCompat` before `fingerPrintingScreenSize` https://app.asana.com/0/1177771139624306/1204944717262422/f', () => {
+        // ensuring this order doesn't change, as it recently caused breakage
+        expect(platformSupport.apple).toEqual([
+            'webCompat',
+            'runtimeChecks',
+            'fingerprintingAudio',
+            'fingerprintingBattery',
+            'fingerprintingCanvas',
+            'cookie',
+            'googleRejected',
+            'gpc',
+            'fingerprintingHardware',
+            'referrer',
+            'fingerprintingScreenSize',
+            'fingerprintingTemporaryStorage',
+            'navigatorInterface',
+            'elementHiding',
+            'exceptionHandler'
+        ])
+    })
+})

--- a/unit-test/features.js
+++ b/unit-test/features.js
@@ -1,7 +1,7 @@
 import { platformSupport } from '../src/features.js'
 
 describe('Features definition', () => {
-    fit('calls `webCompat` before `fingerPrintingScreenSize` https://app.asana.com/0/1177771139624306/1204944717262422/f', () => {
+    it('calls `webCompat` before `fingerPrintingScreenSize` https://app.asana.com/0/1177771139624306/1204944717262422/f', () => {
         // ensuring this order doesn't change, as it recently caused breakage
         expect(platformSupport.apple).toEqual([
             'webCompat',


### PR DESCRIPTION
The fix here is just to ensure `webCompat` runs earlier on the page - I will fast-follow with an integration test once I figure out why this occures.

The PR contains the artefacts to make it easier to review - they'll be removed before merge

https://github.com/duckduckgo/content-scope-scripts/pull/606/files#diff-5cdfca025137b215b9294f8a2f6d0893270002cbf3f7b8efb771da44971382c7