### PR TITLE
Default Click to Load UI to English for unknown locales

### DIFF
--- a/src/features/click-to-load/ctl-config.js
+++ b/src/features/click-to-load/ctl-config.js
@@ -620,11 +620,13 @@ export function getStyles (assets) {
  * @param {string} locale UI locale
  */
 export function getConfig (locale) {
-    const locales = JSON.parse(localesJSON)
-    const fbStrings = locales[locale]['facebook.json']
-    const ytStrings = locales[locale]['youtube.json']
+    const allLocales = JSON.parse(localesJSON)
+    const localeStrings = allLocales[locale] || allLocales.en
 
-    const sharedStrings = locales[locale]['shared.json']
+    const fbStrings = localeStrings['facebook.json']
+    const ytStrings = localeStrings['youtube.json']
+    const sharedStrings = localeStrings['shared.json']
+
     const config = {
         'Facebook, Inc.': {
             informationalModal: {


### PR DESCRIPTION
Some users reported the extension throwing a `TypeError: Cannot read
properties of undefined (reading 'facebook.json')` exception. On
inspection, it seems that the getConfig() Click to Load logic
incorrectly assumed that `locales[locale]` would always result in an
Object.

The logic in question was something like this:

    const locale = args?.locale || 'en'
    const locales = JSON.parse(localesJSON)
    const fbStrings = locales[locale]['facebook.json']
    const ytStrings = locales[locale]['youtube.json']

So it seems that the intention was to default to English. Therefore,
let's add logic like `locales[locale] || locales.en` to ensure that is
the case.