### PR TITLE
don't default to addtional properties in schemas

### DIFF
--- a/scripts/build-types.mjs
+++ b/scripts/build-types.mjs
@@ -75,6 +75,7 @@ export async function buildTypes(mapping = defaultMapping) {
  */
 async function createTypesForSchemaFile(featureName, schemaFilePath) {
     return await compileFromFile(schemaFilePath, {
+        additionalProperties: false,
         bannerComment: `
                 /**
                  * @module ${featureName} Schema
@@ -100,6 +101,7 @@ async function createTypesForSchemaFile(featureName, schemaFilePath) {
 export async function createTypesForSchemaMessages(featureName, schema, rootDir) {
     const typescript = await compile(/** @type {any} */(schema), featureName, {
         cwd: rootDir,
+        additionalProperties: false,
         bannerComment: `
             /**
              * @module ${featureName} Messages

--- a/src/types/duckplayer-settings.d.ts
+++ b/src/types/duckplayer-settings.d.ts
@@ -19,7 +19,6 @@ export interface DuckPlayerSettings {
    * List of domains with specific patch settings
    */
   domains: Domain[];
-  [k: string]: unknown;
 }
 /**
  * Specific configurations for different overlay types


### PR DESCRIPTION
https://app.asana.com/0/1201614831475344/1207053312757015/f

### TL;DR

This PR restricts additional properties in the build-types script.

### What changed?

The `createTypesForSchemaFile` and `createTypesForSchemaMessages` functions in `build-types.mjs` now include the `additionalProperties: false` option.

### Why make this change?

The library that generates the types makes open-ended objects by default by adding the index signature.

without this change, it's really tedious to create schemas since every top-level and nested object requires you to put `"additonalProperties": false`

---

