### PR TITLE
Add the ability to generate a random phone number when filling out forms

### DIFF
--- a/integration-test/playwright/page-objects/broker-protection.js
+++ b/integration-test/playwright/page-objects/broker-protection.js
@@ -45,6 +45,7 @@ export class BrokerProtectionPage {
     async isFormFilled () {
         expect(await this.page.getByLabel('First Name:').inputValue()).toBe('John')
         expect(await this.page.getByLabel('Last Name:').inputValue()).toBe('Smith')
+        expect(await this.page.getByLabel('Phone Number:').inputValue()).toMatch(/^\d{10}$/)
     }
 
     /**

--- a/integration-test/test-pages/broker-protection/actions/fill-form.json
+++ b/integration-test/test-pages/broker-protection/actions/fill-form.json
@@ -12,6 +12,10 @@
         {
           "type": "lastName",
           "selector": "#user_last_name"
+        },
+        {
+          "type": "phone",
+          "selector": "#user_phone"
         }
       ]
     },

--- a/integration-test/test-pages/broker-protection/pages/form.html
+++ b/integration-test/test-pages/broker-protection/pages/form.html
@@ -22,6 +22,10 @@
         Last Name:
         <input type="text" name="first-name" id="user_last_name">
     </label>
+    <label>
+        Phone Number:
+        <input type="text" name="phone" id="user_phone">
+    </label>
     <button class="btn-sbmt">Submit</button>
 </form>
 <script>

--- a/src/features/broker-protection/actions/fill-form.js
+++ b/src/features/broker-protection/actions/fill-form.js
@@ -1,4 +1,4 @@
-import { getElement } from '../utils.js'
+import { getElement, generateRandomInt } from '../utils.js'
 import { ErrorResponse, SuccessResponse } from '../types.js'
 
 /**
@@ -18,16 +18,18 @@ export function fillForm (action, userData) {
     for (const element of action.elements) {
         // get the correct field of the form
         const inputElem = getElement(form, element.selector)
-        // this works for IDs (i.e. #url wouldb e form.elements['url'])
+        // this works for IDs (i.e. #url would be form.elements['url'])
         // let inputElem = form.elements[element.selector]
         // find the correct userData to put in the form
         if (inputElem) {
             if (element.type === '$file_id$') {
                 results.push(setImageUpload(inputElem))
             } else {
+                const value = element.type === "phone" ? generatePhoneNumber() : userData[element.type]
+
                 // @ts-expect-error - double check if this is strict enough
                 // todo: determine if this requires any events to be dispatched also
-                setValueForInput(inputElem, userData[element.type])
+                setValueForInput(inputElem, value)
                 results.push({ result: true })
             }
         }
@@ -107,4 +109,18 @@ function setImageUpload (element) {
         // failed
         return { result: false, error: e.toString() }
     }
+}
+
+export function generatePhoneNumber() {
+    /**
+     * 3 digits, 2-8, last two digits technically can't end in two 1s, but we'll ignore that requirement
+     * Source: https://math.stackexchange.com/questions/920972/how-many-different-phone-numbers-are-possible-within-an-area-code/1115411#1115411
+     */
+    const areaCode = generateRandomInt(200, 899).toString()
+
+    // 555-0100 through 555-0199 are for fictional use (https://en.wikipedia.org/wiki/555_(telephone_number)#Fictional_usage)
+    const exchangeCode = "555"
+    const lineNumber = generateRandomInt(100,199).toString().padStart(4, "0")
+    
+    return `${areaCode}${exchangeCode}${lineNumber}`
 }

--- a/src/features/broker-protection/utils.js
+++ b/src/features/broker-protection/utils.js
@@ -152,3 +152,12 @@ function safeQuerySelectorAllXpath (element, selector) {
         return null
     }
 }
+
+/**
+ * @param {number} min 
+ * @param {number} max 
+ * @returns {number}
+ */
+export function generateRandomInt(min, max) {
+    return Math.floor(Math.random() * (max - min + 1) + min);
+}

--- a/unit-test/broker-protection.js
+++ b/unit-test/broker-protection.js
@@ -10,6 +10,8 @@ import { matchesFullAddress } from '../src/features/broker-protection/comparison
 import { replaceTemplatedUrl } from '../src/features/broker-protection/actions/build-url.js'
 import { processTemplateStringWithUserData } from '../src/features/broker-protection/actions/build-url-transforms.js'
 import { names } from '../src/features/broker-protection/comparisons/constants.js'
+import { generateRandomInt } from '../src/features/broker-protection/utils.js'
+import { generatePhoneNumber } from '../src/features/broker-protection/actions/fill-form.js'
 
 describe('Actions', () => {
     describe('extract', () => {
@@ -546,6 +548,40 @@ describe('Actions', () => {
                         expect(typeof output).toEqual('string')
                     }
                 )
+            )
+        })
+    })
+
+    describe('fillForm', () => {
+        describe('generateRandomPhoneNumber', () => {
+            it('generates a string of integers of an appropriate size', () => {
+                const phoneNumber = generatePhoneNumber();
+
+                expect(typeof phoneNumber).toEqual('string');
+                expect(phoneNumber.length).toBe(10);
+                expect(phoneNumber).toMatch(/^\d{10}$/);
+            })
+        })
+    })
+})
+
+describe('utils', () => {
+    describe('generateRandomInt', () => {
+        it('generates an integers between the min and max values', () => {
+
+            fc.assert(
+                fc.property(fc.integer(), fc.integer(), (a, b) => {
+                    const min = Math.min(a, b)
+                    const max = Math.max(a, b)
+
+                    const result = generateRandomInt(min, max);
+
+                    return (
+                        Number.isInteger(result) &&
+                        result >= min &&
+                        result <= max
+                    )
+                })
             )
         })
     })


### PR DESCRIPTION
Asana: https://app.asana.com/0/0/1206496978629598/f

## Description
Some brokers require phone numbers in order to proceed with opt out requests. We don't ask for user's phone numbers (nor would we want to send real numbers to brokers) so this feature allows us to generate a random phone number on the fly.

In order to prevent sending real phone numbers, I referenced the following resources:
* [Wikipedia article](https://en.wikipedia.org/wiki/555_(telephone_number)#Fictional_usage) on US phone numbers, revealing that 555-0100 and 555-0199 are for fictional use.
* [This stackexchange article](https://math.stackexchange.com/questions/920972/how-many-different-phone-numbers-are-possible-within-an-area-code/1115411#1115411) outlining the safe space for area codes.