### PR TITLE
Strip zip code from city/state matches

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,6 +12,9 @@ permissions:
   id-token: write
   deployments: write
 
+env:
+  PUPPETEER_DOWNLOAD_BASE_URL: https://storage.googleapis.com/chrome-for-testing-public
+
 jobs:
   unit:
     runs-on: ${{ matrix.os }}

--- a/src/features/broker-protection/actions/extract.js
+++ b/src/features/broker-protection/actions/extract.js
@@ -298,7 +298,7 @@ export function getCityStateCombos (inputList) {
     for (let item of inputList) {
         let words
         // Strip out the zip code since we're only interested in city/state here.
-        item = item.replace(/,?.\b\d{5}(?:-\d{4})?\b/, '')
+        item = item.replace(/,?\s*\d{5}(-\d{4})?/, '')
 
         if (item.includes(',')) {
             words = item.split(',').map(item => item.trim())

--- a/src/features/broker-protection/actions/extract.js
+++ b/src/features/broker-protection/actions/extract.js
@@ -297,7 +297,9 @@ export function getCityStateCombos (inputList) {
     const output = []
     for (let item of inputList) {
         let words
-        item = item.replace(/,?.\b\d{5}(?:-\d{4})?\b/, '');
+        // Strip out the zip code since we're only interested in city/state here.
+        item = item.replace(/,?.\b\d{5}(?:-\d{4})?\b/, '')
+
         if (item.includes(',')) {
             words = item.split(',').map(item => item.trim())
         } else {

--- a/src/features/broker-protection/actions/extract.js
+++ b/src/features/broker-protection/actions/extract.js
@@ -295,8 +295,9 @@ export function stringToList (inputList, separator) {
  */
 export function getCityStateCombos (inputList) {
     const output = []
-    for (const item of inputList) {
+    for (let item of inputList) {
         let words
+        item = item.replace(/,?.\b\d{5}(?:-\d{4})?\b/, '');
         if (item.includes(',')) {
             words = item.split(',').map(item => item.trim())
         } else {

--- a/unit-test/broker-protection.js
+++ b/unit-test/broker-protection.js
@@ -95,6 +95,26 @@ describe('Actions', () => {
             })
         })
 
+        describe('get correct city state combo from a string', () => {
+            it('should successfully extract the city/state when a zip code is included', () => {
+                const cityStateZipList = [
+                    'Chicago IL 60611',
+                    'River Forest IL 60305-1243',
+                    'Forest Park IL, 60130-1234',
+                    'Oak Park IL, 60302'
+                ]
+
+                const result = getCityStateCombos(cityStateZipList)
+
+                expect(result).toEqual([
+                    { city: 'Chicago', state: 'IL' },
+                    { city: 'River Forest', state: 'IL' },
+                    { city: 'Forest Park', state: 'IL' },
+                    { city: 'Oak Park', state: 'IL' }
+                ])
+            })
+        })
+
         describe('get correct city state combos from malformedlist', () => {
             const malformedCityStateList = [
                 'Chicago IL, River Forest IL, Fores...'

--- a/unit-test/broker-protection.js
+++ b/unit-test/broker-protection.js
@@ -99,6 +99,7 @@ describe('Actions', () => {
             it('should successfully extract the city/state when a zip code is included', () => {
                 const cityStateZipList = [
                     'Chicago IL 60611',
+                    'Chicago IL   60611',
                     'River Forest IL 60305-1243',
                     'Forest Park IL, 60130-1234',
                     'Oak Park IL, 60302'
@@ -107,6 +108,7 @@ describe('Actions', () => {
                 const result = getCityStateCombos(cityStateZipList)
 
                 expect(result).toEqual([
+                    { city: 'Chicago', state: 'IL' },
                     { city: 'Chicago', state: 'IL' },
                     { city: 'River Forest', state: 'IL' },
                     { city: 'Forest Park', state: 'IL' },


### PR DESCRIPTION
PR: https://app.asana.com/0/72649045549333/1206500016468992

We often pull the user's city/state from somewhere on the broker's search page, but in some cases this string includes the zip code, which was breaking our city/state matcher. This PR strips the zip code out so that the matching continues successfully.