### PR TITLE
Breakage debug flags

### DIFF
--- a/build-output.eslintrc
+++ b/build-output.eslintrc
@@ -1,6 +1,6 @@
 {
     "root": true,
-    "plugins": ["promise", "@typescript-eslint"],
+    "plugins": ["promise", "@typescript-eslint", "eslint-plugin-n"],
     "parserOptions": {
       "ecmaVersion": "latest",
     },

--- a/inject/chrome.js
+++ b/inject/chrome.js
@@ -13,6 +13,7 @@ const allowedMessages = [
     'getClickToLoadState',
     'getYouTubeVideoDetails',
     'openShareFeedbackPage',
+    'addDebugFlag',
     'setYoutubePreviewsEnabled',
     'unblockClickToLoadContent',
     'updateYouTubeCTLAddedFlag',

--- a/inject/mozilla.js
+++ b/inject/mozilla.js
@@ -10,6 +10,7 @@ const allowedMessages = [
     'getClickToLoadState',
     'getYouTubeVideoDetails',
     'openShareFeedbackPage',
+    'addDebugFlag',
     'setYoutubePreviewsEnabled',
     'unblockClickToLoadContent',
     'updateYouTubeCTLAddedFlag',

--- a/src/content-feature.js
+++ b/src/content-feature.js
@@ -31,8 +31,8 @@ export default class ContentFeature {
     #messagingContext
     /** @type {import('../packages/messaging').Messaging} */
     #debugMessaging
-    /** @type {Set<string>} */
-    #debugFlags
+    /** @type {boolean} */
+    #isDebugFlagSet = false
 
     /** @type {{ debug?: boolean, featureSettings?: Record<string, unknown>, assets?: AssetConfig | undefined, site: Site  } | null} */
     #args
@@ -41,7 +41,6 @@ export default class ContentFeature {
         this.name = featureName
         this.#args = null
         this.monitor = new PerformanceMonitor()
-        this.#debugFlags = new Set()
     }
 
     get isDebug () {
@@ -248,15 +247,13 @@ export default class ContentFeature {
     }
 
     /**
-     * Register a string flag that will be added to page breakage reports
-     * @param {string} flag
+     * Register a flag that will be added to page breakage reports
      */
-    addDebugFlag (flag = '') {
-        if (this.#debugFlags.has(flag)) return
-        this.#debugFlags.add(flag)
-        const suffix = flag ? `.${flag}` : ''
+    addDebugFlag () {
+        if (this.#isDebugFlagSet) return
+        this.#isDebugFlagSet = true
         this.debugMessaging?.notify('addDebugFlag', {
-            flag: `${this.name}${suffix}`
+            flag: this.name
         })
     }
 }

--- a/src/content-feature.js
+++ b/src/content-feature.js
@@ -110,7 +110,7 @@ export default class ContentFeature {
         if (this.#messaging) return this.#messaging
 
         // TODO: use createMessaging() from create-messaging.js when all platforms are supported
-        if (this.platform.name === 'extension') {
+        if (this.platform?.name === 'extension') {
             this.#messagingTransport = new SendMessageMessagingTransport()
             const config = new TestTransportConfig(this.#messagingTransport)
             this.#messaging = new Messaging(this.messagingContext, config)
@@ -256,5 +256,6 @@ export default class ContentFeature {
         this.messaging?.notify('addDebugFlag', {
             flag: `${this.name}.${flag}`
         })
+        console.log('calling', this.messaging?.notify, `${this.name}.${flag}`)
     }
 }

--- a/src/content-feature.js
+++ b/src/content-feature.js
@@ -87,10 +87,15 @@ export default class ContentFeature {
      */
     get messagingContext () {
         if (this.#messagingContext) return this.#messagingContext
+
+        const contextName = import.meta.injectName === 'apple-isolated'
+            ? 'contentScopeScriptsIsolated'
+            : 'contentScopeScripts'
+
         this.#messagingContext = new MessagingContext({
-            context: 'contentScopeScripts',
-            featureName: this.name,
-            env: this.isDebug ? 'development' : 'production'
+            context: contextName,
+            env: this.isDebug ? 'development' : 'production',
+            featureName: this.name
         })
         return this.#messagingContext
     }

--- a/src/content-feature.js
+++ b/src/content-feature.js
@@ -251,11 +251,12 @@ export default class ContentFeature {
      * Register a string flag that will be added to page breakage reports
      * @param {string} flag
      */
-    addDebugFlag (flag = 'fired') {
+    addDebugFlag (flag = '') {
         if (this.#debugFlags.has(flag)) return
         this.#debugFlags.add(flag)
+        const suffix = flag ? `.${flag}` : ''
         this.debugMessaging?.notify('addDebugFlag', {
-            flag: `${this.name}.${flag}`
+            flag: `${this.name}${suffix}`
         })
     }
 }

--- a/src/content-feature.js
+++ b/src/content-feature.js
@@ -31,6 +31,8 @@ export default class ContentFeature {
     #messagingContext
     /** @type {import('../packages/messaging').Messaging} */
     #debugMessaging
+    /** @type {Set<string>} */
+    #debugFlags
 
     /** @type {{ debug?: boolean, featureSettings?: Record<string, unknown>, assets?: AssetConfig | undefined, site: Site  } | null} */
     #args
@@ -39,6 +41,7 @@ export default class ContentFeature {
         this.name = featureName
         this.#args = null
         this.monitor = new PerformanceMonitor()
+        this.#debugFlags = new Set()
     }
 
     get isDebug () {
@@ -249,6 +252,8 @@ export default class ContentFeature {
      * @param {string} flag
      */
     addDebugFlag (flag = 'fired') {
+        if (this.#debugFlags.has(flag)) return
+        this.#debugFlags.add(flag)
         this.debugMessaging?.notify('addDebugFlag', {
             flag: `${this.name}.${flag}`
         })

--- a/src/create-messaging.js
+++ b/src/create-messaging.js
@@ -1,4 +1,4 @@
-import { Messaging, MessagingContext, WebkitMessagingConfig, WindowsMessagingConfig } from '../packages/messaging/index.js'
+import { Messaging, WebkitMessagingConfig, WindowsMessagingConfig } from '../packages/messaging/index.js'
 
 /**
  * Extracted so we can iterate on the best way to bring this to all platforms
@@ -7,15 +7,7 @@ import { Messaging, MessagingContext, WebkitMessagingConfig, WindowsMessagingCon
  * @return {Messaging}
  */
 export function createMessaging (feature, injectName) {
-    const contextName = injectName === 'apple-isolated'
-        ? 'contentScopeScriptsIsolated'
-        : 'contentScopeScripts'
-
-    const context = new MessagingContext({
-        context: contextName,
-        env: feature.isDebug ? 'development' : 'production',
-        featureName: feature.name
-    })
+    const context = feature.messagingContext
 
     /** @type {Partial<Record<NonNullable<ImportMeta['injectName']>, () => any>>} */
     const config = {
@@ -33,7 +25,7 @@ export function createMessaging (feature, injectName) {
         },
         'apple-isolated': () => {
             return new WebkitMessagingConfig({
-                webkitMessageHandlerNames: [contextName],
+                webkitMessageHandlerNames: [context.context],
                 secret: '',
                 hasModernWebkitAPI: true
             })

--- a/src/features/click-to-load.js
+++ b/src/features/click-to-load.js
@@ -2,7 +2,7 @@ import { Messaging, TestTransportConfig, WebkitMessagingConfig } from '../../pac
 import { createCustomEvent, originalWindowDispatchEvent } from '../utils.js'
 import { logoImg, loadingImages, closeIcon, facebookLogo } from './click-to-load/ctl-assets.js'
 import { getStyles, getConfig } from './click-to-load/ctl-config.js'
-import { ClickToLoadMessagingTransport } from './click-to-load/ctl-messaging-transport.js'
+import { SendMessageMessagingTransport } from '../sendmessage-transport.js'
 import ContentFeature from '../content-feature.js'
 import { DDGCtlPlaceholderBlockedElement } from './click-to-load/components/ctl-placeholder-blocked.js'
 import { DDGCtlLoginButton } from './click-to-load/components/ctl-login-button.js'
@@ -1924,7 +1924,7 @@ export default class ClickToLoad extends ContentFeature {
     /**
      * This is only called by the current integration between Android and Extension and is now
      * used to connect only these Platforms responses with the temporary implementation of
-     * ClickToLoadMessagingTransport that wraps this communication.
+     * SendMessageMessagingTransport that wraps this communication.
      * This can be removed once they have their own Messaging integration.
      */
     update (message) {
@@ -2001,7 +2001,7 @@ export default class ClickToLoad extends ContentFeature {
         if (this._messaging) return this._messaging
 
         if (this.platform.name === 'android' || this.platform.name === 'extension' || this.platform.name === 'macos') {
-            this._clickToLoadMessagingTransport = new ClickToLoadMessagingTransport()
+            this._clickToLoadMessagingTransport = new SendMessageMessagingTransport()
             const config = new TestTransportConfig(this._clickToLoadMessagingTransport)
             this._messaging = new Messaging(this.messagingContext, config)
             return this._messaging

--- a/src/features/fingerprinting-battery.js
+++ b/src/features/fingerprinting-battery.js
@@ -22,12 +22,22 @@ export default class FingerprintingBattery extends ContentFeature {
 
             for (const [prop, val] of Object.entries(spoofedValues)) {
                 try {
-                    defineProperty(BatteryManager.prototype, prop, { get: () => val })
+                    defineProperty(BatteryManager.prototype, prop, {
+                        get: () => {
+                            this.addDebugFlag()
+                            return val
+                        }
+                    })
                 } catch (e) { }
             }
             for (const eventProp of eventProperties) {
                 try {
-                    defineProperty(BatteryManager.prototype, eventProp, { get: () => null })
+                    defineProperty(BatteryManager.prototype, eventProp, {
+                        get: () => {
+                            this.addDebugFlag()
+                            return null
+                        }
+                    })
                 } catch (e) { }
             }
         }

--- a/src/features/fingerprinting-hardware.js
+++ b/src/features/fingerprinting-hardware.js
@@ -4,16 +4,25 @@ import { wrapProperty } from '../wrapper-utils'
 export default class FingerprintingHardware extends ContentFeature {
     init () {
         wrapProperty(globalThis.Navigator.prototype, 'keyboard', {
-            // @ts-expect-error - error TS2554: Expected 2 arguments, but got 1.
-            get: () => this.getFeatureAttr('keyboard')
+            get: () => {
+                this.addDebugFlag()
+                // @ts-expect-error - error TS2554: Expected 2 arguments, but got 1.
+                return this.getFeatureAttr('keyboard')
+            }
         })
 
         wrapProperty(globalThis.Navigator.prototype, 'hardwareConcurrency', {
-            get: () => this.getFeatureAttr('hardwareConcurrency', 2)
+            get: () => {
+                this.addDebugFlag()
+                return this.getFeatureAttr('hardwareConcurrency', 2)
+            }
         })
 
         wrapProperty(globalThis.Navigator.prototype, 'deviceMemory', {
-            get: () => this.getFeatureAttr('deviceMemory', 8)
+            get: () => {
+                this.addDebugFlag()
+                return this.getFeatureAttr('deviceMemory', 8)
+            }
         })
     }
 }

--- a/src/sendmessage-transport.js
+++ b/src/sendmessage-transport.js
@@ -1,4 +1,4 @@
-import { sendMessage } from './utils'
+import { sendMessage } from './utils.js'
 
 /**
  * Workaround defining MessagingTransport locally because "import()" is not working in `@implements`

--- a/src/sendmessage-transport.js
+++ b/src/sendmessage-transport.js
@@ -1,4 +1,4 @@
-import { sendMessage } from '../../utils'
+import { sendMessage } from './utils'
 
 /**
  * Workaround defining MessagingTransport locally because "import()" is not working in `@implements`
@@ -13,7 +13,7 @@ import { sendMessage } from '../../utils'
  * @deprecated - Use this only to communicate with Android and the Extension while support to {@link Messaging}
  * is not ready and we need to use `sendMessage()`.
  */
-export class ClickToLoadMessagingTransport {
+export class SendMessageMessagingTransport {
     /**
      * Queue of callbacks to be called with messages sent from the Platform.
      * This is used to connect requests with responses and to trigger subscriptions callbacks.

--- a/src/wrapper-utils.js
+++ b/src/wrapper-utils.js
@@ -31,31 +31,6 @@ export function defineProperty (object, propertyName, descriptor) {
 }
 
 /**
- * For each property defined on the object, update it with the target value.
- */
-export function overrideProperty (name, prop) {
-    // Don't update if existing value is undefined or null
-    if (!(prop.origValue === undefined)) {
-        /**
-         * When re-defining properties, we bind the overwritten functions to null. This prevents
-         * sites from using toString to see if the function has been overwritten
-         * without this bind call, a site could run something like
-         * `Object.getOwnPropertyDescriptor(Screen.prototype, "availTop").get.toString()` and see
-         * the contents of the function. Appending .bind(null) to the function definition will
-         * have the same toString call return the default [native code]
-         */
-        try {
-            defineProperty(prop.object, name, {
-                // eslint-disable-next-line no-extra-bind
-                get: (() => prop.targetValue).bind(null)
-            })
-        } catch (e) {
-        }
-    }
-    return prop.origValue
-}
-
-/**
  * add a fake toString() method to a wrapper function to resemble the original function
  * @param {*} newFn
  * @param {*} origFn

--- a/unit-test/content-feature.js
+++ b/unit-test/content-feature.js
@@ -54,14 +54,14 @@ describe('ContentFeature class', () => {
         class MyTestFeature extends ContentFeature {
             // eslint-disable-next-line
             // @ts-ignore partial mock
-            messaging = {
-                notify () {
-                    console.log('AAAAA', arguments)
+            debugMessaging = {
+                notify (name, data) {
+                    console.log('notify', name, data)
                 }
             }
         }
         const feature = new MyTestFeature('someFeatureName')
-        const spyNotify = spyOn(feature.messaging, 'notify')
+        const spyNotify = spyOn(feature.debugMessaging, 'notify')
         feature.addDebugFlag('someflag')
         expect(spyNotify).toHaveBeenCalledWith(
             'addDebugFlag',

--- a/unit-test/content-feature.js
+++ b/unit-test/content-feature.js
@@ -55,9 +55,8 @@ describe('ContentFeature class', () => {
             // eslint-disable-next-line
             // @ts-ignore partial mock
             debugMessaging = {
-                notify (name, data) {
-                    console.log('notify', name, data)
-                }
+                // eslint-disable-next-line
+                notify (name, data) {}
             }
         }
         let feature
@@ -83,6 +82,17 @@ describe('ContentFeature class', () => {
             const spyNotify = spyOn(feature.debugMessaging, 'notify')
             feature.addDebugFlag('someflag')
             expect(spyNotify).not.toHaveBeenCalled()
+        })
+
+        it('should send an empty suffix by default', () => {
+            const spyNotify = spyOn(feature.debugMessaging, 'notify')
+            feature.addDebugFlag()
+            expect(spyNotify).toHaveBeenCalledWith(
+                'addDebugFlag',
+                {
+                    flag: 'someFeatureName'
+                }
+            )
         })
     })
 })

--- a/unit-test/content-feature.js
+++ b/unit-test/content-feature.js
@@ -64,17 +64,6 @@ describe('ContentFeature class', () => {
             feature = new MyTestFeature('someFeatureName')
         })
 
-        it('should send a message to the background', () => {
-            const spyNotify = spyOn(feature.debugMessaging, 'notify')
-            feature.addDebugFlag('someflag')
-            expect(spyNotify).toHaveBeenCalledWith(
-                'addDebugFlag',
-                {
-                    flag: 'someFeatureName.someflag'
-                }
-            )
-        })
-
         it('should not send duplicate flags', () => {
             // send some flag
             feature.addDebugFlag('someflag')

--- a/unit-test/content-feature.js
+++ b/unit-test/content-feature.js
@@ -1,6 +1,6 @@
 import ContentFeature from '../src/content-feature.js'
 
-describe('Helpers checks', () => {
+describe('ContentFeature class', () => {
     it('Should trigger getFeatureSettingEnabled for the correct domain', () => {
         let didRun = false
         class MyTestFeature extends ContentFeature {
@@ -48,5 +48,26 @@ describe('Helpers checks', () => {
             }
         })
         expect(didRun).withContext('Should run').toBeTrue()
+    })
+
+    it('addDebugFlag should send a message to the background', () => {
+        class MyTestFeature extends ContentFeature {
+            // eslint-disable-next-line
+            // @ts-ignore partial mock
+            messaging = {
+                notify () {
+                    console.log('AAAAA', arguments)
+                }
+            }
+        }
+        const feature = new MyTestFeature('someFeatureName')
+        const spyNotify = spyOn(feature.messaging, 'notify')
+        feature.addDebugFlag('someflag')
+        expect(spyNotify).toHaveBeenCalledWith(
+            'addDebugFlag',
+            {
+                flag: 'someFeatureName.someflag'
+            }
+        )
     })
 })

--- a/unit-test/content-feature.js
+++ b/unit-test/content-feature.js
@@ -50,7 +50,7 @@ describe('ContentFeature class', () => {
         expect(didRun).withContext('Should run').toBeTrue()
     })
 
-    it('addDebugFlag should send a message to the background', () => {
+    describe('addDebugFlag', () => {
         class MyTestFeature extends ContentFeature {
             // eslint-disable-next-line
             // @ts-ignore partial mock
@@ -60,14 +60,29 @@ describe('ContentFeature class', () => {
                 }
             }
         }
-        const feature = new MyTestFeature('someFeatureName')
-        const spyNotify = spyOn(feature.debugMessaging, 'notify')
-        feature.addDebugFlag('someflag')
-        expect(spyNotify).toHaveBeenCalledWith(
-            'addDebugFlag',
-            {
-                flag: 'someFeatureName.someflag'
-            }
-        )
+        let feature
+        beforeEach(() => {
+            feature = new MyTestFeature('someFeatureName')
+        })
+
+        it('should send a message to the background', () => {
+            const spyNotify = spyOn(feature.debugMessaging, 'notify')
+            feature.addDebugFlag('someflag')
+            expect(spyNotify).toHaveBeenCalledWith(
+                'addDebugFlag',
+                {
+                    flag: 'someFeatureName.someflag'
+                }
+            )
+        })
+
+        it('should not send duplicate flags', () => {
+            // send some flag
+            feature.addDebugFlag('someflag')
+            // send it again
+            const spyNotify = spyOn(feature.debugMessaging, 'notify')
+            feature.addDebugFlag('someflag')
+            expect(spyNotify).not.toHaveBeenCalled()
+        })
     })
 })

--- a/unit-test/verify-artifacts.js
+++ b/unit-test/verify-artifacts.js
@@ -6,7 +6,7 @@ import { cwd } from '../scripts/script-utils.js'
 const ROOT = join(cwd(import.meta.url), '..')
 const BUILD = join(ROOT, 'build')
 const APPLE_BUILD = join(ROOT, 'Sources/ContentScopeScripts/dist')
-let CSS_OUTPUT_SIZE = 640_000
+let CSS_OUTPUT_SIZE = 700_000
 const CSS_OUTPUT_SIZE_CHROME = CSS_OUTPUT_SIZE * 1.45 // 45% larger for Chrome MV2 due to base64 encoding
 if (process.platform === 'win32') {
     CSS_OUTPUT_SIZE = CSS_OUTPUT_SIZE * 1.1 // 10% larger for Windows due to line endings


### PR DESCRIPTION
https://app.asana.com/0/0/1205073793816810/f

This PR adds an MVP infrastructure for breakage debug flags. Currently this is only passed in web extensions (see https://github.com/duckduckgo/duckduckgo-privacy-extension/pull/2138).
In this PR, flags are sent by `fingerprinting-battery` and `fingerprinting-hardware` features, more will come in the follow-up PR.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205073793816810