### PR TITLE
feat(webcompat): proxy webkit message handlers

### DIFF
--- a/integration-test/playwright/type-helpers.mjs
+++ b/integration-test/playwright/type-helpers.mjs
@@ -58,6 +58,7 @@ export class Build {
     get artifact () {
         const path = this.switch({
             windows: () => 'build/windows/contentScope.js',
+            'apple': () => './Sources/ContentScopeScripts/dist/contentScope.js',
             'apple-isolated': () => './Sources/ContentScopeScripts/dist/contentScopeIsolated.js'
         })
         return readFileSync(path, 'utf8')

--- a/integration-test/playwright/webcompat.spec.js
+++ b/integration-test/playwright/webcompat.spec.js
@@ -1,0 +1,113 @@
+import { test, expect } from '@playwright/test'
+import { readFileSync } from 'fs'
+import {
+    mockWebkitMessaging,
+    wrapWebkitScripts
+} from '@duckduckgo/messaging/lib/test-utils.mjs'
+import { perPlatform } from './type-helpers.mjs'
+
+test('web compat', async ({ page }, testInfo) => {
+    const webcompat = WebcompatSpec.create(page, testInfo)
+    await webcompat.enabled()
+    const results = await webcompat.collectResults()
+    expect(results).toMatchObject({
+        'webkit.messageHandlers - polyfill prevents throw': [{
+            name: 'Error not thrown polyfil',
+            result: true,
+            expected: true
+        }],
+        'webkit.messageHandlers - undefined should throw': [{
+            name: 'undefined handler should throw',
+            result: true,
+            expected: true
+        }],
+        'webkit.messageHandlers - reflected message': [{
+            name: 'reflected message should pass through',
+            result: 'test',
+            expected: 'test'
+        }]
+    })
+})
+
+export class WebcompatSpec {
+    htmlPage = '/webcompat/index.html'
+    config = './integration-test/test-pages/webcompat/config/message-handlers.json'
+
+    /**
+     * @param {import('@playwright/test').Page} page
+     * @param {import('./type-helpers.mjs').Build} build
+     * @param {import('./type-helpers.mjs').PlatformInfo} platform
+     */
+    constructor (page, build, platform) {
+        this.page = page
+        this.build = build
+        this.platform = platform
+        page.on('console', (msg) => {
+            console.log(msg.type(), msg.text())
+        })
+    }
+
+    async enabled () {
+        const config = JSON.parse(readFileSync(this.config, 'utf8'))
+        await this.setup({ config })
+        await this.page.goto(this.htmlPage)
+    }
+
+    collectResults () {
+        return this.page.evaluate(() => {
+            return new Promise(resolve => {
+                // @ts-expect-error - this is added by the test framework
+                if (window.results) return resolve(window.results)
+                window.addEventListener('results-ready', () => {
+                    // @ts-expect-error - this is added by the test framework
+                    resolve(window.results)
+                })
+            })
+        })
+    }
+
+    /**
+     * @param {object} params
+     * @param {Record<string, any>} params.config
+     * @return {Promise<void>}
+     */
+    async setup (params) {
+        const { config } = params
+
+        // read the built file from disk and do replacements
+        const injectedJS = wrapWebkitScripts(this.build.artifact, {
+            $CONTENT_SCOPE$: config,
+            $USER_UNPROTECTED_DOMAINS$: [],
+            $USER_PREFERENCES$: {
+                platform: { name: 'windows' },
+                debug: true
+            }
+        })
+
+        await this.page.addInitScript(mockWebkitMessaging, {
+            messagingContext: {
+                env: 'development',
+                context: 'contentScopeScripts',
+                featureName: 'n/a'
+            },
+            responses: {}
+        })
+
+        // attach the JS
+        await this.page.addInitScript(injectedJS)
+    }
+
+    /**
+     * Helper for creating an instance per platform
+     * @param {import('@playwright/test').Page} page
+     * @param {import('@playwright/test').TestInfo} testInfo
+     */
+    static create (page, testInfo) {
+        // Read the configuration object to determine which platform we're testing against
+        const {
+            platformInfo,
+            build
+        } = perPlatform(testInfo.project.use)
+        return new WebcompatSpec(page, build, platformInfo)
+    }
+}

--- a/integration-test/test-pages/webcompat/config/message-handlers.json
+++ b/integration-test/test-pages/webcompat/config/message-handlers.json
@@ -1,0 +1,34 @@
+{
+  "unprotectedTemporary": [],
+  "features": {
+    "webCompat": {
+      "exceptions": [],
+      "state": "enabled",
+      "settings": {
+        "windowSizing": "enabled",
+        "navigatorCredentials": "enabled",
+        "safariObject": "enabled",
+        "messageHandlers": {
+          "state": "disabled",
+          "handlerStrategies": {
+            "reflect": ["trackerDetectedMessage", "printHandler", "specialPages"],
+            "polyfill": ["*"],
+            "undefined": ["jsHandler"]
+          }
+        },
+        "domains": [
+          {
+            "domain": "localhost",
+            "patchSettings": [
+              {
+                "op": "replace",
+                "path": "/messageHandlers/state",
+                "value": "enabled"
+              }
+            ]
+          }
+        ]
+      }
+    }
+  }
+}

--- a/integration-test/test-pages/webcompat/index.html
+++ b/integration-test/test-pages/webcompat/index.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width">
+    <title>Webcompat</title>
+    <link rel="stylesheet" href="../shared/style.css">
+</head>
+<body>
+<script src="../shared/utils.js"></script>
+
+<p>Webcompat, Message Handlers</p>
+<script>
+    test('webkit.messageHandlers - polyfill prevents throw', async () => {
+        let notThrown = true;
+        try {
+            window.webkit.messageHandlers.anythingatall.postMessage({})
+        } catch (e) {
+            notThrown = false
+        }
+        return [
+            { name: 'Error not thrown polyfil', result: notThrown, expected: true },
+        ]
+    })
+    test('webkit.messageHandlers - undefined should throw', async () => {
+        let thrown = false;
+        try {
+            window.webkit.messageHandlers.jsHandler.postMessage({})
+        } catch (e) {
+            thrown = true
+        }
+        return [
+            { name: 'undefined handler should throw', result: thrown, expected: true },
+        ]
+    })
+    test('webkit.messageHandlers - reflected message', async () => {
+        window.webkit.messageHandlers.printHandler = {
+            postMessage() {
+                return { test: "test" }
+            }
+        }
+
+        const value = window.webkit.messageHandlers.printHandler.postMessage({});
+
+        return [
+            { name: 'reflected message should pass through', result: value.test, expected: 'test' },
+        ]
+    })
+    renderResults();
+
+    async function captureError(fn) {
+        try {
+            // ensure Promise.reject is captured
+            return fn().catch(e => e)
+        } catch (e) {
+            return e
+        }
+    }
+
+</script>
+</body>
+</html>

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -26,6 +26,13 @@ export default defineConfig({
             use: { injectName: 'apple-isolated', platform: 'macos' }
         },
         {
+            name: 'apple',
+            testMatch: [
+                'integration-test/playwright/webcompat.spec.js'
+            ],
+            use: { injectName: 'apple', platform: 'macos' }
+        },
+        {
             name: 'chrome',
             testMatch: 'integration-test/playwright/remote-pages.spec.js',
             use: { injectName: 'chrome', platform: 'extension', ...devices['Desktop Chrome'] }


### PR DESCRIPTION
@jonathanKingston the idea here would be:

- 1) allow a list of known handlers to us ~(we could pass it via config later)~ using remote config
- 2) allow certain handlers to return 'undefined'
- 3) allow other handlers to return a polyfilled `.postMessage`

This will fix a known breakage, but is less-than-ideal in the longer term.

Privacy config PR: https://github.com/duckduckgo/privacy-configuration/pull/1155

Known problems:

- what if a site expects a particular result from postMessage?
- the presence of window.webkit itself is the larger issue

