### PR TITLE
Do not extract cookie stack origins on get.

### DIFF
--- a/src/features/cookie.js
+++ b/src/features/cookie.js
@@ -141,10 +141,9 @@ export default class CookieFeature extends ContentFeature {
 
         function getCookiePolicy () {
             const stack = getStack()
-            const scriptOrigins = getStackTraceOrigins(stack)
             const getCookieContext = {
                 stack,
-                scriptOrigins,
+                scriptOrigins: [],
                 value: 'getter'
             }
 


### PR DESCRIPTION
This mitigates an issue where the `getStackTraceOrigin` method triggers breakage on www.americanexpress.com.

https://app.asana.com/0/892838074342800/1205340475534185/f