### PR TITLE
Minor change to fix the extension unit tests

### DIFF
--- a/src/features/cookie.js
+++ b/src/features/cookie.js
@@ -225,7 +225,7 @@ export default class CookieFeature extends ContentFeature {
             }
         }
 
-        this.defineProperty(Document.prototype, 'cookie', {
+        this.defineProperty(globalThis.Document.prototype, 'cookie', {
             enumerable: true,
             configurable: true,
             set: setCookiePolicy,


### PR DESCRIPTION
Adding explicit `globalThis` reference to satisfy the mocks in

See https://github.com/duckduckgo/duckduckgo-privacy-extension/actions/runs/9253489821/job/25453263673