### PR TITLE
Skip auto-respond-pr.yml for dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,8 +5,22 @@ updates:
     schedule:
       interval: "daily"
     target-branch: "main"
+    open-pull-requests-limit: 20
     labels:
       - "dependencies"
+    groups:
+      eslint:
+        patterns:
+          - "eslint*"
+          - "@typescript-eslint*"
+      stylelint:
+        patterns:
+          - "stylelint*"
+      typescript:
+        patterns:
+          - "typedoc"
+          - "typescript"
+          - "@typescript-eslint*"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,7 +20,13 @@ updates:
         patterns:
           - "typedoc"
           - "typescript"
+          - "@types/*"
           - "@typescript-eslint*"
+      rollup:
+        patterns:
+          - "@rollup/*"
+          - "rollup-*"
+          - "rollup"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/.github/workflows/auto-respond-pr.yml
+++ b/.github/workflows/auto-respond-pr.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   auto_respond:
+    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
**Asana Task/Github Issue:** <!-- Link to Asana Task/Github Issue -->

## Description

- Skip dependabot for now, we're still developing this action and it's not required for anything other than validating builds.
- Adds grouping to dependabot to reduce review overhead.

## Testing Steps

- <!-- Include simple steps on how to check this change is working. Write "N/A" if not applicable. -->

## Checklist

<!--
  These questions are a friendly reminder to shipping code, if you're uncertain ask the AoR owners.
  It's also totally appropriate to not check some of these boxes, if they don't apply to your change.
-->
*Please tick all that apply:*

- [ ] I have tested this change locally
- [ ] I have tested this change locally in all supported browsers
- [ ] This change will be visible to users
- [ ] I have added automated tests that cover this change
- [ ] I have ensured the change is gated by config
- [ ] This change was covered by a ship review
- [ ] This change was covered by a tech design
- [ ] Any dependent config has been merged

