### PR TITLE
fixed CI builds

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -69,14 +69,14 @@ jobs:
       run: npx playwright install --with-deps
     - run: npm run playwright
 #    - run: npm run playwright-e2e
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v4
       if: always()
       with:
         name: playwright-report
         path: test-results
         retention-days: 5
     - run: npm run test-int-x
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v4
       if: always()
       with:
         name: playwright-report-pages


### PR DESCRIPTION
https://app.asana.com/0/1201614831475344/1208302242908228/f

Builds in CI are failing due to https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/

just updating fixes the problem