### PR TITLE
omit dom node from data transfer

### DIFF
--- a/integration-test/playwright/page-objects/broker-protection.js
+++ b/integration-test/playwright/page-objects/broker-protection.js
@@ -109,6 +109,7 @@ export class BrokerProtectionPage {
         expect(meta.extractResults.filter(x => x.result === false)).toHaveLength(9)
         const match = meta.extractResults.find(x => x.result === true)
         expect(match.matchedFields).toMatchObject(['name', 'age', 'addressCityStateList'])
+        expect(match.element).toBe(undefined)
         expect(match.score).toBe(3)
     }
 

--- a/src/features/broker-protection/actions/extract.js
+++ b/src/features/broker-protection/actions/extract.js
@@ -41,13 +41,17 @@ export function extract (action, userData) {
         .filter(x => x.result === true)
         .map(x => aggregateFields(x.scrapedData))
 
+    // omit the DOM node from data transfer
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const debugResults = extractResult.results.map((result) => result.asData())
+
     return new SuccessResponse({
         actionID: action.id,
         actionType: action.actionType,
         response: filtered,
         meta: {
             userData,
-            extractResults: extractResult.results
+            extractResults: debugResults
         }
     })
 }
@@ -55,10 +59,11 @@ export function extract (action, userData) {
 /**
  * @param {Action} action
  * @param {Record<string, any>} userData
+ * @param {Element | Document} [root]
  * @return {{error: string} | {results: ProfileResult[]}}
  */
-export function extractProfiles (action, userData) {
-    const profilesElementList = getElements(document, action.selector) ?? []
+export function extractProfiles (action, userData, root = document) {
+    const profilesElementList = getElements(root, action.selector) ?? []
 
     if (profilesElementList.length === 0) {
         return { error: 'no root elements found for ' + action.selector }

--- a/src/features/broker-protection/types.js
+++ b/src/features/broker-protection/types.js
@@ -52,4 +52,17 @@ export class ProfileResult {
         this.element = params.element
         this.matchedFields = params.matchedFields
     }
+
+    /**
+     * Convert this structure into a format that can be sent between JS contexts/native
+     * @return {{result: boolean, score: number, matchedFields: string[], scrapedData: Record<string, any>}}
+     */
+    asData () {
+        return {
+            scrapedData: this.scrapedData,
+            result: this.result,
+            score: this.score,
+            matchedFields: this.matchedFields
+        }
+    }
 }


### PR DESCRIPTION
`extractProfiles` now returns additional meta data for extended use + debug/analysis tools.

It also returns a DOM node which needs to be omitted from the payload that travels to native.