### PR TITLE
Fix permission response

### DIFF
--- a/src/features/web-compat.js
+++ b/src/features/web-compat.js
@@ -156,7 +156,7 @@ export default class WebCompat extends ContentFeature {
             'speaker'
         ]
         const validPermissionNames = settings.validPermissionNames || defaultValidPermissionNames
-        const returnStatus = settings.validPermissionNames || 'prompt'
+        const returnStatus = settings.permissionResponse || 'prompt'
         permissions.query = new Proxy((query) => {
             this.addDebugFlag()
             if (!query) {


### PR DESCRIPTION
The key was wrong so it would mean we'd have to clear out it's remote values otherwise. See: https://app.asana.com/0/1200277586140538/1205918302689365/f