### PR TITLE
Let extractProfiles support a top-level xpath selector

### DIFF
--- a/src/features/broker-protection/actions/extract.js
+++ b/src/features/broker-protection/actions/extract.js
@@ -28,8 +28,7 @@ import { matchAddressFromAddressListCityState } from '../comparisons/address.js'
  * @return {import('../types.js').ActionResponse}
  */
 export function extractProfiles (action, userData) {
-    const profilesElementList =
-      Array.from(document.querySelectorAll(action.selector)) ?? []
+    const profilesElementList = getElements(document, action.selector) ?? []
 
     const matchedProfiles = profilesElementList
         // first, convert each profile element list into a profile


### PR DESCRIPTION
I was getting an error with a json file that was using an xpath selector in the "profile" section, since we already have a good util to query with either css or xpath selectors, I've swapped `querySelectorAll` out for `getElements`.