### PR TITLE
Clean iframe value to match main frame

### DIFF
--- a/src/features/web-compat.js
+++ b/src/features/web-compat.js
@@ -63,33 +63,6 @@ export default class WebCompat extends ContentFeature {
     }
 
     cleanIframeValue () {
-        /*
-        window.XMLHttpRequest = new Proxy(XMLHttpRequest, {
-            get (target, name) {
-                console.log('new XHR')
-                return Reflect.get(target, name)
-            }
-        })
-
-        window.XMLHttpRequest.prototype.open = new Proxy(window.XMLHttpRequest.prototype.open, {
-            get (target, name) {
-                console.log('XHR open')
-                return Reflect.get(target, name)
-            }
-        })
-
-        window.XMLHttpRequest.prototype.setRequestHeader = new Proxy(window.XMLHttpRequest.prototype.setRequestHeader, {
-            get (target, name) {
-                console.log('XHR setRequestHeader')
-                return Reflect.get(target, name)
-            },
-            apply (target, thisArg, args) {
-                console.log('XHR setRequestHeader', args)
-                return Reflect.apply(target, thisArg, args)
-            }
-        })
-        */
-
         function cleanIframeValue (val) {
             const clone = Object.assign({}, val)
             const deleteKeys = ['iframeProto', 'iframeData', 'remap']
@@ -110,12 +83,6 @@ export default class WebCompat extends ContentFeature {
             apply (target, thisArg, args) {
                 const body = args[0]
                 const cleanKey = 'bi_wvdp'
-                /*
-                if (body && body instanceof FormData && body.has(cleanKey)) {
-                    const val = JSON.parse(body.get(cleanKey))
-                    body.set(cleanKey, JSON.stringify(cleanIframeValue(val)))
-                }
-                */
                 if (body && typeof body === 'string' && body.includes(cleanKey)) {
                     const parts = body.split('&').map((part) => { return part.split('=') })
                     if (parts.length > 0) {

--- a/src/features/web-compat.js
+++ b/src/features/web-compat.js
@@ -63,7 +63,7 @@ export default class WebCompat extends ContentFeature {
     }
 
     cleanIframeValue () {
-        function cleanIframeValue (val) {
+        function cleanValueData (val) {
             const clone = Object.assign({}, val)
             const deleteKeys = ['iframeProto', 'iframeData', 'remap']
             for (const key of deleteKeys) {
@@ -89,7 +89,7 @@ export default class WebCompat extends ContentFeature {
                         parts.forEach((part) => {
                             if (part[0] === cleanKey) {
                                 const val = JSON.parse(decodeURIComponent(part[1]))
-                                part[1] = encodeURIComponent(JSON.stringify(cleanIframeValue(val)))
+                                part[1] = encodeURIComponent(JSON.stringify(cleanValueData(val)))
                             }
                         })
                         args[0] = parts.map((part) => { return part.join('=') }).join('&')

--- a/src/features/web-compat.js
+++ b/src/features/web-compat.js
@@ -76,10 +76,6 @@ export default class WebCompat extends ContentFeature {
         }
 
         window.XMLHttpRequest.prototype.send = new Proxy(window.XMLHttpRequest.prototype.send, {
-            get (target, name) {
-                console.log('XHR send')
-                return Reflect.get(target, name)
-            },
             apply (target, thisArg, args) {
                 const body = args[0]
                 const cleanKey = 'bi_wvdp'


### PR DESCRIPTION
See: https://app.asana.com/0/715106103902962/1203065614519468/f

- This code fixes the existing shim serialization of navigator.permissions.query by using a proxy.
- We then also then have a new sub feature called cleanIframeValue to clean up encoded values to match the parent frame.

