### PR TITLE
duckplayer fixes

### DIFF
--- a/integration-test/playwright/duckplayer.e2e.spec.js
+++ b/integration-test/playwright/duckplayer.e2e.spec.js
@@ -19,4 +19,24 @@ test.describe('e2e: Duck Player Thumbnail Overlays on YouTube.com', () => {
         await overlays.hoverShort()
         await overlays.overlaysDontShow()
     })
+    test('control (without our script): clicking on a short loads correctly', async ({ page }, workerInfo) => {
+        // @ts-expect-error - TS doesn't know about the "use.e2e" property
+        workerInfo.skip(!workerInfo.project.use?.e2e)
+        const overlays = DuckplayerOverlays.create(page, workerInfo)
+        await overlays.gotoYoutubeHomepage()
+        await page.waitForTimeout(2000)
+        await overlays.clicksFirstShortsThumbnail()
+        await overlays.showsShortsPage()
+    })
+    test('e2e: when enabled, clicking shorts has no impact', async ({ page }, workerInfo) => {
+        // @ts-expect-error - TS doesn't know about the "use.e2e" property
+        workerInfo.skip(!workerInfo.project.use?.e2e)
+        const overlays = DuckplayerOverlays.create(page, workerInfo)
+        await overlays.overlaysEnabled({ json: 'overlays-live' })
+        await overlays.userSettingIs('enabled')
+        await overlays.gotoYoutubeHomepage()
+        await page.waitForTimeout(2000)
+        await overlays.clicksFirstShortsThumbnail()
+        await overlays.showsShortsPage()
+    })
 })

--- a/integration-test/playwright/duckplayer.spec.js
+++ b/integration-test/playwright/duckplayer.spec.js
@@ -28,6 +28,19 @@ test.describe('Duck Player Thumbnail Overlays on YouTube.com', () => {
         await overlays.hoverShort()
         await overlays.overlaysDontShow()
     })
+    /**
+     * https://app.asana.com/0/1201048563534612/1204993915251837/f
+     */
+    test('Clicks are not intercepted on shorts when "enabled"', async ({ page }, workerInfo) => {
+        const overlays = DuckplayerOverlays.create(page, workerInfo)
+        await overlays.overlaysEnabled()
+        await overlays.userSettingIs('enabled')
+        await overlays.gotoThumbsPage()
+        const navigation = overlays.requestWillFail()
+        await overlays.clicksFirstShortsThumbnail()
+        const url = await navigation
+        await overlays.opensShort(url)
+    })
     test('Overlays don\'t show on thumbnails when disabled', async ({ page }, workerInfo) => {
         const overlays = DuckplayerOverlays.create(page, workerInfo)
 

--- a/integration-test/playwright/page-objects/duckplayer-overlays.js
+++ b/integration-test/playwright/page-objects/duckplayer-overlays.js
@@ -60,6 +60,22 @@ export class DuckplayerOverlays {
         await this.page.getByRole('button', { name: 'Reject the use of cookies and other data for the purposes described' }).click()
     }
 
+    async clicksFirstShortsThumbnail () {
+        await this.page.locator('[href*="/shorts"] img').first().click({ force: true })
+    }
+
+    async showsShortsPage () {
+        await this.page.waitForURL(/^https:\/\/www.youtube.com\/shorts/, { timeout: 5000 })
+    }
+
+    /**
+     * @param {string} requestUrl
+     */
+    opensShort (requestUrl) {
+        const url = new URL(requestUrl)
+        expect(url.pathname).toBe('/shorts/1')
+    }
+
     /**
      * @param {object} [params]
      * @param {"default" | "incremental-dom"} [params.variant]
@@ -347,6 +363,22 @@ export class DuckplayerOverlays {
         return this.build.name === 'apple-isolated'
             ? 'contentScopeScriptsIsolated'
             : 'contentScopeScripts'
+    }
+
+    /**
+     * @return {Promise<string>}
+     */
+    requestWillFail () {
+        return new Promise((resolve, reject) => {
+            // on windows it will be a failed request
+            const timer = setTimeout(() => {
+                reject(new Error('timed out'))
+            }, 5000)
+            this.page.on('framenavigated', (req) => {
+                clearTimeout(timer)
+                resolve(req.url())
+            })
+        })
     }
 }
 

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "playwright-headed": "playwright test --headed",
     "preplaywright": "npm run build-windows && npm run build-apple",
     "preplaywright-headed": "npm run build-windows && npm run build-apple",
-    "playwright-e2e": "E2E=true playwright test --project duckplayer-e2e --headed"
+    "playwright-e2e": "E2E=true playwright test --project duckplayer-e2e"
   },
   "type": "module",
   "workspaces": [


### PR DESCRIPTION
https://app.asana.com/0/0/1205002113935587/f

This fixes 2 things:

- [x] 1) A previous fix introduced a regression where we always called `e.preventDefault()` when we shouldn't
- [x] 2) YT upgrades the markup on the elements for shorts, so now we double-check on click whether or not it's a valid duck player url before we prevent default and try to navigate.