### PR TITLE
Android webcompat fix

### DIFF
--- a/integration-test/helpers/harness.js
+++ b/integration-test/helpers/harness.js
@@ -113,7 +113,7 @@ export async function setup (ops = {}) {
      * @param {Record<string, any>} [args]
      * @returns {Promise<void>}
      */
-    async function gotoAndWait (page, urlString, args = {}) {
+    async function gotoAndWait (page, urlString, args = {}, evalBeforeInit = null) {
         const url = new URL(urlString)
 
         // Append the flag so that the script knows to wait for incoming args.
@@ -126,6 +126,10 @@ export async function setup (ops = {}) {
             // @ts-expect-error https://app.asana.com/0/1201614831475344/1203979574128023/f
             return window.__content_scope_status === 'loaded'
         })
+
+        if (evalBeforeInit) {
+            await page.evaluate(evalBeforeInit)
+        }
 
         const evalString = `
             const detail = ${JSON.stringify(args)}

--- a/integration-test/test-web-compat.js
+++ b/integration-test/test-web-compat.js
@@ -152,6 +152,17 @@ describe('Ensure Notification and Permissions interface is injected', () => {
         function checkForPermissions () {
             return !!window.navigator.permissions
         }
+        function checkObjectDescriptorIsNotPresent () {
+            const descriptor = Object.getOwnPropertyDescriptor(window.navigator, 'permissions')
+            return descriptor === undefined
+        }
+
+        await gotoAndWait(page, `http://localhost:${port}/blank.html`, { site: { enabledFeatures: [] } })
+        const initialPermissions = await page.evaluate(checkForPermissions)
+        // Base implementation of the test env should have it.
+        expect(initialPermissions).toEqual(true)
+        const initialDescriptorSerialization = await page.evaluate(checkObjectDescriptorIsNotPresent)
+        expect(initialDescriptorSerialization).toEqual(true)
 
         await gotoAndWait(page, `http://localhost:${port}/blank.html`, { site: { enabledFeatures: [] } }, removePermissionsScript)
         const noPermissions = await page.evaluate(checkForPermissions)
@@ -178,5 +189,9 @@ describe('Ensure Notification and Permissions interface is injected', () => {
         }, removePermissionsScript)
         const hasPermissions = await page.evaluate(checkForPermissions)
         expect(hasPermissions).toEqual(true)
+
+        const modifiedDescriptorSerialization = await page.evaluate(checkObjectDescriptorIsNotPresent)
+        // This fails in a test condition purely because we have to add a descriptor to modify the prop
+        expect(modifiedDescriptorSerialization).toEqual(false)
     })
 })

--- a/src/features/web-compat.js
+++ b/src/features/web-compat.js
@@ -51,8 +51,12 @@ export default class WebCompat extends ContentFeature {
         Notification.maxActions = 2
 
         // Expose the API
-        // @ts-expect-error window.Notification isn't assignable
-        window.Notification = Notification
+        this.defineProperty(window, 'Notification', {
+            value: Notification,
+            writable: true,
+            configurable: true,
+            enumerable: false
+        })
     }
 
     /**

--- a/src/features/web-compat.js
+++ b/src/features/web-compat.js
@@ -11,67 +11,6 @@ function windowSizingFix () {
     window.outerWidth = window.innerWidth
 }
 
-/**
- * Notification fix for adding missing API for Android WebView.
- */
-function notificationFix () {
-    if (window.Notification) {
-        return
-    }
-    const Notification = () => {
-        // noop
-    }
-    Notification.requestPermission = () => {
-        return Promise.resolve({ permission: 'denied' })
-    }
-    Notification.permission = 'denied'
-    Notification.maxActions = 2
-
-    // Expose the API
-    // @ts-expect-error window.Notification isn't assignable
-    window.Notification = Notification
-}
-
-/**
- * Adds missing permissions API for Android WebView.
- */
-function permissionsFix (settings) {
-    if (window.navigator.permissions) {
-        return
-    }
-    // @ts-expect-error window.navigator isn't assignable
-    window.navigator.permissions = {}
-    class PermissionStatus extends EventTarget {
-        constructor (name, state) {
-            super()
-            this.name = name
-            this.state = state
-            this.onchange = null // noop
-        }
-    }
-    // Default subset based upon Firefox (the full list is pretty large right now and these are the common ones)
-    const defaultValidPermissionNames = [
-        'geolocation',
-        'notifications',
-        'push',
-        'persistent-storage',
-        'midi'
-    ]
-    const validPermissionNames = settings.validPermissionNames || defaultValidPermissionNames
-    window.navigator.permissions.query = (query) => {
-        if (!query) {
-            throw new TypeError("Failed to execute 'query' on 'Permissions': 1 argument required, but only 0 present.")
-        }
-        if (!query.name) {
-            throw new TypeError("Failed to execute 'query' on 'Permissions': Failed to read the 'name' property from 'PermissionDescriptor': Required member is undefined.")
-        }
-        if (!validPermissionNames.includes(query.name)) {
-            throw new TypeError("Failed to execute 'query' on 'Permissions': Failed to read the 'name' property from 'PermissionDescriptor': The provided value 's' is not a valid enum value of type PermissionName.")
-        }
-        return Promise.resolve(new PermissionStatus(query.name, 'denied'))
-    }
-}
-
 export default class WebCompat extends ContentFeature {
     init () {
         if (this.getFeatureSettingEnabled('windowSizing')) {
@@ -87,11 +26,72 @@ export default class WebCompat extends ContentFeature {
             this.messageHandlersFix()
         }
         if (this.getFeatureSettingEnabled('notification')) {
-            notificationFix()
+            this.notificationFix()
         }
         if (this.getFeatureSettingEnabled('permissions')) {
             const settings = this.getFeatureSettingEnabled('permissions')
-            permissionsFix(settings)
+            this.permissionsFix(settings)
+        }
+    }
+
+    /**
+     * Notification fix for adding missing API for Android WebView.
+     */
+    notificationFix () {
+        if (window.Notification) {
+            return
+        }
+        const Notification = () => {
+            // noop
+        }
+        Notification.requestPermission = () => {
+            return Promise.resolve({ permission: 'denied' })
+        }
+        Notification.permission = 'denied'
+        Notification.maxActions = 2
+
+        // Expose the API
+        // @ts-expect-error window.Notification isn't assignable
+        window.Notification = Notification
+    }
+
+    /**
+     * Adds missing permissions API for Android WebView.
+     */
+    permissionsFix (settings) {
+        if (window.navigator.permissions) {
+            return
+        }
+        // @ts-expect-error window.navigator isn't assignable
+        window.navigator.permissions = {}
+        class PermissionStatus extends EventTarget {
+            constructor (name, state) {
+                super()
+                this.name = name
+                this.state = state
+                this.onchange = null // noop
+            }
+        }
+        // Default subset based upon Firefox (the full list is pretty large right now and these are the common ones)
+        const defaultValidPermissionNames = [
+            'geolocation',
+            'notifications',
+            'push',
+            'persistent-storage',
+            'midi'
+        ]
+        const validPermissionNames = settings.validPermissionNames || defaultValidPermissionNames
+        window.navigator.permissions.query = (query) => {
+            if (!query) {
+                throw new TypeError("Failed to execute 'query' on 'Permissions': 1 argument required, but only 0 present.")
+            }
+            if (!query.name) {
+                throw new TypeError("Failed to execute 'query' on 'Permissions': Failed to read the 'name' property from 'PermissionDescriptor': Required member is undefined.")
+            }
+            if (!validPermissionNames.includes(query.name)) {
+                throw new TypeError("Failed to execute 'query' on 'Permissions': Failed to read the 'name' property from 'PermissionDescriptor': The provided value 's' is not a valid enum value of type PermissionName.")
+            }
+            return Promise.resolve(new PermissionStatus(query.name, 'denied'))
         }
     }
 

--- a/src/features/web-compat.js
+++ b/src/features/web-compat.js
@@ -1,4 +1,4 @@
-import ContentFeature from '../content-feature'
+import ContentFeature from '../content-feature.js'
 
 /**
  * Fixes incorrect sizing value for outerHeight and outerWidth
@@ -66,8 +66,7 @@ export default class WebCompat extends ContentFeature {
         if (window.navigator.permissions) {
             return
         }
-        // @ts-expect-error window.navigator isn't assignable
-        window.navigator.permissions = {}
+        const permissions = {}
         class PermissionStatus extends EventTarget {
             constructor (name, state) {
                 super()
@@ -85,7 +84,8 @@ export default class WebCompat extends ContentFeature {
             'midi'
         ]
         const validPermissionNames = settings.validPermissionNames || defaultValidPermissionNames
-        window.navigator.permissions.query = (query) => {
+        permissions.query = (query) => {
+            this.addDebugFlag()
             if (!query) {
                 throw new TypeError("Failed to execute 'query' on 'Permissions': 1 argument required, but only 0 present.")
             }
@@ -97,6 +97,9 @@ export default class WebCompat extends ContentFeature {
             }
             return Promise.resolve(new PermissionStatus(query.name, 'denied'))
         }
+        // Expose the API
+        // @ts-expect-error window.navigator isn't assignable
+        window.navigator.permissions = permissions
     }
 
     /**

--- a/src/features/web-compat.js
+++ b/src/features/web-compat.js
@@ -86,6 +86,13 @@ export default class WebCompat extends ContentFeature {
         if (this.getFeatureSettingEnabled('messageHandlers')) {
             this.messageHandlersFix()
         }
+        if (this.getFeatureSettingEnabled('notification')) {
+            notificationFix()
+        }
+        if (this.getFeatureSettingEnabled('permissions')) {
+            const settings = this.getFeatureSettingEnabled('permissions')
+            permissionsFix(settings)
+        }
     }
 
     /**
@@ -166,13 +173,6 @@ export default class WebCompat extends ContentFeature {
             })
         } catch {
             // Ignore exceptions that could be caused by conflicting with other extensions
-        }
-        if (this.getFeatureSettingEnabled('notification')) {
-            notificationFix()
-        }
-        if (this.getFeatureSettingEnabled('permissions')) {
-            const settings = this.getFeatureSettingEnabled('permissions')
-            permissionsFix(settings)
         }
     }
 


### PR DESCRIPTION
This code was dropped in https://github.com/duckduckgo/content-scope-scripts/commit/f644105b9aaf6f2f0e9dd1c38c85d27ea2c9a06a through a merge issue.

This change adds a test to verify the shape along with changing to use `defineProperty` for `window.Notification`. As we're shimming raw values this isn't possible for the permissions API.

Note locally I'm having cached config issues from Android, I don't know the cause so needs someone else to verify there's not another issue here. (I was getting only GPC enabled setup)

See: https://app.asana.com/0/0/1205196878614274/f