### PR TITLE
Add windows to inital support for loading tracker cookie blocking

### DIFF
--- a/src/features/cookie.js
+++ b/src/features/cookie.js
@@ -14,7 +14,7 @@ import { isTrackerOrigin } from '../trackers.js'
 
 function initialShouldBlockTrackerCookie () {
     const injectName = import.meta.injectName
-    return injectName === 'chrome' || injectName === 'firefox' || injectName === 'chrome-mv3'
+    return injectName === 'chrome' || injectName === 'firefox' || injectName === 'chrome-mv3' || injectName === 'windows'
 }
 
 // Initial cookie policy pre init


### PR DESCRIPTION
Re-enables windows on startup for cookie protection.