### PR TITLE
forbid .only in playwright tests

### DIFF
--- a/packages/special-pages/playwright.config.js
+++ b/packages/special-pages/playwright.config.js
@@ -31,6 +31,8 @@ export default defineConfig({
         }
     ],
     fullyParallel: !process.env.CI,
+    /* Don't allow `.only` in CI */
+    forbidOnly: Boolean(process.env.CI),
     /* Retry on CI only */
     retries: process.env.CI ? 2 : 0,
     /* Opt out of parallel tests on CI. */

--- a/packages/special-pages/tests/onboarding.spec.js
+++ b/packages/special-pages/tests/onboarding.spec.js
@@ -9,7 +9,7 @@ test.describe('onboarding', () => {
         await onboarding.openPage()
         await onboarding.didSendInitialHandshake()
     })
-    test.only('can be skipped in development', async ({ page }, workerInfo) => {
+    test('can be skipped in development', async ({ page }, workerInfo) => {
         const onboarding = OnboardingPage.create(page, workerInfo)
         await onboarding.reducedMotion()
         await onboarding.darkMode()

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -50,6 +50,8 @@ export default defineConfig({
     },
     /* Run tests in files in parallel */
     fullyParallel: !process.env.CI,
+    /* Don't allow `.only` in CI */
+    forbidOnly: Boolean(process.env.CI),
     /* Retry on CI only */
     retries: process.env.CI ? 2 : 0,
     /* Opt out of parallel tests on CI. */


### PR DESCRIPTION
https://app.asana.com/0/1201614831475344/1207053312757007/f

### TL;DR

This pull request modifies the configuration in the special-pages and the root configuration files, preventing the '.only' construct from being used within CI. The pull request also removes a '.only' statement from a test in `onboarding.spec.js`.

### What changed?

Prevented usage of '.only' within CI in `playwright.config.js` and `packages/special-pages/playwright.config.js`. Removed usage of '.only' in `onboarding.spec.js`.

### Why make this change?

I recently committed (and merged) a `.only` - this will prevent it happening again

---

