### PR TITLE
Check all user addresses against the full scraped address list

### DIFF
--- a/src/features/broker-protection/actions/extract.js
+++ b/src/features/broker-protection/actions/extract.js
@@ -3,6 +3,7 @@ import { ErrorResponse, ProfileResult, SuccessResponse } from '../types.js'
 import { isSameAge } from '../comparisons/is-same-age.js'
 import { isSameName } from '../comparisons/is-same-name.js'
 import { matchesFullAddress } from '../comparisons/matches-full-address.js'
+import { matchesFullAddressList } from '../comparisons/matches-full-address-list.js'
 import { matchAddressFromAddressListCityState } from '../comparisons/address.js'
 
 /**
@@ -218,6 +219,13 @@ function scrapedDataMatchesUserData (userData, scrapedData) {
     if (scrapedData.addressFull) {
         if (matchesFullAddress(userData.addresses, scrapedData.addressFull)) {
             matchedFields.push('addressFull')
+            return { matchedFields, score: matchedFields.length, result: true }
+        }
+    }
+
+    if (scrapedData.addressFullList) {
+        if (matchesFullAddressList(userData.addresses, scrapedData.addressFullList)) {
+            matchedFields.push('addressFullList')
             return { matchedFields, score: matchedFields.length, result: true }
         }
     }

--- a/src/features/broker-protection/comparisons/matches-full-address-list.js
+++ b/src/features/broker-protection/comparisons/matches-full-address-list.js
@@ -1,0 +1,15 @@
+import { matchesFullAddress } from './matches-full-address.js'
+
+/**
+ * @param {object} userAddresses
+ * @param {string[]} comparisonAddressFullList
+ * @return {boolean}
+ */
+export function matchesFullAddressList (userAddresses, comparisonAddressFullList) {
+    for (const address of comparisonAddressFullList) {
+        if (matchesFullAddress(userAddresses, address)) {
+            return true
+        }
+    }
+    return false
+}

--- a/unit-test/broker-protection.js
+++ b/unit-test/broker-protection.js
@@ -7,6 +7,7 @@ import {
     matchAddressFromAddressListCityState
 } from '../src/features/broker-protection/comparisons/address.js'
 import { matchesFullAddress } from '../src/features/broker-protection/comparisons/matches-full-address.js'
+import { matchesFullAddressList } from '../src/features/broker-protection/comparisons/matches-full-address-list.js'
 import { replaceTemplatedUrl } from '../src/features/broker-protection/actions/build-url.js'
 import { processTemplateStringWithUserData } from '../src/features/broker-protection/actions/build-url-transforms.js'
 import { names } from '../src/features/broker-protection/comparisons/constants.js'
@@ -295,6 +296,26 @@ describe('Actions', () => {
 
                 it('should not match when city is not the same', () => {
                     expect(matchesFullAddress(userData.addresses, '123 fake st, not chicago, il, 60602')).toBe(false)
+                })
+            })
+
+            describe('matchesFullAddressList', () => {
+                const scrapedAddressList = [
+                    '228 Main St., Dallas, TX 75080'
+                ]
+
+                it('should not match if the address has not been scraped', () => {
+                    expect(matchesFullAddressList(userData.addresses, scrapedAddressList)).toBe(false)
+                })
+
+                it('should match when the address is in the list', () => {
+                    const updatedScrapedAddressList = [...scrapedAddressList, Object.values(userData.addresses[0]).join(' ')]
+                    expect(matchesFullAddressList(userData.addresses, updatedScrapedAddressList)).toBe(true)
+                })
+
+                it('should not match when the address does not match exactly', () => {
+                    const updatedScrapedAddressList = [...scrapedAddressList, '125 Fake St Chicago IL 60602']
+                    expect(matchesFullAddressList(userData.addresses, updatedScrapedAddressList)).toBe(false)
                 })
             })
         })


### PR DESCRIPTION
Asana: https://app.asana.com/0/0/1206394405750251/f

## Description
We currently check a user's list of addresses against a full address found on the page, but we have the ability to scrape multiple full addresses on the page. This gives us the ability to do matches against the entire list.