### PR TITLE
reload instead of re-throwing

### DIFF
--- a/packages/special-pages/pages/onboarding/app/index.js
+++ b/packages/special-pages/pages/onboarding/app/index.js
@@ -30,7 +30,8 @@ const onboarding = new OnboardingMessages(messaging, baseEnvironment.platform)
 async function init () {
     const result = await callWithRetry(() => onboarding.init())
     if ('error' in result) {
-        throw new Error(result.error)
+        console.error(result.error)
+        return location.reload();
     }
 
     const init = result.value

--- a/packages/special-pages/pages/onboarding/app/index.js
+++ b/packages/special-pages/pages/onboarding/app/index.js
@@ -31,7 +31,7 @@ async function init () {
     const result = await callWithRetry(() => onboarding.init())
     if ('error' in result) {
         console.error(result.error)
-        return location.reload();
+        return location.reload()
     }
 
     const init = result.value


### PR DESCRIPTION
https://app.asana.com/0/0/1207978041075737/f

We're seeing some further delays where where the webkit handlers take some tie to appear. Instead of increasing the retries further (it's already a 10x retry at 300ms intervals), we should just try reloading the page instead.

This has a better chance of resolving the issue - multiple internal testers have reported that reloading fixed the issue. 

We should try it first with onboarding - and if it's stable + fixes bugs, we should use this everywhere.