### PR TITLE
Require bundled config on all platforms

### DIFF
--- a/inject/android.js
+++ b/inject/android.js
@@ -27,7 +27,8 @@ function initCode () {
         platform: processedConfig.platform,
         trackerLookup: processedConfig.trackerLookup,
         documentOriginIsTracker: isTrackerOrigin(processedConfig.trackerLookup),
-        site: processedConfig.site
+        site: processedConfig.site,
+        bundledConfig: processedConfig.bundledConfig
     })
 
     const messageSecret = processedConfig.messageSecret

--- a/inject/apple.js
+++ b/inject/apple.js
@@ -17,7 +17,8 @@ function initCode () {
         platform: processedConfig.platform,
         trackerLookup: processedConfig.trackerLookup,
         documentOriginIsTracker: isTrackerOrigin(processedConfig.trackerLookup),
-        site: processedConfig.site
+        site: processedConfig.site,
+        bundledConfig: processedConfig.bundledConfig
     })
 
     init(processedConfig)

--- a/inject/windows.js
+++ b/inject/windows.js
@@ -17,7 +17,8 @@ function initCode () {
         platform: processedConfig.platform,
         trackerLookup: processedConfig.trackerLookup,
         documentOriginIsTracker: isTrackerOrigin(processedConfig.trackerLookup),
-        site: processedConfig.site
+        site: processedConfig.site,
+        bundledConfig: processedConfig.bundledConfig
     })
 
     init(processedConfig)

--- a/src/content-scope-features.js
+++ b/src/content-scope-features.js
@@ -29,7 +29,7 @@ const performanceMonitor = new PerformanceMonitor()
  * @property {import('./content-feature').Site} site
  * @property {import('./utils.js').Platform} platform
  * @property {boolean} documentOriginIsTracker
- * @property {object} [bundledConfig]
+ * @property {import('./utils.js').RemoteConfig} bundledConfig
  * @property {string} [injectName]
  * @property {object} trackerLookup - provided currently only by the extension
  */

--- a/src/features/cookie.js
+++ b/src/features/cookie.js
@@ -103,7 +103,7 @@ export default class CookieFeature extends ContentFeature {
         if (this.trackerLookup) {
             trackerLookup = this.trackerLookup
         }
-        if (this.bundledConfig) {
+        if (this.bundledConfig?.features?.cookie) {
             // use the bundled config to get a best-effort at the policy, before the background sends the real one
             const { exceptions, settings } = this.bundledConfig.features.cookie
             const tabHostname = getTabHostname()

--- a/src/utils.js
+++ b/src/utils.js
@@ -707,6 +707,7 @@ export function processConfig (data, userList, preferences, platformSpecificFeat
     // Copy feature settings from remote config to preferences object
     output.featureSettings = parseFeatureSettings(data, enabledFeatures)
     output.trackerLookup = import.meta.trackerLookup
+    output.bundledConfig = data
 
     return output
 }

--- a/unit-test/utils.js
+++ b/unit-test/utils.js
@@ -16,7 +16,7 @@ describe('Helpers checks', () => {
     })
 
     it('processes config in expected way for minSupportedVersion and numeric versions', () => {
-        const processedConfig = processConfig({
+        const configIn = {
             features: {
                 testFeature: {
                     state: 'enabled',
@@ -53,16 +53,19 @@ describe('Helpers checks', () => {
                 }
             },
             unprotectedTemporary: []
-        },
-        [],
-        {
-            platform: {
-                name: 'android'
+        }
+        const processedConfig = processConfig(
+            configIn,
+            [],
+            {
+                platform: {
+                    name: 'android'
+                },
+                versionNumber: 99,
+                sessionKey: 'testSessionKey'
             },
-            versionNumber: 99,
-            sessionKey: 'testSessionKey'
-        },
-        [])
+            []
+        )
         expect(processedConfig).toEqual({
             site: {
                 domain: 'localhost',
@@ -87,12 +90,13 @@ describe('Helpers checks', () => {
             versionNumber: 99,
             sessionKey: 'testSessionKey',
             // import.meta.trackerLookup is undefined because we've not overloaded it
-            trackerLookup: undefined
+            trackerLookup: undefined,
+            bundledConfig: configIn
         })
     })
 
     it('processes config in expected way for minSupportedVersion and string versions', () => {
-        const processedConfig = processConfig({
+        const configIn = {
             features: {
                 testFeature: {
                     state: 'enabled',
@@ -129,16 +133,19 @@ describe('Helpers checks', () => {
                 }
             },
             unprotectedTemporary: []
-        },
-        [],
-        {
-            platform: {
-                name: 'ios'
+        }
+        const processedConfig = processConfig(
+            configIn,
+            [],
+            {
+                platform: {
+                    name: 'ios'
+                },
+                versionString: '0.9.9',
+                sessionKey: 'testSessionKey'
             },
-            versionString: '0.9.9',
-            sessionKey: 'testSessionKey'
-        },
-        [])
+            []
+        )
         expect(processedConfig).toEqual({
             site: {
                 domain: 'localhost',
@@ -162,7 +169,8 @@ describe('Helpers checks', () => {
             },
             versionString: '0.9.9',
             sessionKey: 'testSessionKey',
-            trackerLookup: undefined
+            trackerLookup: undefined,
+            bundledConfig: configIn
         })
     })
 


### PR DESCRIPTION
This is a key used by the cookie feature only that was undefined on all platforms other than extensions. We should wire through the same `data` in `processConfig` as it's the same thing.


See: https://app.asana.com/0/0/1205014156625311/1205075392620609/f