### PR TITLE
support matching weights

### DIFF
--- a/integration-test/playwright/broker-protection.spec.js
+++ b/integration-test/playwright/broker-protection.spec.js
@@ -42,7 +42,8 @@ test.describe('Broker Protection communications', () => {
                 relatives: [
                     'Cheryl Lamar'
                 ],
-                profileUrl: baseURL + 'view/John-Smith-CyFdD.F'
+                profileUrl: baseURL + 'view/John-Smith-CyFdD.F',
+                identifier: baseURL + 'view/John-Smith-CyFdD.F'
             }])
         })
 
@@ -68,7 +69,8 @@ test.describe('Broker Protection communications', () => {
                         { city: 'Opa Locka', state: 'FL' }
                     ],
                     phoneNumbers: [],
-                    profileUrl: baseURL + 'view/Ben-Smith-CQEmF3CB'
+                    profileUrl: baseURL + 'view/Ben-Smith-CQEmF3CB',
+                    identifier: baseURL + 'view/Ben-Smith-CQEmF3CB'
                 },
                 {
                     name: 'Ben Smith',
@@ -79,7 +81,8 @@ test.describe('Broker Protection communications', () => {
                         { city: 'Miami', state: 'FL' }
                     ],
                     phoneNumbers: [],
-                    profileUrl: baseURL + 'view/Ben-Smith-DSAJBtFB'
+                    profileUrl: baseURL + 'view/Ben-Smith-DSAJBtFB',
+                    identifier: baseURL + 'view/Ben-Smith-DSAJBtFB'
                 }
             ])
         })
@@ -105,6 +108,7 @@ test.describe('Broker Protection communications', () => {
                     { city: 'More locations...4 more', state: 'addresses' }
                 ],
                 profileUrl: baseURL + 'products/name?firstName=john&middleName=a&lastName=smith&ln=smith&city=orlando&state=fl&id=G421681744450237260',
+                identifier: baseURL + 'products/name?firstName=john&middleName=a&lastName=smith&ln=smith&city=orlando&state=fl&id=G421681744450237260',
                 phoneNumbers: []
             }])
         })
@@ -124,6 +128,7 @@ test.describe('Broker Protection communications', () => {
                     { city: 'Tampa', state: 'FL' }
                 ],
                 profileUrl: baseURL + 'products/name?firstName=ben&lastName=smith&ln=smith&city=tampa&state=fl&id=G-3492284932683347509',
+                identifier: baseURL + 'products/name?firstName=ben&lastName=smith&ln=smith&city=tampa&state=fl&id=G-3492284932683347509',
                 phoneNumbers: []
             }])
         })
@@ -142,6 +147,7 @@ test.describe('Broker Protection communications', () => {
                     '97021405106'
                 ],
                 profileUrl: baseURL + 'person/Smith-41043103849',
+                identifier: baseURL + 'person/Smith-41043103849',
                 addresses: [
                     {
                         city: 'Orlando',
@@ -175,6 +181,7 @@ test.describe('Broker Protection communications', () => {
                     { city: 'Evanston', state: 'IL' }
                 ],
                 profileUrl: baseURL + 'pp/John-Smith-HdDWHRBD',
+                identifier: baseURL + 'pp/John-Smith-HdDWHRBD',
                 relatives: [
                     'Margaret Kelly, 74',
                     'Mary Kelly, 44',
@@ -207,6 +214,7 @@ test.describe('Broker Protection communications', () => {
                     'Jame...'
                 ],
                 profileUrl: baseURL + 'find/person/p286nuu00u98lu9n0n96',
+                identifier: baseURL + 'find/person/p286nuu00u98lu9n0n96',
                 phoneNumbers: []
             }])
         })
@@ -238,7 +246,8 @@ test.describe('Broker Protection communications', () => {
                     'Alexander Makely, 48',
                     'Veronica Berrios, 47'
                 ],
-                profileUrl: baseURL + 'people/John-Smith-AIGwGOFD'
+                profileUrl: baseURL + 'people/John-Smith-AIGwGOFD',
+                identifier: baseURL + 'people/John-Smith-AIGwGOFD'
             }])
         })
     })

--- a/integration-test/playwright/broker-protection.spec.js
+++ b/integration-test/playwright/broker-protection.spec.js
@@ -21,18 +21,8 @@ test.describe('Broker Protection communications', () => {
         })
     })
 
-    test.describe('Executes action and sends success message', () => {
-        test('buildUrl', async ({ page }, workerInfo) => {
-            const dbp = BrokerProtectionPage.create(page, workerInfo)
-            await dbp.enabled()
-            await dbp.navigatesTo('results.html')
-            await dbp.receivesAction('navigate.json')
-            const response = await dbp.waitForMessage('actionCompleted')
-            dbp.isSuccessMessage(response)
-            dbp.isUrlMatch(response[0].payload.params.result.success.response)
-        })
-
-        test('extract', async ({ page }, workerInfo) => {
+    test.describe('Profile extraction', () => {
+        test('extract', async ({ page, baseURL }, workerInfo) => {
             const dbp = BrokerProtectionPage.create(page, workerInfo)
             await dbp.enabled()
             await dbp.navigatesTo('results.html')
@@ -44,24 +34,15 @@ test.describe('Broker Protection communications', () => {
                 alternativeNames: [],
                 age: '38',
                 addresses: [
-                    {
-                        city: 'Chicago',
-                        state: 'IL'
-                    },
-                    {
-                        city: 'Ypsilanti',
-                        state: 'MI'
-                    },
-                    {
-                        city: 'Cadillac',
-                        state: 'MI'
-                    }
+                    { city: 'Chicago', state: 'IL' },
+                    { city: 'Ypsilanti', state: 'MI' },
+                    { city: 'Cadillac', state: 'MI' }
                 ],
                 phoneNumbers: [],
                 relatives: [
                     'Cheryl Lamar'
                 ],
-                profileUrl: 'http://localhost:3220/view/John-Smith-CyFdD.F'
+                profileUrl: baseURL + 'view/John-Smith-CyFdD.F'
             }])
         })
 
@@ -81,22 +62,10 @@ test.describe('Broker Protection communications', () => {
                     ],
                     age: '40',
                     addresses: [
-                        {
-                            city: 'Has lived',
-                            state: 'in:'
-                        },
-                        {
-                            city: 'Miami',
-                            state: 'FL'
-                        },
-                        {
-                            city: 'Miami Gardens',
-                            state: 'FL'
-                        },
-                        {
-                            city: 'Opa Locka',
-                            state: 'FL'
-                        }
+                        { city: 'Has lived', state: 'in:' },
+                        { city: 'Miami', state: 'FL' },
+                        { city: 'Miami Gardens', state: 'FL' },
+                        { city: 'Opa Locka', state: 'FL' }
                     ],
                     phoneNumbers: [],
                     profileUrl: 'http://localhost:3220/view/Ben-Smith-CQEmF3CB'
@@ -106,14 +75,8 @@ test.describe('Broker Protection communications', () => {
                     alternativeNames: null,
                     age: '40',
                     addresses: [
-                        {
-                            city: 'Has lived',
-                            state: 'in:'
-                        },
-                        {
-                            city: 'Miami',
-                            state: 'FL'
-                        }
+                        { city: 'Has lived', state: 'in:' },
+                        { city: 'Miami', state: 'FL' }
                     ],
                     phoneNumbers: [],
                     profileUrl: 'http://localhost:3220/view/Ben-Smith-DSAJBtFB'
@@ -278,6 +241,17 @@ test.describe('Broker Protection communications', () => {
                 profileUrl: baseURL + 'people/John-Smith-AIGwGOFD'
             }])
         })
+    })
+    test.describe('Executes action and sends success message', () => {
+        test('buildUrl', async ({ page }, workerInfo) => {
+            const dbp = BrokerProtectionPage.create(page, workerInfo)
+            await dbp.enabled()
+            await dbp.navigatesTo('results.html')
+            await dbp.receivesAction('navigate.json')
+            const response = await dbp.waitForMessage('actionCompleted')
+            dbp.isSuccessMessage(response)
+            dbp.isUrlMatch(response[0].payload.params.result.success.response)
+        })
 
         test('fillForm', async ({ page }, workerInfo) => {
             const dbp = BrokerProtectionPage.create(page, workerInfo)
@@ -296,6 +270,17 @@ test.describe('Broker Protection communications', () => {
             await dbp.receivesAction('click.json')
             const response = await dbp.waitForMessage('actionCompleted')
             dbp.isSuccessMessage(response)
+        })
+
+        test('clicking with parent selector (considering matching weight/score)', async ({ page }, workerInfo) => {
+            const dbp = BrokerProtectionPage.create(page, workerInfo)
+            await dbp.enabled()
+            await dbp.navigatesTo('results-weighted.html')
+            await dbp.receivesAction('click-weighted.json')
+            const response = await dbp.waitForMessage('actionCompleted')
+
+            dbp.isSuccessMessage(response)
+            await page.waitForURL(url => url.hash === '#2', { timeout: 2000 })
         })
 
         test('getCaptchaInfo', async ({ page }, workerInfo) => {

--- a/integration-test/playwright/broker-protection.spec.js
+++ b/integration-test/playwright/broker-protection.spec.js
@@ -46,7 +46,7 @@ test.describe('Broker Protection communications', () => {
             }])
         })
 
-        test('extract multiple profiles', async ({ page }, workerInfo) => {
+        test('extract multiple profiles', async ({ page, baseURL }, workerInfo) => {
             const dbp = BrokerProtectionPage.create(page, workerInfo)
             await dbp.enabled()
             await dbp.navigatesTo('results-multiple.html')
@@ -68,7 +68,7 @@ test.describe('Broker Protection communications', () => {
                         { city: 'Opa Locka', state: 'FL' }
                     ],
                     phoneNumbers: [],
-                    profileUrl: 'http://localhost:3220/view/Ben-Smith-CQEmF3CB'
+                    profileUrl: baseURL + 'view/Ben-Smith-CQEmF3CB'
                 },
                 {
                     name: 'Ben Smith',
@@ -79,7 +79,7 @@ test.describe('Broker Protection communications', () => {
                         { city: 'Miami', state: 'FL' }
                     ],
                     phoneNumbers: [],
-                    profileUrl: 'http://localhost:3220/view/Ben-Smith-DSAJBtFB'
+                    profileUrl: baseURL + 'view/Ben-Smith-DSAJBtFB'
                 }
             ])
         })
@@ -277,6 +277,17 @@ test.describe('Broker Protection communications', () => {
             await dbp.enabled()
             await dbp.navigatesTo('results-weighted.html')
             await dbp.receivesAction('click-weighted.json')
+            const response = await dbp.waitForMessage('actionCompleted')
+
+            dbp.isSuccessMessage(response)
+            await page.waitForURL(url => url.hash === '#2', { timeout: 2000 })
+        })
+
+        test('clicking with parent selector (clicking the actual parent)', async ({ page }, workerInfo) => {
+            const dbp = BrokerProtectionPage.create(page, workerInfo)
+            await dbp.enabled()
+            await dbp.navigatesTo('results-parent.html')
+            await dbp.receivesAction('click-parent.json')
             const response = await dbp.waitForMessage('actionCompleted')
 
             dbp.isSuccessMessage(response)

--- a/integration-test/playwright/broker-protection.spec.js
+++ b/integration-test/playwright/broker-protection.spec.js
@@ -39,16 +39,30 @@ test.describe('Broker Protection communications', () => {
             await dbp.receivesAction('extract.json')
             const response = await dbp.waitForMessage('actionCompleted')
             dbp.isSuccessMessage(response)
-            dbp.isExtractMatch(response[0].payload.params.result.success.response, {
-                age: '38',
+            dbp.isExtractMatch(response[0].payload.params.result.success.response, [{
                 name: 'John Smith',
-                relatives: ['Cheryl Lamar'],
-                addresses: [{ city: 'Chicago', state: 'IL' }, { city: 'Ypsilanti', state: 'MI' }, {
-                    city: 'Cadillac',
-                    state: 'MI'
-                }],
-                profileUrl: '/view/John-Smith-CyFdD.F'
-            })
+                alternativeNames: [],
+                age: '38',
+                addresses: [
+                    {
+                        city: 'Chicago',
+                        state: 'IL'
+                    },
+                    {
+                        city: 'Ypsilanti',
+                        state: 'MI'
+                    },
+                    {
+                        city: 'Cadillac',
+                        state: 'MI'
+                    }
+                ],
+                phoneNumbers: [],
+                relatives: [
+                    'Cheryl Lamar'
+                ],
+                profileUrl: 'http://localhost:3220/view/John-Smith-CyFdD.F'
+            }])
         })
 
         test('extract multiple profiles', async ({ page }, workerInfo) => {
@@ -58,21 +72,63 @@ test.describe('Broker Protection communications', () => {
             await dbp.receivesAction('extract2.json')
             const response = await dbp.waitForMessage('actionCompleted')
             dbp.isSuccessMessage(response)
-            dbp.isMultiple(response[0].payload.params.result.success.response)
-            dbp.isExtractMatch(response[0].payload.params.result.success.response, {
-                age: '40',
-                name: 'Ben Smith'
-            })
+            dbp.isExtractMatch(response[0].payload.params.result.success.response, [
+                {
+                    name: 'Ben Smith',
+                    alternativeNames: [
+                        'Known as:',
+                        'Ben S Smith'
+                    ],
+                    age: '40',
+                    addresses: [
+                        {
+                            city: 'Has lived',
+                            state: 'in:'
+                        },
+                        {
+                            city: 'Miami',
+                            state: 'FL'
+                        },
+                        {
+                            city: 'Miami Gardens',
+                            state: 'FL'
+                        },
+                        {
+                            city: 'Opa Locka',
+                            state: 'FL'
+                        }
+                    ],
+                    phoneNumbers: [],
+                    profileUrl: 'http://localhost:3220/view/Ben-Smith-CQEmF3CB'
+                },
+                {
+                    name: 'Ben Smith',
+                    alternativeNames: null,
+                    age: '40',
+                    addresses: [
+                        {
+                            city: 'Has lived',
+                            state: 'in:'
+                        },
+                        {
+                            city: 'Miami',
+                            state: 'FL'
+                        }
+                    ],
+                    phoneNumbers: [],
+                    profileUrl: 'http://localhost:3220/view/Ben-Smith-DSAJBtFB'
+                }
+            ])
         })
 
-        test('extract profiles test 3', async ({ page }, workerInfo) => {
+        test('extract profiles test 3', async ({ page, baseURL }, workerInfo) => {
             const dbp = BrokerProtectionPage.create(page, workerInfo)
             await dbp.enabled()
             await dbp.navigatesTo('results-alt.html')
             await dbp.receivesAction('extract3.json')
             const response = await dbp.waitForMessage('actionCompleted')
             dbp.isSuccessMessage(response)
-            dbp.isExtractMatch(response[0].payload.params.result.success.response, {
+            dbp.isExtractMatch(response[0].payload.params.result.success.response, [{
                 name: 'John A Smith',
                 age: '63',
                 alternativeNames: [
@@ -85,54 +141,62 @@ test.describe('Broker Protection communications', () => {
                     { city: 'Miami', state: 'FL' },
                     { city: 'More locations...4 more', state: 'addresses' }
                 ],
-                profileUrl: '/products/name?firstName=john&middleName=a&lastName=smith&ln=smith&city=orlando&state=fl&id=G421681744450237260'
-            })
+                profileUrl: baseURL + 'products/name?firstName=john&middleName=a&lastName=smith&ln=smith&city=orlando&state=fl&id=G421681744450237260',
+                phoneNumbers: []
+            }])
         })
 
-        test('extract profiles test 4', async ({ page }, workerInfo) => {
+        test('extract profiles test 4', async ({ page, baseURL }, workerInfo) => {
             const dbp = BrokerProtectionPage.create(page, workerInfo)
             await dbp.enabled()
             await dbp.navigatesTo('results-4.html')
             await dbp.receivesAction('extract4.json')
             const response = await dbp.waitForMessage('actionCompleted')
             dbp.isSuccessMessage(response)
-            dbp.isExtractMatch(response[0].payload.params.result.success.response,
-                {
-                    name: 'Ben Smith',
-                    age: '55',
-                    alternativeNames: null,
-                    addresses: [
-                        { city: 'Tampa', state: 'FL' }
-                    ],
-                    profileUrl: '/products/name?firstName=ben&lastName=smith&ln=smith&city=tampa&state=fl&id=G-3492284932683347509'
-                })
+            dbp.isExtractMatch(response[0].payload.params.result.success.response, [{
+                name: 'Ben Smith',
+                age: '55',
+                alternativeNames: null,
+                addresses: [
+                    { city: 'Tampa', state: 'FL' }
+                ],
+                profileUrl: baseURL + 'products/name?firstName=ben&lastName=smith&ln=smith&city=tampa&state=fl&id=G-3492284932683347509',
+                phoneNumbers: []
+            }])
         })
 
-        test('extract profiles test 5', async ({ page }, workerInfo) => {
+        test('extract profiles test 5', async ({ page, baseURL }, workerInfo) => {
             const dbp = BrokerProtectionPage.create(page, workerInfo)
             await dbp.enabled()
             await dbp.navigatesTo('results-5.html')
             await dbp.receivesAction('extract5.json')
             const response = await dbp.waitForMessage('actionCompleted')
             dbp.isSuccessMessage(response)
-            dbp.isExtractMatch(response[0].payload.params.result.success.response, {
+            dbp.isExtractMatch(response[0].payload.params.result.success.response, [{
                 name: 'Jonathan Smith',
                 age: '50',
                 phoneNumbers: [
                     '97021405106'
                 ],
-                profileUrl: '/person/Smith-41043103849'
-            })
+                profileUrl: baseURL + 'person/Smith-41043103849',
+                addresses: [
+                    {
+                        city: 'Orlando',
+                        state: 'FL'
+                    }
+                ],
+                relatives: null
+            }])
         })
 
-        test('extract profile from irregular HTML 1', async ({ page }, workerInfo) => {
+        test('extract profile from irregular HTML 1', async ({ page, baseURL }, workerInfo) => {
             const dbp = BrokerProtectionPage.create(page, workerInfo)
             await dbp.enabled()
             await dbp.navigatesTo('results-irregular1.html')
             await dbp.receivesAction('extract-irregular1.json')
             const response = await dbp.waitForMessage('actionCompleted')
             dbp.isSuccessMessage(response)
-            dbp.isExtractMatch(response[0].payload.params.result.success.response, {
+            dbp.isExtractMatch(response[0].payload.params.result.success.response, [{
                 name: 'John M Smith',
                 age: '75',
                 alternativeNames: [
@@ -147,18 +211,25 @@ test.describe('Broker Protection communications', () => {
                     { city: 'Chicago', state: 'IL' },
                     { city: 'Evanston', state: 'IL' }
                 ],
-                profileUrl: '/pp/John-Smith-HdDWHRBD'
-            })
+                profileUrl: baseURL + 'pp/John-Smith-HdDWHRBD',
+                relatives: [
+                    'Margaret Kelly, 74',
+                    'Mary Kelly, 44',
+                    'Michael Kelly, 77',
+                    'Michael Kelly, 46'
+                ],
+                phoneNumbers: []
+            }])
         })
 
-        test('extract profile from irregular HTML 2', async ({ page }, workerInfo) => {
+        test('extract profile from irregular HTML 2', async ({ page, baseURL }, workerInfo) => {
             const dbp = BrokerProtectionPage.create(page, workerInfo)
             await dbp.enabled()
             await dbp.navigatesTo('results-irregular2.html')
             await dbp.receivesAction('extract-irregular2.json')
             const response = await dbp.waitForMessage('actionCompleted')
             dbp.isSuccessMessage(response)
-            dbp.isExtractMatch(response[0].payload.params.result.success.response, {
+            dbp.isExtractMatch(response[0].payload.params.result.success.response, [{
                 name: 'John Smith',
                 age: '71',
                 addresses: [
@@ -172,18 +243,19 @@ test.describe('Broker Protection communications', () => {
                     'Brittany J Hoard',
                     'Jame...'
                 ],
-                profileUrl: '/find/person/p286nuu00u98lu9n0n96'
-            })
+                profileUrl: baseURL + 'find/person/p286nuu00u98lu9n0n96',
+                phoneNumbers: []
+            }])
         })
 
-        test('extract profile from irregular HTML 3', async ({ page }, workerInfo) => {
+        test('extract profile from irregular HTML 3', async ({ page, baseURL }, workerInfo) => {
             const dbp = BrokerProtectionPage.create(page, workerInfo)
             await dbp.enabled()
             await dbp.navigatesTo('results-irregular3.html')
             await dbp.receivesAction('extract-irregular3.json')
             const response = await dbp.waitForMessage('actionCompleted')
             dbp.isSuccessMessage(response)
-            dbp.isExtractMatch(response[0].payload.params.result.success.response, {
+            dbp.isExtractMatch(response[0].payload.params.result.success.response, [{
                 name: 'John I Smith',
                 age: '59',
                 addresses: [
@@ -192,14 +264,19 @@ test.describe('Broker Protection communications', () => {
                     { city: 'Forest Park', state: 'IL' },
                     { city: 'Oak Park', state: 'IL' }
                 ],
-                alternativeNames: null,
+                alternativeNames: [
+                    'John Smith',
+                    'Johni Smith',
+                    'John Farmersmith'
+                ],
+                phoneNumbers: [],
                 relatives: [
                     'Ethel Makely',
                     'Alexander Makely, 48',
                     'Veronica Berrios, 47'
                 ],
-                profileUrl: '/people/John-Smith-AIGwGOFD'
-            })
+                profileUrl: baseURL + 'people/John-Smith-AIGwGOFD'
+            }])
         })
 
         test('fillForm', async ({ page }, workerInfo) => {

--- a/integration-test/playwright/page-objects/broker-protection.js
+++ b/integration-test/playwright/page-objects/broker-protection.js
@@ -103,7 +103,7 @@ export class BrokerProtectionPage {
     /**
      * Simulate the native-side pushing an action into the client-side JS
      *
-     * @param {'extract.json' | 'extract2.json' | 'extract3.json' | 'extract4.json' | 'extract5.json' | 'extract-irregular1.json' | 'extract-irregular2.json' | 'extract-irregular3.json' | 'results2.json' | 'navigate.json' | 'fill-form.json' | 'click.json' | 'expectation.json' | 'get-captcha.json' | 'solve-captcha.json' | 'action-not-found.json'} action - add more action types here
+     * @param {string} action
      * @return {Promise<void>}
      */
     async receivesAction (action) {

--- a/integration-test/playwright/page-objects/broker-protection.js
+++ b/integration-test/playwright/page-objects/broker-protection.js
@@ -60,20 +60,7 @@ export class BrokerProtectionPage {
      * @return {void}
      */
     isExtractMatch (response, person) {
-        if (person.name) { expect(response[0]?.name).toBe(person.name) }
-        if (person.alternativeNames) { expect(response[0]?.alternativeNames).toStrictEqual(person.alternativeNames) }
-        if (person.age) { expect(response[0]?.age).toBe(person.age) }
-        if (person.addresses) { expect(response[0]?.addresses).toStrictEqual(person.addresses) }
-        if (person.relatives) { expect(response[0]?.relatives).toStrictEqual(person.relatives) }
-        if (person.phoneNumbers) { expect(response[0]?.phoneNumbers).toStrictEqual(person.phoneNumbers) }
-        if (person.profileUrl) { expect(response[0]?.profileUrl).toContain(person.profileUrl) }
-    }
-
-    /**
-     * @return {void}
-     */
-    isMultiple (response) {
-        expect(response.length).toBeGreaterThan(1)
+        expect(person).toMatchObject(response)
     }
 
     /**

--- a/integration-test/test-pages/broker-protection/actions/click-parent.json
+++ b/integration-test/test-pages/broker-protection/actions/click-parent.json
@@ -1,0 +1,42 @@
+{
+  "state": {
+    "action": {
+      "actionType": "click",
+      "elements": [
+        {
+          "type": "button",
+          "selector": ".",
+          "parent": {
+            "profileMatch": {
+              "selector": ".record",
+              "profile": {
+                "name": {
+                  "selector": ".name"
+                },
+                "age": {
+                  "selector": ".age"
+                },
+                "addressCityState": {
+                  "selector": ".address"
+                }
+              }
+            }
+          }
+        }
+      ]
+    },
+    "data": {
+      "firstName": "John",
+      "middleName": "Robert",
+      "lastName": "Cole",
+      "age": "39",
+      "addresses": [
+        {
+          "addressLine1": "123 Fake St",
+          "city": "New York",
+          "state": "NY"
+        }
+      ]
+    }
+  }
+}

--- a/integration-test/test-pages/broker-protection/actions/click-weighted.json
+++ b/integration-test/test-pages/broker-protection/actions/click-weighted.json
@@ -1,0 +1,42 @@
+{
+  "state": {
+    "action": {
+      "actionType": "click",
+      "elements": [
+        {
+          "type": "button",
+          "selector": ".opt-out",
+          "parent": {
+            "profileMatch": {
+              "selector": ".record",
+              "profile": {
+                "name": {
+                  "selector": ".name"
+                },
+                "age": {
+                  "selector": ".age"
+                },
+                "addressCityState": {
+                  "selector": ".address"
+                }
+              }
+            }
+          }
+        }
+      ]
+    },
+    "data": {
+      "firstName": "John",
+      "middleName": "Robert",
+      "lastName": "Cole",
+      "age": "39",
+      "addresses": [
+        {
+          "addressLine1": "123 Fake St",
+          "city": "New York",
+          "state": "NY"
+        }
+      ]
+    }
+  }
+}

--- a/integration-test/test-pages/broker-protection/pages/results-parent.html
+++ b/integration-test/test-pages/broker-protection/pages/results-parent.html
@@ -1,0 +1,35 @@
+<div class="records">
+    <a class="record" data-index="0">
+        <span class="name">
+            <span class="fname">John</span>
+            <span class="lname">Cole</span>
+        </span>
+        <span class="address">New York, NY</span>
+    </a>
+    <a class="record" data-index="1">
+        <span class="name">
+            <span class="fname">John</span>
+            <span class="mname">A</span>
+            <span class="lname">Cole</span>
+        </span>
+        <span class="age">39</span>
+        <span class="address">New York, NY</span>
+    </a>
+    <a class="record" data-index="2">
+        <span class="name">
+            <span class="fname">John</span>
+            <span class="mname">R</span>
+            <span class="lname">Cole</span>
+        </span>
+        <span class="age">39</span>
+        <span class="address">New York, NY</span>
+    </a>
+</div>
+<script>
+    document.addEventListener('click', (e) => {
+        e.preventDefault();
+        if (e.target.tagName === 'A') {
+            window.location.hash = '#' + e.target.dataset.index
+        }
+    })
+</script>

--- a/integration-test/test-pages/broker-protection/pages/results-weighted.html
+++ b/integration-test/test-pages/broker-protection/pages/results-weighted.html
@@ -1,0 +1,38 @@
+<ul class="records">
+    <li class="record">
+        <p class="name">
+            <span class="fname">John</span>
+            <span class="lname">Cole</span>
+        </p>
+        <span class="address">New York, NY</span>
+        <button class="opt-out" data-index="0">Opt out</button>
+    </li>
+    <li class="record">
+        <p class="name">
+            <span class="fname">John</span>
+            <span class="mname">A</span>
+            <span class="lname">Cole</span>
+        </p>
+        <span class="age">39</span>
+        <span class="address">New York, NY</span>
+        <button class="opt-out" data-index="1">Opt out</button>
+    </li>
+    <li class="record">
+        <p class="name">
+            <span class="fname">John</span>
+            <span class="mname">R</span>
+            <span class="lname">Cole</span>
+        </p>
+        <span class="age">39</span>
+        <span class="address">New York, NY</span>
+        <button class="opt-out" data-index="2">Opt out</button>
+    </li>
+</ul>
+<script>
+    document.addEventListener('click', (e) => {
+        e.preventDefault();
+        if (e.target.tagName === 'BUTTON') {
+            window.location.hash = '#' + e.target.dataset.index
+        }
+    })
+</script>

--- a/src/features/broker-protection/actions/click.js
+++ b/src/features/broker-protection/actions/click.js
@@ -11,11 +11,22 @@ export function click (action, userData) {
     // there can be multiple elements provided by the action
     for (const element of action.elements) {
         const root = selectRootElement(element, userData)
-        const elem = getElement(root, element.selector)
+
+        const elem = element.selector === '.'
+            ? root
+            : getElement(root, element.selector)
+
         if (!elem) {
             return new ErrorResponse({ actionID: action.id, message: `could not find element to click with selector '${element.selector}'!` })
         }
-        elem.click()
+        if ('disabled' in elem) {
+            if (elem.disabled) {
+                return new ErrorResponse({ actionID: action.id, message: `could not click disabled element ${element.selector}'!` })
+            }
+        }
+        if ('click' in elem && typeof elem.click === 'function') {
+            elem.click()
+        }
     }
 
     return new SuccessResponse({ actionID: action.id, actionType: action.actionType, response: null })

--- a/src/features/broker-protection/actions/click.js
+++ b/src/features/broker-protection/actions/click.js
@@ -1,14 +1,17 @@
 import { getElement } from '../utils.js'
 import { ErrorResponse, SuccessResponse } from '../types.js'
+import { extractProfiles } from './extract.js'
 
 /**
- * @param action // TODO: get type based on actionType
+ * @param {Record<string, any>} action
+ * @param {Record<string, any>} userData
  * @return {import('../types.js').ActionResponse}
  */
-export function click (action) {
+export function click (action, userData) {
     // there can be multiple elements provided by the action
     for (const element of action.elements) {
-        const elem = getElement(document, element.selector)
+        const root = selectRootElement(element, userData)
+        const elem = getElement(root, element.selector)
         if (!elem) {
             return new ErrorResponse({ actionID: action.id, message: `could not find element to click with selector '${element.selector}'!` })
         }
@@ -16,4 +19,29 @@ export function click (action) {
     }
 
     return new SuccessResponse({ actionID: action.id, actionType: action.actionType, response: null })
+}
+
+/**
+ * @param {{parent?: {profileMatch?: Record<string, any>}}} clickElement
+ * @param {Record<string, any>} userData
+ * @return {Node}
+ */
+function selectRootElement (clickElement, userData) {
+    // if there's no 'parent' field, just use the document
+    if (!clickElement.parent) return document
+
+    // if the 'parent' field contains 'profileMatch', try to match it
+    if (clickElement.parent.profileMatch) {
+        const extraction = extractProfiles(clickElement.parent.profileMatch, userData)
+        if ('results' in extraction) {
+            const sorted = extraction.results
+                .filter(x => x.result === true)
+                .sort((a, b) => b.score - a.score)
+            if (sorted[0]) {
+                return sorted[0].element
+            }
+        }
+    }
+
+    throw new Error('`parent` was present on the element, but the configuration is not supported')
 }

--- a/src/features/broker-protection/actions/click.js
+++ b/src/features/broker-protection/actions/click.js
@@ -11,10 +11,7 @@ export function click (action, userData) {
     // there can be multiple elements provided by the action
     for (const element of action.elements) {
         const root = selectRootElement(element, userData)
-
-        const elem = element.selector === '.'
-            ? root
-            : getElement(root, element.selector)
+        const elem = getElement(root, element.selector)
 
         if (!elem) {
             return new ErrorResponse({ actionID: action.id, message: `could not find element to click with selector '${element.selector}'!` })

--- a/src/features/broker-protection/comparisons/address.js
+++ b/src/features/broker-protection/comparisons/address.js
@@ -3,7 +3,7 @@ import { states } from './constants.js'
 /**
  * @param userAddresses
  * @param foundAddresses
- * @return {{cityFound, stateFound}|boolean}
+ * @return {boolean}
  */
 export function matchAddressFromAddressListCityState (userAddresses, foundAddresses) {
     if (!userAddresses || userAddresses.length < 1 || !foundAddresses || foundAddresses.length < 1) {
@@ -23,7 +23,7 @@ export function matchAddressFromAddressListCityState (userAddresses, foundAddres
             stateFound = possibleLocation.state
 
             if (isSameAddressCityState(userCity, userState, cityFound, stateFound)) {
-                return { cityFound, stateFound }
+                return true
             }
         }
     }

--- a/src/features/broker-protection/execute.js
+++ b/src/features/broker-protection/execute.js
@@ -1,5 +1,5 @@
 import { buildUrl } from './actions/build-url.js'
-import { extractProfiles } from './actions/extract.js'
+import { extract } from './actions/extract.js'
 import { fillForm } from './actions/fill-form.js'
 import { getCaptchaInfo, solveCaptcha } from './actions/captcha.js'
 import { click } from './actions/click.js'
@@ -19,9 +19,9 @@ export function execute (action, data) {
         case 'navigate':
             return buildUrl(action, data)
         case 'extract':
-            return extractProfiles(action, data)
+            return extract(action, data)
         case 'click':
-            return click(action)
+            return click(action, data)
         case 'expectation':
             return expectation(action)
         case 'fillForm':

--- a/src/features/broker-protection/utils.js
+++ b/src/features/broker-protection/utils.js
@@ -71,6 +71,10 @@ function matchesXPath (element, selector) {
  */
 function isXpath (selector) {
     if (!(typeof selector === 'string')) return false
+
+    // see: https://www.w3.org/TR/xpath20/
+    // "When the context item is a node, it can also be referred to as the context node. The context item is returned by an expression consisting of a single dot"
+    if (selector === '.') return true
     return selector.startsWith('//') || selector.startsWith('./') || selector.startsWith('(')
 }
 

--- a/unit-test/broker-protection.js
+++ b/unit-test/broker-protection.js
@@ -218,11 +218,11 @@ describe('Actions', () => {
 
             describe('matchAddressFromAddressListCityState', () => {
                 it('should match when city/state is present', () => {
-                    expect(matchAddressFromAddressListCityState(userData.addresses, ['chicago, il', 'schaumburg, il']))
+                    expect(matchAddressFromAddressListCityState(userData.addresses, [{ city: 'chicago', state: 'il' }])).toBe(true)
                 })
 
                 it('should not match when city/state is not present', () => {
-                    expect(matchAddressFromAddressListCityState(userData.addresses, ['los angeles, ca', 'portland, or']))
+                    expect(matchAddressFromAddressListCityState(userData.addresses, [{ city: 'los angeles', state: 'ca' }])).toBe(false)
                 })
             })
 


### PR DESCRIPTION
https://app.asana.com/0/0/1206543393124882/f

previous click actions looked like this: 

```json
{
  "actionType": "click",
  "elements": [
    {
      "type": "button",
      "selector": ".opt-out"
    }
  ]
}
```

when used, the `document` is used as the 'root element'. Meaning that the CSS selector `.opt-out` here is the equivalent of

```js
document.querySelector('.opt-out')
```

This change allows us to declare a 'parent' element to replace 'document' as the root element where the search should occur. 

The first supported 'parent' selector is a profile match, therefore the following definition is the same as saying

- first select the parent, based on profile matching logic
- use that as the root element for the the subsequent match

![Untitled (8)](https://github.com/duckduckgo/content-scope-scripts/assets/1643522/dfd13cbe-17e8-4986-aa19-b94e5a99030a)
