### PR TITLE
add initial data to duckplayer page

### DIFF
--- a/packages/special-pages/pages/duckplayer/src/js/index.js
+++ b/packages/special-pages/pages/duckplayer/src/js/index.js
@@ -812,8 +812,8 @@ document.addEventListener('DOMContentLoaded', async () => {
     const result = await Comms.init(page)
 
     if (!('value' in result)) {
-        console.warn('cannot continue as the initialSetup call didnt complete');
-        console.error(result.error);
+        console.warn('cannot continue as the initialSetup call didnt complete')
+        console.error(result.error)
         return
     }
 

--- a/packages/special-pages/pages/duckplayer/src/js/index.js
+++ b/packages/special-pages/pages/duckplayer/src/js/index.js
@@ -90,12 +90,16 @@ const VideoPlayer = {
      * @param {object} opts
      * @param {string} opts.base
      * @param {ImportMeta['env']} opts.env
+     * @param {import('./messages').DuckPlayerPageSettings} opts.settings
      */
     init: (opts) => {
         VideoPlayer.loadVideoById()
         VideoPlayer.autoFocusVideo(opts.env)
         VideoPlayer.setTabTitle()
         VideoPlayer.setClickListener(opts.base)
+        if (opts.settings.pip.state === 'enabled') {
+            VideoPlayer.enablePiP()
+        }
     },
 
     /**
@@ -229,6 +233,26 @@ const VideoPlayer = {
                     document.title = 'Duck Player - ' + validTitle
                 }
             })
+        })
+    },
+
+    enablePiP: () => {
+        VideoPlayer.onIframeLoaded(() => {
+            try {
+                const iframe = VideoPlayer.iframe()
+                const iframeDocument = iframe?.contentDocument
+                const iframeWindow = iframe?.contentWindow
+                if (iframeDocument && iframeWindow) {
+                    // @ts-expect-error - typescript doesn't know about CSSStyleSheet here for some reason
+                    const styleSheet = new iframeWindow.CSSStyleSheet()
+                    styleSheet.replaceSync('button.ytp-pip-button { display: inline-block !important; }')
+                    // See https://developer.mozilla.org/en-US/docs/Web/API/Document/adoptedStyleSheets#append_a_new_stylesheet
+                    iframeDocument.adoptedStyleSheets = [...iframeDocument.adoptedStyleSheets, styleSheet]
+                }
+            } catch (e) {
+                // ignore errors
+                console.warn(e)
+            }
         })
     },
 
@@ -817,13 +841,10 @@ document.addEventListener('DOMContentLoaded', async () => {
         return
     }
 
-    // here we have access to userValues and settings
-    console.log(result.value.userValues)
-    console.log(result.value.settings)
-
     VideoPlayer.init({
         base: baseUrl(import.meta.injectName),
-        env: import.meta.env
+        env: import.meta.env,
+        settings: result.value.settings
     })
     Tooltip.init()
     PlayOnYouTube.init({

--- a/packages/special-pages/pages/duckplayer/src/js/messages.js
+++ b/packages/special-pages/pages/duckplayer/src/js/messages.js
@@ -28,6 +28,19 @@ export class DuckPlayerPageMessages {
      * @returns {Promise<InitialSetup>} params
      */
     initialSetup () {
+        if (this.injectName === 'integration') {
+            return Promise.resolve({
+                settings: {
+                    pip: {
+                        state: 'enabled'
+                    }
+                },
+                userValues: new UserValues({
+                    overlayInteracted: false,
+                    privatePlayerMode: { alwaysAsk: {} }
+                })
+            })
+        }
         return this.messaging.request('initialSetup')
     }
 
@@ -125,7 +138,7 @@ export class DuckPlayerPageSettings {
     /**
      * @param {object} params
      * @param {object} params.pip
-     * @param {"enabled" | "disabled"} params.pip.status
+     * @param {"enabled" | "disabled"} params.pip.state
      */
     constructor (params) {
         /**

--- a/packages/special-pages/pages/duckplayer/src/js/messages.js
+++ b/packages/special-pages/pages/duckplayer/src/js/messages.js
@@ -1,4 +1,10 @@
 /**
+ * @typedef {object} InitialSetup - The initial payload used to communicate render-blocking information
+ * @property {UserValues} userValues - The state of the user values
+ * @property {DuckPlayerPageSettings} settings - Additional settings
+ */
+
+/**
  * Notifications or requests that the Duck Player Page will
  * send to the native side
  */
@@ -14,6 +20,15 @@ export class DuckPlayerPageMessages {
          */
         this.messaging = messaging
         this.injectName = injectName
+    }
+
+    /**
+     * This is sent when the user wants to set Duck Player as the default.
+     *
+     * @returns {Promise<InitialSetup>} params
+     */
+    initialSetup () {
+        return this.messaging.request('initialSetup')
     }
 
     /**
@@ -97,6 +112,27 @@ export class UserValues {
          * @type {boolean}
          */
         this.overlayInteracted = params.overlayInteracted
+    }
+}
+
+/**
+ * Sent in the initial page load request. Used to provide features toggles
+ * and other none-user-specific settings.
+ *
+ * Note: This will be improved soon with better remote config integration.
+ */
+export class DuckPlayerPageSettings {
+    /**
+     * @param {object} params
+     * @param {object} params.pip
+     * @param {"enabled" | "disabled"} params.pip.status
+     */
+    constructor (params) {
+        /**
+         * 'enabled' means that the FE should show the PIP button
+         * 'disabled' means that the FE should never show it
+         */
+        this.pip = params.pip
     }
 }
 

--- a/packages/special-pages/tests/page-objects/duck-player.js
+++ b/packages/special-pages/tests/page-objects/duck-player.js
@@ -49,7 +49,7 @@ export class DuckPlayerPage {
             initialSetup: {
                 settings: {
                     pip: {
-                        status: 'disabled'
+                        state: 'disabled'
                     }
                 },
                 userValues: {
@@ -312,7 +312,7 @@ export class DuckPlayerPage {
      * @return {Promise<void>}
      */
     async didReceiveFirstSettingsUpdate () {
-        await this.mocks.waitForCallCount({ count: 1, method: 'getUserValues' })
+        await this.mocks.waitForCallCount({ count: 1, method: 'initialSetup' })
     }
 
     async toggleAlwaysOpenSetting () {

--- a/packages/special-pages/tests/page-objects/duck-player.js
+++ b/packages/special-pages/tests/page-objects/duck-player.js
@@ -49,10 +49,10 @@ export class DuckPlayerPage {
             initialSetup: {
                 settings: {
                     pip: {
-                        status: "disabled"
+                        status: 'disabled'
                     }
                 },
-                userValues:  {
+                userValues: {
                     privatePlayerMode: { alwaysAsk: {} },
                     overlayInteracted: false
                 }

--- a/packages/special-pages/tests/page-objects/duck-player.js
+++ b/packages/special-pages/tests/page-objects/duck-player.js
@@ -45,6 +45,19 @@ export class DuckPlayerPage {
         })
         // default mocks - just enough to render the first page without error
         this.mocks.defaultResponses({
+            /** @type {Awaited<ReturnType<import("../../pages/duckplayer/src/js/index.js").DuckPlayerPageMessages['initialSetup']>>} */
+            initialSetup: {
+                settings: {
+                    pip: {
+                        status: "disabled"
+                    }
+                },
+                userValues:  {
+                    privatePlayerMode: { alwaysAsk: {} },
+                    overlayInteracted: false
+                }
+
+            },
             /** @type {import("../../pages/duckplayer/src/js/index.js").UserValues} */
             getUserValues: {
                 privatePlayerMode: { alwaysAsk: {} },


### PR DESCRIPTION
https://app.asana.com/0/72649045549333/1207466745891032/f

Adding more initial data to the first call when duckplayer opens.

**NOTE** we are aware that a better integration with remote config is a better long term approach for special pages in general - that will be addressed as a separate project :)