### PR TITLE
Move unsupported cookie feature from MacOS, iOS and Android

### DIFF
--- a/src/features.js
+++ b/src/features.js
@@ -3,7 +3,6 @@ const baseFeatures = /** @type {const} */([
     'fingerprintingAudio',
     'fingerprintingBattery',
     'fingerprintingCanvas',
-    'cookie',
     'googleRejected',
     'gpc',
     'fingerprintingHardware',
@@ -17,6 +16,7 @@ const baseFeatures = /** @type {const} */([
 
 const otherFeatures = /** @type {const} */([
     'clickToLoad',
+    'cookie',
     'windowsPermissionUsage',
     'webCompat',
     'duckPlayer',
@@ -38,19 +38,23 @@ export const platformSupport = {
         'clickToLoad'
     ],
     windows: [
+        'cookie',
         ...baseFeatures,
         'windowsPermissionUsage',
         'duckPlayer'
     ],
     firefox: [
+        'cookie',
         ...baseFeatures,
         'clickToLoad'
     ],
     chrome: [
+        'cookie',
         ...baseFeatures,
         'clickToLoad'
     ],
     'chrome-mv3': [
+        'cookie',
         ...baseFeatures,
         'clickToLoad'
     ],

--- a/unit-test/features.js
+++ b/unit-test/features.js
@@ -9,7 +9,6 @@ describe('Features definition', () => {
             'fingerprintingAudio',
             'fingerprintingBattery',
             'fingerprintingCanvas',
-            'cookie',
             'googleRejected',
             'gpc',
             'fingerprintingHardware',


### PR DESCRIPTION
(they impement their own protection without this)

This is for: https://app.asana.com/0/1163321984198618/1205014156625274/f and https://app.asana.com/0/0/1205004102989886/f