### PR TITLE
simplify handling of paths

### DIFF
--- a/src/features/broker-protection/actions/build-url-transforms.js
+++ b/src/features/broker-protection/actions/build-url-transforms.js
@@ -139,7 +139,7 @@ export function processTemplateStringWithUserData (input, action, userData) {
      */
     return String(input).replace(/\$%7B(.+?)%7D|\$\{(.+?)}/g, (match, encodedValue, plainValue) => {
         const comparison = encodedValue ?? plainValue
-        const [dataKey, ...transforms] = comparison.split('|')
+        const [dataKey, ...transforms] = comparison.split(/\||%7C/)
         const data = userData[dataKey]
         return applyTransforms(dataKey, data, transforms, action)
     })

--- a/unit-test/broker-protection.js
+++ b/unit-test/broker-protection.js
@@ -247,6 +247,14 @@ describe('Actions', () => {
             expect(result).toEqual({ url: 'https://example.com/profile/John-Smith/a/b/c/search?state=il&city=Chicago&fage=24' })
         })
 
+        it('should handle url encodings', () => {
+            const result = replaceTemplatedUrl({
+                id: 0,
+                url: 'https://example.com/name/$%7BfirstName%7Cdowncase%7D-$%7BlastName%7Cdowncase%7D/$%7Bcity%7Cdowncase%7D-$%7Bstate%7CstateFull%7Cdowncase%7D?age=$%7Bage%7D'
+            }, userData)
+            expect(result).toEqual({ url: 'https://example.com/name/john-smith/chicago-illinois?age=24' })
+        })
+
         it('should build url when given valid data from path segments with modifiers path and url', () => {
             const result = replaceTemplatedUrl({
                 id: 0,


### PR DESCRIPTION
I don't remember the exact reason for handling the encoded path variables manually in the past - there must have been a reason but I cannot think what it was.

Regardless this PR just makes it simpler since we no longer even try, and just defer to decodeURIComponent instead.