### PR TITLE
naming: use injectName vs platform in the correct places

### DIFF
--- a/packages/special-pages/pages/example/app/index.js
+++ b/packages/special-pages/pages/example/app/index.js
@@ -50,7 +50,7 @@ export async function init (messaging, baseEnvironment) {
         render(
             <EnvironmentProvider
                 debugState={environment.debugState}
-                platform={environment.platform}
+                injectName={environment.injectName}
                 willThrow={environment.willThrow}
             >
                 <UpdateEnvironment search={window.location.search}/>
@@ -61,7 +61,7 @@ export async function init (messaging, baseEnvironment) {
             , root)
     } else if (environment.display === 'components') {
         render(
-            <EnvironmentProvider debugState={false} platform={environment.platform}>
+            <EnvironmentProvider debugState={false} injectName={environment.injectName}>
                 <TranslationProvider translationObject={strings} fallback={enStrings} textLength={environment.textLength}>
                     <Components />
                 </TranslationProvider>

--- a/packages/special-pages/pages/example/src/js/index.js
+++ b/packages/special-pages/pages/example/src/js/index.js
@@ -38,11 +38,11 @@ export class ExamplePage {
 }
 
 const baseEnvironment = new Environment()
-    .withPlatform(document.documentElement.dataset.platform)
+    .withInjectName(document.documentElement.dataset.platform)
     .withEnv(import.meta.env)
 
 const messaging = createSpecialPageMessaging({
-    injectName: baseEnvironment.platform,
+    injectName: baseEnvironment.injectName,
     env: baseEnvironment.env,
     pageName: /** @type {string} */(import.meta.pageName)
 })

--- a/packages/special-pages/pages/onboarding/app/components/Switch.js
+++ b/packages/special-pages/pages/onboarding/app/components/Switch.js
@@ -16,7 +16,7 @@ import { useEnv } from '../../../../shared/components/EnvironmentProvider'
 export function Switch ({ checked = false, variant, ...props }) {
     const { onChecked, onUnchecked, ariaLabel, pending } = props
     const env = useEnv()
-    const platform = variant || env.platform
+    const platform = variant || env.injectName
     function change (e) {
         if (e.target.checked === true) {
             onChecked()

--- a/packages/special-pages/pages/onboarding/app/index.js
+++ b/packages/special-pages/pages/onboarding/app/index.js
@@ -15,17 +15,17 @@ import { TranslationProvider } from '../../../shared/components/TranslationsProv
 import enStrings from '../src/locales/en/onboarding.json'
 
 const baseEnvironment = new Environment()
-    .withPlatform(document.documentElement.dataset.platform)
+    .withInjectName(document.documentElement.dataset.platform)
     .withEnv(import.meta.env)
 
 // share this in the app, it's an instance of `OnboardingMessages` where all your native comms should be
 const messaging = createSpecialPageMessaging({
-    injectName: baseEnvironment.platform,
+    injectName: baseEnvironment.injectName,
     env: baseEnvironment.env,
     pageName: 'onboarding'
 })
 
-const onboarding = new OnboardingMessages(messaging, baseEnvironment.platform)
+const onboarding = new OnboardingMessages(messaging, baseEnvironment.injectName)
 
 async function init () {
     const result = await callWithRetry(() => onboarding.init())
@@ -67,7 +67,7 @@ async function init () {
         render(
             <EnvironmentProvider
                 debugState={environment.debugState}
-                platform={environment.platform}
+                injectName={environment.injectName}
                 willThrow={environment.willThrow}
             >
                 <UpdateEnvironment search={window.location.search} />
@@ -87,7 +87,7 @@ async function init () {
     }
     if (environment.display === 'components') {
         render(
-            <EnvironmentProvider debugState={false} platform={environment.platform}>
+            <EnvironmentProvider debugState={false} injectName={environment.injectName}>
                 <TranslationProvider translationObject={strings} fallback={enStrings}>
                     <Components />
                 </TranslationProvider>

--- a/packages/special-pages/pages/onboarding/app/pages/SettingsStep.js
+++ b/packages/special-pages/pages/onboarding/app/pages/SettingsStep.js
@@ -20,7 +20,7 @@ import { useEnv } from '../../../../shared/components/EnvironmentProvider'
  * @param {string} [props.subtitle] - optional subtitle
  */
 export function SettingsStep ({ onNextPage, data, metaData, subtitle }) {
-    const { platform } = useEnv()
+    const { injectName } = useEnv()
     const { state } = useRollin([300])
     const { t } = useTypedTranslation()
 
@@ -41,7 +41,7 @@ export function SettingsStep ({ onNextPage, data, metaData, subtitle }) {
             uiValue: appState.UIValues[rowId],
             pending: pendingId === rowId,
             id: rowId,
-            data: data[rowId](t, platform),
+            data: data[rowId](t, injectName),
             meta: metaData[step.id]?.rows?.[rowId]
         }
     })

--- a/packages/special-pages/pages/release-notes/app/index.js
+++ b/packages/special-pages/pages/release-notes/app/index.js
@@ -47,7 +47,7 @@ export async function init (messages, baseEnvironment) {
         render(
             <EnvironmentProvider
                 debugState={environment.debugState}
-                platform={environment.platform}
+                injectName={environment.injectName}
                 willThrow={environment.willThrow}
             >
                 <TranslationProvider translationObject={strings} fallback={enStrings} textLength={environment.textLength}>
@@ -62,7 +62,7 @@ export async function init (messages, baseEnvironment) {
         render(
             <EnvironmentProvider
                 debugState={environment.debugState}
-                platform={environment.platform}
+                injectName={environment.injectName}
                 willThrow={environment.willThrow}
             >
                 <TranslationProvider translationObject={strings} fallback={enStrings} textLength={environment.textLength}>

--- a/packages/special-pages/pages/release-notes/src/js/index.js
+++ b/packages/special-pages/pages/release-notes/src/js/index.js
@@ -87,12 +87,12 @@ export class ReleaseNotesPage {
 }
 
 const baseEnvironment = new Environment()
-    .withPlatform(document.documentElement.dataset.platform)
+    .withInjectName(document.documentElement.dataset.platform)
     .withEnv(import.meta.env) // use the build's ENV
 
 // share this in the app, it's an instance of `ReleaseNotesMessages` where all your native comms should be
 const messaging = createSpecialPageMessaging({
-    injectName: baseEnvironment.platform,
+    injectName: baseEnvironment.injectName,
     env: import.meta.env,
     pageName: import.meta.pageName || 'unknown'
 })

--- a/packages/special-pages/shared/components/EnvironmentProvider.js
+++ b/packages/special-pages/shared/components/EnvironmentProvider.js
@@ -5,7 +5,7 @@ const EnvironmentContext = createContext({
     isReducedMotion: false,
     isDarkMode: false,
     debugState: false,
-    platform: /** @type {import('../environment').Environment['platform']} */('windows'),
+    injectName: /** @type {import('../environment').Environment['injectName']} */('windows'),
     willThrow: false
 })
 
@@ -18,10 +18,10 @@ const REDUCED_MOTION_QUERY = '(prefers-reduced-motion: reduce)'
  * @param {Object} props - The props for the settings provider.
  * @param {import("preact").ComponentChild} props.children - The children components to be wrapped by the settings provider.
  * @param {boolean} props.debugState - The flag indicating if debug state is enabled.
- * @param {ImportMeta['injectName']} [props.platform] - The flag indicating if debug state is enabled.
+ * @param {ImportMeta['injectName']} [props.injectName] - The flag indicating if debug state is enabled.
  * @param {boolean} [props.willThrow] - used to simulate a fatal exception
  */
-export function EnvironmentProvider ({ children, debugState, willThrow = false, platform = 'windows' }) {
+export function EnvironmentProvider ({ children, debugState, willThrow = false, injectName = 'windows' }) {
     const [theme, setTheme] = useState(window.matchMedia(THEME_QUERY).matches ? 'dark' : 'light')
     const [isReducedMotion, setReducedMotion] = useState(window.matchMedia(REDUCED_MOTION_QUERY).matches)
 
@@ -51,7 +51,7 @@ export function EnvironmentProvider ({ children, debugState, willThrow = false, 
             isReducedMotion,
             debugState,
             isDarkMode: theme === 'dark',
-            platform,
+            injectName,
             willThrow
         }}>{children}</EnvironmentContext.Provider>
     )

--- a/packages/special-pages/shared/environment.js
+++ b/packages/special-pages/shared/environment.js
@@ -7,7 +7,7 @@ export class Environment {
      * @param {'app' | 'components'} [params.display] - whether to show the application or component list
      * @param {'production' | 'development'} [params.env] - application environment
      * @param {URLSearchParams} [params.urlParams] - URL params passed into the page
-     * @param {ImportMeta['injectName']} [params.platform] - application platform
+     * @param {ImportMeta['injectName']} [params.injectName] - application platform
      * @param {boolean} [params.willThrow] - whether the application will simulate an error
      * @param {boolean} [params.debugState] - whether to show debugging UI
      * @param {string} [params.locale] - for applications strings
@@ -16,7 +16,7 @@ export class Environment {
     constructor ({
         env = 'production',
         urlParams = new URLSearchParams(location.search),
-        platform = 'windows',
+        injectName = 'windows',
         willThrow = urlParams.get('willThrow') === 'true',
         debugState = urlParams.has('debugState'),
         display = 'app',
@@ -25,7 +25,7 @@ export class Environment {
     } = {}) {
         this.display = display
         this.urlParams = urlParams
-        this.platform = platform
+        this.injectName = injectName
         this.willThrow = willThrow
         this.debugState = debugState
         this.env = env
@@ -34,15 +34,15 @@ export class Environment {
     }
 
     /**
-     * @param {string|null|undefined} platform
+     * @param {string|null|undefined} injectName
      * @returns {Environment}
      */
-    withPlatform (platform) {
-        if (!platform) return this
-        if (!isPlatform(platform)) return this
+    withInjectName (injectName) {
+        if (!injectName) return this
+        if (!isInjectName(injectName)) return this
         return new Environment({
             ...this,
-            platform
+            injectName: injectName
         })
     }
 
@@ -110,7 +110,7 @@ export class Environment {
  * @param {any} input
  * @returns {input is ImportMeta['injectName']}
  */
-function isPlatform (input) {
+function isInjectName (input) {
     /** @type {ImportMeta['injectName'][]} */
     const allowed = ['windows', 'apple', 'integration', 'android']
     return allowed.includes(input)

--- a/packages/special-pages/shared/environment.js
+++ b/packages/special-pages/shared/environment.js
@@ -42,7 +42,7 @@ export class Environment {
         if (!isInjectName(injectName)) return this
         return new Environment({
             ...this,
-            injectName: injectName
+            injectName
         })
     }
 


### PR DESCRIPTION
We were incorrectly using 'platform' in places where we meant the 'injectName'

- `platform.name` throughout all of CSS is something that can be set at runtime, to values like `ios`, `macos`, `android` etc.
- `import.meta.injectName` is the build target and has higher-level values like `windows`, `apple` etc. 

This PR is just being more precise with naming to avoid confusion.

