### PR TITLE
support allow-popups-to-escape-sandbox attribute in duckplayer embed

### DIFF
--- a/packages/special-pages/pages/duckplayer/src/index.html
+++ b/packages/special-pages/pages/duckplayer/src/index.html
@@ -12,9 +12,9 @@
         <iframe
                 id="player"
                 frameborder="0"
-                allow="autoplay; encrypted-media"
+                allow="autoplay; encrypted-media; fullscreen"
                 allowfullscreen
-                sandbox="allow-popups allow-scripts allow-same-origin"
+                sandbox="allow-popups allow-scripts allow-same-origin allow-popups-to-escape-sandbox"
         ></iframe>
     </div>
     <div class="toolbar">

--- a/packages/special-pages/tests/duckplayer.spec.js
+++ b/packages/special-pages/tests/duckplayer.spec.js
@@ -45,6 +45,11 @@ test.describe('duckplayer iframe', () => {
         await duckplayer.withStorageValues()
         await duckplayer.storageClearedAfterReload()
     })
+    test('allows popups from embed', async ({ page }, workerInfo) => {
+        const duckplayer = DuckPlayerPage.create(page, workerInfo)
+        await duckplayer.openWithVideoID()
+        await duckplayer.allowsPopups()
+    })
 })
 
 test.describe('duckplayer toolbar', () => {

--- a/packages/special-pages/tests/page-objects/duck-player.js
+++ b/packages/special-pages/tests/page-objects/duck-player.js
@@ -375,4 +375,9 @@ export class DuckPlayerPage {
         const { platformInfo, build } = perPlatform(testInfo.project.use)
         return new DuckPlayerPage(page, build, platformInfo)
     }
+
+    async allowsPopups () {
+        const expected = 'allow-popups allow-scripts allow-same-origin allow-popups-to-escape-sandbox'
+        await expect(this.page.locator('iframe')).toHaveAttribute('sandbox', expected)
+    }
 }


### PR DESCRIPTION
https://app.asana.com/0/0/1207824905837486/f

updated the `sandbox` attribute in the iframe used by DuckPlayer. This change allows sites within the iframe to open popups.