### PR TITLE
Remove throw in content feature due to extension using it as a class

### DIFF
--- a/src/content-feature.js
+++ b/src/content-feature.js
@@ -97,7 +97,6 @@ export default class ContentFeature {
      */
     _createMessagingContext () {
         const injectName = import.meta.injectName
-        if (typeof injectName === 'undefined') throw new Error('import.meta.injectName missing')
         const contextName = injectName === 'apple-isolated'
             ? 'contentScopeScriptsIsolated'
             : 'contentScopeScripts'


### PR DESCRIPTION
See: https://github.com/duckduckgo/duckduckgo-privacy-extension/pull/2335
This file is being used in a context without the replacement, I think this is acceptable for now especially as only apple isolated is the edge case here.