### PR TITLE
use message to open duckplayer from overlay

### DIFF
--- a/integration-test/playwright/page-objects/duckplayer-overlays.js
+++ b/integration-test/playwright/page-objects/duckplayer-overlays.js
@@ -346,16 +346,26 @@ export class DuckplayerOverlays {
     }
 
     async watchInDuckPlayer () {
-        const failure = new Promise(resolve => {
-            this.page.context().on('requestfailed', f => {
-                if (f.url().startsWith('duck')) resolve(f.url())
-            })
+        const action = () => this.page.getByRole('link', { name: 'Watch in Duck Player' }).click()
+
+        await this.build.switch({
+            'apple-isolated': async () => {
+                await action()
+                await this.duckPlayerLoadsFor('123')
+            },
+            windows: async () => {
+                const failure = new Promise(resolve => {
+                    this.page.context().on('requestfailed', f => {
+                        if (f.url().startsWith('duck')) resolve(f.url())
+                    })
+                })
+
+                await action()
+
+                // assert the page tried to navigate to duck player
+                expect(await failure).toEqual('duck://player/123')
+            }
         })
-
-        await this.page.getByRole('link', { name: 'Watch in Duck Player' }).click()
-
-        // assert the page tried to navigate to duck player
-        expect(await failure).toEqual('duck://player/123')
     }
 
     async watchHere () {

--- a/integration-test/playwright/type-helpers.mjs
+++ b/integration-test/playwright/type-helpers.mjs
@@ -48,7 +48,7 @@ export class Build {
             }
             return fn()
         }
-        throw new Error('missing impl for that')
+        throw new Error('missing impl for that on platform: ' + this.name)
     }
 
     /**

--- a/src/features/duck-player.js
+++ b/src/features/duck-player.js
@@ -89,7 +89,8 @@ export default class DuckPlayerFeature extends ContentFeature {
 
         const comms = new DuckPlayerOverlayMessages(this.messaging)
         const env = new Environment({
-            debug: args.debug
+            debug: args.debug,
+            platform: this.platform
         })
 
         if (overlaysEnabled) {

--- a/src/features/duckplayer/overlay-messages.js
+++ b/src/features/duckplayer/overlay-messages.js
@@ -121,7 +121,10 @@ function assertCustomEvent (event) {
 export class Pixel {
     /**
      * A list of known pixels
-     * @param {{name: "overlay"} | {name: "play.use", remember: "0" | "1"} | {name: "play.do_not_use", remember: "0" | "1"}} input
+     * @param {{name: "overlay"}
+     *   | {name: "play.use", remember: "0" | "1"}
+     *   | {name: "play.use.thumbnail"}
+     *   | {name: "play.do_not_use", remember: "0" | "1"}} input
      */
     constructor (input) {
         this.input = input
@@ -134,6 +137,7 @@ export class Pixel {
     params () {
         switch (this.input.name) {
         case 'overlay': return {}
+        case 'play.use.thumbnail': return {}
         case 'play.use':
         case 'play.do_not_use': {
             return { remember: this.input.remember }

--- a/src/features/duckplayer/overlays.js
+++ b/src/features/duckplayer/overlays.js
@@ -127,10 +127,12 @@ export class Environment {
 
     /**
      * @param {object} params
+     * @param {import('../../utils.js').Platform} params.platform
      * @param {boolean|null|undefined} [params.debug]
      */
     constructor (params) {
         this.debug = Boolean(params.debug)
+        this.platform = params.platform
     }
 
     /**
@@ -184,5 +186,9 @@ export class Environment {
 
     isTestMode () {
         return this.debug === true
+    }
+
+    get opensVideoOverlayLinksViaMessage () {
+        return this.platform.name !== 'windows'
     }
 }

--- a/src/features/duckplayer/overlays.js
+++ b/src/features/duckplayer/overlays.js
@@ -127,7 +127,7 @@ export class Environment {
 
     /**
      * @param {object} params
-     * @param {import('../../utils.js').Platform} params.platform
+     * @param {{name: string}} params.platform
      * @param {boolean|null|undefined} [params.debug]
      */
     constructor (params) {

--- a/src/features/duckplayer/thumbnails.js
+++ b/src/features/duckplayer/thumbnails.js
@@ -58,7 +58,7 @@
 import { SideEffects, VideoParams } from './util.js'
 import { IconOverlay } from './icon-overlay.js'
 import { Environment } from './overlays.js'
-import { OpenInDuckPlayerMsg } from './overlay-messages.js'
+import { OpenInDuckPlayerMsg, Pixel } from './overlay-messages.js'
 
 /**
  * @typedef ThumbnailParams
@@ -92,6 +92,10 @@ export class Thumbnails {
             // create the icon & append it to the page
             const icon = new IconOverlay()
             icon.appendHoverOverlay((href) => {
+                if (this.environment.opensVideoOverlayLinksViaMessage) {
+                    this.messages.sendPixel(new Pixel({ name: 'play.use.thumbnail' }))
+                }
+
                 this.messages.openDuckPlayer(new OpenInDuckPlayerMsg({ href }))
             })
 

--- a/src/features/duckplayer/video-overlay.js
+++ b/src/features/duckplayer/video-overlay.js
@@ -269,6 +269,8 @@ export class VideoOverlay {
      * But, if the checkbox was not checked, then we want to keep the state
      * as 'alwaysAsk'
      *
+     * @param {boolean} remember
+     * @param {VideoParams} params
      */
     userOptIn (remember, params) {
         /** @type {import("../duck-player.js").UserValues['privatePlayerMode']} */
@@ -285,7 +287,12 @@ export class VideoOverlay {
             privatePlayerMode
         }
         this.messages.setUserValues(outgoing)
-            .then(() => this.environment.setHref(params.toPrivatePlayerUrl()))
+            .then(() => {
+                if (this.environment.opensVideoOverlayLinksViaMessage) {
+                    return this.messages.openDuckPlayer(new OpenInDuckPlayerMsg({ href: params.toPrivatePlayerUrl() }))
+                }
+                return this.environment.setHref(params.toPrivatePlayerUrl())
+            })
             .catch(e => console.error('error setting user choice', e))
     }
 


### PR DESCRIPTION
https://app.asana.com/0/1201141132935289/1207702853516473/f

This just removes a single instance where the page location was updated by the JS. 

**Note** This needs testing on macOS + Windows

- [ ] macOS
- [ ] windows