### PR TITLE
Android messaging

### DIFF
--- a/inject/android.js
+++ b/inject/android.js
@@ -37,6 +37,10 @@ function initCode () {
     // Sends messages to the platform
     const messageInterface = processedConfig.messageInterface
 
+    /**
+     * New features on Android should use the shared {@link Messaging} library
+     * See: `packages/messaging/lib/examples/android.example.js`
+     */
     const wrappedUpdate = ((providedSecret, ...args) => {
         if (providedSecret === messageSecret) {
             update(...args)

--- a/packages/messaging/index.js
+++ b/packages/messaging/index.js
@@ -17,12 +17,15 @@
  *
  * - Windows: {@link WindowsMessagingConfig}
  * - Webkit: {@link WebkitMessagingConfig}
+ * - Android: {@link AndroidMessagingConfig}
  * - Schema: {@link "Messaging Schema"}
+ * - Implementation Guide: {@link "Messaging Implementation Guide"}
  *
  */
 import { WindowsMessagingConfig, WindowsMessagingTransport, WindowsInteropMethods, WindowsNotification, WindowsRequestMessage } from './lib/windows.js'
 import { WebkitMessagingConfig, WebkitMessagingTransport } from './lib/webkit.js'
 import { NotificationMessage, RequestMessage, Subscription, MessageResponse, MessageError, SubscriptionEvent } from './schema.js'
+import { AndroidMessagingConfig, AndroidMessagingTransport } from './lib/android.js'
 
 /**
  * Common options/config that are *not* transport specific.
@@ -48,7 +51,7 @@ export class MessagingContext {
 export class Messaging {
     /**
      * @param {MessagingContext} messagingContext
-     * @param {WebkitMessagingConfig | WindowsMessagingConfig | TestTransportConfig} config
+     * @param {WebkitMessagingConfig | WindowsMessagingConfig | AndroidMessagingConfig | TestTransportConfig} config
      */
     constructor (messagingContext, config) {
         this.messagingContext = messagingContext
@@ -198,7 +201,7 @@ export class TestTransport {
 }
 
 /**
- * @param {WebkitMessagingConfig | WindowsMessagingConfig | TestTransportConfig} config
+ * @param {WebkitMessagingConfig | WindowsMessagingConfig | AndroidMessagingConfig | TestTransportConfig} config
  * @param {MessagingContext} messagingContext
  * @returns {MessagingTransport}
  */
@@ -208,6 +211,9 @@ function getTransport (config, messagingContext) {
     }
     if (config instanceof WindowsMessagingConfig) {
         return new WindowsMessagingTransport(config, messagingContext)
+    }
+    if (config instanceof AndroidMessagingConfig) {
+        return new AndroidMessagingTransport(config, messagingContext)
     }
     if (config instanceof TestTransportConfig) {
         return new TestTransport(config, messagingContext)
@@ -245,5 +251,7 @@ export {
     MessageError,
     SubscriptionEvent,
     WindowsNotification,
-    WindowsRequestMessage
+    WindowsRequestMessage,
+    AndroidMessagingConfig,
+    AndroidMessagingTransport
 }

--- a/packages/messaging/lib/android.js
+++ b/packages/messaging/lib/android.js
@@ -201,12 +201,12 @@ export class AndroidMessagingConfig {
         /**
          * Capture the global handler and remove it from the global object.
          */
-        this.#captureGlobalHandler()
+        this._captureGlobalHandler()
 
         /**
          * Assign the incoming handler method to the global object.
          */
-        this.#assignHandlerMethod()
+        this._assignHandlerMethod()
     }
 
     /**
@@ -252,26 +252,26 @@ export class AndroidMessagingConfig {
      * @param {MessageResponse | SubscriptionEvent} payload
      * @internal
      */
-    #dispatch(payload) {
+    _dispatch (payload) {
         // do nothing if the response is empty
         // this prevents the next `in` checks from throwing in test/debug scenarios
-        if (!payload) return this.#log('no response')
+        if (!payload) return this._log('no response')
 
         // if the payload has an 'id' field, then it's a message response
         if ('id' in payload) {
             if (this.listeners.has(payload.id)) {
-                this.#tryCatch(() => this.listeners.get(payload.id)?.(payload))
+                this._tryCatch(() => this.listeners.get(payload.id)?.(payload))
             } else {
-                this.#log('no listeners for ', payload)
+                this._log('no listeners for ', payload)
             }
         }
 
         // if the payload has an 'subscriptionName' field, then it's a push event
         if ('subscriptionName' in payload) {
             if (this.listeners.has(payload.subscriptionName)) {
-                this.#tryCatch(() => this.listeners.get(payload.subscriptionName)?.(payload))
+                this._tryCatch(() => this.listeners.get(payload.subscriptionName)?.(payload))
             } else {
-                this.#log('no subscription listeners for ', payload)
+                this._log('no subscription listeners for ', payload)
             }
         }
     }
@@ -281,7 +281,7 @@ export class AndroidMessagingConfig {
      * @param {(...args: any[]) => any} fn
      * @param {string} [context]
      */
-    #tryCatch(fn, context = 'none') {
+    _tryCatch (fn, context = 'none') {
         try {
             return fn()
         } catch (e) {
@@ -295,16 +295,16 @@ export class AndroidMessagingConfig {
     /**
      * @param {...any} args
      */
-    #log(...args) {
+    _log (...args) {
         if (this.debug) {
-            console.log('AndroidMessagingConfig', ...args);
+            console.log('AndroidMessagingConfig', ...args)
         }
     }
 
     /**
      * Capture the global handler and remove it from the global object.
      */
-    #captureGlobalHandler() {
+    _captureGlobalHandler () {
         const { target, javascriptInterface } = this
 
         if (Object.prototype.hasOwnProperty.call(target, javascriptInterface)) {
@@ -312,7 +312,7 @@ export class AndroidMessagingConfig {
             delete target[javascriptInterface]
         } else {
             this.#capturedHandler = () => {
-                this.#log('Android messaging interface not available', javascriptInterface)
+                this._log('Android messaging interface not available', javascriptInterface)
             }
         }
     }
@@ -321,13 +321,13 @@ export class AndroidMessagingConfig {
      * Assign the incoming handler method to the global object.
      * This is the method that Android will call to deliver messages.
      */
-    #assignHandlerMethod() {
+    _assignHandlerMethod () {
         /**
          * @type {(secret: string, response: MessageResponse | SubscriptionEvent) => void}
          */
         const responseHandler = (providedSecret, response) => {
             if (providedSecret === this.secret) {
-                this.#dispatch(response)
+                this._dispatch(response)
             }
         }
 

--- a/packages/messaging/lib/android.js
+++ b/packages/messaging/lib/android.js
@@ -1,0 +1,338 @@
+/**
+ * @description
+ *
+ * A wrapper for messaging on Android.
+ *
+ * You must share a {@link AndroidMessagingConfig} instance between features
+ *
+ * @example
+ *
+ * ```javascript
+ * [[include:packages/messaging/lib/examples/windows.example.js]]```
+ *
+ */
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+import { MessagingTransport, MessageResponse, SubscriptionEvent } from '../index.js'
+import { isResponseFor, isSubscriptionEventFor } from '../schema.js'
+
+/**
+ * An implementation of {@link MessagingTransport} for Android
+ *
+ * All messages go through `window.chrome.webview` APIs
+ *
+ * @implements {MessagingTransport}
+ */
+export class AndroidMessagingTransport {
+    /**
+     * @param {AndroidMessagingConfig} config
+     * @param {import('../index.js').MessagingContext} messagingContext
+     * @internal
+     */
+    constructor (config, messagingContext) {
+        this.messagingContext = messagingContext
+        this.config = config
+    }
+
+    /**
+     * @param {import('../index.js').NotificationMessage} msg
+     */
+    notify (msg) {
+        try {
+            this.config.sendMessageThrows?.(JSON.stringify(msg))
+        } catch (e) {
+            console.error('.notify failed', e)
+        }
+    }
+
+    /**
+     * @param {import('../index.js').RequestMessage} msg
+     * @return {Promise<any>}
+     */
+    request (msg) {
+        return new Promise((resolve, reject) => {
+            // subscribe early
+            const unsub = this.config.subscribe(msg.id, handler)
+
+            try {
+                this.config.sendMessageThrows?.(JSON.stringify(msg))
+            } catch (e) {
+                unsub()
+                reject(new Error('request failed to send: ' + e.message || 'unknown error'))
+            }
+
+            function handler (data) {
+                if (isResponseFor(msg, data)) {
+                    // success case, forward .result only
+                    if (data.result) {
+                        resolve(data.result || {})
+                        return unsub()
+                    }
+
+                    // error case, forward the error as a regular promise rejection
+                    if (data.error) {
+                        reject(new Error(data.error.message))
+                        return unsub()
+                    }
+
+                    // getting here is undefined behavior
+                    unsub()
+                    throw new Error('unreachable: must have `result` or `error` key by this point')
+                }
+            }
+        })
+    }
+
+    /**
+     * @param {import('../index.js').Subscription} msg
+     * @param {(value: unknown | undefined) => void} callback
+     */
+    subscribe (msg, callback) {
+        const unsub = this.config.subscribe(msg.subscriptionName, (data) => {
+            if (isSubscriptionEventFor(msg, data)) {
+                callback(data.params || {})
+            }
+        })
+        return () => {
+            unsub()
+        }
+    }
+}
+
+/**
+ * Android shared messaging configuration. This class should be constructed once and then shared
+ * between features (because of the way it modifies globals).
+ *
+ * For example, if Android is injecting a JavaScript module like C-S-S which contains multiple 'sub-features', then
+ * this class would be instantiated once and then shared between all sub-features.
+ *
+ * The following example shows all the fields that are required to be passed in:
+ *
+ * ```js
+ * const config = new AndroidMessagingConfig({
+ *     // a value that native has injected into the script
+ *     secret: 'abc',
+ *
+ *     // the name of the window method that android will deliver responses through
+ *     messageCallback: 'callback_123',
+ *
+ *     // the `@JavascriptInterface` name from native that will be used to receive messages
+ *     javascriptInterface: "ContentScopeScripts",
+ *
+ *     // the global object where methods will be registered
+ *     target: globalThis
+ * });
+ * ```
+ * Once an instance of {@link AndroidMessagingConfig} is created, you can then use it to construct
+ * many instances of {@link Messaging} (one per feature). See `examples/android.example.js` for an example.
+ *
+ *
+ * ## Native integration
+ *
+ * Assuming you have the following:
+ *  - a `@JavascriptInterface` named `"ContentScopeScripts"`
+ *  - a sub-feature called `"featureA"`
+ *  - and a method on `"featureA"` called `"helloWorld"`
+ *
+ * Then delivering a {@link NotificationMessage} to it, would be roughly this in JavaScript (remember `params` is optional though)
+ *
+ * ```
+ * const secret = "abc";
+ * const json = JSON.stringify({
+ *     context: "ContentScopeScripts",
+ *     featureName: "featureA",
+ *     method: "helloWorld",
+ *     params: { "foo": "bar" }
+ * });
+ * window.ContentScopeScripts.process(json, secret)
+ * ```
+ * When you receive the JSON payload (note that it will be a string), you'll need to deserialize/verify it according to {@link "Messaging Implementation Guide"}
+ *
+ *
+ * ## Responding to a {@link RequestMessage}, or pushing a {@link SubscriptionEvent}
+ *
+ * If you receive a {@link RequestMessage}, you'll need to deliver a {@link MessageResponse}.
+ * Similarly, if you want to push new data, you need to deliver a {@link SubscriptionEvent}. In both
+ * cases you'll do this through a global `window` method. Given the snippet below, this is how it would relate
+ * to the {@link AndroidMessagingConfig}:
+ *
+ * - `$messageCallback` matches {@link AndroidMessagingConfig.messageCallback}
+ * - `$secret` matches {@link AndroidMessagingConfig.secret}
+ * - `$message` is JSON string that represents one of {@link MessageResponse} or {@link SubscriptionEvent}
+ *
+ * ```kotlin
+ * object ReplyHandler {
+ *     fun constructReply(message: String, messageCallback: String, messageSecret: String): String {
+ *         return """
+ *             (function() {
+ *                 window['$messageCallback']('$secret', $message);
+ *             })();
+ *         """.trimIndent()
+ *     }
+ * }
+ * ```
+ */
+export class AndroidMessagingConfig {
+    /** @type {(json: string, secret: string) => void} */
+    #capturedHandler
+    /**
+     * @param {object} params
+     * @param {Record<string, any>} params.target
+     * @param {boolean} params.debug
+     * @param {string} params.secret - a secret to ensure that messages are only
+     * processed by the correct handler
+     * @param {string} params.javascriptInterface - the name of the javascript interface
+     * registered on the native side
+     * @param {string} params.messageCallback - the name of the callback that the native
+     * side will use to send messages back to the javascript side
+     */
+    constructor (params) {
+        this.target = params.target
+        this.debug = params.debug
+        this.javascriptInterface = params.javascriptInterface
+        this.secret = params.secret
+        this.messageCallback = params.messageCallback
+
+        /**
+         * @type {Map<string, (msg: MessageResponse | SubscriptionEvent) => void>}
+         * @internal
+         */
+        this.listeners = new globalThis.Map()
+
+        /**
+         * Capture the global handler and remove it from the global object.
+         */
+        this.#captureGlobalHandler()
+
+        /**
+         * Assign the incoming handler method to the global object.
+         */
+        this.#assignHandlerMethod()
+    }
+
+    /**
+     * The transport can call this to transmit a JSON payload along with a secret
+     * to the native Android handler.
+     *
+     * Note: This can throw - it's up to the transport to handle the error.
+     *
+     * @type {(json: string) => void}
+     * @throws
+     * @internal
+     */
+    sendMessageThrows (json) {
+        this.#capturedHandler(json, this.secret)
+    }
+
+    /**
+     * A subscription on Android is just a named listener. All messages from
+     * android -> are delivered through a single function, and this mapping is used
+     * to route the messages to the correct listener.
+     *
+     * Note: Use this to implement request->response by unsubscribing after the first
+     * response.
+     *
+     * @param {string} id
+     * @param {(msg: MessageResponse | SubscriptionEvent) => void} callback
+     * @returns {() => void}
+     * @internal
+     */
+    subscribe (id, callback) {
+        this.listeners.set(id, callback)
+        return () => {
+            this.listeners.delete(id)
+        }
+    }
+
+    /**
+     * Accept incoming messages and try to deliver it to a registered listener.
+     *
+     * This code is defensive to prevent any single handler from affecting another if
+     * it throws (producer interference).
+     *
+     * @param {MessageResponse | SubscriptionEvent} payload
+     * @internal
+     */
+    #dispatch(payload) {
+        // do nothing if the response is empty
+        // this prevents the next `in` checks from throwing in test/debug scenarios
+        if (!payload) return this.#log('no response')
+
+        // if the payload has an 'id' field, then it's a message response
+        if ('id' in payload) {
+            if (this.listeners.has(payload.id)) {
+                this.#tryCatch(() => this.listeners.get(payload.id)?.(payload))
+            } else {
+                this.#log('no listeners for ', payload)
+            }
+        }
+
+        // if the payload has an 'subscriptionName' field, then it's a push event
+        if ('subscriptionName' in payload) {
+            if (this.listeners.has(payload.subscriptionName)) {
+                this.#tryCatch(() => this.listeners.get(payload.subscriptionName)?.(payload))
+            } else {
+                this.#log('no subscription listeners for ', payload)
+            }
+        }
+    }
+
+    /**
+     *
+     * @param {(...args: any[]) => any} fn
+     * @param {string} [context]
+     */
+    #tryCatch(fn, context = 'none') {
+        try {
+            return fn()
+        } catch (e) {
+            if (this.debug) {
+                console.error('AndroidMessagingConfig error:', context)
+                console.error(e)
+            }
+        }
+    }
+
+    /**
+     * @param {...any} args
+     */
+    #log(...args) {
+        if (this.debug) {
+            console.log('AndroidMessagingConfig', ...args);
+        }
+    }
+
+    /**
+     * Capture the global handler and remove it from the global object.
+     */
+    #captureGlobalHandler() {
+        const { target, javascriptInterface } = this
+
+        if (Object.prototype.hasOwnProperty.call(target, javascriptInterface)) {
+            this.#capturedHandler = target[javascriptInterface].process.bind(target[javascriptInterface])
+            delete target[javascriptInterface]
+        } else {
+            this.#capturedHandler = () => {
+                this.#log('Android messaging interface not available', javascriptInterface)
+            }
+        }
+    }
+
+    /**
+     * Assign the incoming handler method to the global object.
+     * This is the method that Android will call to deliver messages.
+     */
+    #assignHandlerMethod() {
+        /**
+         * @type {(secret: string, response: MessageResponse | SubscriptionEvent) => void}
+         */
+        const responseHandler = (providedSecret, response) => {
+            if (providedSecret === this.secret) {
+                this.#dispatch(response)
+            }
+        }
+
+        Object.defineProperty(this.target, this.messageCallback, {
+            value: responseHandler
+        })
+    }
+}

--- a/packages/messaging/lib/android.js
+++ b/packages/messaging/lib/android.js
@@ -173,7 +173,7 @@ export class AndroidMessagingTransport {
  */
 export class AndroidMessagingConfig {
     /** @type {(json: string, secret: string) => void} */
-    #capturedHandler
+    _capturedHandler
     /**
      * @param {object} params
      * @param {Record<string, any>} params.target
@@ -220,7 +220,7 @@ export class AndroidMessagingConfig {
      * @internal
      */
     sendMessageThrows (json) {
-        this.#capturedHandler(json, this.secret)
+        this._capturedHandler(json, this.secret)
     }
 
     /**
@@ -308,10 +308,10 @@ export class AndroidMessagingConfig {
         const { target, javascriptInterface } = this
 
         if (Object.prototype.hasOwnProperty.call(target, javascriptInterface)) {
-            this.#capturedHandler = target[javascriptInterface].process.bind(target[javascriptInterface])
+            this._capturedHandler = target[javascriptInterface].process.bind(target[javascriptInterface])
             delete target[javascriptInterface]
         } else {
-            this.#capturedHandler = () => {
+            this._capturedHandler = () => {
                 this._log('Android messaging interface not available', javascriptInterface)
             }
         }

--- a/packages/messaging/lib/examples/android.example.js
+++ b/packages/messaging/lib/examples/android.example.js
@@ -1,0 +1,70 @@
+import { Messaging, MessagingContext } from '../../index.js'
+import { AndroidMessagingConfig } from '../android.js'
+
+/**
+ * This should match the string provided in the Android codebase
+ * @type {string}
+ */
+const javascriptInterface = 'ContentScopeScripts'
+
+/**
+ * Create a *single* instance of AndroidMessagingConfig and share it.
+ */
+const config = new AndroidMessagingConfig({
+    secret: 'abc',
+    messageCallback: 'callback_123', // the method that android will execute with responses
+    target: globalThis, // where the global properties exist
+    javascriptInterface,
+    debug: false,
+})
+
+/**
+ * Context is per-feature;
+ */
+const messagingContext = new MessagingContext({
+    context: javascriptInterface,
+    featureName: 'hello-world',
+    env: 'development'
+})
+
+/**
+ * And then send notifications!
+ */
+const messaging = new Messaging(messagingContext, config)
+messaging.notify('helloWorld')
+
+/**
+ * Or request some data
+ */
+messaging.request('getData', { foo: 'bar' }).then(console.log).catch(console.error)
+
+/**
+ * Or subscribe for push messages
+ */
+const unsubscribe = messaging.subscribe('getData', (data) => console.log(data))
+
+// later
+unsubscribe()
+
+/**
+ * Create messaging for 2 separate features
+ */
+const messagingContext1 = new MessagingContext({
+    context: javascriptInterface,
+    featureName: 'hello-world',
+    env: 'development'
+})
+
+/**
+ * Just change the feature name for a second feature
+ */
+const messagingContext2 = { ...messagingContext1, featureName: 'duckPlayer' }
+
+/**
+ * Now, each feature has its own isolated messaging...
+ */
+const messaging1 = new Messaging(messagingContext, config)
+messaging1.notify('helloWorld')
+
+const messaging2 = new Messaging(messagingContext2, config)
+messaging2.notify('getUserValues')

--- a/packages/messaging/lib/examples/android.example.js
+++ b/packages/messaging/lib/examples/android.example.js
@@ -15,7 +15,7 @@ const config = new AndroidMessagingConfig({
     messageCallback: 'callback_123', // the method that android will execute with responses
     target: globalThis, // where the global properties exist
     javascriptInterface,
-    debug: false,
+    debug: false
 })
 
 /**

--- a/packages/messaging/native.js
+++ b/packages/messaging/native.js
@@ -7,13 +7,22 @@
  * Notifications do not require a response, but requests do. The following spec explains the difference and
  * how to handle each.
  *
+ * The purpose of this library is to enable 3 idiomatic JavaScript methods for communicating with native platforms:
+ *
  * ```javascript
  * // notifications
  * messaging.notify("helloWorld", { some: "data" })
  *
  * // requests
  * await messaging.request("helloWorld", { some: "data" })
+ *
+ * // subscriptions
+ * const unsubscribe = messaging.subscribe("helloWorld", (data) => {
+ *    console.log(data)
+ * });
  * ```
+ *
+ * The following describes how you [native engineers] can implement support for this.
  *
  * ## Step 1) Receiving a notification or request message:
  *
@@ -169,7 +178,6 @@
  * {
  *   "context": "contentScopeScripts",
  *   "featureName": "duckPlayer",
- *   "method": "getUserValues",
  *   "id": "abc123",
  *   "result": { "hello":  "world" }
  * }
@@ -181,7 +189,6 @@
  * {
  *   "context": "contentScopeScripts",
  *   "featureName": "duckPlayer",
- *   "method": "getUserValues",
  *   "id": "abc123",
  *   "error": {
  *     "message": "oops!"

--- a/unit-test/messaging.js
+++ b/unit-test/messaging.js
@@ -63,7 +63,7 @@ describe('Android', () => {
             secret: 'abc',
             javascriptInterface: 'ContentScopeScripts',
             messageCallback: 'callback_abc_def',
-            debug: false,
+            debug: false
         })
         return config
     }

--- a/unit-test/messaging.js
+++ b/unit-test/messaging.js
@@ -2,8 +2,9 @@ import {
     Messaging,
     MessagingContext,
     TestTransportConfig,
-    RequestMessage, NotificationMessage, Subscription
+    RequestMessage, NotificationMessage, Subscription, MessageResponse, SubscriptionEvent
 } from '@duckduckgo/messaging'
+import { AndroidMessagingConfig } from '@duckduckgo/messaging/lib/android.js'
 
 describe('Messaging Transports', () => {
     it('calls transport with a RequestMessage', () => {
@@ -48,6 +49,141 @@ describe('Messaging Transports', () => {
             featureName: 'hello-world',
             subscriptionName: 'helloWorld'
         }), callback)
+    })
+})
+
+describe('Android', () => {
+    /**
+     * @param {Record<string, any>} target
+     * @return {AndroidMessagingConfig}
+     */
+    function createConfig (target) {
+        const config = new AndroidMessagingConfig({
+            target,
+            secret: 'abc',
+            javascriptInterface: 'ContentScopeScripts',
+            messageCallback: 'callback_abc_def',
+            debug: false,
+        })
+        return config
+    }
+    /**
+     * @param {string} featureName
+     * @param {AndroidMessagingConfig} config
+     */
+    function createContext (featureName, config) {
+        const messageContextA = new MessagingContext({
+            context: config.javascriptInterface,
+            featureName,
+            env: 'development'
+        })
+        const messaging = new Messaging(messageContextA, config)
+        return { messaging }
+    }
+    it('sends notification to 1 feature', () => {
+        const spy = jasmine.createSpy()
+        const target = {
+            ContentScopeScripts: {
+                process: spy
+            }
+        }
+        const config = createConfig(target)
+        const { messaging } = createContext('featureA', config)
+        messaging.notify('helloWorld')
+        const payload = '{"context":"ContentScopeScripts","featureName":"featureA","method":"helloWorld","params":{}}'
+        const secret = 'abc'
+        expect(spy).toHaveBeenCalledWith(payload, secret)
+    })
+    it('sends notification to 2 separate features', () => {
+        const spy = jasmine.createSpy()
+        const target = {
+            ContentScopeScripts: {
+                process: spy
+            }
+        }
+        const config = createConfig(target)
+        const { messaging } = createContext('featureA', config)
+        const { messaging: bMessaging } = createContext('featureB', config)
+        messaging.notify('helloWorld')
+        bMessaging.notify('helloWorld')
+        const expected1 = '{"context":"ContentScopeScripts","featureName":"featureA","method":"helloWorld","params":{}}'
+        const expected2 = '{"context":"ContentScopeScripts","featureName":"featureA","method":"helloWorld","params":{}}'
+        expect(spy).toHaveBeenCalledTimes(2)
+        expect(spy).toHaveBeenCalledWith(expected1, 'abc')
+        expect(spy).toHaveBeenCalledWith(expected2, 'abc')
+    })
+    it('sends request and gets response', async () => {
+        const spy = jasmine.createSpy()
+        /** @type {MessageResponse} */
+        let msg
+        /** @type {string} */
+        let token
+        const target = {
+            ContentScopeScripts: {
+                process: (outgoing, _token) => {
+                    msg = JSON.parse(outgoing)
+                    token = _token
+                    spy(outgoing, _token)
+                }
+            }
+        }
+        const config = createConfig(target)
+        const { messaging } = createContext('featureA', config)
+        const request = messaging.request('helloWorld')
+
+        // @ts-expect-error - unit-testing
+        if (!msg) throw new Error('must have set msg by this point in the test')
+
+        // simulate a valid response
+        const response = new MessageResponse({
+            id: msg.id,
+            context: msg.context,
+            featureName: msg.featureName,
+            result: { foo: 'bar' }
+        })
+
+        // pretend to call back from native
+        target[config.messageCallback](config.secret, response)
+
+        // wait for it to resolve
+        const result = await request
+
+        // ensure the outgoing payload was correct
+        const expectedOutgoing = '{"context":"ContentScopeScripts","featureName":"featureA","method":"helloWorld","id":"helloWorld.response","params":{}}'
+        expect(spy).toHaveBeenCalledWith(expectedOutgoing, 'abc')
+
+        // ensure the result is correct
+        expect(result).toEqual({ foo: 'bar' })
+
+        // @ts-expect-error - unit-testing
+        expect(token).toEqual(config.secret)
+    })
+    it('allows subscriptions', (done) => {
+        const spy = jasmine.createSpy()
+        const globalTarget = {
+            ContentScopeScripts: {
+                process: spy
+            }
+        }
+        const config = createConfig(globalTarget)
+        const { messaging } = createContext('featureA', config)
+
+        // create the message as the native side would
+        const subEvent1 = new SubscriptionEvent({
+            context: config.javascriptInterface,
+            featureName: 'featureA',
+            subscriptionName: 'onUpdate',
+            params: { foo: 'bar' }
+        })
+
+        // subscribe to 'onUpdate'
+        messaging.subscribe('onUpdate', (data) => {
+            expect(data).toEqual(subEvent1.params)
+            done()
+        })
+
+        // simulate native calling this method
+        globalTarget[config.messageCallback](config.secret, subEvent1)
     })
 })
 

--- a/unit-test/verify-artifacts.js
+++ b/unit-test/verify-artifacts.js
@@ -6,7 +6,7 @@ import { cwd } from '../scripts/script-utils.js'
 const ROOT = join(cwd(import.meta.url), '..')
 const BUILD = join(ROOT, 'build')
 const APPLE_BUILD = join(ROOT, 'Sources/ContentScopeScripts/dist')
-let CSS_OUTPUT_SIZE = 700_000
+let CSS_OUTPUT_SIZE = 702_000
 const CSS_OUTPUT_SIZE_CHROME = CSS_OUTPUT_SIZE * 1.45 // 45% larger for Chrome MV2 due to base64 encoding
 if (process.platform === 'win32') {
     CSS_OUTPUT_SIZE = CSS_OUTPUT_SIZE * 1.1 // 10% larger for Windows due to line endings

--- a/unit-test/verify-artifacts.js
+++ b/unit-test/verify-artifacts.js
@@ -6,7 +6,7 @@ import { cwd } from '../scripts/script-utils.js'
 const ROOT = join(cwd(import.meta.url), '..')
 const BUILD = join(ROOT, 'build')
 const APPLE_BUILD = join(ROOT, 'Sources/ContentScopeScripts/dist')
-let CSS_OUTPUT_SIZE = 710_000
+let CSS_OUTPUT_SIZE = 720_000
 const CSS_OUTPUT_SIZE_CHROME = CSS_OUTPUT_SIZE * 1.45 // 45% larger for Chrome MV2 due to base64 encoding
 if (process.platform === 'win32') {
     CSS_OUTPUT_SIZE = CSS_OUTPUT_SIZE * 1.1 // 10% larger for Windows due to line endings

--- a/unit-test/verify-artifacts.js
+++ b/unit-test/verify-artifacts.js
@@ -6,7 +6,7 @@ import { cwd } from '../scripts/script-utils.js'
 const ROOT = join(cwd(import.meta.url), '..')
 const BUILD = join(ROOT, 'build')
 const APPLE_BUILD = join(ROOT, 'Sources/ContentScopeScripts/dist')
-let CSS_OUTPUT_SIZE = 702_000
+let CSS_OUTPUT_SIZE = 710_000
 const CSS_OUTPUT_SIZE_CHROME = CSS_OUTPUT_SIZE * 1.45 // 45% larger for Chrome MV2 due to base64 encoding
 if (process.platform === 'win32') {
     CSS_OUTPUT_SIZE = CSS_OUTPUT_SIZE * 1.1 // 10% larger for Windows due to line endings


### PR DESCRIPTION
https://app.asana.com/0/0/1205488960627879/f

This matches the implementation already being used in `inject/android.js` -> The idea here is to review/iterate/merge this PR into the messaging library so that any new features can utilise it. 

I want to avoid the scope being too large, which is why this doesn't include changing any existing features - it's 100% isolated/safe as it doesn't alter anything about any existing features :)

Alistair and MarcOS have heavily tested this already in their Subscription work, so we're confident we have all the pieces in place - I also added a bunch of docs too :)

