### PR TITLE
Fix regex in test duckplayer-overlays.js

### DIFF
--- a/integration-test/playwright/page-objects/duckplayer-overlays.js
+++ b/integration-test/playwright/page-objects/duckplayer-overlays.js
@@ -65,7 +65,7 @@ export class DuckplayerOverlays {
     }
 
     async showsShortsPage () {
-        await this.page.waitForURL(/^https:\/\/www.youtube.com\/shorts/, { timeout: 5000 })
+        await this.page.waitForURL(/^https:\/\/www\.youtube\.com\/shorts/, { timeout: 5000 })
     }
 
     /**


### PR DESCRIPTION
Prevents warning about overly matching regexp.