### PR TITLE
Make variant a1 the new default for duck player desktop overlay

### DIFF
--- a/integration-test/playwright/duckplayer.spec.js
+++ b/integration-test/playwright/duckplayer.spec.js
@@ -232,7 +232,7 @@ test.describe('Video Player overlays', () => {
         // No video overlay
         await overlays.videoOverlayDoesntShow()
     })
-    test('Selecting \'watch in duck player\'', async ({ page }, workerInfo) => {
+    test('Selecting \'Turn On Duck Player\'', async ({ page }, workerInfo) => {
         const overlays = DuckplayerOverlays.create(page, workerInfo)
 
         // Given overlays feature is enabled
@@ -242,10 +242,10 @@ test.describe('Video Player overlays', () => {
         await overlays.userSettingIs('always ask')
         await overlays.gotoPlayerPage()
 
-        await overlays.watchInDuckPlayer()
+        await overlays.turnOnDuckPlayer()
         await overlays.userSettingWasUpdatedTo('always ask') // not updated
     })
-    test('Selecting \'watch in duck player\' + remember', async ({ page }, workerInfo) => {
+    test('Selecting \'Turn On Duck Player\' + remember', async ({ page }, workerInfo) => {
         const overlays = DuckplayerOverlays.create(page, workerInfo)
 
         // Given overlays feature is enabled
@@ -256,10 +256,10 @@ test.describe('Video Player overlays', () => {
         await overlays.gotoPlayerPage()
 
         await overlays.rememberMyChoice()
-        await overlays.watchInDuckPlayer()
+        await overlays.turnOnDuckPlayer()
         await overlays.userSettingWasUpdatedTo('enabled') // updated
     })
-    test('Selecting \'watch here\'', async ({ page }, workerInfo) => {
+    test('Selecting \'No Thanks\'', async ({ page }, workerInfo) => {
         const overlays = DuckplayerOverlays.create(page, workerInfo)
 
         // Given overlays feature is enabled
@@ -269,10 +269,10 @@ test.describe('Video Player overlays', () => {
         await overlays.userSettingIs('always ask')
         await overlays.gotoPlayerPage()
 
-        await overlays.watchHere()
+        await overlays.noThanks()
         await overlays.secondOverlayExistsOnVideo()
     })
-    test('Selecting \'watch here\' + remember', async ({ page }, workerInfo) => {
+    test('Selecting \'No Thanks\' + remember', async ({ page }, workerInfo) => {
         const overlays = DuckplayerOverlays.create(page, workerInfo)
 
         // Given overlays feature is enabled
@@ -283,11 +283,11 @@ test.describe('Video Player overlays', () => {
         await overlays.gotoPlayerPage()
 
         await overlays.rememberMyChoice()
-        await overlays.watchHere()
+        await overlays.noThanks()
         await overlays.userSettingWasUpdatedTo('always ask remembered') // updated
     })
     test.describe('with remote config overrides', () => {
-        test('Selecting \'watch here\' + remember', async ({ page }, workerInfo) => {
+        test('Selecting \'No Thanks\' + remember', async ({ page }, workerInfo) => {
             const overlays = DuckplayerOverlays.create(page, workerInfo)
 
             // config with some CSS selectors overridden

--- a/integration-test/playwright/duckplayer.spec.js
+++ b/integration-test/playwright/duckplayer.spec.js
@@ -300,7 +300,7 @@ test.describe('Video Player overlays', () => {
         })
     })
     test.describe('with UI settings overrides', () => {
-        test('displays default overlay copy when no cohort is given', async ({ page }, workerInfo) => {
+        test('displays default overlay copy', async ({ page }, workerInfo) => {
             const overlays = DuckplayerOverlays.create(page, workerInfo)
 
             // Given overlays feature is enabled
@@ -313,51 +313,6 @@ test.describe('Video Player overlays', () => {
 
             // Then the overlay shows the correct copy for the default variant
             await overlays.overlayCopyIsDefault()
-        })
-
-        test('displays default overlay copy in control cohort', async ({ page }, workerInfo) => {
-            const overlays = DuckplayerOverlays.create(page, workerInfo)
-
-            // Given overlays feature is enabled
-            await overlays.withRemoteConfig()
-
-            // And my setting is 'always ask'
-            // And I'm in the 'control' experiment cohort
-            await overlays.initialSetupIs('always ask', 'default overlay copy')
-            await overlays.gotoPlayerPage()
-
-            // Then the overlay shows the correct copy for the default variant
-            await overlays.overlayCopyIsDefault()
-        })
-
-        test('displays overlay copy for cohort A1', async ({ page }, workerInfo) => {
-            const overlays = DuckplayerOverlays.create(page, workerInfo)
-
-            // Given overlays feature is enabled
-            await overlays.withRemoteConfig()
-
-            // And my setting is 'always ask'
-            // And I'm in the 'A1' experiment cohort
-            await overlays.initialSetupIs('always ask', 'overlay copy a1')
-            await overlays.gotoPlayerPage()
-
-            // Then the overlay shows the correct copy for the A1 variant
-            await overlays.overlayCopyIsA1()
-        })
-
-        test('displays overlay copy for cohort B1', async ({ page }, workerInfo) => {
-            const overlays = DuckplayerOverlays.create(page, workerInfo)
-
-            // Given overlays feature is enabled
-            await overlays.withRemoteConfig()
-
-            // And my setting is 'always ask'
-            // And I'm in the 'B1' experiment cohort
-            await overlays.initialSetupIs('always ask', 'overlay copy b1')
-            await overlays.gotoPlayerPage()
-
-            // Then the overlay shows the correct copy for the B1 variant
-            await overlays.overlayCopyIsB1()
         })
 
         test('forces next video to play in Duck Player', async ({ page }, workerInfo) => {

--- a/integration-test/playwright/page-objects/duckplayer-overlays.js
+++ b/integration-test/playwright/page-objects/duckplayer-overlays.js
@@ -36,18 +36,6 @@ const userValues = {
 
 // Possible UI Settings
 const uiSettings = {
-    /** @type {import("../../../src/features/duck-player.js").UISettings} */
-    'default overlay copy': {
-        overlayCopy: 'default'
-    },
-    /** @type {import("../../../src/features/duck-player.js").UISettings} */
-    'overlay copy a1': {
-        overlayCopy: 'a1'
-    },
-    /** @type {import("../../../src/features/duck-player.js").UISettings} */
-    'overlay copy b1': {
-        overlayCopy: 'b1'
-    },
     'play in duck player': {
         playInDuckPlayer: true
     }

--- a/integration-test/playwright/page-objects/duckplayer-overlays.js
+++ b/integration-test/playwright/page-objects/duckplayer-overlays.js
@@ -190,9 +190,9 @@ export class DuckplayerOverlays {
 
     async overlayBlocksVideo () {
         await this.page.locator('ddg-video-overlay').waitFor({ state: 'visible', timeout: 1000 })
-        await this.page.getByRole('link', { name: 'Watch in Duck Player' }).waitFor({ state: 'visible', timeout: 1000 })
+        await this.page.getByRole('link', { name: 'Turn On Duck Player' }).waitFor({ state: 'visible', timeout: 1000 })
         await this.page
-            .getByText('Duck Player provides a clean viewing experience without personalized ads and prevents viewing activity from influencing your YouTube recommendations.')
+            .getByText('What you watch in DuckDuckGo won’t influence your recommendations on YouTube.')
             .waitFor({ timeout: 100 })
     }
 
@@ -205,7 +205,7 @@ export class DuckplayerOverlays {
 
         // this is added because 'getAttribute' does not auto-wait
         await expect(async () => {
-            const link = await this.page.getByRole('link', { name: 'Watch in Duck Player' }).getAttribute('href')
+            const link = await this.page.getByRole('link', { name: 'Turn On Duck Player' }).getAttribute('href')
             expect(link).toEqual('duck://player/' + videoID)
         }).toPass({ timeout: 5000 })
     }
@@ -612,7 +612,7 @@ export class DuckplayerOverlays {
         await this.page.getByText('What you watch in DuckDuckGo won’t influence your recommendations on YouTube.', { exact: true }).waitFor({ state: 'visible', timeout: 1000 })
 
         await this.page.getByRole('link', { name: 'Turn On Duck Player' }).waitFor({ state: 'visible', timeout: 1000 })
-        await this.page.getByRole('button', { name: 'Watch Here' }).waitFor({ state: 'visible', timeout: 1000 })
+        await this.page.getByRole('button', { name: 'No Thanks' }).waitFor({ state: 'visible', timeout: 1000 })
 
         await this.page.getByLabel('Remember my choice').waitFor({ state: 'visible', timeout: 1000 })
     }

--- a/integration-test/playwright/page-objects/duckplayer-overlays.js
+++ b/integration-test/playwright/page-objects/duckplayer-overlays.js
@@ -628,34 +628,6 @@ export class DuckplayerOverlays {
 
         await this.page.getByLabel('Remember my choice').waitFor({ state: 'visible', timeout: 1000 })
     }
-
-    /**
-     * Checks for presence of overlay copy A1 experiment
-     */
-    async overlayCopyIsA1 () {
-        await this.page.locator('ddg-video-overlay').waitFor({ state: 'visible', timeout: 1000 })
-        await this.page.getByText('Turn on Duck Player to watch without targeted ads', { exact: true }).waitFor({ state: 'visible', timeout: 1000 })
-        await this.page.getByText('What you watch in DuckDuckGo won’t influence your recommendations on YouTube.', { exact: true }).waitFor({ state: 'visible', timeout: 1000 })
-
-        await this.page.getByRole('link', { name: 'Turn On Duck Player' }).waitFor({ state: 'visible', timeout: 1000 })
-        await this.page.getByRole('button', { name: 'No Thanks' }).waitFor({ state: 'visible', timeout: 1000 })
-
-        await this.page.getByLabel('Remember my choice').waitFor({ state: 'visible', timeout: 1000 })
-    }
-
-    /**
-     * Checks for presence of overlay copy B1 experiment
-     */
-    async overlayCopyIsB1 () {
-        await this.page.locator('ddg-video-overlay').waitFor({ state: 'visible', timeout: 1000 })
-        await this.page.getByText('Drowning in ads on YouTube? Turn on Duck Player.', { exact: true }).waitFor({ state: 'visible', timeout: 1000 })
-        await this.page.getByText('What you watch in DuckDuckGo won’t influence your recommendations on YouTube.', { exact: true }).waitFor({ state: 'visible', timeout: 1000 })
-
-        await this.page.getByRole('link', { name: 'Turn On Duck Player' }).waitFor({ state: 'visible', timeout: 1000 })
-        await this.page.getByRole('button', { name: 'No Thanks' }).waitFor({ state: 'visible', timeout: 1000 })
-
-        await this.page.getByLabel('Remember my choice').waitFor({ state: 'visible', timeout: 1000 })
-    }
 }
 
 class DuckplayerOverlaysMobile {

--- a/integration-test/playwright/page-objects/duckplayer-overlays.js
+++ b/integration-test/playwright/page-objects/duckplayer-overlays.js
@@ -393,8 +393,8 @@ export class DuckplayerOverlays {
         // if we get here, the element was absent
     }
 
-    async watchInDuckPlayer () {
-        const action = () => this.page.getByRole('link', { name: 'Watch in Duck Player' }).click()
+    async turnOnDuckPlayer () {
+        const action = () => this.page.getByRole('link', { name: 'Turn On Duck Player' }).click()
 
         await this.build.switch({
             'apple-isolated': async () => {
@@ -416,8 +416,8 @@ export class DuckplayerOverlays {
         })
     }
 
-    async watchHere () {
-        await this.page.getByText('Watch Here').click()
+    async noThanks () {
+        await this.page.getByText('No Thanks').click()
     }
 
     async rememberMyChoice () {
@@ -608,10 +608,10 @@ export class DuckplayerOverlays {
      */
     async overlayCopyIsDefault () {
         await this.page.locator('ddg-video-overlay').waitFor({ state: 'visible', timeout: 1000 })
-        await this.page.getByText('Tired of targeted YouTube ads and recommendations?', { exact: true }).waitFor({ state: 'visible', timeout: 1000 })
-        await this.page.getByText('Duck Player provides a clean viewing experience without personalized ads and prevents viewing activity from influencing your YouTube recommendations.', { exact: true }).waitFor({ state: 'visible', timeout: 1000 })
+        await this.page.getByText('Turn on Duck Player to watch without targeted ads', { exact: true }).waitFor({ state: 'visible', timeout: 1000 })
+        await this.page.getByText('What you watch in DuckDuckGo won’t influence your recommendations on YouTube.', { exact: true }).waitFor({ state: 'visible', timeout: 1000 })
 
-        await this.page.getByRole('link', { name: 'Watch in Duck Player' }).waitFor({ state: 'visible', timeout: 1000 })
+        await this.page.getByRole('link', { name: 'Turn On Duck Player' }).waitFor({ state: 'visible', timeout: 1000 })
         await this.page.getByRole('button', { name: 'Watch Here' }).waitFor({ state: 'visible', timeout: 1000 })
 
         await this.page.getByLabel('Remember my choice').waitFor({ state: 'visible', timeout: 1000 })

--- a/integration-test/test-pages/duckplayer/scripts/test.mjs
+++ b/integration-test/test-pages/duckplayer/scripts/test.mjs
@@ -5,7 +5,7 @@ customElements.define(DDGVideoOverlayMobile.CUSTOM_TAG_NAME, DDGVideoOverlayMobi
 
 const elem = /** @type {DDGVideoOverlayMobile} */(document.createElement(DDGVideoOverlayMobile.CUSTOM_TAG_NAME))
 elem.testMode = true
-elem.text = overlayCopyVariants.a1
+elem.text = overlayCopyVariants.default
 
 elem.addEventListener('opt-in', (/** @type {CustomEvent} */e) => {
     console.log('did opt in?', e.detail)

--- a/src/features/duck-player.js
+++ b/src/features/duck-player.js
@@ -48,7 +48,6 @@ import { Environment, initOverlays } from './duckplayer/overlays.js'
 
 /**
  * @typedef UISettings - UI-specific settings
- * @property {'default'|'a1'|'b1'} overlayCopy - Overlay copy experiment variant
  * @property {boolean} [allowFirstVideo] - should the first video be allowed to load/play?
  * @property {boolean} [playInDuckPlayer] - Forces next video to be played in Duck Player regardless of user setting
  */

--- a/src/features/duckplayer/components/ddg-video-overlay.js
+++ b/src/features/duckplayer/components/ddg-video-overlay.js
@@ -58,7 +58,7 @@ export class DDGVideoOverlay extends HTMLElement {
      * @returns {HTMLDivElement}
      */
     createOverlay () {
-        const overlayCopy = overlayCopyVariants[this.ui?.overlayCopy || 'default']
+        const overlayCopy = overlayCopyVariants.default
         const overlayElement = document.createElement('div')
         overlayElement.classList.add('ddg-video-player-overlay')
         const svgIcon = trustedUnsafe(dax)

--- a/src/features/duckplayer/overlay-messages.js
+++ b/src/features/duckplayer/overlay-messages.js
@@ -33,9 +33,7 @@ export class DuckPlayerOverlayMessages {
                     overlayInteracted: false,
                     privatePlayerMode: { alwaysAsk: {} }
                 },
-                ui: {
-                    overlayCopy: this.environment.getOverlayCopyOverride() || 'default'
-                }
+                ui: {}
             })
         }
         return this.messaging.request(constants.MSG_NAME_INITIAL_SETUP)

--- a/src/features/duckplayer/overlays.js
+++ b/src/features/duckplayer/overlays.js
@@ -243,22 +243,6 @@ export class Environment {
         return false
     }
 
-    /**
-     * @returns {import("../duck-player.js").UISettings['overlayCopy'] | null}
-     */
-    getOverlayCopyOverride () {
-        if (this.isIntegrationMode()) {
-            const allowedOverlayCopyOverrides = ['default', 'a1', 'b1']
-
-            const url = new URLSearchParams(window.location.href)
-            const override = url.get('overlayCopy')
-            if (override && allowedOverlayCopyOverrides.includes(override)) {
-                return /** @type {import("../duck-player.js").UISettings['overlayCopy']} */ (override)
-            }
-        }
-        return null
-    }
-
     isIntegrationMode () {
         return this.debug === true && this.injectName === 'integration'
     }

--- a/src/features/duckplayer/text.js
+++ b/src/features/duckplayer/text.js
@@ -80,25 +80,11 @@ export function nl2br (text) {
  */
 
 /**
- *  @type {Record<import('../duck-player').UISettings['overlayCopy'], OverlayCopyTranslation>}
+ *  @type {Record<'default', OverlayCopyTranslation>}
  */
 export const overlayCopyVariants = {
     default: {
-        title: i18n.t('videoOverlayTitle'),
-        subtitle: html`<b>${i18n.t('playText')}</b> ${i18n.t('videoOverlaySubtitle')}`,
-        buttonOptOut: i18n.t('videoButtonOptOut'),
-        buttonOpen: i18n.t('videoButtonOpen'),
-        rememberLabel: i18n.t('rememberLabel')
-    },
-    a1: {
         title: i18n.t('videoOverlayTitle2'),
-        subtitle: i18n.t('videoOverlaySubtitle2'),
-        buttonOptOut: i18n.t('videoButtonOptOut2'),
-        buttonOpen: i18n.t('videoButtonOpen2'),
-        rememberLabel: i18n.t('rememberLabel')
-    },
-    b1: {
-        title: nl2br(i18n.t('videoOverlayTitle3')),
         subtitle: i18n.t('videoOverlaySubtitle2'),
         buttonOptOut: i18n.t('videoButtonOptOut2'),
         buttonOpen: i18n.t('videoButtonOpen2'),


### PR DESCRIPTION
https://app.asana.com/0/1207252092703676/1207352313241844/f

Adopts variant a1 from the copy experiment as the default for Duck Player overlays