### PR TITLE
duckplayer: remove label click trigger on mobile

### DIFF
--- a/special-pages/pages/duckplayer/app/components/Switch.jsx
+++ b/special-pages/pages/duckplayer/app/components/Switch.jsx
@@ -9,12 +9,14 @@ import cn from "classnames";
  * @param {boolean} props.checked - Indicates whether the switch is checked or not.
  * @param {() => void} props.onChange - The callback function to be called when the switch is toggled.
  * @param {ImportMeta['platform']} props.platformName - The callback function to be called when the switch is toggled.
+ * @param {string} props.id
  */
-export function Switch({ checked, onChange, platformName = 'ios' }) {
+export function Switch({ checked, onChange, id, platformName = 'ios' }) {
     return (
         <button role="switch"
                 aria-checked={checked}
                 onClick={onChange}
+                id={id}
                 className={cn(styles.switch, {
                     [styles.ios]: platformName === 'ios',
                     [styles.android]: platformName === 'android',

--- a/special-pages/pages/duckplayer/app/components/SwitchBarMobile.jsx
+++ b/special-pages/pages/duckplayer/app/components/SwitchBarMobile.jsx
@@ -37,9 +37,9 @@ export function SwitchBarMobile({platformName}) {
     });
 
     return (
-        <div class={classes} data-state={state} onTransitionEnd={onTransitionEnd}>
-            <div class={styles.labelRow}>
-                <label onClick={blockClick} for={inputId}>
+        <div class={classes} data-state={state} data-allow-animation="true" onTransitionEnd={onTransitionEnd}>
+            <div class={styles.labelRow} onClick={blockClick}>
+                <label for={inputId} class={styles.label}>
                     <span className={styles.text}>
                         {t('keepEnabled')}
                     </span>

--- a/special-pages/pages/duckplayer/app/components/SwitchBarMobile.jsx
+++ b/special-pages/pages/duckplayer/app/components/SwitchBarMobile.jsx
@@ -1,7 +1,7 @@
 import { h } from "preact";
 import cn from "classnames";
 import styles from "./SwitchBarMobile.module.css"
-import { useContext } from "preact/hooks";
+import { useContext, useId } from "preact/hooks";
 import { SwitchContext } from "../providers/SwitchProvider.jsx";
 import { Switch } from "./Switch.jsx";
 import { useTypedTranslation } from "../types.js";
@@ -15,6 +15,7 @@ import { useTypedTranslation } from "../types.js";
 export function SwitchBarMobile({platformName}) {
     const {onChange, onDone, state} = useContext(SwitchContext);
     const { t } = useTypedTranslation();
+    const inputId = useId();
 
     function blockClick(e) {
         if (state === 'exiting') {
@@ -37,16 +38,19 @@ export function SwitchBarMobile({platformName}) {
 
     return (
         <div class={classes} data-state={state} onTransitionEnd={onTransitionEnd}>
-            <label onClick={blockClick} class={styles.label}>
-                <span className={styles.text}>
-                    {t('keepEnabled')}
-                </span>
+            <div class={styles.labelRow}>
+                <label onClick={blockClick} for={inputId}>
+                    <span className={styles.text}>
+                        {t('keepEnabled')}
+                    </span>
+                </label>
                 <Switch
                     checked={state !== 'showing'}
                     onChange={onChange}
                     platformName={platformName}
+                    id={inputId}
                 />
-            </label>
+            </div>
         </div>
     )
 }

--- a/special-pages/pages/duckplayer/app/components/SwitchBarMobile.module.css
+++ b/special-pages/pages/duckplayer/app/components/SwitchBarMobile.module.css
@@ -38,7 +38,7 @@
     gap: 16px;
 }
 
-.labelRow label {
+.label {
     pointer-events: none;
 }
 

--- a/special-pages/pages/duckplayer/app/components/SwitchBarMobile.module.css
+++ b/special-pages/pages/duckplayer/app/components/SwitchBarMobile.module.css
@@ -30,7 +30,7 @@
     display: none;
 }
 
-.label {
+.labelRow {
     display: flex;
     align-items: center;
     justify-content: space-between;

--- a/special-pages/pages/duckplayer/app/components/SwitchBarMobile.module.css
+++ b/special-pages/pages/duckplayer/app/components/SwitchBarMobile.module.css
@@ -38,6 +38,11 @@
     gap: 16px;
 }
 
+.labelRow label {
+    pointer-events: none;
+}
+
+
 .checkbox {}
 
 .text {

--- a/special-pages/tests/duckplayer.spec.js
+++ b/special-pages/tests/duckplayer.spec.js
@@ -160,7 +160,7 @@ test.describe('duckplayer mobile settings', () => {
         await duckplayer.openWithVideoID()
         await duckplayer.hasLoadedIframe()
         await duckplayer.reducedMotion()
-        await page.getByLabel('Keep Duck Player turned on').click() // can't 'check' here
+        await page.getByRole('switch').click()
         await page.getByLabel('Keep Duck Player turned on').waitFor({ state: 'hidden' })
         await duckplayer.sentUpdatedSettings()
     })


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/0/0/1208542811348500/f

## Description

It's common in a web-based UI to have the label wrapping an input, and then click on the label toggle the switch. In the case of iOS/Android this is not as common (if at all)

So this change is just for the mobile devices - we still use an associated label, but we move the trigger to just the switch.

## Testing Steps

- visit this on a mobile device https://deploy-preview-1121--content-scope-scripts.netlify.app/build/pages/duckplayer/
- try tapping the label text to the left of the switch
  - it SHOULD NOT activate the switch

## Checklist

<!--
  These questions are a friendly reminder to shipping code, if you're uncertain ask the AoR owners.
  It's also totally appropriate to not check some of these boxes, if they don't apply to your change.
-->
*Please tick all that apply:*

- [x] I have tested this change locally
- [x] I have tested this change locally in all supported browsers
- [x] This change will be visible to users
- [x] I have added automated tests that cover this change
- [ ] I have ensured the change is gated by config
- [ ] This change was covered by a ship review
- [ ] This change was covered by a tech design
- [ ] Any dependent config has been merged

