### PR TITLE
Set Facebook Click to Load breakage flags

### DIFF
--- a/inject/android.js
+++ b/inject/android.js
@@ -12,7 +12,8 @@ const allowedMessages = [
     'openShareFeedbackPage',
     'setYoutubePreviewsEnabled',
     'unblockClickToLoadContent',
-    'updateYouTubeCTLAddedFlag'
+    'updateYouTubeCTLAddedFlag',
+    'updateFacebookCTLBreakageFlags'
 ]
 
 function initCode () {

--- a/inject/chrome.js
+++ b/inject/chrome.js
@@ -15,7 +15,8 @@ const allowedMessages = [
     'openShareFeedbackPage',
     'setYoutubePreviewsEnabled',
     'unblockClickToLoadContent',
-    'updateYouTubeCTLAddedFlag'
+    'updateYouTubeCTLAddedFlag',
+    'updateFacebookCTLBreakageFlags'
 ]
 const messageSecret = randomString()
 

--- a/inject/mozilla.js
+++ b/inject/mozilla.js
@@ -12,7 +12,8 @@ const allowedMessages = [
     'openShareFeedbackPage',
     'setYoutubePreviewsEnabled',
     'unblockClickToLoadContent',
-    'updateYouTubeCTLAddedFlag'
+    'updateYouTubeCTLAddedFlag',
+    'updateFacebookCTLBreakageFlags'
 ]
 const messageSecret = randomString()
 


### PR DESCRIPTION
Take care to set the new Facebook Click to Load breakage flags, to
give us a better idea how often the feature causes website breakage
for our users.