### PR TITLE
Remove unused logic from referrer trimming

### DIFF
--- a/src/features/referrer.js
+++ b/src/features/referrer.js
@@ -2,22 +2,11 @@ import ContentFeature from '../content-feature'
 import { wrapProperty } from '../wrapper-utils'
 
 export default class Referrer extends ContentFeature {
-    init (args) {
-        // Unfortunately, we only have limited information about the referrer and current frame. A single
-        // page may load many requests and sub frames, all with different referrers. Since we
-        if (args.referrer && // make sure the referrer was set correctly
-            args.referrer.referrer !== undefined && // referrer value will be undefined when it should be unchanged.
-            document.referrer && // don't change the value if it isn't set
-            document.referrer !== '' && // don't add referrer information
-            new URL(document.URL).hostname !== new URL(document.referrer).hostname) { // don't replace the referrer for the current host.
-            let trimmedReferer = document.referrer
-            if (new URL(document.referrer).hostname === args.referrer.referrerHost) {
-                // make sure the real referrer & replacement referrer match if we're going to replace it
-                trimmedReferer = args.referrer.referrer
-            } else {
-                // if we don't have a matching referrer, just trim it to origin.
-                trimmedReferer = new URL(document.referrer).origin + '/'
-            }
+    init () {
+        // If the referer is a different host to the current one, trim it.
+        if (new URL(document.URL).hostname !== new URL(document.referrer).hostname) {
+            // trim referrer to origin.
+            const trimmedReferer = new URL(document.referrer).origin + '/'
             wrapProperty(Document.prototype, 'referrer', {
                 get: () => trimmedReferer
             })


### PR DESCRIPTION
https://app.asana.com/0/892838074342800/1205066264803671/f

We previously had a code path in the referrer trimming code to take a referrer value sent by the background script. Since we removed eTLD+1 truncation, this isn't needed anymore (this script has enough context to apply the trimming itself), so we can remove that code path.