### PR TITLE
Sanitize input to cookie setter

### DIFF
--- a/inject/integration.js
+++ b/inject/integration.js
@@ -30,7 +30,8 @@ function generateConfig () {
             enabledFeatures: [
                 'fingerprintingCanvas',
                 'fingerprintingScreenSize',
-                'navigatorInterface'
+                'navigatorInterface',
+                'cookie'
             ]
         },
         trackerLookup

--- a/integration-test/test-cookie.js
+++ b/integration-test/test-cookie.js
@@ -1,0 +1,55 @@
+import { setup } from './helpers/harness.js'
+
+describe('Cookie protection tests', () => {
+    let browser
+    let teardown
+    let setupServer
+
+    beforeAll(async () => {
+        ({ browser, teardown, setupServer } = await setup())
+        setupServer('8080')
+    })
+    afterAll(async () => {
+        await teardown()
+    })
+
+    it('should restrict the expiry of first-party cookies', async () => {
+        const page = await browser.newPage()
+        await page.goto('http://localhost:8080/index.html')
+
+        const result = await page.evaluate(async () => {
+            document.cookie = 'test=1; expires=Wed, 21 Aug 2040 20:00:00 UTC;'
+            // wait for a tick, as cookie modification happens in a promise
+            await new Promise((resolve) => setTimeout(resolve, 1))
+            // @ts-expect-error - cookieStore API types are missing here
+            // eslint-disable-next-line no-undef
+            return cookieStore.get('test')
+        })
+        expect(result.name).toEqual('test')
+        expect(result.value).toEqual('1')
+        expect(result.expires).toBeLessThan(Date.now() + 605_000_000)
+    })
+
+    it('non-string cookie values do not bypass protection', async () => {
+        const page = await browser.newPage()
+        await page.goto('http://localhost:8080/index.html')
+
+        const result = await page.evaluate(async () => {
+            // @ts-expect-error - Invalid argument to document.cookie on purpose for test
+            document.cookie = {
+                toString () {
+                    const expires = (new Date(+new Date() + 86400 * 1000 * 100)).toUTCString()
+                    return 'a=b; expires=' + expires
+                }
+            }
+            // wait for a tick, as cookie modification happens in a promise
+            await new Promise((resolve) => setTimeout(resolve, 1))
+            // @ts-expect-error - cookieStore API types are missing here
+            // eslint-disable-next-line no-undef
+            return cookieStore.get('a')
+        })
+        expect(result.name).toEqual('a')
+        expect(result.value).toEqual('b')
+        expect(result.expires).toBeLessThan(Date.now() + 605_000_000)
+    })
+})

--- a/src/features/cookie.js
+++ b/src/features/cookie.js
@@ -186,7 +186,7 @@ export default class CookieFeature extends ContentFeature {
             // if the value is valid. We will override this set later if the policy dictates that
             // the expiry should be changed.
             // @ts-expect-error - error TS18048: 'cookieSetter' is possibly 'undefined'.
-            cookieSetter.call(document, value)
+            cookieSetter.call(document, argValue)
 
             try {
                 // wait for config before doing same-site tests
@@ -249,7 +249,12 @@ export default class CookieFeature extends ContentFeature {
                 ...restOfPolicy
             }
         } else {
-            cookiePolicy = Object.assign(cookiePolicy, restOfPolicy)
+            // copy non-null entries from restOfPolicy to cookiePolicy
+            Object.keys(restOfPolicy).forEach(key => {
+                if (restOfPolicy[key]) {
+                    cookiePolicy[key] = restOfPolicy[key]
+                }
+            })
         }
 
         loadedPolicyResolve()

--- a/src/features/cookie.js
+++ b/src/features/cookie.js
@@ -158,8 +158,16 @@ export default class CookieFeature extends ContentFeature {
             return cookieGetter.call(document)
         }
 
-        function setCookiePolicy (value) {
+        /**
+         * @param {any} argValue
+         */
+        function setCookiePolicy (argValue) {
             let setCookieContext = null
+            if (!argValue.toString || typeof argValue.toString() !== 'string') {
+                // not a string, or string-like
+                return
+            }
+            const value = argValue.toString()
             if (cookiePolicy.debug) {
                 const stack = getStack()
                 setCookieContext = {


### PR DESCRIPTION
This fixes an issue where passing an object to `document.cookie` could bypass our protections.

While setting up tests, I also found a bug with one of the policy merging code paths, where we were overwriting the cookie policy with `undefined` when the feature setting is missing.