### PR TITLE
Fix up Notification API after breakages

### DIFF
--- a/integration-test/test-web-compat.js
+++ b/integration-test/test-web-compat.js
@@ -140,6 +140,22 @@ describe('Ensure Notification and Permissions interface is injected', () => {
 
         const modifiedDescriptorSerialization = await page.evaluate(checkObjectDescriptorSerializedValue)
         expect(modifiedDescriptorSerialization).toEqual(initialDescriptorSerialization)
+
+        const permissionDenied = await page.evaluate(() => {
+            return window.Notification.requestPermission()
+        })
+        expect(permissionDenied).toEqual('denied')
+
+        const permissionPropDenied = await page.evaluate(() => {
+            return window.Notification.permission
+        })
+        expect(permissionPropDenied).toEqual('denied')
+
+        const maxActionsPropDenied = await page.evaluate(() => {
+            // @ts-expect-error - This is a property that should exist but experimental.
+            return window.Notification.maxActions
+        })
+        expect(maxActionsPropDenied).toEqual(2)
     })
 
     it('should expose window.navigator.permissions when enabled', async () => {

--- a/src/features/web-compat.js
+++ b/src/features/web-compat.js
@@ -52,18 +52,34 @@ export default class WebCompat extends ContentFeature {
         if (window.Notification) {
             return
         }
-        const Notification = () => {
-            // noop
-        }
-        Notification.requestPermission = () => {
-            return Promise.resolve({ permission: 'denied' })
-        }
-        Notification.permission = 'denied'
-        Notification.maxActions = 2
-
         // Expose the API
         this.defineProperty(window, 'Notification', {
-            value: Notification,
+            value: () => {
+                // noop
+            },
+            writable: true,
+            configurable: true,
+            enumerable: false
+        })
+
+        this.defineProperty(window.Notification, 'requestPermission', {
+            value: () => {
+                return Promise.resolve('denied')
+            },
+            writable: true,
+            configurable: true,
+            enumerable: false
+        })
+
+        this.defineProperty(window.Notification, 'permission', {
+            value: 'denied',
+            writable: true,
+            configurable: true,
+            enumerable: false
+        })
+
+        this.defineProperty(window.Notification, 'maxActions', {
+            value: 2,
             writable: true,
             configurable: true,
             enumerable: false


### PR DESCRIPTION
See: https://app.asana.com/0/0/1205849148737722/f

This was broken so adding a test for it.
The return value for `requestPermission` appears to have been wrong too.