### PR TITLE
PIR: prevent invalid value for age

### DIFF
--- a/src/features/broker-protection/actions/extract.js
+++ b/src/features/broker-protection/actions/extract.js
@@ -134,8 +134,9 @@ export function createProfile (elementFactory, extractData) {
             // Note: This can return a string, string[], or null
             const extractedValue = extractValue(key, value, evaluatedValue)
 
-            // try to use the extracted value first, then the originally evaluated, falling back to null
-            output[key] = extractedValue || evaluatedValue || null
+            // try to use the extracted value, or fall back to null
+            // this allows 'extractValue' to return null|undefined
+            output[key] = extractedValue || null
         }
     }
     return output
@@ -291,7 +292,7 @@ export function aggregateFields (profile) {
  * @param {string} key
  * @param {ExtractProfileProperty} value
  * @param {string | string[]} elementValue
- * @return {string|string[]|null}
+ * @return {string|string[]|null|undefined}
  */
 export function extractValue (key, value, elementValue) {
     if (!elementValue) return null

--- a/unit-test/broker-protection-extract.js
+++ b/unit-test/broker-protection-extract.js
@@ -1,6 +1,4 @@
-import {
-    createProfile
-} from '../src/features/broker-protection/actions/extract.js'
+import { createProfile } from '../src/features/broker-protection/actions/extract.js'
 
 describe('create profiles from extracted data', () => {
     it('handles combined, single strings', () => {
@@ -30,10 +28,12 @@ describe('create profiles from extracted data', () => {
             { text: 'Henry White   ,46', expected: { name: 'Henry White', age: '46' } },
             { text: 'Linda Brown ~ , 35', expected: { name: 'Linda Brown ~', age: '35' } },
             { text: 'Emma Green, 30 any', expected: { name: 'Emma Green', age: '30' } },
-            { text: '  Sophia Blue, 26', expected: { name: 'Sophia Blue', age: '26' } }
+            { text: '  Sophia Blue, 26', expected: { name: 'Sophia Blue', age: '26' } },
 
-            // this is an example to be fixed in the next PR
-            // { text: 'John smith', expected: { name: 'John smith', age: null } }
+            // examples where age is absent, so the result should be null
+            { text: 'John smith', expected: { name: 'John smith', age: null } },
+            { text: 'John smith   ,   ', expected: { name: 'John smith', age: null } },
+            { text: 'John smith   \n,\n   ', expected: { name: 'John smith', age: null } }
         ]
 
         for (const elementExample of elementExamples) {


### PR DESCRIPTION
See https://app.asana.com/0/0/1206745203094838/f

Building upon #930 - this is an actual fix that is reproducible in the tests now.