### PR TITLE
set screenY and screenTop to 0 when equal to screen height

### DIFF
--- a/src/features/web-compat.js
+++ b/src/features/web-compat.js
@@ -5,6 +5,11 @@ import { URL } from '../captured-globals.js'
  * Fixes incorrect sizing value for outerHeight and outerWidth
  */
 function windowSizingFix () {
+    // macOS browser incorrectly reports window height for window.screenY / window.screenTop
+    if (window.screenY === window.screen.height) {
+        window.screenY = window.screenTop = 0
+    }
+
     if (window.outerHeight !== 0 && window.outerWidth !== 0) {
         return
     }

--- a/src/features/web-compat.js
+++ b/src/features/web-compat.js
@@ -4,10 +4,17 @@ import { URL } from '../captured-globals.js'
 /**
  * Fixes incorrect sizing value for outerHeight and outerWidth
  */
-function windowSizingFix () {
-    // macOS browser incorrectly reports window height for window.screenY / window.screenTop
+function windowSizingFix (settings) {
+    // macOS browser incorrectly reports screen height for window.screenY / window.screenTop
     if (window.screenY === window.screen.height) {
-        window.screenY = window.screenTop = 0
+        let screenYOverride = settings?.screenYOverride
+
+        if (typeof screenYOverride === 'undefined') {
+            // @ts-expect-error - typescript known about availTop in this context
+            screenYOverride = window.screen.availTop
+        }
+
+        window.screenY = window.screenTop = screenYOverride
     }
 
     if (window.outerHeight !== 0 && window.outerWidth !== 0) {
@@ -81,7 +88,8 @@ export default class WebCompat extends ContentFeature {
 
     init () {
         if (this.getFeatureSettingEnabled('windowSizing')) {
-            windowSizingFix()
+            const settings = this.getFeatureSetting('windowSizing')
+            windowSizingFix(settings)
         }
         if (this.getFeatureSettingEnabled('navigatorCredentials')) {
             this.navigatorCredentialsFix()


### PR DESCRIPTION
Background: https://app.asana.com/0/276630244458377/1206165160907347/f
See also https://developer.mozilla.org/en-US/docs/Web/API/Window/screenY

For Mac where we are incorrectly providing the screen height instead of `A number equal to the number of CSS pixels from the top edge of the browser viewport to the top edge of the screen.`, which should be the actual value or 0.