### PR TITLE
update ClickToLoad to use shared C-S-S (Mac)

### DIFF
--- a/packages/messaging/lib/webkit.js
+++ b/packages/messaging/lib/webkit.js
@@ -425,5 +425,6 @@ function captureGlobals () {
         globals.importKey = window.crypto.subtle.importKey.bind(window.crypto.subtle)
         globals.encrypt = window.crypto.subtle.encrypt.bind(window.crypto.subtle)
         globals.decrypt = window.crypto.subtle.decrypt.bind(window.crypto.subtle)
+    }
     return globals
 }

--- a/packages/messaging/lib/webkit.js
+++ b/packages/messaging/lib/webkit.js
@@ -399,14 +399,8 @@ export class SecureMessagingParams {
  */
 function captureGlobals () {
     // Create base with null prototype
-    return {
+    const globals = {
         window,
-        // Methods must be bound to their interface, otherwise they throw Illegal invocation
-        encrypt: window.crypto.subtle.encrypt.bind(window.crypto.subtle),
-        decrypt: window.crypto.subtle.decrypt.bind(window.crypto.subtle),
-        generateKey: window.crypto.subtle.generateKey.bind(window.crypto.subtle),
-        exportKey: window.crypto.subtle.exportKey.bind(window.crypto.subtle),
-        importKey: window.crypto.subtle.importKey.bind(window.crypto.subtle),
         getRandomValues: window.crypto.getRandomValues.bind(window.crypto),
         TextEncoder,
         TextDecoder,
@@ -424,4 +418,12 @@ function captureGlobals () {
         /** @type {Record<string, any>} */
         capturedWebkitHandlers: {}
     }
+    if (isSecureContext) {
+        // skip for HTTP content since window.crypto.subtle is unavailable
+        globals.generateKey = window.crypto.subtle.generateKey.bind(window.crypto.subtle)
+        globals.exportKey = window.crypto.subtle.exportKey.bind(window.crypto.subtle)
+        globals.importKey = window.crypto.subtle.importKey.bind(window.crypto.subtle)
+        globals.encrypt = window.crypto.subtle.encrypt.bind(window.crypto.subtle)
+        globals.decrypt = window.crypto.subtle.decrypt.bind(window.crypto.subtle)
+    return globals
 }

--- a/src/features.js
+++ b/src/features.js
@@ -30,7 +30,8 @@ const otherFeatures = /** @type {const} */([
 export const platformSupport = {
     apple: [
         'webCompat',
-        ...baseFeatures
+        ...baseFeatures,
+        'clickToLoad'
     ],
     'apple-isolated': [
         'duckPlayer',
@@ -71,7 +72,7 @@ export const platformSupport = {
 }
 
 // Certain features are injected into the page in Firefox
-// This is because Firefox does not support proxies for custom elements, it's advided you don't use this without a good reason
+// This is because Firefox does not support proxies for custom elements, it's advised you don't use this without a good reason
 /** @type {FeatureName[]} */
 export const runtimeInjected = [
     'runtimeChecks'

--- a/src/features.js
+++ b/src/features.js
@@ -30,13 +30,13 @@ const otherFeatures = /** @type {const} */([
 export const platformSupport = {
     apple: [
         'webCompat',
-        ...baseFeatures,
-        'clickToLoad'
+        ...baseFeatures
     ],
     'apple-isolated': [
         'duckPlayer',
         'brokerProtection',
-        'performanceMetrics'
+        'performanceMetrics',
+        'clickToLoad'
     ],
     android: [
         ...baseFeatures,

--- a/src/features/click-to-load.js
+++ b/src/features/click-to-load.js
@@ -2025,7 +2025,7 @@ export default class ClickToLoad extends ContentFeature {
             const config = new WebkitMessagingConfig({
                 secret: '',
                 hasModernWebkitAPI: true,
-                webkitMessageHandlerNames: ['contentScopeScripts']
+                webkitMessageHandlerNames: ['contentScopeScriptsIsolated'] // contentScopeScriptsIsolated
             })
             this._messaging = new Messaging(this.messagingContext, config)
             return this._messaging

--- a/src/features/click-to-load.js
+++ b/src/features/click-to-load.js
@@ -2025,7 +2025,7 @@ export default class ClickToLoad extends ContentFeature {
             const config = new WebkitMessagingConfig({
                 secret: '',
                 hasModernWebkitAPI: true,
-                webkitMessageHandlerNames: ['contentScopeScriptsIsolated'] // contentScopeScriptsIsolated
+                webkitMessageHandlerNames: ['contentScopeScriptsIsolated']
             })
             this._messaging = new Messaging(this.messagingContext, config)
             return this._messaging

--- a/src/features/click-to-load.js
+++ b/src/features/click-to-load.js
@@ -2016,12 +2016,12 @@ export default class ClickToLoad extends ContentFeature {
     get messaging () {
         if (this._messaging) return this._messaging
 
-        if (this.platform.name === 'android' || this.platform.name === 'extension' || this.platform.name === 'macos') {
+        if (this.platform.name === 'android' || this.platform.name === 'extension') {
             this._clickToLoadMessagingTransport = new SendMessageMessagingTransport()
             const config = new TestTransportConfig(this._clickToLoadMessagingTransport)
             this._messaging = new Messaging(this.messagingContext, config)
             return this._messaging
-        } else if (this.platform.name === 'ios') {
+        } else if (this.platform.name === 'ios' || this.platform.name === 'macos') {
             const config = new WebkitMessagingConfig({
                 secret: '',
                 hasModernWebkitAPI: true,


### PR DESCRIPTION
Supporting work for https://app.asana.com/0/72649045549333/1205105078450227/f

Specifically, it includes fixes to:
- handle missing `window.crypto.subtle` in `captureGlobals` for HTTP pages (https://app.asana.com/0/0/1206422390411022/1206518726679048/f)
- enabled Mac webkit messaging for CTL
