### PR TITLE
Extract identifier from profile url

### DIFF
--- a/src/features/broker-protection/actions/extract.js
+++ b/src/features/broker-protection/actions/extract.js
@@ -191,7 +191,7 @@ export function aggregateFields (profile) {
         addresses,
         phoneNumbers,
         relatives: profile.relativesList,
-	...profile.profileUrl
+        ...profile.profileUrl
     }
 }
 
@@ -240,27 +240,26 @@ function extractValue (key, value, elementValue) {
         },
         phoneList: () => stringToList(elementValue, value.separator),
         relativesList: () => stringToList(elementValue, value.separator),
-	profileUrl: () => {
-	    const url = {
+        profileUrl: () => {
+            const url = {
                 profileUrl: elementValue
             }
 
             if (value.identifier && value.identifierType) {
-                const parsedUrl = new URL(elementValue);
-                const { identifier, identifierType } = value;
-                const urlParams = parsedUrl.searchParams;
+                const parsedUrl = new URL(elementValue)
+                const { identifier, identifierType } = value
+                const urlParams = parsedUrl.searchParams
 
                 // Attempt to parse out an id from the search parameters
-                if (identifierType === "param" && urlParams.has(identifier)) {
-                    url.identifier = urlParams.get(identifier);
-                
+                if (identifierType === 'param' && urlParams.has(identifier)) {
+                    url.identifier = urlParams.get(identifier)
+
                 // TODO: add support for path based id finding
-                } else if (identifierType === "path") {
                 }
             }
 
-            return url;
-	}
+            return url
+        }
     }
 
     if (key in extractors) {

--- a/src/features/broker-protection/actions/extract.js
+++ b/src/features/broker-protection/actions/extract.js
@@ -191,7 +191,7 @@ export function aggregateFields (profile) {
         addresses,
         phoneNumbers,
         relatives: profile.relativesList,
-        profileUrl: profile.profileUrl
+	...profile.profileUrl
     }
 }
 
@@ -239,7 +239,25 @@ function extractValue (key, value, elementValue) {
             return stringToList(phoneNumber)
         },
         phoneList: () => stringToList(elementValue, value.separator),
-        relativesList: () => stringToList(elementValue, value.separator)
+        relativesList: () => stringToList(elementValue, value.separator),
+	profileUrl: () => {
+	    const url = {
+                profileUrl: elementValue
+            }
+
+            if (value.identifier && value.identifierType) {
+                const parsedUrl = new URL(elementValue);
+                const { identifier, identifierType } = value;
+                const urlParams = parsedUrl.searchParams;
+
+                // Attempt to parse out an id from the search parameters
+                if (identifierType === "param" && urlParams.has(identifier)) {
+                    url.identifier = urlParams.get(identifier);
+                }
+            }
+
+            return url;
+	}
     }
 
     if (key in extractors) {

--- a/src/features/broker-protection/actions/extract.js
+++ b/src/features/broker-protection/actions/extract.js
@@ -11,6 +11,7 @@ import { matchAddressFromAddressListCityState } from '../comparisons/address.js'
  */
 
 /**
+ * @typedef {'param'|'path'} IdentifierType
  * @typedef {Object} ExtractProfileProperty
  * For example: {
  *   "selector": ".//div[@class='col-sm-24 col-md-8 relatives']//li"
@@ -20,6 +21,8 @@ import { matchAddressFromAddressListCityState } from '../comparisons/address.js'
  * @property {string} [afterText] - get all text after this string
  * @property {string} [beforeText] - get all text before this string
  * @property {string} [separator] - split the text on this string
+ * @property {IdentifierType} [identifierType] - the type (path/param) of the identifier
+ * @property {string} [identifier] - the identifier itself (either a param name, or a templated URI)
  */
 
 /**
@@ -241,24 +244,18 @@ function extractValue (key, value, elementValue) {
         phoneList: () => stringToList(elementValue, value.separator),
         relativesList: () => stringToList(elementValue, value.separator),
         profileUrl: () => {
-            const url = {
-                profileUrl: elementValue
+            const profile = {
+                profileUrl: elementValue,
+                identifier: elementValue
             }
 
-            if (value.identifier && value.identifierType) {
-                const parsedUrl = new URL(elementValue)
-                const { identifier, identifierType } = value
-                const urlParams = parsedUrl.searchParams
-
-                // Attempt to parse out an id from the search parameters
-                if (identifierType === 'param' && urlParams.has(identifier)) {
-                    url.identifier = urlParams.get(identifier)
-
-                // TODO: add support for path based id finding
-                }
+            if (!value.identifierType || !value.identifier) {
+                return profile
             }
 
-            return url
+            const profileUrl = Array.isArray(elementValue) ? elementValue[0] : elementValue
+            profile.identifier = getIdFromProfileUrl(profileUrl, value.identifierType, value.identifier)
+            return profile
         }
     }
 
@@ -321,4 +318,24 @@ const rules = {
     profileUrl: function (link) {
         return link?.href ?? null
     }
+}
+
+/**
+ * Parse a profile id from a profile URL
+ * @param {string} profileUrl
+ * @param {IdentifierType} identifierType
+ * @param {string} identifier
+ * @return {string}
+ */
+export function getIdFromProfileUrl (profileUrl, identifierType, identifier) {
+    const parsedUrl = new URL(profileUrl)
+    const urlParams = parsedUrl.searchParams
+
+    // Attempt to parse out an id from the search parameters
+    if (identifierType === 'param' && urlParams.has(identifier)) {
+        const profileId = urlParams.get(identifier)
+        return profileId || profileUrl
+    }
+
+    return profileUrl
 }

--- a/src/features/broker-protection/actions/extract.js
+++ b/src/features/broker-protection/actions/extract.js
@@ -253,6 +253,9 @@ function extractValue (key, value, elementValue) {
                 // Attempt to parse out an id from the search parameters
                 if (identifierType === "param" && urlParams.has(identifier)) {
                     url.identifier = urlParams.get(identifier);
+                
+                // TODO: add support for path based id finding
+                } else if (identifierType === "path") {
                 }
             }
 

--- a/unit-test/broker-protection.js
+++ b/unit-test/broker-protection.js
@@ -1,7 +1,7 @@
 import fc from 'fast-check'
 import { isSameAge } from '../src/features/broker-protection/comparisons/is-same-age.js'
 import { getNicknames, isSameName } from '../src/features/broker-protection/comparisons/is-same-name.js'
-import { getCityStateCombos, stringToList } from '../src/features/broker-protection/actions/extract.js'
+import { getCityStateCombos, stringToList, getIdFromProfileUrl } from '../src/features/broker-protection/actions/extract.js'
 import {
     matchAddressCityState,
     matchAddressFromAddressListCityState
@@ -209,6 +209,43 @@ describe('Actions', () => {
                 it('should not match when city is not the same', () => {
                     expect(matchesFullAddress(userData.addresses, '123 fake st, not chicago, il, 60602')).toBe(false)
                 })
+            })
+        })
+
+        describe('getIdFromProfileUrl', () => {
+            it('should return the profile URL as the identifier if the identifierType is "path"', () => {
+                const profileUrl = 'https://duckduckgo.com/my/profile/john-smith/223'
+                const identifierType = 'path'
+                // eslint-disable-next-line no-template-curly-in-string
+                const identifier = 'https://duckduckgo.com/my/profile/${firstName}-${lastName}/${id}'
+
+                expect(getIdFromProfileUrl(profileUrl, identifierType, identifier)).toEqual(profileUrl)
+            })
+
+            it('should return the profile URL as the identifier if the identifierType is "param" and the param is not found', () => {
+                const profileUrl = 'https://duckduckgo.com/my/profile?id=test'
+                const identifierType = 'param'
+                const identifier = 'pid'
+
+                expect(getIdFromProfileUrl(profileUrl, identifierType, identifier)).toEqual(profileUrl)
+            })
+
+            it('should return the profile URL as the identifier if the identifierType is "param" and the identifier is a path', () => {
+                const profileUrl = 'https://duckduckgo.com/my/profile/john-smith/223'
+                const identifierType = 'param'
+                // eslint-disable-next-line no-template-curly-in-string
+                const identifier = 'https://duckduckgo.com/my/profile/${firstName}-${lastName}/${id}'
+
+                expect(getIdFromProfileUrl(profileUrl, identifierType, identifier)).toEqual(profileUrl)
+            })
+
+            it('should return the id as the identifier if the identifierType is "param" and the param is found in the url', () => {
+                const id = 'test'
+                const profileUrl = `https://duckduckgo.com/my/profile?id=${id}`
+                const identifierType = 'param'
+                const identifier = 'id'
+
+                expect(getIdFromProfileUrl(profileUrl, identifierType, identifier)).toEqual(id)
             })
         })
     })


### PR DESCRIPTION
Asana: https://app.asana.com/0/0/1205912576739062/f
Accompanying broker JSON PR: https://github.com/duckduckgo/data-broker-protection-json/pull/40

Additional context: https://app.asana.com/0/608920331025329/1205560036177758

## Description

We're [adding](https://github.com/duckduckgo/data-broker-protection-json/pull/40) a profile identifier to the broker JSON that should allow us to extract a unique id from a profile URL (vs. using the entire URL, which is what we're doing currently). This prevents us from having duplicate information in the database due to url params being in a different order, etc.