### PR TITLE
Fix legacy sendMessage method to account for no window object

### DIFF
--- a/src/sendmessage-transport.js
+++ b/src/sendmessage-transport.js
@@ -1,4 +1,4 @@
-import { sendMessage } from './utils.js'
+import { legacySendMessage } from './utils.js'
 import { TestTransportConfig } from '../packages/messaging/index.js'
 
 /**
@@ -67,7 +67,7 @@ export class SendMessageMessagingTransport {
             params = msg.params?.youTubeCTLAddedFlag
         }
 
-        sendMessage(msg.method, params)
+        legacySendMessage(msg.method, params)
     }
 
     /**
@@ -94,7 +94,7 @@ export class SendMessageMessagingTransport {
             params = req.params?.videoURL
         }
 
-        sendMessage(req.method, params)
+        legacySendMessage(req.method, params)
 
         return new this.globals.Promise((resolve) => {
             this._subscribe(comparator, (msgRes, unsubscribe) => {

--- a/src/utils.js
+++ b/src/utils.js
@@ -799,8 +799,9 @@ export function createCustomEvent (eventName, eventDetail) {
     return new OriginalCustomEvent(eventName, eventDetail)
 }
 
-export function sendMessage (messageType, options) {
+/** @deprecated */
+export function legacySendMessage (messageType, options) {
     // FF & Chrome
-    return originalWindowDispatchEvent(createCustomEvent('sendMessageProxy' + messageSecret, { detail: { messageType, options } }))
+    return originalWindowDispatchEvent && originalWindowDispatchEvent(createCustomEvent('sendMessageProxy' + messageSecret, { detail: { messageType, options } }))
     // TBD other platforms
 }


### PR DESCRIPTION
The extension continues to include parts of our code in node environments. This just makes sendMessage conditionally not work in these tests, this is only used for debug flags and not needed to test the node related tests.