### PR TITLE
PIR: don't exclude addressFull

### DIFF
--- a/src/features/broker-protection/actions/extract.js
+++ b/src/features/broker-protection/actions/extract.js
@@ -152,13 +152,7 @@ function findFromElements (elements, key, extractField) {
     const elementValues = []
     if (elements) {
         for (const element of elements) {
-            let elementValue = rules[key]?.(element) ?? element?.innerText ?? null
-            if (extractField?.afterText) {
-                elementValue = elementValue?.split(extractField.afterText)[1]?.trim() || elementValue
-            }
-            if (extractField?.beforeText) {
-                elementValue = elementValue?.split(extractField.beforeText)[0].trim() || elementValue
-            }
+            const elementValue = findFromElement(element, key, extractField)
             elementValues.push(elementValue)
         }
     }
@@ -317,6 +311,7 @@ export function extractValue (key, value, elementValue) {
             }
             return stringToList(phoneNumber)
         },
+        addressFull: () => elementValue,
         phoneList: () => stringToList(elementValue, value.separator),
         relativesList: () => stringToList(elementValue, value.separator),
         profileUrl: () => {

--- a/unit-test/broker-protection-extract.js
+++ b/unit-test/broker-protection-extract.js
@@ -99,4 +99,25 @@ describe('create profiles from extracted data', () => {
             expect(profile).toEqual(elementExample.expected)
         }
     })
+    it('handles addressFull', () => {
+        const elementExamples = [
+            {
+                selectors: {
+                    addressFull: {
+                        selector: 'example'
+                    }
+                },
+                elements: [{ innerText: 'abc, Dallas, Tx' }],
+                expected: {
+                    addressFull: 'abc, Dallas, Tx'
+                }
+            }
+        ]
+
+        for (const elementExample of elementExamples) {
+            const elementFactory = () => elementExample.elements
+            const profile = createProfile(elementFactory, elementExample.selectors)
+            expect(profile).toEqual(elementExample.expected)
+        }
+    })
 })


### PR DESCRIPTION
https://app.asana.com/0/0/1206775911419667/f

In the previous change #931 - we're now respecting when `extract` returns null (as a way of validating data)

In doing that, it accidentally excludes valid values for `addressFull` since that was the only field that does not incur processing.

**NOTE** I have verified no other fields are affected by checking our JSON files.