### PR TITLE
pir: scroll element into view first

### DIFF
--- a/integration-test/playwright/broker-protection.spec.js
+++ b/integration-test/playwright/broker-protection.spec.js
@@ -404,6 +404,34 @@ test.describe('Broker Protection communications', () => {
             const response = await dbp.waitForMessage('actionCompleted')
             dbp.isSuccessMessage(response)
         })
+
+        test('expectation: element exists', async ({ page }, workerInfo) => {
+            const dbp = BrokerProtectionPage.create(page, workerInfo)
+            await dbp.enabled()
+            await dbp.navigatesTo('form.html')
+
+            // control: ensure the element is absent
+            await dbp.elementIsAbsent('.slow-element')
+
+            // now send in the action
+            await dbp.receivesInlineAction({
+                state: {
+                    action: {
+                        actionType: 'expectation',
+                        id: 'test-expectation',
+                        expectations: [
+                            {
+                                type: 'element-exists',
+                                selector: '.slow-element'
+                            }
+                        ]
+                    }
+                }
+            })
+
+            const response = await dbp.waitForMessage('actionCompleted')
+            dbp.isSuccessMessage(response)
+        })
     })
 
     test.describe('retrying', () => {

--- a/integration-test/playwright/broker-protection.spec.js
+++ b/integration-test/playwright/broker-protection.spec.js
@@ -422,7 +422,8 @@ test.describe('Broker Protection communications', () => {
                         expectations: [
                             {
                                 type: 'element-exists',
-                                selector: '.slow-element'
+                                selector: '.slow-element',
+                                parent: 'body.delay-complete'
                             }
                         ]
                     }

--- a/integration-test/playwright/broker-protection.spec.js
+++ b/integration-test/playwright/broker-protection.spec.js
@@ -421,7 +421,7 @@ test.describe('Broker Protection communications', () => {
                         id: 'test-expectation',
                         expectations: [
                             {
-                                type: 'element-exists',
+                                type: 'element',
                                 selector: '.slow-element',
                                 parent: 'body.delay-complete'
                             }

--- a/integration-test/playwright/page-objects/broker-protection.js
+++ b/integration-test/playwright/page-objects/broker-protection.js
@@ -40,6 +40,15 @@ export class BrokerProtectionPage {
     }
 
     /**
+     * @param {string} selector
+     */
+    async elementIsAbsent (selector) {
+        // control - ensure the element isn't there first
+        const e = await this.page.$(selector)
+        expect(e).toBeNull()
+    }
+
+    /**
      * @return {Promise<void>}
      */
     async isFormFilled () {
@@ -124,6 +133,14 @@ export class BrokerProtectionPage {
     async receivesAction (action) {
         const actionJson = JSON.parse(readFileSync('./integration-test/test-pages/broker-protection/actions/' + action, 'utf8'))
         await this.simulateSubscriptionMessage('onActionReceived', actionJson)
+    }
+
+    /**
+     * @param {{state: {action: Record<string, any>}}} action
+     * @return {Promise<void>}
+     */
+    async receivesInlineAction (action) {
+        await this.simulateSubscriptionMessage('onActionReceived', action)
     }
 
     /**

--- a/integration-test/test-pages/broker-protection/pages/form.html
+++ b/integration-test/test-pages/broker-protection/pages/form.html
@@ -45,6 +45,12 @@
     document.forms.testform.onsubmit = (e) => {
       e.preventDefault();
     }
+    setTimeout(() => {
+        const next = document.createElement('div')
+        next.classList.add('slow-element');
+        next.textContent = 'Slow loading element'
+        document.forms.testform.appendChild(next)
+    }, 1000)
 </script>
 </body>
 </html>

--- a/integration-test/test-pages/broker-protection/pages/form.html
+++ b/integration-test/test-pages/broker-protection/pages/form.html
@@ -46,6 +46,7 @@
       e.preventDefault();
     }
     setTimeout(() => {
+        document.body.classList.add('delay-complete')
         const next = document.createElement('div')
         next.classList.add('slow-element');
         next.textContent = 'Slow loading element'

--- a/src/features/broker-protection.js
+++ b/src/features/broker-protection.js
@@ -25,7 +25,10 @@ export default class BrokerProtection extends ContentFeature {
                     ? action.retry
                     : undefined
 
-                if (action.actionType === 'extract') {
+                /**
+                 * Special case for the exact action
+                 */
+                if (!retryConfig && action.actionType === 'extract') {
                     retryConfig = {
                         interval: { ms: 1000 },
                         maxAttempts: 30
@@ -33,18 +36,16 @@ export default class BrokerProtection extends ContentFeature {
                 }
 
                 /**
-                 * When an expectation contains a check for an element, retry it
+                 * Special case for when expectation contains a check for an element, retry it
                  */
-                if (action.actionType === 'expectation') {
-                    if (action.expectations.some(x => x.type === 'element-exists')) {
+                if (!retryConfig && action.actionType === 'expectation') {
+                    if (action.expectations.some(x => x.type === 'element')) {
                         retryConfig = {
                             interval: { ms: 1000 },
                             maxAttempts: 30
                         }
                     }
                 }
-
-                console.log({ action, data, retryConfig })
 
                 const { result, exceptions } = await retry(() => execute(action, data), retryConfig)
 

--- a/src/features/broker-protection.js
+++ b/src/features/broker-protection.js
@@ -44,6 +44,8 @@ export default class BrokerProtection extends ContentFeature {
                     }
                 }
 
+                console.log({ action, data, retryConfig })
+
                 const { result, exceptions } = await retry(() => execute(action, data), retryConfig)
 
                 if (result) {

--- a/src/features/broker-protection.js
+++ b/src/features/broker-protection.js
@@ -32,6 +32,18 @@ export default class BrokerProtection extends ContentFeature {
                     }
                 }
 
+                /**
+                 * When an expectation contains a check for an element, retry it
+                 */
+                if (action.actionType === 'expectation') {
+                    if (action.expectations.some(x => x.type === 'element-exists')) {
+                        retryConfig = {
+                            interval: { ms: 1000 },
+                            maxAttempts: 30
+                        }
+                    }
+                }
+
                 const { result, exceptions } = await retry(() => execute(action, data), retryConfig)
 
                 if (result) {

--- a/src/features/broker-protection/actions/expectation.js
+++ b/src/features/broker-protection/actions/expectation.js
@@ -22,13 +22,13 @@ export function expectation (action, root = document) {
 }
 
 /**
- * @param {{type: string; selector: string; parent?: string; expect?: string}[]} expectations
+ * @param {{type: "element" | "text" | "url"; selector: string; parent?: string; expect?: string}[]} expectations
  * @param {Document | HTMLElement} root
  * @return {({result: true} | {result: false; error: string})[]}
  */
 export function expectMany (expectations, root) {
     return expectations.map(expectation => {
-        if (expectation.type === 'element-exists') {
+        if (expectation.type === 'element') {
             if (expectation.parent) {
                 const parent = getElement(root, expectation.parent)
                 if (!parent) return { result: false, error: `parent element not found with selector: ${expectation.parent}` }

--- a/src/features/broker-protection/actions/expectation.js
+++ b/src/features/broker-protection/actions/expectation.js
@@ -22,40 +22,120 @@ export function expectation (action, root = document) {
 }
 
 /**
- * @param {{type: "element" | "text" | "url"; selector: string; parent?: string; expect?: string}[]} expectations
+ * Return a true/false result for every expectation
+ *
+ * @param {import("../types").Expectation[]} expectations
  * @param {Document | HTMLElement} root
- * @return {({result: true} | {result: false; error: string})[]}
+ * @return {import("../types").BooleanResult[]}
  */
 export function expectMany (expectations, root) {
     return expectations.map(expectation => {
-        if (expectation.type === 'element') {
-            if (expectation.parent) {
-                const parent = getElement(root, expectation.parent)
-                if (!parent) return { result: false, error: `parent element not found with selector: ${expectation.parent}` }
-                parent.scrollIntoView()
+        switch (expectation.type) {
+        case 'element': return elementExpectation(expectation, root)
+        case 'text': return textExpectation(expectation, root)
+        case 'url': return urlExpectation(expectation)
+        default: {
+            return {
+                result: false,
+                error: `unknown expectation type: ${expectation.type}`
             }
-            const elementExists = getElement(root, expectation.selector) !== null
-            if (elementExists) {
-                return { result: true }
-            }
-            return { result: false, error: `element with selector ${expectation.selector} not found.` }
         }
-        if (expectation.type === 'text' && expectation.expect) {
-            // get the target element text
-            const elem = getElement(root, expectation.selector)
-            if (!elem) {
-                return { result: false, error: `element with selector ${expectation.selector} not found.` }
-            }
-            const textExists = Boolean(elem?.textContent?.includes(expectation.expect))
-            if (textExists) return { result: true }
-            return { result: false, error: `expected element with selector ${expectation.selector} to have text: ${expectation.expect}, but it didn't` }
-        } else if (expectation.type === 'url' && expectation.expect) {
-            const url = window.location.href
-            if (url.includes(expectation.expect)) {
-                return { result: true }
-            }
-            return { result: false, error: `expected URL to include ${expectation.expect}, but it didn't` }
         }
-        return { result: false, error: `unknown expectation type: ${expectation.type}` }
     })
+}
+
+/**
+ * Verify that an element exists. If the `.parent` property exists,
+ * scroll it into view first
+ *
+ * @param {import("../types").Expectation} expectation
+ * @param {Document | HTMLElement} root
+ * @return {import("../types").BooleanResult}
+ */
+export function elementExpectation (expectation, root) {
+    if (expectation.parent) {
+        const parent = getElement(root, expectation.parent)
+        if (!parent) {
+            return {
+                result: false,
+                error: `parent element not found with selector: ${expectation.parent}`
+            }
+        }
+        parent.scrollIntoView()
+    }
+
+    const elementExists = getElement(root, expectation.selector) !== null
+
+    if (!elementExists) {
+        return {
+            result: false,
+            error: `element with selector ${expectation.selector} not found.`
+        }
+    }
+    return { result: true }
+}
+
+/**
+ * Check that an element includes a given text string
+ *
+ * @param {import("../types").Expectation} expectation
+ * @param {Document | HTMLElement} root
+ * @return {import("../types").BooleanResult}
+ */
+export function textExpectation (expectation, root) {
+    // get the target element first
+    const elem = getElement(root, expectation.selector)
+    if (!elem) {
+        return {
+            result: false,
+            error: `element with selector ${expectation.selector} not found.`
+        }
+    }
+
+    // todo: remove once we have stronger types
+    if (!expectation.expect) {
+        return {
+            result: false,
+            error: 'missing key: \'expect\''
+        }
+    }
+
+    // todo: is this too strict a match? we may also want to try innerText
+    const textExists = Boolean(elem?.textContent?.includes(expectation.expect))
+
+    if (!textExists) {
+        return {
+            result: false,
+            error: `expected element with selector ${expectation.selector} to have text: ${expectation.expect}, but it didn't`
+        }
+    }
+
+    return { result: true }
+}
+
+/**
+ * Check that the current URL includes a given string
+ *
+ * @param {import("../types").Expectation} expectation
+ * @return {import("../types").BooleanResult}
+ */
+export function urlExpectation (expectation) {
+    const url = window.location.href
+
+    // todo: remove once we have stronger types
+    if (!expectation.expect) {
+        return {
+            result: false,
+            error: 'missing key: \'expect\''
+        }
+    }
+
+    if (!url.includes(expectation.expect)) {
+        return {
+            result: false,
+            error: `expected URL to include ${expectation.expect}, but it didn't`
+        }
+    }
+
+    return { result: true }
 }

--- a/src/features/broker-protection/actions/expectation.js
+++ b/src/features/broker-protection/actions/expectation.js
@@ -11,7 +11,7 @@ export function expectation (action, root = document) {
 
     const allExpectationsMatch = expectations.every(expectation => {
         if (expectation.type === 'element-exists') {
-            return getElement(root, action.selector) !== null
+            return getElement(root, expectation.selector) !== null
         }
         if (expectation.type === 'text') {
             // get the target element text

--- a/src/features/broker-protection/actions/expectation.js
+++ b/src/features/broker-protection/actions/expectation.js
@@ -7,27 +7,55 @@ import { ErrorResponse, SuccessResponse } from '../types.js'
  * @return {import('../types.js').ActionResponse}
  */
 export function expectation (action, root = document) {
-    const expectations = action.expectations
+    const results = expectMany(action.expectations, root)
 
-    const allExpectationsMatch = expectations.every(expectation => {
-        if (expectation.type === 'element-exists') {
-            return getElement(root, expectation.selector) !== null
-        }
-        if (expectation.type === 'text') {
-            // get the target element text
-            const elem = getElement(root, expectation.selector)
-            return Boolean(elem?.textContent?.includes(expectation.expect))
-        } else if (expectation.type === 'url') {
-            const url = window.location.href
-            return url.includes(expectation.expect)
-        }
-
-        return false
+    const errors = results.filter(x => x.result === false).map(x => {
+        if ('error' in x) return x.error
+        return 'unknown error'
     })
 
-    if (!allExpectationsMatch) {
-        return new ErrorResponse({ actionID: action.id, message: 'Expectation not found.' })
-    } else {
-        return new SuccessResponse({ actionID: action.id, actionType: action.actionType, response: null })
+    if (errors.length > 0) {
+        return new ErrorResponse({ actionID: action.id, message: errors.join(', ') })
     }
+
+    return new SuccessResponse({ actionID: action.id, actionType: action.actionType, response: null })
+}
+
+/**
+ * @param {{type: string; selector: string; parent?: string; expect?: string}[]} expectations
+ * @param {Document | HTMLElement} root
+ * @return {({result: true} | {result: false; error: string})[]}
+ */
+export function expectMany (expectations, root) {
+    return expectations.map(expectation => {
+        if (expectation.type === 'element-exists') {
+            if (expectation.parent) {
+                const parent = getElement(root, expectation.parent)
+                if (!parent) return { result: false, error: `parent element not found with selector: ${expectation.parent}` }
+                parent.scrollIntoView()
+            }
+            const elementExists = getElement(root, expectation.selector) !== null
+            if (elementExists) {
+                return { result: true }
+            }
+            return { result: false, error: `element with selector ${expectation.selector} not found.` }
+        }
+        if (expectation.type === 'text' && expectation.expect) {
+            // get the target element text
+            const elem = getElement(root, expectation.selector)
+            if (!elem) {
+                return { result: false, error: `element with selector ${expectation.selector} not found.` }
+            }
+            const textExists = Boolean(elem?.textContent?.includes(expectation.expect))
+            if (textExists) return { result: true }
+            return { result: false, error: `expected element with selector ${expectation.selector} to have text: ${expectation.expect}, but it didn't` }
+        } else if (expectation.type === 'url' && expectation.expect) {
+            const url = window.location.href
+            if (url.includes(expectation.expect)) {
+                return { result: true }
+            }
+            return { result: false, error: `expected URL to include ${expectation.expect}, but it didn't` }
+        }
+        return { result: false, error: `unknown expectation type: ${expectation.type}` }
+    })
 }

--- a/src/features/broker-protection/actions/expectation.js
+++ b/src/features/broker-protection/actions/expectation.js
@@ -10,6 +10,9 @@ export function expectation (action, root = document) {
     const expectations = action.expectations
 
     const allExpectationsMatch = expectations.every(expectation => {
+        if (expectation.type === 'element-exists') {
+            return getElement(root, action.selector) !== null
+        }
         if (expectation.type === 'text') {
             // get the target element text
             const elem = getElement(root, expectation.selector)

--- a/src/features/broker-protection/actions/fill-form.js
+++ b/src/features/broker-protection/actions/fill-form.js
@@ -12,6 +12,9 @@ export function fillForm (action, userData, root = document) {
     if (!form) return new ErrorResponse({ actionID: action.id, message: 'missing form' })
     if (!userData) return new ErrorResponse({ actionID: action.id, message: 'user data was absent' })
 
+    // ensure the element is in the current viewport
+    form.scrollIntoView?.()
+
     const results = fillMany(form, action.elements, userData)
 
     const errors = results.filter(x => x.result === false).map(x => {
@@ -42,9 +45,6 @@ export function fillMany (root, elements, data) {
             results.push({ result: false, error: `element not found for selector: "${element.selector}"` })
             continue
         }
-
-        // ensure the element is in the current viewport
-        inputElem.scrollIntoView?.()
 
         if (element.type === '$file_id$') {
             results.push(setImageUpload(inputElem))

--- a/src/features/broker-protection/actions/fill-form.js
+++ b/src/features/broker-protection/actions/fill-form.js
@@ -42,6 +42,10 @@ export function fillMany (root, elements, data) {
             results.push({ result: false, error: `element not found for selector: "${element.selector}"` })
             continue
         }
+
+        // ensure the element is in the current viewport
+        inputElem.scrollIntoView?.()
+
         if (element.type === '$file_id$') {
             results.push(setImageUpload(inputElem))
         } else if (element.type === '$generated_phone_number$') {

--- a/src/features/broker-protection/types.js
+++ b/src/features/broker-protection/types.js
@@ -1,5 +1,7 @@
 /**
  * @typedef {SuccessResponse | ErrorResponse} ActionResponse
+ * @typedef {{ result: true } | { result: false; error: string }} BooleanResult
+ * @typedef {{type: "element" | "text" | "url"; selector: string; parent?: string; expect?: string}} Expectation
  */
 
 /**


### PR DESCRIPTION
https://app.asana.com/0/0/1206930392257127/f

The integration test is the best explanation here. 

Before the expectation action only supported `url` and `text`. This PR adds support for a third kind `element`

When the expectation has `type: "element"`, we'll first check if it needs a parent to be scrolled into view, and then we'll verify if the element exists.

NOTE: This change is safe because we're not currently using any other `types` (only `url` and `text` so far).