### PR TITLE
DuckPlayer modal experiment updates

### DIFF
--- a/integration-test/playwright/duckplayer.spec.js
+++ b/integration-test/playwright/duckplayer.spec.js
@@ -359,6 +359,51 @@ test.describe('Video Player overlays', () => {
             // Then the overlay shows the correct copy for the B1 variant
             await overlays.overlayCopyIsB1()
         })
+
+        test('forces next video to play in Duck Player', async ({ page }, workerInfo) => {
+            const overlays = DuckplayerOverlays.create(page, workerInfo)
+
+            // Given overlays feature is enabled
+            await overlays.withRemoteConfig()
+
+            // And my setting is 'always ask'
+            // And the UI setting for 'play in Duck Player' is set to true
+            await overlays.initialSetupIs('always ask', 'play in duck player')
+            await overlays.gotoThumbsPage()
+            await overlays.overlaysDontShow()
+
+            // When I click on the first thumbnail
+            await overlays.clicksFirstThumbnail()
+
+            // Then our player loads for the correct video
+            await overlays.duckPlayerLoadsFor('1')
+        })
+
+        test('forces next video to play in Duck Player after UI settings change', async ({ page }, workerInfo) => {
+            const overlays = DuckplayerOverlays.create(page, workerInfo)
+
+            // Given overlays feature is enabled
+            await overlays.withRemoteConfig()
+
+            // And my setting is 'always ask'
+            // And the UI setting for 'play in Duck Player' is not set
+            await overlays.initialSetupIs('always ask')
+            await overlays.gotoThumbsPage()
+
+
+            // Then overlays act as normal initially
+            await overlays.hoverAThumbnail()
+            await overlays.isVisible()
+
+            // When a UI settings update arrives
+            await overlays.uiChangedSettingTo('play in duck player')
+
+            // And I click on the first thumbnail
+            await overlays.clicksFirstThumbnail()
+
+            // Then our player loads for the correct video
+            await overlays.duckPlayerLoadsFor('1')
+        })
     })
 })
 

--- a/integration-test/playwright/duckplayer.spec.js
+++ b/integration-test/playwright/duckplayer.spec.js
@@ -390,7 +390,6 @@ test.describe('Video Player overlays', () => {
             await overlays.initialSetupIs('always ask')
             await overlays.gotoThumbsPage()
 
-
             // Then overlays act as normal initially
             await overlays.hoverAThumbnail()
             await overlays.isVisible()

--- a/integration-test/playwright/page-objects/duckplayer-overlays.js
+++ b/integration-test/playwright/page-objects/duckplayer-overlays.js
@@ -46,6 +46,9 @@ const uiSettings = {
     /** @type {import("../../../src/features/duck-player.js").UISettings} */
     'overlay copy b1': {
         overlayCopy: 'b1'
+    },
+    'play in duck player': {
+        playInDuckPlayer: true
     }
 }
 
@@ -303,6 +306,22 @@ export class DuckplayerOverlays {
             },
             name: 'onUserValuesChanged',
             payload: userValues[setting],
+            injectName: this.build.name
+        })
+    }
+
+    /**
+     * @param {keyof uiSettings} setting
+     */
+    async uiChangedSettingTo (setting) {
+        await this.page.evaluate(simulateSubscriptionMessage, {
+            messagingContext: {
+                context: this.messagingContext,
+                featureName: 'duckPlayer',
+                env: 'development'
+            },
+            name: 'onUIValuesChanged',
+            payload: uiSettings[setting],
             injectName: this.build.name
         })
     }

--- a/packages/special-pages/messages/duckplayer/initialSetup.response.json
+++ b/packages/special-pages/messages/duckplayer/initialSetup.response.json
@@ -28,6 +28,16 @@
               "enum": ["enabled", "disabled"]
             }
           }
+        },
+        "focusMode": {
+          "type": "object",
+          "required": ["state"],
+          "properties": {
+            "state": {
+              "type": "string",
+              "enum": ["enabled", "disabled"]
+            }
+          }
         }
       }
     },

--- a/packages/special-pages/pages/duckplayer/app/index.js
+++ b/packages/special-pages/pages/duckplayer/app/index.js
@@ -61,7 +61,8 @@ export async function init (messaging, baseEnvironment) {
         .withPlatformName(baseEnvironment.urlParams.get('platform'))
         .withFeatureState('pip', init.settings.pip)
         .withFeatureState('autoplay', init.settings.autoplay)
-        .withDisabledFocusMode(baseEnvironment.urlParams.get('focusMode') === 'disabled')
+        .withFeatureState('focusMode', init.settings.focusMode)
+        .withDisabledFocusMode(baseEnvironment.urlParams.get('focusMode'))
 
     console.log(settings)
 

--- a/packages/special-pages/pages/duckplayer/app/settings.js
+++ b/packages/special-pages/pages/duckplayer/app/settings.js
@@ -26,8 +26,11 @@ export class Settings {
     withFeatureState (named, settings) {
         if (!settings) return this
         /** @type {(keyof import("../../../types/duckplayer").DuckPlayerPageSettings)[]} */
-        const valid = ['pip', 'autoplay']
-        if (!valid.includes(named)) return this
+        const valid = ['pip', 'autoplay', 'focusMode']
+        if (!valid.includes(named)) {
+            console.warn(`Excluding invalid feature key ${named}`)
+            return this
+        }
 
         if (settings.state === 'enabled' || settings.state === 'disabled') {
             return new Settings({
@@ -51,19 +54,18 @@ export class Settings {
     }
 
     /**
-     * @param {boolean} condition
+     * @param {string|null|undefined} newState
      * @return {Settings}
      */
-    withDisabledFocusMode (condition) {
-        /** @type {ImportMeta['platform'][]} */
-        return new Settings({
-            ...this,
-            focusMode: {
-                state: condition
-                    ? 'disabled'
-                    : 'enabled'
-            }
-        })
+    withDisabledFocusMode (newState) {
+        if (newState === 'disabled' || newState === 'enabled') {
+            return new Settings({
+                ...this,
+                focusMode: { state: newState }
+            })
+        }
+
+        return this
     }
 
     /**

--- a/packages/special-pages/tests/duckplayer.spec.js
+++ b/packages/special-pages/tests/duckplayer.spec.js
@@ -68,6 +68,14 @@ test.describe('duckplayer iframe', () => {
         await duckplayer.hasLoadedIframe()
         await duckplayer.pipButtonIsAbsent()
     })
+    test('focusMode on by default', async ({ page }, workerInfo) => {
+        test.skip(isMobile(workerInfo))
+        const duckplayer = DuckPlayerPage.create(page, workerInfo)
+        // load as normal
+        await duckplayer.openWithVideoID()
+        await duckplayer.hasLoadedIframe()
+        await duckplayer.focusModeIs('on')
+    })
     test('focusMode setting', async ({ page }, workerInfo) => {
         test.skip(isMobile(workerInfo))
         const duckplayer = DuckPlayerPage.create(page, workerInfo)

--- a/packages/special-pages/tests/duckplayer.spec.js
+++ b/packages/special-pages/tests/duckplayer.spec.js
@@ -68,6 +68,24 @@ test.describe('duckplayer iframe', () => {
         await duckplayer.hasLoadedIframe()
         await duckplayer.pipButtonIsAbsent()
     })
+    test('focusMode setting', async ({ page }, workerInfo) => {
+        test.skip(isMobile(workerInfo))
+        const duckplayer = DuckPlayerPage.create(page, workerInfo)
+        // load as normal
+        duckplayer.focusModeSettingIs({ state: 'enabled' })
+        await duckplayer.openWithVideoID()
+        await duckplayer.hasLoadedIframe()
+        await duckplayer.focusModeIs('on')
+    })
+    test('focusMode setting disabled', async ({ page }, workerInfo) => {
+        test.skip(isMobile(workerInfo))
+        const duckplayer = DuckPlayerPage.create(page, workerInfo)
+        // load as normal
+        duckplayer.focusModeSettingIs({ state: 'disabled' })
+        await duckplayer.openWithVideoID()
+        await duckplayer.hasLoadedIframe()
+        await duckplayer.focusModeIsAbsent()
+    })
 })
 
 test.describe('duckplayer toolbar', () => {

--- a/packages/special-pages/tests/page-objects/duck-player.js
+++ b/packages/special-pages/tests/page-objects/duck-player.js
@@ -51,6 +51,9 @@ export class DuckPlayerPage {
                 settings: {
                     pip: {
                         state: 'disabled'
+                    },
+                    focusMode: {
+                        state: 'disabled'
                     }
                 },
                 userValues: {
@@ -115,6 +118,15 @@ export class DuckPlayerPage {
     }
 
     /**
+     * @param {{ state: 'enabled' | 'disabled' }} setting
+     */
+    focusModeSettingIs (setting) {
+        const clone = structuredClone(this.defaults)
+        clone.initialSetup.settings.focusMode = setting
+        this.mocks.defaultResponses(clone)
+    }
+
+    /**
      * We don't need to actually load the content for these tests.
      * By mocking the response, we make the tests about 10x faster and also ensure they work offline.
      * @param {URLSearchParams} urlParams
@@ -160,7 +172,7 @@ export class DuckPlayerPage {
                             padding: 0;
                             height: 100%;
                             width: 100%;
-                            background: black; 
+                            background: black;
                             color: white;
                             display: grid;
                             align-items: center;
@@ -257,6 +269,17 @@ export class DuckPlayerPage {
     async pipButtonIsAbsent () {
         const count = await this.page.frameLocator('iframe').getByRole('button', { name: 'PIP' }).count()
         expect(count).toBe(0)
+    }
+
+    /**
+     * @param {'on'|'off'} focusModeValue
+     */
+    async focusModeIs (focusModeValue) {
+        await expect(this.page.getByRole('document')).toHaveAttribute('data-focus-mode', focusModeValue)
+    }
+
+    async focusModeIsAbsent () {
+        await expect(this.page.getByRole('document')).not.toHaveAttribute('data-focus-mode')
     }
 
     async hasTheSameTitleAsEmbed () {

--- a/packages/special-pages/tests/page-objects/duck-player.js
+++ b/packages/special-pages/tests/page-objects/duck-player.js
@@ -51,9 +51,6 @@ export class DuckPlayerPage {
                 settings: {
                     pip: {
                         state: 'disabled'
-                    },
-                    focusMode: {
-                        state: 'disabled'
                     }
                 },
                 userValues: {

--- a/packages/special-pages/types/duckplayer.ts
+++ b/packages/special-pages/types/duckplayer.ts
@@ -96,6 +96,9 @@ export interface DuckPlayerPageSettings {
   autoplay?: {
     state: "enabled" | "disabled";
   };
+  focusMode?: {
+    state: "enabled" | "disabled";
+  };
 }
 /**
  * Generated from @see "../messages/duckplayer/setUserValues.request.json"

--- a/src/features/duck-player.js
+++ b/src/features/duck-player.js
@@ -14,6 +14,7 @@
  * On Page Load
  *   - {@link DuckPlayerOverlayMessages.initialSetup} is initially called to get the current settings
  *   - {@link DuckPlayerOverlayMessages.onUserValuesChanged} subscription begins immediately - it will continue to listen for updates
+ *   - {@link DuckPlayerOverlayMessages.onUIValuesChanged} subscription begins immediately - it will continue to listen for updates
  *
  * Then the following message can be sent at any time
  *   - {@link DuckPlayerOverlayMessages.setUserValues}
@@ -47,7 +48,8 @@ import { Environment, initOverlays } from './duckplayer/overlays.js'
 
 /**
  * @typedef UISettings - UI-specific settings
- * @property {'default'|'a1'|'b1'} overlayCopy
+ * @property {'default'|'a1'|'b1'} overlayCopy - Overlay copy experiment variant
+ * @property {boolean} [playInDuckPlayer] - Forces next video to be played in Duck Player regardless of user setting
  */
 
 /**

--- a/src/features/duckplayer/overlay-messages.js
+++ b/src/features/duckplayer/overlay-messages.js
@@ -85,6 +85,14 @@ export class DuckPlayerOverlayMessages {
     }
 
     /**
+     * Get notification when ui settings changed
+     * @param {(userValues: import("../duck-player.js").UISettings) => void} cb
+     */
+    onUIValuesChanged (cb) {
+        return this.messaging.subscribe('onUIValuesChanged', cb)
+    }
+
+    /**
      * This allows our SERP to interact with Duck Player settings.
      */
     serpProxy () {


### PR DESCRIPTION
Asana: https://app.asana.com/0/72649045549333/1208132886429471/f

## 1. Allows setting focusMode on initialSetup

Updated `initialSetup` payload

```
{
	settings: {
		focusMode: {
			state: 'disabled'
		}
		pip: ...
	},
	...
}
```

## 2. Implements reactive UI settings to force next video to play in Duck Player

Updated `initialSetup` payload

```
{
	ui: {
		playInDuckPlayer: boolean
	},
	userValues: ...
}
```

New subscription event `onUIValuesChanged` with payload

```
{
	playInDuckPlayer: boolean
}
```