### PR TITLE
Strip newlines from name matches

### DIFF
--- a/src/features/broker-protection/actions/extract.js
+++ b/src/features/broker-protection/actions/extract.js
@@ -218,11 +218,11 @@ export function aggregateFields (profile) {
  * @param {string | string[]} elementValue
  * @return {string|string[]|null}
  */
-function extractValue (key, value, elementValue) {
+export function extractValue (key, value, elementValue) {
     if (!elementValue) return null
 
     const extractors = {
-        name: () => typeof elementValue === 'string' && elementValue.trim(),
+        name: () => typeof elementValue === 'string' && elementValue.replace(/\n/g, ' ').trim(),
         age: () => typeof elementValue === 'string' && elementValue.match(/\d+/)?.[0],
         alternativeNamesList: () => stringToList(elementValue, value.separator),
         addressCityStateList: () => {

--- a/unit-test/broker-protection.js
+++ b/unit-test/broker-protection.js
@@ -1,7 +1,7 @@
 import fc from 'fast-check'
 import { isSameAge } from '../src/features/broker-protection/comparisons/is-same-age.js'
 import { getNicknames, isSameName } from '../src/features/broker-protection/comparisons/is-same-name.js'
-import { getCityStateCombos, stringToList, getIdFromProfileUrl } from '../src/features/broker-protection/actions/extract.js'
+import { getCityStateCombos, stringToList, getIdFromProfileUrl, extractValue } from '../src/features/broker-protection/actions/extract.js'
 import {
     matchAddressCityState,
     matchAddressFromAddressListCityState
@@ -41,6 +41,13 @@ describe('Actions', () => {
 
             it("should return the name if it's not in the list", () => {
                 expect(getNicknames(null)).toEqual([])
+            })
+        })
+
+        describe('extractValue', () => {
+            it('should convert newlines to spaces in names', () => {
+                expect(extractValue('name', { selector: 'example' }, 'John\nSmith')).toEqual('John Smith')
+                expect(extractValue('name', { selector: 'example' }, 'John\nT\nSmith')).toEqual('John T Smith')
             })
         })
 


### PR DESCRIPTION
Asana: https://app.asana.com/0/0/1206646445020571/f

Sometimes when the parts of the name (first/middle/last) are on different lines, C-S-S returns the string with newlines in between the parts. This minor tweak strips those newlines out.