### PR TITLE
Add an ESLint rule to prevent private methods for now.

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -17,6 +17,13 @@
         "windowsInteropRemoveEventListener": "readonly"
     },
     "rules": {
+        "no-restricted-syntax": [
+            "error",
+            {
+                "selector": "MethodDefinition[key.type='PrivateIdentifier']",
+                "message": "Private methods are currently unsupported in older WebKit and ESR Firefox"
+            }
+        ],
         "indent": ["error", 4],
         "require-await": ["error"],
         "promise/prefer-await-to-then": ["error"],


### PR DESCRIPTION
Rule to prevent the breakage being fixed in https://github.com/duckduckgo/content-scope-scripts/pull/617 that has happened a few times now.

I looked into other setups like https://github.com/amilajack/eslint-plugin-compat but they only appear to cover DOM APIs and have some [concerning shortcomings ](https://github.com/amilajack/eslint-plugin-compat/issues/545) so I just concentrated on the issue at hand here.

Prior to #617 the lint rule looks like this:

<img width="809" alt="image" src="https://github.com/duckduckgo/content-scope-scripts/assets/338988/a744629d-1193-45ca-96f2-1a68c3cad8a2">
