### PR TITLE
Make messaging a relative path again

### DIFF
--- a/inject/android.js
+++ b/inject/android.js
@@ -5,7 +5,7 @@
 import { load, init } from '../src/content-scope-features.js'
 import { processConfig, isGloballyDisabled } from './../src/utils'
 import { isTrackerOrigin } from '../src/trackers'
-import { AndroidMessagingConfig } from '@duckduckgo/messaging'
+import { AndroidMessagingConfig } from '../packages/messaging/index.js'
 
 function initCode () {
     // @ts-expect-error https://app.asana.com/0/1201614831475344/1203979574128023/f

--- a/inject/apple.js
+++ b/inject/apple.js
@@ -5,7 +5,7 @@
 import { load, init } from '../src/content-scope-features.js'
 import { processConfig, isGloballyDisabled } from './../src/utils'
 import { isTrackerOrigin } from '../src/trackers'
-import { WebkitMessagingConfig, TestTransportConfig } from '@duckduckgo/messaging'
+import { WebkitMessagingConfig, TestTransportConfig } from '../packages/messaging/index.js'
 
 function initCode () {
     // @ts-expect-error https://app.asana.com/0/1201614831475344/1203979574128023/f

--- a/inject/integration.js
+++ b/inject/integration.js
@@ -1,6 +1,6 @@
 import { load, init } from '../src/content-scope-features.js'
 import { isTrackerOrigin } from '../src/trackers'
-import { TestTransportConfig } from '@duckduckgo/messaging'
+import { TestTransportConfig } from '../packages/messaging/index.js'
 function getTopLevelURL () {
     try {
         // FROM: https://stackoverflow.com/a/7739035/73479

--- a/inject/windows.js
+++ b/inject/windows.js
@@ -5,7 +5,7 @@
 import { load, init } from '../src/content-scope-features.js'
 import { processConfig, isGloballyDisabled, windowsSpecificFeatures } from './../src/utils'
 import { isTrackerOrigin } from '../src/trackers'
-import { WindowsMessagingConfig } from '@duckduckgo/messaging'
+import { WindowsMessagingConfig } from '../packages/messaging/index.js'
 
 function initCode () {
     // @ts-expect-error https://app.asana.com/0/1201614831475344/1203979574128023/f

--- a/src/content-feature.js
+++ b/src/content-feature.js
@@ -5,7 +5,7 @@ import { immutableJSONPatch } from 'immutable-json-patch'
 import { PerformanceMonitor } from './performance.js'
 import { hasMozProxies, wrapToString } from './wrapper-utils.js'
 import { getOwnPropertyDescriptor, objectKeys } from './captured-globals.js'
-import { Messaging, MessagingContext } from '@duckduckgo/messaging'
+import { Messaging, MessagingContext } from '../packages/messaging/index.js'
 import { extensionConstructMessagingConfig } from './sendmessage-transport.js'
 
 /**

--- a/src/features/click-to-load.js
+++ b/src/features/click-to-load.js
@@ -1,4 +1,4 @@
-import { Messaging, TestTransportConfig, WebkitMessagingConfig } from '@duckduckgo/messaging'
+import { Messaging, TestTransportConfig, WebkitMessagingConfig } from '../../packages/messaging/index.js'
 import { createCustomEvent, originalWindowDispatchEvent } from '../utils.js'
 import { logoImg, loadingImages, closeIcon, facebookLogo } from './click-to-load/ctl-assets.js'
 import { getStyles, getConfig } from './click-to-load/ctl-config.js'

--- a/src/sendmessage-transport.js
+++ b/src/sendmessage-transport.js
@@ -1,5 +1,5 @@
 import { sendMessage } from './utils.js'
-import { TestTransportConfig } from '@duckduckgo/messaging'
+import { TestTransportConfig } from '../packages/messaging/index.js'
 
 /**
  * Workaround defining MessagingTransport locally because "import()" is not working in `@implements`


### PR DESCRIPTION
We're not post processing our JS in most cases. As can be see in test fails: https://github.com/duckduckgo/duckduckgo-privacy-extension/pull/2328

This was a last minute change to a PR that wasn't tested.