### PR TITLE
Fixes Release Notes button style

### DIFF
--- a/packages/special-pages/shared/components/Button/Button.module.css
+++ b/packages/special-pages/shared/components/Button/Button.module.css
@@ -67,13 +67,13 @@
 }
 
 /* Backward-compatible styles for use with Release Notes */
-[data-platform-name=""] {
-    .button {
+body:not([data-platform-name]) {
+    & .button {
         background-blend-mode: normal, color-burn, normal;
-        background: linear-gradient(180deg, var(rgba(255, 255, 255, 0.12) 0%, rgba(255, 255, 255, 0) 100%), linear-gradient(180deg, rgba(0, 0, 0, 0) 0%, rgba(0, 0, 0, 0.06) 100%)), #007aff;
+        background: linear-gradient(180deg, rgba(255, 255, 255, 0.12) 0%, rgba(255, 255, 255, 0) 100%), linear-gradient(180deg, rgba(0, 0, 0, 0) 0%, rgba(0, 0, 0, 0.06) 100%), #007aff;
         border-radius: var(--sp-2);
-        border: 1px solid rgba(40, var(145, 255, 0.05));
-        box-shadow: 0 0 1px 0 rgba(40, var(145, 255, 0.05), 0 1px 1px 0 rgba(40, 145, 255, 0.1));
+        border: 1px solid rgba(40, 145, 255, 0.05);
+        box-shadow: 0 0 1px 0 rgba(40, 145, 255, 0.05), 0 1px 1px 0 rgba(40, 145, 255, 0.1);
         color: white;
         font-size: calc(13 * var(--px-in-rem));
         font-weight: 600;
@@ -81,11 +81,11 @@
         padding: 0 var(--sp-4);
 
         &:hover {
-            background: linear-gradient(0deg, var(rgba(255, 255, 255, 0) 0%, rgba(255, 255, 255, 0.16) 100%)), #2749db;
+            background: linear-gradient(0deg, rgba(255, 255, 255, 0) 0%, rgba(255, 255, 255, 0.16) 100%), #2749db;
         }
 
         &:active {
-            background: linear-gradient(0deg, var(rgba(255, 255, 255, 0) 0%, rgba(255, 255, 255, 0.16) 100%)), #1743d1;
+            background: linear-gradient(0deg, rgba(255, 255, 255, 0) 0%, rgba(255, 255, 255, 0.16) 100%), #1743d1;
         }
     }
 }


### PR DESCRIPTION
Asana: https://app.asana.com/0/1206594217596623/1208235498182984/f

A recent update I made to the shared Button component broke its styling in backward-compatibility mode (currently only used by the Release notes special page)

The problem can be seen by running the local server on main and navigating to http://127.0.0.1:3210/build/integration/pages/release-notes/?display=components

<img width="214" alt="image" src="https://github.com/user-attachments/assets/9459aed4-ed8e-4249-b664-8da2526bf4f1">

This fix removes the stray `var(` properties in the CSS and updates the backward-compatibility selector to `body:not([data-platform-name])`

How to test this fix:

1. Check out branch `mgurgel/fixes-release-notes-button-style`
2. cd into the `packages/special-pages` folder
3. Run `npm run watch` alongside `npm run serve`
4. Navigate to http://127.0.0.1:3210/build/integration/pages/release-notes/?display=components You should see the button styling as shown below

![](https://github.com/user-attachments/assets/d0ec15a8-344d-4fd9-9792-ee993f70b784)

5. Navigate to http://127.0.0.1:3210/build/integration/pages/special-error/?display=components to confirm there were no changes to the macOS-style button

<img width="201" alt="image" src="https://github.com/user-attachments/assets/1373eaa7-baa3-4fc5-b3b9-144d8a1ad37e">


6. Navigate to http://127.0.0.1:3210/build/integration/pages/special-error/?display=components&platform=ios to confirm there were no changes to the iOS-style button

<img width="404" alt="image" src="https://github.com/user-attachments/assets/6aafd9b0-c602-43cf-8082-c61bc5d2d3c1">


