### PR TITLE
feat: add retry logic

### DIFF
--- a/integration-test/playwright/page-objects/broker-protection.js
+++ b/integration-test/playwright/page-objects/broker-protection.js
@@ -220,14 +220,13 @@ export class BrokerProtectionPage {
 
     /**
      * @param {object} response
-     * @return {boolean}
      */
     isErrorMessage (response) {
-        return !!response[0].payload?.params?.result?.error
+        expect('error' in response[0].payload?.params?.result).toBe(true)
     }
 
     isSuccessMessage (response) {
-        return !!response[0].payload?.params?.result?.sucesss
+        expect('success' in response[0].payload?.params?.result).toBe(true)
     }
 
     /**

--- a/integration-test/test-pages/broker-protection/pages/retry.html
+++ b/integration-test/test-pages/broker-protection/pages/retry.html
@@ -1,0 +1,23 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport"
+          content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">
+    <meta http-equiv="X-UA-Compatible" content="ie=edge">
+    <title>Retry</title>
+</head>
+<body>
+    <h1 hidden>Retry</h1>
+    <button disabled id="button" onclick="show()" type="button">Click Me</button>
+    <script>
+        function show() {
+            document.querySelector('h1').hidden = false;
+        }
+        const timeout = new URLSearchParams(location.search).get('timeout') || '1000';
+        setTimeout(() => {
+            document.querySelector('#button').disabled = false;
+        }, Number(timeout));
+    </script>
+</body>
+</html>

--- a/src/features/broker-protection.js
+++ b/src/features/broker-protection.js
@@ -1,5 +1,10 @@
 import ContentFeature from '../content-feature.js'
 import { execute } from './broker-protection/execute.js'
+import { retry } from '../timer-utils.js'
+
+/**
+ * @typedef {import("./broker-protection/types.js").ActionResponse} ActionResponse
+ */
 
 export default class BrokerProtection extends ContentFeature {
     init () {
@@ -7,11 +12,32 @@ export default class BrokerProtection extends ContentFeature {
             try {
                 const action = params.state.action
                 const data = params.state.data
+
                 if (!action) {
                     return this.messaging.notify('actionError', { error: 'No action found.' })
                 }
-                const result = execute(action, data)
-                this.messaging.notify('actionCompleted', { result })
+
+                // Choose retry logic if it exists on the action
+                const retryConfig = action.retry?.environment === 'web'
+                    ? action.retry
+                    : undefined
+
+                retry(() => execute(action, data), retryConfig)
+                    // eslint-disable-next-line promise/prefer-await-to-then
+                    .then(({ result, errors }) => {
+                        if (result) {
+                            this.messaging.notify('actionCompleted', { result })
+                        } else {
+                            this.messaging.notify('actionError', { error: 'No response found, errors: ' + errors.join(', ') })
+                        }
+                    })
+                    // eslint-disable-next-line promise/prefer-await-to-then
+                    .catch(error => {
+                        if (this.isDebug) {
+                            console.error('unhandled exception: ', error)
+                        }
+                        this.messaging.notify('actionError', { error: error.toString() })
+                    })
             } catch (e) {
                 console.log('unhandled exception: ', e)
                 this.messaging.notify('actionError', { error: e.toString() })

--- a/src/features/broker-protection.js
+++ b/src/features/broker-protection.js
@@ -24,11 +24,11 @@ export default class BrokerProtection extends ContentFeature {
 
                 retry(() => execute(action, data), retryConfig)
                     // eslint-disable-next-line promise/prefer-await-to-then
-                    .then(({ result, errors }) => {
+                    .then(({ result, exceptions }) => {
                         if (result) {
                             this.messaging.notify('actionCompleted', { result })
                         } else {
-                            this.messaging.notify('actionError', { error: 'No response found, errors: ' + errors.join(', ') })
+                            this.messaging.notify('actionError', { error: 'No response found, exceptions: ' + exceptions.join(', ') })
                         }
                     })
                     // eslint-disable-next-line promise/prefer-await-to-then

--- a/src/timer-utils.js
+++ b/src/timer-utils.js
@@ -24,6 +24,7 @@ export async function retry (fn, config = DEFAULT_RETRY_CONFIG) {
         }
 
         // stop when there's a good result to return
+        // since fn() returns either { success: <value> } or { error: ... }
         if (lastResult && 'success' in lastResult) break
 
         // don't pause on the last item

--- a/src/timer-utils.js
+++ b/src/timer-utils.js
@@ -11,16 +11,16 @@ export const DEFAULT_RETRY_CONFIG = {
  * @template {{ success: T } | { error: { message: string } }} FnReturn
  * @param {() => FnReturn} fn
  * @param {typeof DEFAULT_RETRY_CONFIG} [config]
- * @return {Promise<{ result: FnReturn | undefined, errors: string[] }>}
+ * @return {Promise<{ result: FnReturn | undefined, exceptions: string[] }>}
  */
 export async function retry (fn, config = DEFAULT_RETRY_CONFIG) {
     let lastResult
-    const errors = []
+    const exceptions = []
     for (let i = 0; i < config.maxAttempts; i++) {
         try {
             lastResult = fn()
         } catch (e) {
-            errors.push(e.toString())
+            exceptions.push(e.toString())
         }
 
         // stop when there's a good result to return
@@ -32,5 +32,5 @@ export async function retry (fn, config = DEFAULT_RETRY_CONFIG) {
         await new Promise(resolve => setTimeout(resolve, config.interval.ms))
     }
 
-    return { result: lastResult, errors }
+    return { result: lastResult, exceptions }
 }

--- a/src/timer-utils.js
+++ b/src/timer-utils.js
@@ -1,0 +1,36 @@
+export const DEFAULT_RETRY_CONFIG = {
+    interval: { ms: 0 },
+    maxAttempts: 1
+}
+
+/**
+ * A generic retry mechanism for synchronous functions that return
+ * a 'success' or 'error' response
+ *
+ * @template T
+ * @template {{ success: T } | { error: { message: string } }} FnReturn
+ * @param {() => FnReturn} fn
+ * @param {typeof DEFAULT_RETRY_CONFIG} [config]
+ * @return {Promise<{ result: FnReturn | undefined, errors: string[] }>}
+ */
+export async function retry (fn, config = DEFAULT_RETRY_CONFIG) {
+    let lastResult
+    const errors = []
+    for (let i = 0; i < config.maxAttempts; i++) {
+        try {
+            lastResult = fn()
+        } catch (e) {
+            errors.push(e.toString())
+        }
+
+        // stop when there's a good result to return
+        if (lastResult && 'success' in lastResult) break
+
+        // don't pause on the last item
+        if (i === config.maxAttempts - 1) break
+
+        await new Promise(resolve => setTimeout(resolve, config.interval.ms))
+    }
+
+    return { result: lastResult, errors }
+}

--- a/unit-test/timer-utils.js
+++ b/unit-test/timer-utils.js
@@ -2,19 +2,24 @@ import fc from 'fast-check'
 import { DEFAULT_RETRY_CONFIG, retry } from '../src/timer-utils.js'
 
 describe('retry function tests', () => {
-    it('should always catch errors if the retried function always throws', async () => {
+    // This represents the default arguments to the `retry` helper function
+    const defaultProps = () => fc.integer({ min: 1, max: 10 })
+        .map(n => ({ ...DEFAULT_RETRY_CONFIG, maxAttempts: n }))
+
+    it('should catch errors if the retried function always throws', async () => {
         await fc.assert(
-            fc.asyncProperty(fc.integer({ min: 1, max: 10 }).map(n => ({ ...DEFAULT_RETRY_CONFIG, maxAttempts: n })), async (config) => {
+            fc.asyncProperty(defaultProps(), async (config) => {
                 const errorFunction = jasmine.createSpy('errorFunction', () => {
-                    throw new Error('Always fails') // A function that always throws an error
+                    // A function that always throws an error
+                    throw new Error('Always fails')
                 }).and.callThrough()
 
                 const { result, exceptions } = await retry(errorFunction, config)
 
-                // The result of our retry operation should be undefined since we always fail
+                // result should be undefined since we always throw
                 expect(result).toBe(undefined)
 
-                // The error function should have been called config.maxAttempts times
+                // should have been called config.maxAttempts times
                 expect(errorFunction.calls.count()).toEqual(config.maxAttempts)
 
                 // Size of errors should be equal to maxAttempts because the function always fails
@@ -23,11 +28,11 @@ describe('retry function tests', () => {
     })
     it('should assign lastResult correctly and stop retrying when success is obtained', async () => {
         await fc.assert(
-            fc.asyncProperty(fc.integer({ min: 1, max: 10 }).map(n => ({ ...DEFAULT_RETRY_CONFIG, maxAttempts: n })), async (config) => {
+            fc.asyncProperty(defaultProps(), async (config) => {
                 let callCount = 0
                 const successfulFunction = jasmine.createSpy('successfulFunction', () => {
                     callCount += 1
-                    // The function fails for the first (n-1) times and succeeds on the nth time
+                    // The function fails for the first (n-1) times and succeeds on the last try
                     if (callCount === config.maxAttempts) {
                         return { success: 'Function succeeded' }
                     } else {
@@ -37,28 +42,29 @@ describe('retry function tests', () => {
 
                 const { result, exceptions } = await retry(successfulFunction, config)
 
-                // Expect retry to return a successful result
+                // Expect retry to eventually return a successful result
                 expect(result).toEqual({ success: 'Function succeeded' })
 
-                // The error function should have been called config.maxAttempts times
+                // should have been called config.maxAttempts times
                 expect(successfulFunction.calls.count()).toEqual(config.maxAttempts)
 
-                // Last attempt wouldn't be a fail so minus 1 from the errors
+                // no exceptions were thrown, so this should be empty
                 expect(exceptions).toEqual([])
             }))
     })
     it('should return last result if a function is never successful', async () => {
         await fc.assert(
-            fc.asyncProperty(fc.integer({ min: 1, max: 10 }).map(n => ({ ...DEFAULT_RETRY_CONFIG, maxAttempts: n })), async (config) => {
+            fc.asyncProperty(defaultProps(), async (config) => {
                 const errorFunction = jasmine.createSpy('successfulFunction', () => {
                     return { error: { message: 'something went wrong' } }
                 }).and.callThrough()
 
                 const { result, exceptions } = await retry(errorFunction, config)
 
-                // should be just the last error as a result
+                // this line just helps typescript understand that we're expecting 'result.error'
                 if (result && !('error' in result)) throw new Error('unreachable')
 
+                // should be just the last error as a `result`
                 expect(result?.error.message).toEqual('something went wrong')
 
                 // should be empty since nothing threw

--- a/unit-test/timer-utils.js
+++ b/unit-test/timer-utils.js
@@ -1,0 +1,68 @@
+import fc from 'fast-check'
+import { DEFAULT_RETRY_CONFIG, retry } from '../src/timer-utils.js'
+
+describe('retry function tests', () => {
+    it('should always catch errors if the retried function always throws', async () => {
+        await fc.assert(
+            fc.asyncProperty(fc.integer({ min: 1, max: 10 }).map(n => ({ ...DEFAULT_RETRY_CONFIG, maxAttempts: n })), async (config) => {
+                const errorFunction = jasmine.createSpy('errorFunction', () => {
+                    throw new Error('Always fails') // A function that always throws an error
+                }).and.callThrough()
+
+                const { result, exceptions } = await retry(errorFunction, config)
+
+                // The result of our retry operation should be undefined since we always fail
+                expect(result).toBe(undefined)
+
+                // The error function should have been called config.maxAttempts times
+                expect(errorFunction.calls.count()).toEqual(config.maxAttempts)
+
+                // Size of errors should be equal to maxAttempts because the function always fails
+                expect(exceptions.length).toEqual(config.maxAttempts)
+            }))
+    })
+    it('should assign lastResult correctly and stop retrying when success is obtained', async () => {
+        await fc.assert(
+            fc.asyncProperty(fc.integer({ min: 1, max: 10 }).map(n => ({ ...DEFAULT_RETRY_CONFIG, maxAttempts: n })), async (config) => {
+                let callCount = 0
+                const successfulFunction = jasmine.createSpy('successfulFunction', () => {
+                    callCount += 1
+                    // The function fails for the first (n-1) times and succeeds on the nth time
+                    if (callCount === config.maxAttempts) {
+                        return { success: 'Function succeeded' }
+                    } else {
+                        return { error: { message: 'something went wrong' } }
+                    }
+                }).and.callThrough()
+
+                const { result, exceptions } = await retry(successfulFunction, config)
+
+                // Expect retry to return a successful result
+                expect(result).toEqual({ success: 'Function succeeded' })
+
+                // The error function should have been called config.maxAttempts times
+                expect(successfulFunction.calls.count()).toEqual(config.maxAttempts)
+
+                // Last attempt wouldn't be a fail so minus 1 from the errors
+                expect(exceptions).toEqual([])
+            }))
+    })
+    it('should return last result if a function is never successful', async () => {
+        await fc.assert(
+            fc.asyncProperty(fc.integer({ min: 1, max: 10 }).map(n => ({ ...DEFAULT_RETRY_CONFIG, maxAttempts: n })), async (config) => {
+                const errorFunction = jasmine.createSpy('successfulFunction', () => {
+                    return { error: { message: 'something went wrong' } }
+                }).and.callThrough()
+
+                const { result, exceptions } = await retry(errorFunction, config)
+
+                // should be just the last error as a result
+                if (result && !('error' in result)) throw new Error('unreachable')
+
+                expect(result?.error.message).toEqual('something went wrong')
+
+                // should be empty since nothing threw
+                expect(exceptions).toEqual([])
+            }))
+    })
+})


### PR DESCRIPTION
Asana: https://app.asana.com/0/0/1206543393124878/f

This allows actions to be defined with a 'retry' config.

The 'environment: web' part allows this to be interpreted by native at a later point (to consolidate logic that's being added on each native side)

```
retry: {
   environment: 'web',
   maxAttempts: 10,
   interval: { ms: 1000 }
}
```