### PR TITLE
added locale strings for DuckPlayer

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "copy-sjcl": "node scripts/generateSJCL.js",
     "bundle-config": "node scripts/bundleConfig.mjs",
     "build": "npm run build-locales && npm run build-types && npm run bundle-trackers && npm run build-firefox && npm run build-chrome && npm run build-apple && npm run build-android && npm run build-windows && npm run build-integration && npm run build-chrome-mv3",
-    "build-locales": "node scripts/buildLocales.js --dir src/locales/click-to-load --output build/locales/ctl-locales.js",
+    "build-locales": "node scripts/buildLocales.js",
     "build-firefox": "node scripts/inject.js --platform firefox",
     "build-chrome": "node scripts/inject.js --platform chrome",
     "build-chrome-mv3": "node scripts/inject.js --platform chrome-mv3",

--- a/packages/special-pages/pages/duckplayer/app/index.js
+++ b/packages/special-pages/pages/duckplayer/app/index.js
@@ -86,7 +86,7 @@ export async function init (messaging, baseEnvironment) {
                 willThrow={environment.willThrow}>
                 <ErrorBoundary didCatch={didCatch} fallback={<Fallback showDetails={environment.env === 'development'}/>}>
                     <UpdateEnvironment search={window.location.search}/>
-                    <TranslationProvider translationObject={strings} fallback={enStrings} textLength={environment.textLength}>
+                    <TranslationProvider translationObject={enStrings} fallback={enStrings} textLength={environment.textLength}>
                         <MessagingContext.Provider value={messaging}>
                             <SettingsProvider settings={settings}>
                                 <UserValuesProvider initial={init.userValues}>
@@ -105,7 +105,7 @@ export async function init (messaging, baseEnvironment) {
         render(
             <EnvironmentProvider debugState={false} injectName={environment.injectName}>
                 <MessagingContext.Provider value={messaging}>
-                    <TranslationProvider translationObject={strings} fallback={enStrings} textLength={environment.textLength}>
+                    <TranslationProvider translationObject={enStrings} fallback={enStrings} textLength={environment.textLength}>
                         <Components />
                     </TranslationProvider>
                 </MessagingContext.Provider>

--- a/packages/special-pages/pages/duckplayer/app/index.js
+++ b/packages/special-pages/pages/duckplayer/app/index.js
@@ -41,19 +41,20 @@ export async function init (messaging, baseEnvironment) {
 
     document.body.dataset.display = environment.display
 
-    const strings = environment.locale === 'en'
-        ? enStrings
-        : await fetch(`./locales/${environment.locale}/duckplayer.json`)
-            .then(resp => {
-                if (!resp.ok) {
-                    throw new Error('did not give a result')
-                }
-                return resp.json()
-            })
-            .catch(e => {
-                console.error('Could not load locale', environment.locale, e)
-                return enStrings
-            })
+    // This will be re-enabled in the mobile PR
+    // const strings = environment.locale === 'en'
+    //     ? enStrings
+    //     : await fetch(`./locales/${environment.locale}/duckplayer.json`)
+    //         .then(resp => {
+    //             if (!resp.ok) {
+    //                 throw new Error('did not give a result')
+    //             }
+    //             return resp.json()
+    //         })
+    //         .catch(e => {
+    //             console.error('Could not load locale', environment.locale, e)
+    //             return enStrings
+    //         })
 
     const settings = new Settings({})
         .withPlatformName(baseEnvironment.injectName)

--- a/packages/special-pages/pages/duckplayer/src/locales/bg/duckplayer.json
+++ b/packages/special-pages/pages/duckplayer/src/locales/bg/duckplayer.json
@@ -1,0 +1,38 @@
+{
+  "smartling" : {
+    "string_format" : "icu",
+    "translate_paths" : [
+    {
+      "path" : "*/title",
+      "key" : "{*}/title",
+      "instruction" : "*/note"
+    }]
+  },
+  "alwaysWatchHere" : {
+    "title" : "Видеоклиповете в YouTube винаги да се отварят тук",
+    "note" : "label text for a checkbox that enables this feature for all videos, not just the current one"
+  },
+  "keepEnabled" : {
+    "title" : "Duck Player да остане включен",
+    "note" : "label text for a checkbox that enables this feature for all videos, not just the current one"
+  },
+  "openInfoButton" : {
+    "title" : "Отваряне на информацията",
+    "note" : "aria label text on a button, to indicate there's more information to be shown if clicked"
+  },
+  "openSettingsButton" : {
+    "title" : "Отваряне на настройки",
+    "note" : "aria label text on a button, opens a screen where the user can change settings"
+  },
+  "watchOnYoutube" : {
+    "title" : "Гледане в YouTube",
+    "note" : "text on a link that takes the user from the current page back onto YouTube.com"
+  },
+  "invalidIdError" : {
+    "title" : "<b>ГРЕШКА:</b> невалиден идентификатор на видеоклипа",
+    "note" : "Shown when the page URL doesn't match a known video ID. Note for translators: The <b> tag makes the word 'ERROR:' bold. Depending on the grammar of the target language, you might need to move it so that the correct word is emphasized."
+  },
+  "tooltipInfo" : {
+    "title" : "Duck Player осигурява чисто изживяване без персонализирани реклами в YouTube и предотвратява влиянието на вече гледаните видеоклипове върху препоръките на YouTube."
+  }
+}

--- a/packages/special-pages/pages/duckplayer/src/locales/cs/duckplayer.json
+++ b/packages/special-pages/pages/duckplayer/src/locales/cs/duckplayer.json
@@ -1,0 +1,38 @@
+{
+  "smartling" : {
+    "string_format" : "icu",
+    "translate_paths" : [
+    {
+      "path" : "*/title",
+      "key" : "{*}/title",
+      "instruction" : "*/note"
+    }]
+  },
+  "alwaysWatchHere" : {
+    "title" : "Vždy otevírat videa YouTube tady",
+    "note" : "label text for a checkbox that enables this feature for all videos, not just the current one"
+  },
+  "keepEnabled" : {
+    "title" : "Nechat zapnutý přehrávač Duck Player",
+    "note" : "label text for a checkbox that enables this feature for all videos, not just the current one"
+  },
+  "openInfoButton" : {
+    "title" : "Otevřít informace",
+    "note" : "aria label text on a button, to indicate there's more information to be shown if clicked"
+  },
+  "openSettingsButton" : {
+    "title" : "Otevřené nastavení",
+    "note" : "aria label text on a button, opens a screen where the user can change settings"
+  },
+  "watchOnYoutube" : {
+    "title" : "Sledovat na YouTube",
+    "note" : "text on a link that takes the user from the current page back onto YouTube.com"
+  },
+  "invalidIdError" : {
+    "title" : "<b>CHYBA:</b> Neplatné ID videa",
+    "note" : "Shown when the page URL doesn't match a known video ID. Note for translators: The <b> tag makes the word 'ERROR:' bold. Depending on the grammar of the target language, you might need to move it so that the correct word is emphasized."
+  },
+  "tooltipInfo" : {
+    "title" : "Přehrávač Duck Player nabízí sledování v minimalistickém prostředí bez personalizovaných reklam a brání tomu, aby sledovaná videa ovlivňovala tvoje doporučení na YouTube."
+  }
+}

--- a/packages/special-pages/pages/duckplayer/src/locales/da/duckplayer.json
+++ b/packages/special-pages/pages/duckplayer/src/locales/da/duckplayer.json
@@ -1,0 +1,38 @@
+{
+  "smartling" : {
+    "string_format" : "icu",
+    "translate_paths" : [
+    {
+      "path" : "*/title",
+      "key" : "{*}/title",
+      "instruction" : "*/note"
+    }]
+  },
+  "alwaysWatchHere" : {
+    "title" : "Åbn altid YouTube-videoer her",
+    "note" : "label text for a checkbox that enables this feature for all videos, not just the current one"
+  },
+  "keepEnabled" : {
+    "title" : "Hold Duck Player slået til",
+    "note" : "label text for a checkbox that enables this feature for all videos, not just the current one"
+  },
+  "openInfoButton" : {
+    "title" : "Åbn info",
+    "note" : "aria label text on a button, to indicate there's more information to be shown if clicked"
+  },
+  "openSettingsButton" : {
+    "title" : "Åbn Indstillinger",
+    "note" : "aria label text on a button, opens a screen where the user can change settings"
+  },
+  "watchOnYoutube" : {
+    "title" : "Se på YouTube",
+    "note" : "text on a link that takes the user from the current page back onto YouTube.com"
+  },
+  "invalidIdError" : {
+    "title" : "<b>FEJL:</b> Ugyldigt video-ID",
+    "note" : "Shown when the page URL doesn't match a known video ID. Note for translators: The <b> tag makes the word 'ERROR:' bold. Depending on the grammar of the target language, you might need to move it so that the correct word is emphasized."
+  },
+  "tooltipInfo" : {
+    "title" : "Duck Player giver en ren seeroplevelse uden målrettede annoncer og forhindrer, at visningsaktivitet påvirker dine YouTube-anbefalinger."
+  }
+}

--- a/packages/special-pages/pages/duckplayer/src/locales/de/duckplayer.json
+++ b/packages/special-pages/pages/duckplayer/src/locales/de/duckplayer.json
@@ -1,0 +1,38 @@
+{
+  "smartling" : {
+    "string_format" : "icu",
+    "translate_paths" : [
+    {
+      "path" : "*/title",
+      "key" : "{*}/title",
+      "instruction" : "*/note"
+    }]
+  },
+  "alwaysWatchHere" : {
+    "title" : "YouTube-Videos immer hier öffnen",
+    "note" : "label text for a checkbox that enables this feature for all videos, not just the current one"
+  },
+  "keepEnabled" : {
+    "title" : "Duck Player aktiviert lassen",
+    "note" : "label text for a checkbox that enables this feature for all videos, not just the current one"
+  },
+  "openInfoButton" : {
+    "title" : "Info öffnen",
+    "note" : "aria label text on a button, to indicate there's more information to be shown if clicked"
+  },
+  "openSettingsButton" : {
+    "title" : "Einstellungen öffnen",
+    "note" : "aria label text on a button, opens a screen where the user can change settings"
+  },
+  "watchOnYoutube" : {
+    "title" : "Auf YouTube ansehen",
+    "note" : "text on a link that takes the user from the current page back onto YouTube.com"
+  },
+  "invalidIdError" : {
+    "title" : "<b>FEHLER:</b> Ungültige Video-ID",
+    "note" : "Shown when the page URL doesn't match a known video ID. Note for translators: The <b> tag makes the word 'ERROR:' bold. Depending on the grammar of the target language, you might need to move it so that the correct word is emphasized."
+  },
+  "tooltipInfo" : {
+    "title" : "Mit Duck Player kannst du dir ungestört und ohne personalisierte Werbung Inhalte ansehen. Er verhindert, dass das, was du dir ansiehst, deine YouTube-Empfehlungen beeinflussen."
+  }
+}

--- a/packages/special-pages/pages/duckplayer/src/locales/el/duckplayer.json
+++ b/packages/special-pages/pages/duckplayer/src/locales/el/duckplayer.json
@@ -1,0 +1,38 @@
+{
+  "smartling" : {
+    "string_format" : "icu",
+    "translate_paths" : [
+    {
+      "path" : "*/title",
+      "key" : "{*}/title",
+      "instruction" : "*/note"
+    }]
+  },
+  "alwaysWatchHere" : {
+    "title" : "Ανοίγετε πάντα τα βίντεο του YouTube εδώ",
+    "note" : "label text for a checkbox that enables this feature for all videos, not just the current one"
+  },
+  "keepEnabled" : {
+    "title" : "Διατηρήστε το Duck Player ενεργοποιημένο",
+    "note" : "label text for a checkbox that enables this feature for all videos, not just the current one"
+  },
+  "openInfoButton" : {
+    "title" : "Ανοίξτε για πληροφορίες",
+    "note" : "aria label text on a button, to indicate there's more information to be shown if clicked"
+  },
+  "openSettingsButton" : {
+    "title" : "Άνοιγμα ρυθμίσεων",
+    "note" : "aria label text on a button, opens a screen where the user can change settings"
+  },
+  "watchOnYoutube" : {
+    "title" : "Παρακολούθηση στο YouTube",
+    "note" : "text on a link that takes the user from the current page back onto YouTube.com"
+  },
+  "invalidIdError" : {
+    "title" : "<b>ΣΦΑΛΜΑ:</b> Μη έγκυρο αναγνωριστικό βίντεο",
+    "note" : "Shown when the page URL doesn't match a known video ID. Note for translators: The <b> tag makes the word 'ERROR:' bold. Depending on the grammar of the target language, you might need to move it so that the correct word is emphasized."
+  },
+  "tooltipInfo" : {
+    "title" : "Το Duck Player παρέχει μια καθαρή εμπειρία προβολής χωρίς εξατομικευμένες διαφημίσεις, ενώ εμποδίζει τη δραστηριότητα προβολής να επηρεάσει τις συστάσεις που θα λαμβάνετε στο YouTube."
+  }
+}

--- a/packages/special-pages/pages/duckplayer/src/locales/en/duckplayer.json
+++ b/packages/special-pages/pages/duckplayer/src/locales/en/duckplayer.json
@@ -32,5 +32,8 @@
   "invalidIdError": {
     "title": "<b>ERROR:</b> Invalid video id",
     "note": "Shown when the page URL doesn't match a known video ID. Note for translators: The <b> tag makes the word 'ERROR:' bold. Depending on the grammar of the target language, you might need to move it so that the correct word is emphasized."
+  },
+  "tooltipInfo": {
+    "title": "Duck Player provides a clean viewing experience without personalized ads and prevents viewing activity from influencing your YouTube recommendations."
   }
 }

--- a/packages/special-pages/pages/duckplayer/src/locales/es/duckplayer.json
+++ b/packages/special-pages/pages/duckplayer/src/locales/es/duckplayer.json
@@ -1,0 +1,38 @@
+{
+  "smartling" : {
+    "string_format" : "icu",
+    "translate_paths" : [
+    {
+      "path" : "*/title",
+      "key" : "{*}/title",
+      "instruction" : "*/note"
+    }]
+  },
+  "alwaysWatchHere" : {
+    "title" : "Abrir siempre los vídeos de YouTube aquí",
+    "note" : "label text for a checkbox that enables this feature for all videos, not just the current one"
+  },
+  "keepEnabled" : {
+    "title" : "Mantener Duck Player activado",
+    "note" : "label text for a checkbox that enables this feature for all videos, not just the current one"
+  },
+  "openInfoButton" : {
+    "title" : "Abrir información",
+    "note" : "aria label text on a button, to indicate there's more information to be shown if clicked"
+  },
+  "openSettingsButton" : {
+    "title" : "Abrir ajustes",
+    "note" : "aria label text on a button, opens a screen where the user can change settings"
+  },
+  "watchOnYoutube" : {
+    "title" : "Ver en YouTube",
+    "note" : "text on a link that takes the user from the current page back onto YouTube.com"
+  },
+  "invalidIdError" : {
+    "title" : "<b>ERROR:</b> ID de vídeo no válida",
+    "note" : "Shown when the page URL doesn't match a known video ID. Note for translators: The <b> tag makes the word 'ERROR:' bold. Depending on the grammar of the target language, you might need to move it so that the correct word is emphasized."
+  },
+  "tooltipInfo" : {
+    "title" : "Duck Player ofrece una experiencia de visualización limpia sin anuncios personalizados e impide que la actividad de visualización influya en tus recomendaciones de YouTube."
+  }
+}

--- a/packages/special-pages/pages/duckplayer/src/locales/et/duckplayer.json
+++ b/packages/special-pages/pages/duckplayer/src/locales/et/duckplayer.json
@@ -1,0 +1,38 @@
+{
+  "smartling" : {
+    "string_format" : "icu",
+    "translate_paths" : [
+    {
+      "path" : "*/title",
+      "key" : "{*}/title",
+      "instruction" : "*/note"
+    }]
+  },
+  "alwaysWatchHere" : {
+    "title" : "Ava YouTube'i videod alati siin",
+    "note" : "label text for a checkbox that enables this feature for all videos, not just the current one"
+  },
+  "keepEnabled" : {
+    "title" : "Hoia Duck Player sisse lülitatud",
+    "note" : "label text for a checkbox that enables this feature for all videos, not just the current one"
+  },
+  "openInfoButton" : {
+    "title" : "Ava teave",
+    "note" : "aria label text on a button, to indicate there's more information to be shown if clicked"
+  },
+  "openSettingsButton" : {
+    "title" : "Ava seaded",
+    "note" : "aria label text on a button, opens a screen where the user can change settings"
+  },
+  "watchOnYoutube" : {
+    "title" : "Vaata YouTube'is",
+    "note" : "text on a link that takes the user from the current page back onto YouTube.com"
+  },
+  "invalidIdError" : {
+    "title" : "<b>VIGA:</b> vale video ID",
+    "note" : "Shown when the page URL doesn't match a known video ID. Note for translators: The <b> tag makes the word 'ERROR:' bold. Depending on the grammar of the target language, you might need to move it so that the correct word is emphasized."
+  },
+  "tooltipInfo" : {
+    "title" : "Duck Player pakub isikupärastatud reklaamidest vaba vaatamiskogemust ja takistab, et vaatamisaktiivsus mõjutaks sinu YouTube'i soovitusi."
+  }
+}

--- a/packages/special-pages/pages/duckplayer/src/locales/fi/duckplayer.json
+++ b/packages/special-pages/pages/duckplayer/src/locales/fi/duckplayer.json
@@ -1,0 +1,38 @@
+{
+  "smartling" : {
+    "string_format" : "icu",
+    "translate_paths" : [
+    {
+      "path" : "*/title",
+      "key" : "{*}/title",
+      "instruction" : "*/note"
+    }]
+  },
+  "alwaysWatchHere" : {
+    "title" : "Avaa YouTube-videot aina täällä",
+    "note" : "label text for a checkbox that enables this feature for all videos, not just the current one"
+  },
+  "keepEnabled" : {
+    "title" : "Pidä Duck Player käytössä",
+    "note" : "label text for a checkbox that enables this feature for all videos, not just the current one"
+  },
+  "openInfoButton" : {
+    "title" : "Avaa tiedot",
+    "note" : "aria label text on a button, to indicate there's more information to be shown if clicked"
+  },
+  "openSettingsButton" : {
+    "title" : "Avaa asetukset",
+    "note" : "aria label text on a button, opens a screen where the user can change settings"
+  },
+  "watchOnYoutube" : {
+    "title" : "Katso YouTubessa",
+    "note" : "text on a link that takes the user from the current page back onto YouTube.com"
+  },
+  "invalidIdError" : {
+    "title" : "<b>VIRHE:</b> virheellinen videotunnus",
+    "note" : "Shown when the page URL doesn't match a known video ID. Note for translators: The <b> tag makes the word 'ERROR:' bold. Depending on the grammar of the target language, you might need to move it so that the correct word is emphasized."
+  },
+  "tooltipInfo" : {
+    "title" : "Duck Player tarjoaa puhtaan katselukokemuksen ilman kohdennettuja mainoksia ja estää katseluhistoriaa vaikuttamasta YouTube-suosituksiisi."
+  }
+}

--- a/packages/special-pages/pages/duckplayer/src/locales/fr/duckplayer.json
+++ b/packages/special-pages/pages/duckplayer/src/locales/fr/duckplayer.json
@@ -1,0 +1,38 @@
+{
+  "smartling" : {
+    "string_format" : "icu",
+    "translate_paths" : [
+    {
+      "path" : "*/title",
+      "key" : "{*}/title",
+      "instruction" : "*/note"
+    }]
+  },
+  "alwaysWatchHere" : {
+    "title" : "Toujours ouvrir les vidéos YouTube ici",
+    "note" : "label text for a checkbox that enables this feature for all videos, not just the current one"
+  },
+  "keepEnabled" : {
+    "title" : "Laisser Duck Player activé",
+    "note" : "label text for a checkbox that enables this feature for all videos, not just the current one"
+  },
+  "openInfoButton" : {
+    "title" : "Ouvrir les infos",
+    "note" : "aria label text on a button, to indicate there's more information to be shown if clicked"
+  },
+  "openSettingsButton" : {
+    "title" : "Ouvrez les Paramètres",
+    "note" : "aria label text on a button, opens a screen where the user can change settings"
+  },
+  "watchOnYoutube" : {
+    "title" : "Regarder sur YouTube",
+    "note" : "text on a link that takes the user from the current page back onto YouTube.com"
+  },
+  "invalidIdError" : {
+    "title" : "<b>ERREUR :</b> identifiant vidéo non valide",
+    "note" : "Shown when the page URL doesn't match a known video ID. Note for translators: The <b> tag makes the word 'ERROR:' bold. Depending on the grammar of the target language, you might need to move it so that the correct word is emphasized."
+  },
+  "tooltipInfo" : {
+    "title" : "Duck Player offre une expérience de visionnage épurée, sans publicités personnalisées, et empêche l'activité de visionnage d'influencer vos recommandations YouTube."
+  }
+}

--- a/packages/special-pages/pages/duckplayer/src/locales/hr/duckplayer.json
+++ b/packages/special-pages/pages/duckplayer/src/locales/hr/duckplayer.json
@@ -1,0 +1,38 @@
+{
+  "smartling" : {
+    "string_format" : "icu",
+    "translate_paths" : [
+    {
+      "path" : "*/title",
+      "key" : "{*}/title",
+      "instruction" : "*/note"
+    }]
+  },
+  "alwaysWatchHere" : {
+    "title" : "YouTube videozapise uvijek otvaraj ovdje",
+    "note" : "label text for a checkbox that enables this feature for all videos, not just the current one"
+  },
+  "keepEnabled" : {
+    "title" : "Drži Duck Player uključen",
+    "note" : "label text for a checkbox that enables this feature for all videos, not just the current one"
+  },
+  "openInfoButton" : {
+    "title" : "Više informacija",
+    "note" : "aria label text on a button, to indicate there's more information to be shown if clicked"
+  },
+  "openSettingsButton" : {
+    "title" : "Otvori Postavke",
+    "note" : "aria label text on a button, opens a screen where the user can change settings"
+  },
+  "watchOnYoutube" : {
+    "title" : "Pogledaj na YouTubeu",
+    "note" : "text on a link that takes the user from the current page back onto YouTube.com"
+  },
+  "invalidIdError" : {
+    "title" : "<b>POGREŠKA:</b> Nevažeći ID videozapisa",
+    "note" : "Shown when the page URL doesn't match a known video ID. Note for translators: The <b> tag makes the word 'ERROR:' bold. Depending on the grammar of the target language, you might need to move it so that the correct word is emphasized."
+  },
+  "tooltipInfo" : {
+    "title" : "Duck Player pruža čisti doživljaj gledanja bez personaliziranih oglasa i sprječava da aktivnosti gledanja utječu na tvoje preporuke na YouTubeu."
+  }
+}

--- a/packages/special-pages/pages/duckplayer/src/locales/hu/duckplayer.json
+++ b/packages/special-pages/pages/duckplayer/src/locales/hu/duckplayer.json
@@ -1,0 +1,38 @@
+{
+  "smartling" : {
+    "string_format" : "icu",
+    "translate_paths" : [
+    {
+      "path" : "*/title",
+      "key" : "{*}/title",
+      "instruction" : "*/note"
+    }]
+  },
+  "alwaysWatchHere" : {
+    "title" : "Mindig itt nyissa meg a YouTube-videókat",
+    "note" : "label text for a checkbox that enables this feature for all videos, not just the current one"
+  },
+  "keepEnabled" : {
+    "title" : "Maradjon bekapcsolva a Duck Player",
+    "note" : "label text for a checkbox that enables this feature for all videos, not just the current one"
+  },
+  "openInfoButton" : {
+    "title" : "Információk megtekintése",
+    "note" : "aria label text on a button, to indicate there's more information to be shown if clicked"
+  },
+  "openSettingsButton" : {
+    "title" : "Beállítások megnyitása",
+    "note" : "aria label text on a button, opens a screen where the user can change settings"
+  },
+  "watchOnYoutube" : {
+    "title" : "Lejátszás YouTube-on",
+    "note" : "text on a link that takes the user from the current page back onto YouTube.com"
+  },
+  "invalidIdError" : {
+    "title" : "<b>HIBA:</b> Érvénytelen videoazonosító",
+    "note" : "Shown when the page URL doesn't match a known video ID. Note for translators: The <b> tag makes the word 'ERROR:' bold. Depending on the grammar of the target language, you might need to move it so that the correct word is emphasized."
+  },
+  "tooltipInfo" : {
+    "title" : "A Duck Player személyre szabott hirdetések nélküli, letisztult megtekintési élményt nyújt, és megakadályozza, hogy a megtekintési tevékenységed befolyásolja a neked szóló YouTube-ajánlásokat."
+  }
+}

--- a/packages/special-pages/pages/duckplayer/src/locales/it/duckplayer.json
+++ b/packages/special-pages/pages/duckplayer/src/locales/it/duckplayer.json
@@ -1,0 +1,38 @@
+{
+  "smartling" : {
+    "string_format" : "icu",
+    "translate_paths" : [
+    {
+      "path" : "*/title",
+      "key" : "{*}/title",
+      "instruction" : "*/note"
+    }]
+  },
+  "alwaysWatchHere" : {
+    "title" : "Apri sempre i video di YouTube qui",
+    "note" : "label text for a checkbox that enables this feature for all videos, not just the current one"
+  },
+  "keepEnabled" : {
+    "title" : "Tieni Duck Player attivo",
+    "note" : "label text for a checkbox that enables this feature for all videos, not just the current one"
+  },
+  "openInfoButton" : {
+    "title" : "Apri le informazioni",
+    "note" : "aria label text on a button, to indicate there's more information to be shown if clicked"
+  },
+  "openSettingsButton" : {
+    "title" : "Apri Impostazioni",
+    "note" : "aria label text on a button, opens a screen where the user can change settings"
+  },
+  "watchOnYoutube" : {
+    "title" : "Guarda su YouTube",
+    "note" : "text on a link that takes the user from the current page back onto YouTube.com"
+  },
+  "invalidIdError" : {
+    "title" : "<b>ERRORE:</b> ID video non valido",
+    "note" : "Shown when the page URL doesn't match a known video ID. Note for translators: The <b> tag makes the word 'ERROR:' bold. Depending on the grammar of the target language, you might need to move it so that the correct word is emphasized."
+  },
+  "tooltipInfo" : {
+    "title" : "Duck Player offre un'esperienza di visualizzazione pulita, senza annunci personalizzati, e impedisce che l'attività di visualizzazione incida sulle raccomandazioni di YouTube."
+  }
+}

--- a/packages/special-pages/pages/duckplayer/src/locales/lt/duckplayer.json
+++ b/packages/special-pages/pages/duckplayer/src/locales/lt/duckplayer.json
@@ -1,0 +1,38 @@
+{
+  "smartling" : {
+    "string_format" : "icu",
+    "translate_paths" : [
+    {
+      "path" : "*/title",
+      "key" : "{*}/title",
+      "instruction" : "*/note"
+    }]
+  },
+  "alwaysWatchHere" : {
+    "title" : "Visada atidaryti „YouTube“ vaizdo įrašus čia",
+    "note" : "label text for a checkbox that enables this feature for all videos, not just the current one"
+  },
+  "keepEnabled" : {
+    "title" : "Laikyti „Duck Player“ įjungtą",
+    "note" : "label text for a checkbox that enables this feature for all videos, not just the current one"
+  },
+  "openInfoButton" : {
+    "title" : "Atidaryti informaciją",
+    "note" : "aria label text on a button, to indicate there's more information to be shown if clicked"
+  },
+  "openSettingsButton" : {
+    "title" : "Atidaryti Nustatymus",
+    "note" : "aria label text on a button, opens a screen where the user can change settings"
+  },
+  "watchOnYoutube" : {
+    "title" : "Žiūrėti „YouTube“",
+    "note" : "text on a link that takes the user from the current page back onto YouTube.com"
+  },
+  "invalidIdError" : {
+    "title" : "<b>KLAIDA:</b> netinkamas vaizdo įrašo ID",
+    "note" : "Shown when the page URL doesn't match a known video ID. Note for translators: The <b> tag makes the word 'ERROR:' bold. Depending on the grammar of the target language, you might need to move it so that the correct word is emphasized."
+  },
+  "tooltipInfo" : {
+    "title" : "„Duck Player“ užtikrina nepriekaištingą žiūrėjimo patirtį be suasmenintų reklamų ir neleidžia žiūrėjimo veiklai daryti įtakos „YouTube“ rekomendacijoms."
+  }
+}

--- a/packages/special-pages/pages/duckplayer/src/locales/lv/duckplayer.json
+++ b/packages/special-pages/pages/duckplayer/src/locales/lv/duckplayer.json
@@ -1,0 +1,38 @@
+{
+  "smartling" : {
+    "string_format" : "icu",
+    "translate_paths" : [
+    {
+      "path" : "*/title",
+      "key" : "{*}/title",
+      "instruction" : "*/note"
+    }]
+  },
+  "alwaysWatchHere" : {
+    "title" : "Vienmēr atvērt YouTube videoklipus šeit",
+    "note" : "label text for a checkbox that enables this feature for all videos, not just the current one"
+  },
+  "keepEnabled" : {
+    "title" : "Paturēt Duck Player ieslēgtu",
+    "note" : "label text for a checkbox that enables this feature for all videos, not just the current one"
+  },
+  "openInfoButton" : {
+    "title" : "Atvērt informāciju",
+    "note" : "aria label text on a button, to indicate there's more information to be shown if clicked"
+  },
+  "openSettingsButton" : {
+    "title" : "Atvērt iestatījumus",
+    "note" : "aria label text on a button, opens a screen where the user can change settings"
+  },
+  "watchOnYoutube" : {
+    "title" : "Skatīties pie YouTube",
+    "note" : "text on a link that takes the user from the current page back onto YouTube.com"
+  },
+  "invalidIdError" : {
+    "title" : "<b>KĻŪDA:</b> Nederīgs video ID",
+    "note" : "Shown when the page URL doesn't match a known video ID. Note for translators: The <b> tag makes the word 'ERROR:' bold. Depending on the grammar of the target language, you might need to move it so that the correct word is emphasized."
+  },
+  "tooltipInfo" : {
+    "title" : "Duck Player nodrošina netraucētu skatīšanās pieredzi bez personalizētām reklāmām un neļauj skatīšanās darbībām ietekmēt tavus YouTube ieteikumus."
+  }
+}

--- a/packages/special-pages/pages/duckplayer/src/locales/nb/duckplayer.json
+++ b/packages/special-pages/pages/duckplayer/src/locales/nb/duckplayer.json
@@ -1,0 +1,38 @@
+{
+  "smartling" : {
+    "string_format" : "icu",
+    "translate_paths" : [
+    {
+      "path" : "*/title",
+      "key" : "{*}/title",
+      "instruction" : "*/note"
+    }]
+  },
+  "alwaysWatchHere" : {
+    "title" : "Åpne alltid YouTube-videoer her",
+    "note" : "label text for a checkbox that enables this feature for all videos, not just the current one"
+  },
+  "keepEnabled" : {
+    "title" : "La Duck Player være på",
+    "note" : "label text for a checkbox that enables this feature for all videos, not just the current one"
+  },
+  "openInfoButton" : {
+    "title" : "Åpne informasjon",
+    "note" : "aria label text on a button, to indicate there's more information to be shown if clicked"
+  },
+  "openSettingsButton" : {
+    "title" : "Åpne innstillingene",
+    "note" : "aria label text on a button, opens a screen where the user can change settings"
+  },
+  "watchOnYoutube" : {
+    "title" : "Se på YouTube",
+    "note" : "text on a link that takes the user from the current page back onto YouTube.com"
+  },
+  "invalidIdError" : {
+    "title" : "<b>FEIL:</b> Ugyldig video-ID",
+    "note" : "Shown when the page URL doesn't match a known video ID. Note for translators: The <b> tag makes the word 'ERROR:' bold. Depending on the grammar of the target language, you might need to move it so that the correct word is emphasized."
+  },
+  "tooltipInfo" : {
+    "title" : "Duck Player tilbyr en ren seeropplevelse uten tilpassede annonser og forhindrer at seeraktiviteten din påvirker YouTube-anbefalingene dine."
+  }
+}

--- a/packages/special-pages/pages/duckplayer/src/locales/nl/duckplayer.json
+++ b/packages/special-pages/pages/duckplayer/src/locales/nl/duckplayer.json
@@ -1,0 +1,38 @@
+{
+  "smartling" : {
+    "string_format" : "icu",
+    "translate_paths" : [
+    {
+      "path" : "*/title",
+      "key" : "{*}/title",
+      "instruction" : "*/note"
+    }]
+  },
+  "alwaysWatchHere" : {
+    "title" : "YouTube-video's altijd hier openen",
+    "note" : "label text for a checkbox that enables this feature for all videos, not just the current one"
+  },
+  "keepEnabled" : {
+    "title" : "Houd Duck Player ingeschakeld",
+    "note" : "label text for a checkbox that enables this feature for all videos, not just the current one"
+  },
+  "openInfoButton" : {
+    "title" : "Meer info",
+    "note" : "aria label text on a button, to indicate there's more information to be shown if clicked"
+  },
+  "openSettingsButton" : {
+    "title" : "Open Instellingen",
+    "note" : "aria label text on a button, opens a screen where the user can change settings"
+  },
+  "watchOnYoutube" : {
+    "title" : "Kijken op YouTube",
+    "note" : "text on a link that takes the user from the current page back onto YouTube.com"
+  },
+  "invalidIdError" : {
+    "title" : "<b>FOUT:</b> ongeldige video-id",
+    "note" : "Shown when the page URL doesn't match a known video ID. Note for translators: The <b> tag makes the word 'ERROR:' bold. Depending on the grammar of the target language, you might need to move it so that the correct word is emphasized."
+  },
+  "tooltipInfo" : {
+    "title" : "Duck Player biedt puur kijkplezier zonder gepersonaliseerde advertenties en voorkomt dat de dingen die je bekijkt je YouTube-aanbevelingen beïnvloeden."
+  }
+}

--- a/packages/special-pages/pages/duckplayer/src/locales/pl/duckplayer.json
+++ b/packages/special-pages/pages/duckplayer/src/locales/pl/duckplayer.json
@@ -1,0 +1,38 @@
+{
+  "smartling" : {
+    "string_format" : "icu",
+    "translate_paths" : [
+    {
+      "path" : "*/title",
+      "key" : "{*}/title",
+      "instruction" : "*/note"
+    }]
+  },
+  "alwaysWatchHere" : {
+    "title" : "Zawsze otwieraj filmy z YouTube tutaj",
+    "note" : "label text for a checkbox that enables this feature for all videos, not just the current one"
+  },
+  "keepEnabled" : {
+    "title" : "Nie wyłączaj odtwarzacza Duck Player",
+    "note" : "label text for a checkbox that enables this feature for all videos, not just the current one"
+  },
+  "openInfoButton" : {
+    "title" : "Otwórz informacje",
+    "note" : "aria label text on a button, to indicate there's more information to be shown if clicked"
+  },
+  "openSettingsButton" : {
+    "title" : "Otwórz ustawienia",
+    "note" : "aria label text on a button, opens a screen where the user can change settings"
+  },
+  "watchOnYoutube" : {
+    "title" : "Obejrzyj na YouTube",
+    "note" : "text on a link that takes the user from the current page back onto YouTube.com"
+  },
+  "invalidIdError" : {
+    "title" : "<b>BŁĄD:</b> nieprawidłowy identyfikator filmu",
+    "note" : "Shown when the page URL doesn't match a known video ID. Note for translators: The <b> tag makes the word 'ERROR:' bold. Depending on the grammar of the target language, you might need to move it so that the correct word is emphasized."
+  },
+  "tooltipInfo" : {
+    "title" : "Duck Player zapewnia czyste środowisko oglądania bez spersonalizowanych reklam i sprawia, że aktywność związana z oglądaniem filmów nie wpływa na rekomendacje YouTube'a."
+  }
+}

--- a/packages/special-pages/pages/duckplayer/src/locales/pt/duckplayer.json
+++ b/packages/special-pages/pages/duckplayer/src/locales/pt/duckplayer.json
@@ -1,0 +1,38 @@
+{
+  "smartling" : {
+    "string_format" : "icu",
+    "translate_paths" : [
+    {
+      "path" : "*/title",
+      "key" : "{*}/title",
+      "instruction" : "*/note"
+    }]
+  },
+  "alwaysWatchHere" : {
+    "title" : "Abrir sempre os vídeos do YouTube aqui",
+    "note" : "label text for a checkbox that enables this feature for all videos, not just the current one"
+  },
+  "keepEnabled" : {
+    "title" : "Manter o Duck Player ligado",
+    "note" : "label text for a checkbox that enables this feature for all videos, not just the current one"
+  },
+  "openInfoButton" : {
+    "title" : "Abrir Informações",
+    "note" : "aria label text on a button, to indicate there's more information to be shown if clicked"
+  },
+  "openSettingsButton" : {
+    "title" : "Abre Definições",
+    "note" : "aria label text on a button, opens a screen where the user can change settings"
+  },
+  "watchOnYoutube" : {
+    "title" : "Ver no YouTube",
+    "note" : "text on a link that takes the user from the current page back onto YouTube.com"
+  },
+  "invalidIdError" : {
+    "title" : "<b>ERRO:</b> ID de vídeo inválido",
+    "note" : "Shown when the page URL doesn't match a known video ID. Note for translators: The <b> tag makes the word 'ERROR:' bold. Depending on the grammar of the target language, you might need to move it so that the correct word is emphasized."
+  },
+  "tooltipInfo" : {
+    "title" : "O Duck Player oferece uma experiência de visualização limpa sem anúncios personalizados e evita que as atividades de visualização influenciem as recomendações do YouTube."
+  }
+}

--- a/packages/special-pages/pages/duckplayer/src/locales/ro/duckplayer.json
+++ b/packages/special-pages/pages/duckplayer/src/locales/ro/duckplayer.json
@@ -1,0 +1,38 @@
+{
+  "smartling" : {
+    "string_format" : "icu",
+    "translate_paths" : [
+    {
+      "path" : "*/title",
+      "key" : "{*}/title",
+      "instruction" : "*/note"
+    }]
+  },
+  "alwaysWatchHere" : {
+    "title" : "Deschide întotdeauna videoclipurile YouTube aici",
+    "note" : "label text for a checkbox that enables this feature for all videos, not just the current one"
+  },
+  "keepEnabled" : {
+    "title" : "Menține Duck Player activat",
+    "note" : "label text for a checkbox that enables this feature for all videos, not just the current one"
+  },
+  "openInfoButton" : {
+    "title" : "Deschide Informațiile",
+    "note" : "aria label text on a button, to indicate there's more information to be shown if clicked"
+  },
+  "openSettingsButton" : {
+    "title" : "Deschide Setări",
+    "note" : "aria label text on a button, opens a screen where the user can change settings"
+  },
+  "watchOnYoutube" : {
+    "title" : "Vizionează pe YouTube",
+    "note" : "text on a link that takes the user from the current page back onto YouTube.com"
+  },
+  "invalidIdError" : {
+    "title" : "<b>EROARE:</b> ID video incorect",
+    "note" : "Shown when the page URL doesn't match a known video ID. Note for translators: The <b> tag makes the word 'ERROR:' bold. Depending on the grammar of the target language, you might need to move it so that the correct word is emphasized."
+  },
+  "tooltipInfo" : {
+    "title" : "Duck Player oferă o experiență de vizionare fără perturbări, fără reclame personalizate și împiedică activitatea de vizionare să îți influențeze recomandările YouTube."
+  }
+}

--- a/packages/special-pages/pages/duckplayer/src/locales/ru/duckplayer.json
+++ b/packages/special-pages/pages/duckplayer/src/locales/ru/duckplayer.json
@@ -1,0 +1,38 @@
+{
+  "smartling" : {
+    "string_format" : "icu",
+    "translate_paths" : [
+    {
+      "path" : "*/title",
+      "key" : "{*}/title",
+      "instruction" : "*/note"
+    }]
+  },
+  "alwaysWatchHere" : {
+    "title" : "Всегда открывайте видео на YouTube здесь",
+    "note" : "label text for a checkbox that enables this feature for all videos, not just the current one"
+  },
+  "keepEnabled" : {
+    "title" : "Держите Duck Player включенным",
+    "note" : "label text for a checkbox that enables this feature for all videos, not just the current one"
+  },
+  "openInfoButton" : {
+    "title" : "Открыть информацию",
+    "note" : "aria label text on a button, to indicate there's more information to be shown if clicked"
+  },
+  "openSettingsButton" : {
+    "title" : "Открыть Настройки",
+    "note" : "aria label text on a button, opens a screen where the user can change settings"
+  },
+  "watchOnYoutube" : {
+    "title" : "Смотреть на YouTube",
+    "note" : "text on a link that takes the user from the current page back onto YouTube.com"
+  },
+  "invalidIdError" : {
+    "title" : "<b>ОШИБКА:</b> Неверный идентификатор видео",
+    "note" : "Shown when the page URL doesn't match a known video ID. Note for translators: The <b> tag makes the word 'ERROR:' bold. Depending on the grammar of the target language, you might need to move it so that the correct word is emphasized."
+  },
+  "tooltipInfo" : {
+    "title" : "Проигрыватель Duck Player обеспечивает беспрепятственный просмотр без персонализированной рекламы и влияния просмотренных роликов на рекомендации в YouTube."
+  }
+}

--- a/packages/special-pages/pages/duckplayer/src/locales/sk/duckplayer.json
+++ b/packages/special-pages/pages/duckplayer/src/locales/sk/duckplayer.json
@@ -1,0 +1,38 @@
+{
+  "smartling" : {
+    "string_format" : "icu",
+    "translate_paths" : [
+    {
+      "path" : "*/title",
+      "key" : "{*}/title",
+      "instruction" : "*/note"
+    }]
+  },
+  "alwaysWatchHere" : {
+    "title" : "Vždy otvárajte videá YouTube tu",
+    "note" : "label text for a checkbox that enables this feature for all videos, not just the current one"
+  },
+  "keepEnabled" : {
+    "title" : "Nechajte zapnutý prehrávač Duck Player",
+    "note" : "label text for a checkbox that enables this feature for all videos, not just the current one"
+  },
+  "openInfoButton" : {
+    "title" : "Otvorené informácie",
+    "note" : "aria label text on a button, to indicate there's more information to be shown if clicked"
+  },
+  "openSettingsButton" : {
+    "title" : "Otvoriť nastavenia",
+    "note" : "aria label text on a button, opens a screen where the user can change settings"
+  },
+  "watchOnYoutube" : {
+    "title" : "Pozrieť na YouTube",
+    "note" : "text on a link that takes the user from the current page back onto YouTube.com"
+  },
+  "invalidIdError" : {
+    "title" : "<b>CHYBA:</b> Neplatný identifikátor videa",
+    "note" : "Shown when the page URL doesn't match a known video ID. Note for translators: The <b> tag makes the word 'ERROR:' bold. Depending on the grammar of the target language, you might need to move it so that the correct word is emphasized."
+  },
+  "tooltipInfo" : {
+    "title" : "Duck Player poskytuje čisté zobrazenie bez personalizovaných reklám a zabraňuje tomu, aby aktivita pri sledovaní ovplyvňovala vaše odporúčania v službe YouTube."
+  }
+}

--- a/packages/special-pages/pages/duckplayer/src/locales/sl/duckplayer.json
+++ b/packages/special-pages/pages/duckplayer/src/locales/sl/duckplayer.json
@@ -1,0 +1,38 @@
+{
+  "smartling" : {
+    "string_format" : "icu",
+    "translate_paths" : [
+    {
+      "path" : "*/title",
+      "key" : "{*}/title",
+      "instruction" : "*/note"
+    }]
+  },
+  "alwaysWatchHere" : {
+    "title" : "Videoposnetke iz YouTuba vedno odpri tukaj",
+    "note" : "label text for a checkbox that enables this feature for all videos, not just the current one"
+  },
+  "keepEnabled" : {
+    "title" : "Predvajalnik Duck Player naj ostane vklopljen",
+    "note" : "label text for a checkbox that enables this feature for all videos, not just the current one"
+  },
+  "openInfoButton" : {
+    "title" : "Prikaži informacije",
+    "note" : "aria label text on a button, to indicate there's more information to be shown if clicked"
+  },
+  "openSettingsButton" : {
+    "title" : "Odpri nastavitve",
+    "note" : "aria label text on a button, opens a screen where the user can change settings"
+  },
+  "watchOnYoutube" : {
+    "title" : "Glej na YouTubu",
+    "note" : "text on a link that takes the user from the current page back onto YouTube.com"
+  },
+  "invalidIdError" : {
+    "title" : "<b>NAPAKA:</b> Neveljaven ID videoposnetka",
+    "note" : "Shown when the page URL doesn't match a known video ID. Note for translators: The <b> tag makes the word 'ERROR:' bold. Depending on the grammar of the target language, you might need to move it so that the correct word is emphasized."
+  },
+  "tooltipInfo" : {
+    "title" : "Predvajalnik Duck Player zagotavlja čisto izkušnjo gledanja brez prilagojenih oglasov in preprečuje, da bi dejavnost gledanja vplivala na vaša priporočila v YouTubu."
+  }
+}

--- a/packages/special-pages/pages/duckplayer/src/locales/sv/duckplayer.json
+++ b/packages/special-pages/pages/duckplayer/src/locales/sv/duckplayer.json
@@ -1,0 +1,38 @@
+{
+  "smartling" : {
+    "string_format" : "icu",
+    "translate_paths" : [
+    {
+      "path" : "*/title",
+      "key" : "{*}/title",
+      "instruction" : "*/note"
+    }]
+  },
+  "alwaysWatchHere" : {
+    "title" : "Öppna alltid YouTube-videor här",
+    "note" : "label text for a checkbox that enables this feature for all videos, not just the current one"
+  },
+  "keepEnabled" : {
+    "title" : "Låt Duck Player vara aktiverat",
+    "note" : "label text for a checkbox that enables this feature for all videos, not just the current one"
+  },
+  "openInfoButton" : {
+    "title" : "Öppna info",
+    "note" : "aria label text on a button, to indicate there's more information to be shown if clicked"
+  },
+  "openSettingsButton" : {
+    "title" : "Öppna inställningar",
+    "note" : "aria label text on a button, opens a screen where the user can change settings"
+  },
+  "watchOnYoutube" : {
+    "title" : "Se på Youtube",
+    "note" : "text on a link that takes the user from the current page back onto YouTube.com"
+  },
+  "invalidIdError" : {
+    "title" : "<b>FEL:</b> Ogiltigt video-ID",
+    "note" : "Shown when the page URL doesn't match a known video ID. Note for translators: The <b> tag makes the word 'ERROR:' bold. Depending on the grammar of the target language, you might need to move it so that the correct word is emphasized."
+  },
+  "tooltipInfo" : {
+    "title" : "Duck Player ger en störningsfri visningsupplevelse utan personliga annonser och förhindrar att din tittaraktivitet påverkar YouTube-rekommendationer."
+  }
+}

--- a/packages/special-pages/pages/duckplayer/src/locales/tr/duckplayer.json
+++ b/packages/special-pages/pages/duckplayer/src/locales/tr/duckplayer.json
@@ -1,0 +1,38 @@
+{
+  "smartling" : {
+    "string_format" : "icu",
+    "translate_paths" : [
+    {
+      "path" : "*/title",
+      "key" : "{*}/title",
+      "instruction" : "*/note"
+    }]
+  },
+  "alwaysWatchHere" : {
+    "title" : "YouTube videolarını her zaman burada aç",
+    "note" : "label text for a checkbox that enables this feature for all videos, not just the current one"
+  },
+  "keepEnabled" : {
+    "title" : "Duck Player'ı açık tut",
+    "note" : "label text for a checkbox that enables this feature for all videos, not just the current one"
+  },
+  "openInfoButton" : {
+    "title" : "Bilgileri Aç",
+    "note" : "aria label text on a button, to indicate there's more information to be shown if clicked"
+  },
+  "openSettingsButton" : {
+    "title" : "Ayarları Aç",
+    "note" : "aria label text on a button, opens a screen where the user can change settings"
+  },
+  "watchOnYoutube" : {
+    "title" : "Youtube'da İzle",
+    "note" : "text on a link that takes the user from the current page back onto YouTube.com"
+  },
+  "invalidIdError" : {
+    "title" : "<b>HATA:</b> Geçersiz video kimliği",
+    "note" : "Shown when the page URL doesn't match a known video ID. Note for translators: The <b> tag makes the word 'ERROR:' bold. Depending on the grammar of the target language, you might need to move it so that the correct word is emphasized."
+  },
+  "tooltipInfo" : {
+    "title" : "Duck Player, kişiselleştirilmiş reklamlar olmadan temiz bir görüntüleme deneyimi sağlar ve görüntüleme etkinliğinin YouTube önerilerinizi etkilemesini önler."
+  }
+}

--- a/scripts/buildLocales.js
+++ b/scripts/buildLocales.js
@@ -1,6 +1,6 @@
 import { readdirSync, readFileSync } from 'fs'
 import { join } from 'path'
-import { parseArgs, write } from './script-utils.js'
+import { write } from './script-utils.js'
 
 /**
  * This script loads the current JSON-based locales files and merges them into
@@ -33,10 +33,12 @@ function bundle (localesRoot) {
         '`'
 }
 
-const requiredFields = ['dir', 'output']
-const help = 'usage: buildLocales <locales/feature dir>'
-const args = parseArgs(process.argv.slice(2), requiredFields, help)
+const jobs = {
+    'src/locales/click-to-load': 'build/locales/ctl-locales.js',
+    'src/locales/duckplayer': 'build/locales/duckplayer-locales.js'
+}
 
-// run the build and write the files
-const bundled = bundle(args.dir)
-write([args.output], bundled)
+for (const [dir, output] of Object.entries(jobs)) {
+    const bundled = bundle(dir)
+    write([output], bundled)
+}

--- a/src/locales/duckplayer/bg/overlays.json
+++ b/src/locales/duckplayer/bg/overlays.json
@@ -1,0 +1,27 @@
+{
+  "smartling" : {
+    "string_format" : "icu",
+    "translate_paths" : [
+    {
+      "path" : "*/title",
+      "key" : "{*}/title",
+      "instruction" : "*/note"
+    }]
+  },
+  "videoOverlayTitle2" : {
+    "title" : "Включете Duck Player, за да гледате без насочени реклами",
+    "note" : "Text displayed as a title in the video overlay to encourage users to enable Duck Player for an ad-free experience."
+  },
+  "videoButtonOpen2" : {
+    "title" : "Включване на Duck Player",
+    "note" : "Button text to prompt users to activate Duck Player."
+  },
+  "videoButtonOptOut2" : {
+    "title" : "Не, благодаря",
+    "note" : "Button text to allow users to decline using Duck Player."
+  },
+  "rememberLabel" : {
+    "title" : "Запомни моя избор",
+    "note" : "Label text for an option to remember the user’s choice regarding the use of Duck Player."
+  }
+}

--- a/src/locales/duckplayer/cs/overlays.json
+++ b/src/locales/duckplayer/cs/overlays.json
@@ -1,0 +1,27 @@
+{
+  "smartling" : {
+    "string_format" : "icu",
+    "translate_paths" : [
+    {
+      "path" : "*/title",
+      "key" : "{*}/title",
+      "instruction" : "*/note"
+    }]
+  },
+  "videoOverlayTitle2" : {
+    "title" : "Zapněte si Duck Player a sledujte videa bez cílených reklam",
+    "note" : "Text displayed as a title in the video overlay to encourage users to enable Duck Player for an ad-free experience."
+  },
+  "videoButtonOpen2" : {
+    "title" : "Zapni si Duck Player",
+    "note" : "Button text to prompt users to activate Duck Player."
+  },
+  "videoButtonOptOut2" : {
+    "title" : "Ne, děkuji",
+    "note" : "Button text to allow users to decline using Duck Player."
+  },
+  "rememberLabel" : {
+    "title" : "Zapamatovat mou volbu",
+    "note" : "Label text for an option to remember the user’s choice regarding the use of Duck Player."
+  }
+}

--- a/src/locales/duckplayer/da/overlays.json
+++ b/src/locales/duckplayer/da/overlays.json
@@ -1,0 +1,27 @@
+{
+  "smartling" : {
+    "string_format" : "icu",
+    "translate_paths" : [
+    {
+      "path" : "*/title",
+      "key" : "{*}/title",
+      "instruction" : "*/note"
+    }]
+  },
+  "videoOverlayTitle2" : {
+    "title" : "Slå Duck Player til for at se indhold uden målrettede reklamer",
+    "note" : "Text displayed as a title in the video overlay to encourage users to enable Duck Player for an ad-free experience."
+  },
+  "videoButtonOpen2" : {
+    "title" : "Slå Duck Player til",
+    "note" : "Button text to prompt users to activate Duck Player."
+  },
+  "videoButtonOptOut2" : {
+    "title" : "Nej tak.",
+    "note" : "Button text to allow users to decline using Duck Player."
+  },
+  "rememberLabel" : {
+    "title" : "Husk mit valg",
+    "note" : "Label text for an option to remember the user’s choice regarding the use of Duck Player."
+  }
+}

--- a/src/locales/duckplayer/de/overlays.json
+++ b/src/locales/duckplayer/de/overlays.json
@@ -1,0 +1,27 @@
+{
+  "smartling" : {
+    "string_format" : "icu",
+    "translate_paths" : [
+    {
+      "path" : "*/title",
+      "key" : "{*}/title",
+      "instruction" : "*/note"
+    }]
+  },
+  "videoOverlayTitle2" : {
+    "title" : "Aktiviere den Duck Player, um ohne gezielte Werbung zu schauen",
+    "note" : "Text displayed as a title in the video overlay to encourage users to enable Duck Player for an ad-free experience."
+  },
+  "videoButtonOpen2" : {
+    "title" : "Duck Player aktivieren",
+    "note" : "Button text to prompt users to activate Duck Player."
+  },
+  "videoButtonOptOut2" : {
+    "title" : "Nein, danke",
+    "note" : "Button text to allow users to decline using Duck Player."
+  },
+  "rememberLabel" : {
+    "title" : "Meine Auswahl merken",
+    "note" : "Label text for an option to remember the user’s choice regarding the use of Duck Player."
+  }
+}

--- a/src/locales/duckplayer/el/overlays.json
+++ b/src/locales/duckplayer/el/overlays.json
@@ -1,0 +1,27 @@
+{
+  "smartling" : {
+    "string_format" : "icu",
+    "translate_paths" : [
+    {
+      "path" : "*/title",
+      "key" : "{*}/title",
+      "instruction" : "*/note"
+    }]
+  },
+  "videoOverlayTitle2" : {
+    "title" : "Ενεργοποιήστε το Duck Player για παρακολούθηση χωρίς στοχευμένες διαφημίσεις",
+    "note" : "Text displayed as a title in the video overlay to encourage users to enable Duck Player for an ad-free experience."
+  },
+  "videoButtonOpen2" : {
+    "title" : "Ενεργοποίηση του Duck Player",
+    "note" : "Button text to prompt users to activate Duck Player."
+  },
+  "videoButtonOptOut2" : {
+    "title" : "Όχι, ευχαριστώ",
+    "note" : "Button text to allow users to decline using Duck Player."
+  },
+  "rememberLabel" : {
+    "title" : "Θυμηθείτε την επιλογή μου",
+    "note" : "Label text for an option to remember the user’s choice regarding the use of Duck Player."
+  }
+}

--- a/src/locales/duckplayer/en/overlays.json
+++ b/src/locales/duckplayer/en/overlays.json
@@ -1,0 +1,28 @@
+{
+  "smartling": {
+    "string_format": "icu",
+    "translate_paths": [
+      {
+        "path": "*/title",
+        "key": "{*}/title",
+        "instruction": "*/note"
+      }
+    ]
+  },
+  "videoOverlayTitle2": {
+    "title": "Turn on Duck Player to watch without targeted ads",
+    "note": "Text displayed as a title in the video overlay to encourage users to enable Duck Player for an ad-free experience."
+  },
+  "videoButtonOpen2": {
+    "title": "Turn On Duck Player",
+    "note": "Button text to prompt users to activate Duck Player."
+  },
+  "videoButtonOptOut2": {
+    "title": "No Thanks",
+    "note": "Button text to allow users to decline using Duck Player."
+  },
+  "rememberLabel": {
+    "title": "Remember my choice",
+    "note": "Label text for an option to remember the user’s choice regarding the use of Duck Player."
+  }
+}

--- a/src/locales/duckplayer/es/overlays.json
+++ b/src/locales/duckplayer/es/overlays.json
@@ -1,0 +1,27 @@
+{
+  "smartling" : {
+    "string_format" : "icu",
+    "translate_paths" : [
+    {
+      "path" : "*/title",
+      "key" : "{*}/title",
+      "instruction" : "*/note"
+    }]
+  },
+  "videoOverlayTitle2" : {
+    "title" : "Activa Duck Player para ver sin anuncios personalizados",
+    "note" : "Text displayed as a title in the video overlay to encourage users to enable Duck Player for an ad-free experience."
+  },
+  "videoButtonOpen2" : {
+    "title" : "Activar Duck Player",
+    "note" : "Button text to prompt users to activate Duck Player."
+  },
+  "videoButtonOptOut2" : {
+    "title" : "No, gracias",
+    "note" : "Button text to allow users to decline using Duck Player."
+  },
+  "rememberLabel" : {
+    "title" : "Recordar mi elección",
+    "note" : "Label text for an option to remember the user’s choice regarding the use of Duck Player."
+  }
+}

--- a/src/locales/duckplayer/et/overlays.json
+++ b/src/locales/duckplayer/et/overlays.json
@@ -1,0 +1,27 @@
+{
+  "smartling" : {
+    "string_format" : "icu",
+    "translate_paths" : [
+    {
+      "path" : "*/title",
+      "key" : "{*}/title",
+      "instruction" : "*/note"
+    }]
+  },
+  "videoOverlayTitle2" : {
+    "title" : "Sihitud reklaamideta vaatamiseks lülita sisse Duck Player",
+    "note" : "Text displayed as a title in the video overlay to encourage users to enable Duck Player for an ad-free experience."
+  },
+  "videoButtonOpen2" : {
+    "title" : "Lülita Duck Player sisse",
+    "note" : "Button text to prompt users to activate Duck Player."
+  },
+  "videoButtonOptOut2" : {
+    "title" : "Ei aitäh",
+    "note" : "Button text to allow users to decline using Duck Player."
+  },
+  "rememberLabel" : {
+    "title" : "Jäta mu valik meelde",
+    "note" : "Label text for an option to remember the user’s choice regarding the use of Duck Player."
+  }
+}

--- a/src/locales/duckplayer/fi/overlays.json
+++ b/src/locales/duckplayer/fi/overlays.json
@@ -1,0 +1,27 @@
+{
+  "smartling" : {
+    "string_format" : "icu",
+    "translate_paths" : [
+    {
+      "path" : "*/title",
+      "key" : "{*}/title",
+      "instruction" : "*/note"
+    }]
+  },
+  "videoOverlayTitle2" : {
+    "title" : "Jos haluat katsoa ilman kohdennettuja mainoksia, ota Duck Player käyttöön",
+    "note" : "Text displayed as a title in the video overlay to encourage users to enable Duck Player for an ad-free experience."
+  },
+  "videoButtonOpen2" : {
+    "title" : "Ota Duck Player käyttöön",
+    "note" : "Button text to prompt users to activate Duck Player."
+  },
+  "videoButtonOptOut2" : {
+    "title" : "Ei kiitos",
+    "note" : "Button text to allow users to decline using Duck Player."
+  },
+  "rememberLabel" : {
+    "title" : "Muista valintani",
+    "note" : "Label text for an option to remember the user’s choice regarding the use of Duck Player."
+  }
+}

--- a/src/locales/duckplayer/fr/overlays.json
+++ b/src/locales/duckplayer/fr/overlays.json
@@ -1,0 +1,27 @@
+{
+  "smartling" : {
+    "string_format" : "icu",
+    "translate_paths" : [
+    {
+      "path" : "*/title",
+      "key" : "{*}/title",
+      "instruction" : "*/note"
+    }]
+  },
+  "videoOverlayTitle2" : {
+    "title" : "Activez Duck Player pour une vidéo sans publicités ciblées",
+    "note" : "Text displayed as a title in the video overlay to encourage users to enable Duck Player for an ad-free experience."
+  },
+  "videoButtonOpen2" : {
+    "title" : "Activez Duck Player",
+    "note" : "Button text to prompt users to activate Duck Player."
+  },
+  "videoButtonOptOut2" : {
+    "title" : "Non merci",
+    "note" : "Button text to allow users to decline using Duck Player."
+  },
+  "rememberLabel" : {
+    "title" : "Mémoriser mon choix",
+    "note" : "Label text for an option to remember the user’s choice regarding the use of Duck Player."
+  }
+}

--- a/src/locales/duckplayer/hr/overlays.json
+++ b/src/locales/duckplayer/hr/overlays.json
@@ -1,0 +1,27 @@
+{
+  "smartling" : {
+    "string_format" : "icu",
+    "translate_paths" : [
+    {
+      "path" : "*/title",
+      "key" : "{*}/title",
+      "instruction" : "*/note"
+    }]
+  },
+  "videoOverlayTitle2" : {
+    "title" : "Uključi Duck Player za gledanje bez ciljanih oglasa",
+    "note" : "Text displayed as a title in the video overlay to encourage users to enable Duck Player for an ad-free experience."
+  },
+  "videoButtonOpen2" : {
+    "title" : "Uključi Duck Player",
+    "note" : "Button text to prompt users to activate Duck Player."
+  },
+  "videoButtonOptOut2" : {
+    "title" : "Ne, hvala",
+    "note" : "Button text to allow users to decline using Duck Player."
+  },
+  "rememberLabel" : {
+    "title" : "Zapamti moj izbor",
+    "note" : "Label text for an option to remember the user’s choice regarding the use of Duck Player."
+  }
+}

--- a/src/locales/duckplayer/hu/overlays.json
+++ b/src/locales/duckplayer/hu/overlays.json
@@ -1,0 +1,27 @@
+{
+  "smartling" : {
+    "string_format" : "icu",
+    "translate_paths" : [
+    {
+      "path" : "*/title",
+      "key" : "{*}/title",
+      "instruction" : "*/note"
+    }]
+  },
+  "videoOverlayTitle2" : {
+    "title" : "Kapcsold be a Duck Playert, hogy célzott hirdetések nélkül videózhass",
+    "note" : "Text displayed as a title in the video overlay to encourage users to enable Duck Player for an ad-free experience."
+  },
+  "videoButtonOpen2" : {
+    "title" : "Duck Player bekapcsolása",
+    "note" : "Button text to prompt users to activate Duck Player."
+  },
+  "videoButtonOptOut2" : {
+    "title" : "Nem, köszönöm",
+    "note" : "Button text to allow users to decline using Duck Player."
+  },
+  "rememberLabel" : {
+    "title" : "Választott beállítás megjegyzése",
+    "note" : "Label text for an option to remember the user’s choice regarding the use of Duck Player."
+  }
+}

--- a/src/locales/duckplayer/it/overlays.json
+++ b/src/locales/duckplayer/it/overlays.json
@@ -1,0 +1,27 @@
+{
+  "smartling" : {
+    "string_format" : "icu",
+    "translate_paths" : [
+    {
+      "path" : "*/title",
+      "key" : "{*}/title",
+      "instruction" : "*/note"
+    }]
+  },
+  "videoOverlayTitle2" : {
+    "title" : "Attiva Duck Player per guardare senza annunci personalizzati",
+    "note" : "Text displayed as a title in the video overlay to encourage users to enable Duck Player for an ad-free experience."
+  },
+  "videoButtonOpen2" : {
+    "title" : "Attiva Duck Player",
+    "note" : "Button text to prompt users to activate Duck Player."
+  },
+  "videoButtonOptOut2" : {
+    "title" : "No, grazie",
+    "note" : "Button text to allow users to decline using Duck Player."
+  },
+  "rememberLabel" : {
+    "title" : "Ricorda la mia scelta",
+    "note" : "Label text for an option to remember the user’s choice regarding the use of Duck Player."
+  }
+}

--- a/src/locales/duckplayer/lt/overlays.json
+++ b/src/locales/duckplayer/lt/overlays.json
@@ -1,0 +1,27 @@
+{
+  "smartling" : {
+    "string_format" : "icu",
+    "translate_paths" : [
+    {
+      "path" : "*/title",
+      "key" : "{*}/title",
+      "instruction" : "*/note"
+    }]
+  },
+  "videoOverlayTitle2" : {
+    "title" : "Įjunkite „Duck Player“, kad galėtumėte žiūrėti be tikslinių reklamų",
+    "note" : "Text displayed as a title in the video overlay to encourage users to enable Duck Player for an ad-free experience."
+  },
+  "videoButtonOpen2" : {
+    "title" : "Įjunkite „Duck Player“",
+    "note" : "Button text to prompt users to activate Duck Player."
+  },
+  "videoButtonOptOut2" : {
+    "title" : "Ne, dėkoju",
+    "note" : "Button text to allow users to decline using Duck Player."
+  },
+  "rememberLabel" : {
+    "title" : "Įsiminti mano pasirinkimą",
+    "note" : "Label text for an option to remember the user’s choice regarding the use of Duck Player."
+  }
+}

--- a/src/locales/duckplayer/lv/overlays.json
+++ b/src/locales/duckplayer/lv/overlays.json
@@ -1,0 +1,27 @@
+{
+  "smartling" : {
+    "string_format" : "icu",
+    "translate_paths" : [
+    {
+      "path" : "*/title",
+      "key" : "{*}/title",
+      "instruction" : "*/note"
+    }]
+  },
+  "videoOverlayTitle2" : {
+    "title" : "Ieslēdz Duck Player, lai skatītos bez mērķētām reklāmām",
+    "note" : "Text displayed as a title in the video overlay to encourage users to enable Duck Player for an ad-free experience."
+  },
+  "videoButtonOpen2" : {
+    "title" : "Ieslēgt Duck Player",
+    "note" : "Button text to prompt users to activate Duck Player."
+  },
+  "videoButtonOptOut2" : {
+    "title" : "Nē, paldies",
+    "note" : "Button text to allow users to decline using Duck Player."
+  },
+  "rememberLabel" : {
+    "title" : "Atcerēties manu izvēli",
+    "note" : "Label text for an option to remember the user’s choice regarding the use of Duck Player."
+  }
+}

--- a/src/locales/duckplayer/nb/overlays.json
+++ b/src/locales/duckplayer/nb/overlays.json
@@ -1,0 +1,27 @@
+{
+  "smartling" : {
+    "string_format" : "icu",
+    "translate_paths" : [
+    {
+      "path" : "*/title",
+      "key" : "{*}/title",
+      "instruction" : "*/note"
+    }]
+  },
+  "videoOverlayTitle2" : {
+    "title" : "Slå på Duck Player for å se på uten målrettede annonser",
+    "note" : "Text displayed as a title in the video overlay to encourage users to enable Duck Player for an ad-free experience."
+  },
+  "videoButtonOpen2" : {
+    "title" : "Slå på Duck Player",
+    "note" : "Button text to prompt users to activate Duck Player."
+  },
+  "videoButtonOptOut2" : {
+    "title" : "Nei takk",
+    "note" : "Button text to allow users to decline using Duck Player."
+  },
+  "rememberLabel" : {
+    "title" : "Husk valget mitt",
+    "note" : "Label text for an option to remember the user’s choice regarding the use of Duck Player."
+  }
+}

--- a/src/locales/duckplayer/nl/overlays.json
+++ b/src/locales/duckplayer/nl/overlays.json
@@ -1,0 +1,27 @@
+{
+  "smartling" : {
+    "string_format" : "icu",
+    "translate_paths" : [
+    {
+      "path" : "*/title",
+      "key" : "{*}/title",
+      "instruction" : "*/note"
+    }]
+  },
+  "videoOverlayTitle2" : {
+    "title" : "Zet Duck Player aan om te kijken zonder gerichte advertenties",
+    "note" : "Text displayed as a title in the video overlay to encourage users to enable Duck Player for an ad-free experience."
+  },
+  "videoButtonOpen2" : {
+    "title" : "Duck Player aanzetten",
+    "note" : "Button text to prompt users to activate Duck Player."
+  },
+  "videoButtonOptOut2" : {
+    "title" : "Nee, bedankt",
+    "note" : "Button text to allow users to decline using Duck Player."
+  },
+  "rememberLabel" : {
+    "title" : "Mijn keuze onthouden",
+    "note" : "Label text for an option to remember the user’s choice regarding the use of Duck Player."
+  }
+}

--- a/src/locales/duckplayer/pl/overlays.json
+++ b/src/locales/duckplayer/pl/overlays.json
@@ -1,0 +1,27 @@
+{
+  "smartling" : {
+    "string_format" : "icu",
+    "translate_paths" : [
+    {
+      "path" : "*/title",
+      "key" : "{*}/title",
+      "instruction" : "*/note"
+    }]
+  },
+  "videoOverlayTitle2" : {
+    "title" : "Włącz Duck Player, aby oglądać bez reklam ukierunkowanych",
+    "note" : "Text displayed as a title in the video overlay to encourage users to enable Duck Player for an ad-free experience."
+  },
+  "videoButtonOpen2" : {
+    "title" : "Włącz Duck Player",
+    "note" : "Button text to prompt users to activate Duck Player."
+  },
+  "videoButtonOptOut2" : {
+    "title" : "Nie, dziękuję",
+    "note" : "Button text to allow users to decline using Duck Player."
+  },
+  "rememberLabel" : {
+    "title" : "Zapamiętaj mój wybór",
+    "note" : "Label text for an option to remember the user’s choice regarding the use of Duck Player."
+  }
+}

--- a/src/locales/duckplayer/pt/overlays.json
+++ b/src/locales/duckplayer/pt/overlays.json
@@ -1,0 +1,27 @@
+{
+  "smartling" : {
+    "string_format" : "icu",
+    "translate_paths" : [
+    {
+      "path" : "*/title",
+      "key" : "{*}/title",
+      "instruction" : "*/note"
+    }]
+  },
+  "videoOverlayTitle2" : {
+    "title" : "Ativa o Duck Player para ver sem anúncios personalizados",
+    "note" : "Text displayed as a title in the video overlay to encourage users to enable Duck Player for an ad-free experience."
+  },
+  "videoButtonOpen2" : {
+    "title" : "Ligar o Duck Player",
+    "note" : "Button text to prompt users to activate Duck Player."
+  },
+  "videoButtonOptOut2" : {
+    "title" : "Não, obrigado",
+    "note" : "Button text to allow users to decline using Duck Player."
+  },
+  "rememberLabel" : {
+    "title" : "Memorizar a minha opção",
+    "note" : "Label text for an option to remember the user’s choice regarding the use of Duck Player."
+  }
+}

--- a/src/locales/duckplayer/ro/overlays.json
+++ b/src/locales/duckplayer/ro/overlays.json
@@ -1,0 +1,27 @@
+{
+  "smartling" : {
+    "string_format" : "icu",
+    "translate_paths" : [
+    {
+      "path" : "*/title",
+      "key" : "{*}/title",
+      "instruction" : "*/note"
+    }]
+  },
+  "videoOverlayTitle2" : {
+    "title" : "Activează Duck Player pentru a viziona fără reclame direcționate",
+    "note" : "Text displayed as a title in the video overlay to encourage users to enable Duck Player for an ad-free experience."
+  },
+  "videoButtonOpen2" : {
+    "title" : "Activează Duck Player",
+    "note" : "Button text to prompt users to activate Duck Player."
+  },
+  "videoButtonOptOut2" : {
+    "title" : "Nu, mulțumesc",
+    "note" : "Button text to allow users to decline using Duck Player."
+  },
+  "rememberLabel" : {
+    "title" : "Reține alegerea mea",
+    "note" : "Label text for an option to remember the user’s choice regarding the use of Duck Player."
+  }
+}

--- a/src/locales/duckplayer/ru/overlays.json
+++ b/src/locales/duckplayer/ru/overlays.json
@@ -1,0 +1,27 @@
+{
+  "smartling" : {
+    "string_format" : "icu",
+    "translate_paths" : [
+    {
+      "path" : "*/title",
+      "key" : "{*}/title",
+      "instruction" : "*/note"
+    }]
+  },
+  "videoOverlayTitle2" : {
+    "title" : "Duck Player — просмотр без целевой рекламы",
+    "note" : "Text displayed as a title in the video overlay to encourage users to enable Duck Player for an ad-free experience."
+  },
+  "videoButtonOpen2" : {
+    "title" : "Включить Duck Player",
+    "note" : "Button text to prompt users to activate Duck Player."
+  },
+  "videoButtonOptOut2" : {
+    "title" : "Нет, спасибо",
+    "note" : "Button text to allow users to decline using Duck Player."
+  },
+  "rememberLabel" : {
+    "title" : "Запомнить выбор",
+    "note" : "Label text for an option to remember the user’s choice regarding the use of Duck Player."
+  }
+}

--- a/src/locales/duckplayer/sk/overlays.json
+++ b/src/locales/duckplayer/sk/overlays.json
@@ -1,0 +1,27 @@
+{
+  "smartling" : {
+    "string_format" : "icu",
+    "translate_paths" : [
+    {
+      "path" : "*/title",
+      "key" : "{*}/title",
+      "instruction" : "*/note"
+    }]
+  },
+  "videoOverlayTitle2" : {
+    "title" : "Zapnite Duck Player a pozerajte bez cielených reklám",
+    "note" : "Text displayed as a title in the video overlay to encourage users to enable Duck Player for an ad-free experience."
+  },
+  "videoButtonOpen2" : {
+    "title" : "Zapnúť prehrávač Duck Player",
+    "note" : "Button text to prompt users to activate Duck Player."
+  },
+  "videoButtonOptOut2" : {
+    "title" : "Nie, ďakujem",
+    "note" : "Button text to allow users to decline using Duck Player."
+  },
+  "rememberLabel" : {
+    "title" : "Zapamätať si moju voľbu",
+    "note" : "Label text for an option to remember the user’s choice regarding the use of Duck Player."
+  }
+}

--- a/src/locales/duckplayer/sl/overlays.json
+++ b/src/locales/duckplayer/sl/overlays.json
@@ -1,0 +1,27 @@
+{
+  "smartling" : {
+    "string_format" : "icu",
+    "translate_paths" : [
+    {
+      "path" : "*/title",
+      "key" : "{*}/title",
+      "instruction" : "*/note"
+    }]
+  },
+  "videoOverlayTitle2" : {
+    "title" : "Vklopite predvajalnik Duck Player za gledanje brez ciljanih oglasov",
+    "note" : "Text displayed as a title in the video overlay to encourage users to enable Duck Player for an ad-free experience."
+  },
+  "videoButtonOpen2" : {
+    "title" : "Vklopi predvajalnik Duck Player",
+    "note" : "Button text to prompt users to activate Duck Player."
+  },
+  "videoButtonOptOut2" : {
+    "title" : "Ne, hvala",
+    "note" : "Button text to allow users to decline using Duck Player."
+  },
+  "rememberLabel" : {
+    "title" : "Zapomni si mojo izbiro",
+    "note" : "Label text for an option to remember the user’s choice regarding the use of Duck Player."
+  }
+}

--- a/src/locales/duckplayer/sv/overlays.json
+++ b/src/locales/duckplayer/sv/overlays.json
@@ -1,0 +1,27 @@
+{
+  "smartling" : {
+    "string_format" : "icu",
+    "translate_paths" : [
+    {
+      "path" : "*/title",
+      "key" : "{*}/title",
+      "instruction" : "*/note"
+    }]
+  },
+  "videoOverlayTitle2" : {
+    "title" : "Aktivera Duck Player för att titta utan riktade annonser",
+    "note" : "Text displayed as a title in the video overlay to encourage users to enable Duck Player for an ad-free experience."
+  },
+  "videoButtonOpen2" : {
+    "title" : "Aktivera Duck Player",
+    "note" : "Button text to prompt users to activate Duck Player."
+  },
+  "videoButtonOptOut2" : {
+    "title" : "Nej tack",
+    "note" : "Button text to allow users to decline using Duck Player."
+  },
+  "rememberLabel" : {
+    "title" : "Kom ihåg mitt val",
+    "note" : "Label text for an option to remember the user’s choice regarding the use of Duck Player."
+  }
+}

--- a/src/locales/duckplayer/tr/overlays.json
+++ b/src/locales/duckplayer/tr/overlays.json
@@ -1,0 +1,27 @@
+{
+  "smartling" : {
+    "string_format" : "icu",
+    "translate_paths" : [
+    {
+      "path" : "*/title",
+      "key" : "{*}/title",
+      "instruction" : "*/note"
+    }]
+  },
+  "videoOverlayTitle2" : {
+    "title" : "Hedeflenmiş reklamlar olmadan izlemek için Duck Player'ı açın",
+    "note" : "Text displayed as a title in the video overlay to encourage users to enable Duck Player for an ad-free experience."
+  },
+  "videoButtonOpen2" : {
+    "title" : "Duck Player'ı Aç",
+    "note" : "Button text to prompt users to activate Duck Player."
+  },
+  "videoButtonOptOut2" : {
+    "title" : "Hayır Teşekkürler",
+    "note" : "Button text to allow users to decline using Duck Player."
+  },
+  "rememberLabel" : {
+    "title" : "Seçimimi hatırla",
+    "note" : "Label text for an option to remember the user’s choice regarding the use of Duck Player."
+  }
+}


### PR DESCRIPTION
https://app.asana.com/0/1201141132935289/1208258427490256/f

- added locale strings for duckplayer
- limit localization to none-desktop, this prevents Desktop from using them yet (untested)

## What was added
- I added strings in 24 languages for the DuckPlayer overlay + the DuckPlayer application
  - This was done in a way that prevents the existing DuckPlayer on Desktop from using them (because it's untested there)

## What was changed
- I moved the localization config back into the `package.json` script , because we now have more than 1  feature using the bundled strings