### PR TITLE
Dynamic page title based on error kind

### DIFF
--- a/packages/special-pages/pages/special-error/app/components/App.jsx
+++ b/packages/special-pages/pages/special-error/app/components/App.jsx
@@ -33,18 +33,14 @@ function PageTitle() {
     const { t } = useTypedTranslation()
 
     useEffect(() => {
-        let title
-
         switch(kind) {
             case 'phishing':
-                title = t('phishingPageHeading')
+                document.title = t('phishingPageHeading')
                 break;
             default:
-                title = t('sslPageHeading')
+                document.title = t('sslPageHeading')
         }
-
-        document.title = title
-    }, [])
+    }, [kind, t])
 
     return null
 }

--- a/packages/special-pages/pages/special-error/app/components/App.jsx
+++ b/packages/special-pages/pages/special-error/app/components/App.jsx
@@ -1,9 +1,11 @@
 import { h } from "preact";
-import { useState } from "preact/hooks";
+import { useEffect, useState } from "preact/hooks";
 import { useEnv } from "../../../../shared/components/EnvironmentProvider";
 import { useMessaging } from "../providers/MessagingProvider";
 import { ErrorBoundary } from '../../../../shared/components/ErrorBoundary'
 import { ErrorFallback } from "./ErrorFallback";
+import { useTypedTranslation } from '../types'
+import { useErrorData } from "../providers/SpecialErrorProvider";
 import { Warning } from "./Warning";
 import { AdvancedInfo } from "./AdvancedInfo";
 
@@ -26,6 +28,27 @@ export function SpecialErrorView() {
     )
 }
 
+function PageTitle() {
+    const { kind } = useErrorData()
+    const { t } = useTypedTranslation()
+
+    useEffect(() => {
+        let title
+
+        switch(kind) {
+            case 'phishing':
+                title = t('phishingPageHeading')
+                break;
+            default:
+                title = t('sslPageHeading')
+        }
+
+        document.title = title
+    }, [])
+
+    return null
+}
+
 export function App() {
     const { messaging } = useMessaging()
 
@@ -40,6 +63,7 @@ export function App() {
 
     return (
         <main className={styles.main}>
+            <PageTitle />
             <ErrorBoundary didCatch={didCatch} fallback={<ErrorFallback />}>
                 <SpecialErrorView />
                 <WillThrow/>

--- a/packages/special-pages/pages/special-error/src/index.html
+++ b/packages/special-pages/pages/special-error/src/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <title>SSL Error Page</title>
+    <title>Error</title>
     <meta name="robots" content="noindex,nofollow">
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <script src="js/inline.js"></script>


### PR DESCRIPTION
Asana: https://app.asana.com/0/1206594217596623/1208270234071170/f

- Sets the page title to match translated heading for that kind of error, e.g.
    - Phishing: "Warning: This site puts your personal information at risk"
    - SSL error: "Warning: This site may be insecure"

## Testing

- Run the macOS app with this branch of C-S-S
- Follow the steps to reproduce in the Asana task
- Verify that the page title in the back button popover matches the kind of error