### PR TITLE
only accept first 11 chars of video id

### DIFF
--- a/packages/special-pages/pages/duckplayer/src/js/index.js
+++ b/packages/special-pages/pages/duckplayer/src/js/index.js
@@ -278,6 +278,7 @@ const Comms = {
     messaging: undefined,
     /**
      * NATIVE NOTE: Gets the video id from the location object, works for MacOS < > 12
+     * @return {string}
      */
     getVideoIdFromLocation: () => {
         /**
@@ -301,18 +302,20 @@ const Comms = {
      * Validates that the input string is a valid video id.
      * If so, returns the video id otherwise returns false.
      * @param {string} input
-     * @returns {(string|false)}
+     * @returns {(string|null)}
      */
     validateVideoId: (input) => {
-        if (/^[a-zA-Z0-9-_]+$/g.test(input)) {
-            return input
+        if (typeof input !== 'string') return null
+        const subject = input.slice(0, 11)
+        if (/^[a-zA-Z0-9-_]+$/g.test(subject)) {
+            return subject
         }
-        return false
+        return null
     },
 
     /**
      * Returns a sanitized video id if there is a valid one.
-     * @returns {(string|false)}
+     * @returns {(string|null)}
      */
     getValidVideoId: () => {
         return Comms.validateVideoId(Comms.getVideoIdFromLocation())

--- a/packages/special-pages/pages/duckplayer/src/js/index.js
+++ b/packages/special-pages/pages/duckplayer/src/js/index.js
@@ -304,7 +304,7 @@ const Comms = {
      * @param {string} input
      * @returns {(string|null)}
      */
-    validateVideoId: (input) => {
+    sanitiseVideoId: (input) => {
         if (typeof input !== 'string') return null
         const subject = input.slice(0, 11)
         if (/^[a-zA-Z0-9-_]+$/g.test(subject)) {
@@ -318,7 +318,7 @@ const Comms = {
      * @returns {(string|null)}
      */
     getValidVideoId: () => {
-        return Comms.validateVideoId(Comms.getVideoIdFromLocation())
+        return Comms.sanitiseVideoId(Comms.getVideoIdFromLocation())
     },
 
     /**

--- a/packages/special-pages/tests/duckplayer.spec.js
+++ b/packages/special-pages/tests/duckplayer.spec.js
@@ -8,6 +8,11 @@ test.describe('duckplayer iframe', () => {
         await duckplayer.hasLoadedIframe()
         await duckplayer.videoHasFocus()
     })
+    test('only accepts first 11 chars of an id', async ({ page }, workerInfo) => {
+        const duckplayer = DuckPlayerPage.create(page, workerInfo)
+        await duckplayer.openWithVideoID('this_has_too_many_chars')
+        await duckplayer.hasLoadedIframe('this_has_to')
+    })
     test.skip('reflects title from embed', async ({ page }, workerInfo) => {
         const duckplayer = DuckPlayerPage.create(page, workerInfo)
         await duckplayer.openWithVideoID()


### PR DESCRIPTION
https://app.asana.com/0/0/1206957893781164/f

### TL;DR

Modified validation and sanitization of video IDs in the duck-player module.

### What changed?

1. The `validateVideoId` function now checks first if the input is a string. If not, it returns `null`. If the input is a string, the function extracts the first 11 characters, validates them against a regex pattern and returns these characters if they pass the validation.
2. The function `getValidVideoId` now potentially returns `null` instead of `false`.

### How to test?

The testing responsibilities have been accounted for in the `duckplayer.spec.js` file. A test has been added that checks whether the ID validation correctly accepts only the first 11 characters of a video ID.

### Why make this change?

This change was required to improve the validation of video IDs, considering only the necessary characters and properly handling different data types. It also paves the way for more robust error handling by returning `null` instead of `false` in certain functions.

---

