### PR TITLE
remove flakiness from release-notes tests

### DIFF
--- a/packages/special-pages/tests/page-objects/release-notes.js
+++ b/packages/special-pages/tests/page-objects/release-notes.js
@@ -96,6 +96,10 @@ export class ReleaseNotesPage {
      * @param {boolean} [options.privacyPro]
      */
     async sendSubscriptionMessage (messageType, options) {
+        // Wait for the subscription handler to appear before trying to simulate push events.
+        // This prevents a race condition where playwright is sending data before `.subscribe` was called
+        await this.page.waitForFunction(() => 'onUpdate' in window && typeof window.onUpdate === 'function')
+
         const data = options?.privacyPro
             ? { ...sampleData[messageType] }
             : { ...sampleData[messageType], releaseNotesPrivacyPro: null }


### PR DESCRIPTION
The release-notes integration tests became flaky - even failing sometimes locally.

With retries in CI they would pass, but it was unpredictable. This fixes it.