### PR TITLE
Connect permissions API to native + update structure

### DIFF
--- a/integration-test/test-web-compat.js
+++ b/integration-test/test-web-compat.js
@@ -198,7 +198,6 @@ describe('Permissions API', () => {
             expect(initialPermissions).toEqual(true)
             const initialDescriptorSerialization = await page.evaluate(checkObjectDescriptorIsNotPresent)
             expect(initialDescriptorSerialization).toEqual(true)
-    
             await gotoAndWait(page, `http://localhost:${port}/blank.html`, { site: { enabledFeatures: [] } }, removePermissionsScript)
             const noPermissions = await page.evaluate(checkForPermissions)
             expect(noPermissions).toEqual(false)
@@ -223,12 +222,12 @@ describe('Permissions API', () => {
                             supportedPermissions: {
                                 geolocation: {},
                                 push: {
-                                    name: "notifications"
+                                    name: 'notifications'
                                 },
                                 camera: {
-                                    name: "video_capture",
+                                    name: 'video_capture',
                                     native: true
-                                },
+                                }
                             }
                         }
                     }
@@ -237,7 +236,7 @@ describe('Permissions API', () => {
         })
 
         async function checkPermission (name) {
-            const payload = `window.navigator.permissions.query(${JSON.stringify({name : name})})`
+            const payload = `window.navigator.permissions.query(${JSON.stringify({ name })})`
             const result = await page.evaluate(payload).catch((e) => {
                 return { threw: e }
             })
@@ -246,32 +245,26 @@ describe('Permissions API', () => {
             })
             return { result, message }
         }
-
-        it('should expose window.navigator.permissions when enabled', async () => {   
+        it('should expose window.navigator.permissions when enabled', async () => {
             const hasPermissions = await page.evaluate(checkForPermissions)
             expect(hasPermissions).toEqual(true)
-    
             const modifiedDescriptorSerialization = await page.evaluate(checkObjectDescriptorIsNotPresent)
             // This fails in a test condition purely because we have to add a descriptor to modify the prop
             expect(modifiedDescriptorSerialization).toEqual(false)
         })
-
-        it('should throw error when permission not supported', async () => {       
+        it('should throw error when permission not supported', async () => {
             const { result } = await checkPermission('notexistent')
             expect(result.threw).not.toBeUndefined()
             expect(result.threw.message).toContain('notexistent')
         })
-
-        it('should return prompt by default', async () => {    
+        it('should return prompt by default', async () => {
             const { result } = await checkPermission('geolocation')
-            expect(result).toEqual(jasmine.objectContaining({ name: 'geolocation', state: 'prompt'}))
-        })   
-    
+            expect(result).toEqual(jasmine.objectContaining({ name: 'geolocation', state: 'prompt' }))
+        })
         it('should return updated name when configured', async () => {
             const { result } = await checkPermission('push')
-            expect(result).toEqual(jasmine.objectContaining({ name: 'notifications', state: 'prompt'}))
+            expect(result).toEqual(jasmine.objectContaining({ name: 'notifications', state: 'prompt' }))
         })
-
         it('should propagate result from native when configured', async () => {
             // Fake result from native
             await page.evaluate(() => {
@@ -280,12 +273,10 @@ describe('Permissions API', () => {
                     return Promise.resolve({ state: 'granted' })
                 }
             })
-
             const { result, message } = await checkPermission('camera')
-            expect(result).toEqual(jasmine.objectContaining({ name: 'video_capture', state: 'granted'}))
+            expect(result).toEqual(jasmine.objectContaining({ name: 'video_capture', state: 'granted' }))
             expect(message).toEqual(jasmine.objectContaining({ featureName: 'webCompat', method: 'permissionsQuery', params: { name: 'camera' } }))
         })
-
         it('should default to prompt when native sends unexpected response', async () => {
             await page.evaluate(() => {
                 globalThis.cssMessaging.impl.request = () => {
@@ -293,10 +284,9 @@ describe('Permissions API', () => {
                 }
             })
             const { result, message } = await checkPermission('camera')
-            expect(result).toEqual(jasmine.objectContaining({ name: 'video_capture', state: 'prompt'}))
+            expect(result).toEqual(jasmine.objectContaining({ name: 'video_capture', state: 'prompt' }))
             expect(message).toEqual(jasmine.objectContaining({ featureName: 'webCompat', method: 'permissionsQuery', params: { name: 'camera' } }))
         })
-    
         it('should default to prompt when native error occurs', async () => {
             await page.evaluate(() => {
                 globalThis.cssMessaging.impl.request = () => {
@@ -304,7 +294,7 @@ describe('Permissions API', () => {
                 }
             })
             const { result, message } = await checkPermission('camera')
-            expect(result).toEqual(jasmine.objectContaining({ name: 'video_capture', state: 'prompt'}))
+            expect(result).toEqual(jasmine.objectContaining({ name: 'video_capture', state: 'prompt' }))
             expect(message).toEqual(jasmine.objectContaining({ featureName: 'webCompat', method: 'permissionsQuery', params: { name: 'camera' } }))
         })
     })

--- a/src/features/web-compat.js
+++ b/src/features/web-compat.js
@@ -13,6 +13,7 @@ function windowSizingFix () {
 }
 
 const MSG_WEB_SHARE = 'webShare'
+const MSG_PERMISSIONS_QUERY = 'permissionsQuery'
 
 function canShare (data) {
     if (typeof data !== 'object') return false
@@ -264,8 +265,12 @@ export default class WebCompat extends ContentFeature {
             const returnName = permSetting.name || query.name
             let returnStatus = settings.permissionResponse || 'prompt'
             if (permSetting.native) {
-                const response = await this.messaging.request('permissionsQuery', query)
-                returnStatus = response.state
+                try {
+                    const response = await this.messaging.request(MSG_PERMISSIONS_QUERY, query)
+                    returnStatus = response.state || 'prompt'
+                } catch (err) {
+                    // do nothing - keep returnStatus as-is
+                }                
             }
             return Promise.resolve(new PermissionStatus(returnName, returnStatus))
         }, {

--- a/src/features/web-compat.js
+++ b/src/features/web-compat.js
@@ -270,7 +270,7 @@ export default class WebCompat extends ContentFeature {
                     returnStatus = response.state || 'prompt'
                 } catch (err) {
                     // do nothing - keep returnStatus as-is
-                }                
+                }
             }
             return Promise.resolve(new PermissionStatus(returnName, returnStatus))
         }, {


### PR DESCRIPTION
**Asana task**: https://app.asana.com/0/0/1205860617093734/f

**Description**:
* Make use of native support for permissions API done in https://github.com/duckduckgo/Android/pull/3877
* Support new config structure from https://github.com/duckduckgo/privacy-configuration/pull/1598

**Steps to test this PR**:
_Requirements_
* Build the Android app with a local copy of contentScope.js to include changes in this PR
* Apply config with the changes from https://github.com/duckduckgo/privacy-configuration/pull/1598
  * You can use https://jsonblob.com/api/jsonBlob/1160261143960084480 which already includes them

_Session-based permissions: deny_
- [ ] Go to https://nshuba.github.io/test-site/ and select "camera" from the drop-down
- [ ] Click "Query Permission" and verify that the printed state is 'prompt' and returned name is 'video_capture'
- [ ] Click "Request Camera" and deny the permission
- [ ] Click "Query Permission" and verify that the printed state is 'prompt'. 
  * **Note**: ideally this should be "denied", but we don't store denials on-disk. 
  * We can revisit how to better handle this in https://app.asana.com/0/1200396763693192/1205944992235904/f

_Session-based permissions: allow_
- [ ] Open a new tab, navigate to the test site and select "camera" from the drop-down
- [ ] Click "Query Permission" and verify that the printed state is 'prompt' and returned name is 'video_capture'
- [ ] Click "Request Camera" and allow the permission
- [ ] Click "Query Permission" and verify that the printed state is 'granted' and returned name is 'video_capture'
- [ ] From the dropdown, change "camera" to "microphone"
- [ ] Click "Query Permission" and verify that the printed state is 'prompt' and returned name is 'audio_capture'
- [ ] Click "Request Microphone" and allow the permission
- [ ] Click "Query Permission" and verify that the printed state is 'granted' and returned name is 'audio_capture'

_Permanent permissions_
- [ ] Open a new tab, navigate to the test site and select "camera" from the drop-down
- [ ] Click "Query Permission" and verify that the printed state is 'prompt'
- [ ] Go to Settings --> Permissions --> Site Permissions
- [ ] Change the Camera permission to Allow and the Microphone permission to Deny
- [ ] Go back to the tab you just opened, refresh and select "camera" from the drop-down
- [ ] Click "Query Permission" and verify that the printed state is 'granted' and returned name is 'video_capture'
- [ ] From the dropdown, change "camera" to "microphone"
- [ ] Click "Query Permission" and verify that the printed state is 'denied' and returned name is 'audio_capture'

_Unsupported_
- [ ] From the dropdown, change "microphone" to "ambient-light-sensor"
- [ ] Click "Query Permission" and verify that we get an exception printed