### PR TITLE
add apple assets to PR releases

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -32,7 +32,7 @@ jobs:
           git config --global user.name "github-actions[bot]"
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
           git checkout -b pr-releases/pr-${PR_NUMBER}
-          git add -f build
+          git add -f build Sources
           git commit -m "Add build folder for PR #${PR_NUMBER}"
           git push -u origin pr-releases/pr-${PR_NUMBER} --force
 


### PR DESCRIPTION
In the GitHub Actions workflow for PR builds (`.github/workflows/build-pr.yml`), this change updates the script to also add the `Sources` folder to the build before committing. 

https://app.asana.com/0/1201614831475344/1207021389478142/f

