### PR TITLE
don't build on netlify for dependabot PRs

### DIFF
--- a/netlfiy.toml
+++ b/netlfiy.toml
@@ -1,0 +1,2 @@
+[build]
+ignore = "git log -1 --pretty=%B | grep dependabot"


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/0/1201614831475344/1208567543316321/f

## Description

as they recommend here https://www.netlify.com/blog/2020/04/27/ignore-unnecessary-builds-to-optimize-your-build-times/

## Testing Steps

- <!-- Include simple steps on how to check this change is working. Write "N/A" if not applicable. -->

## Checklist

<!--
  These questions are a friendly reminder to shipping code, if you're uncertain ask the AoR owners.
  It's also totally appropriate to not check some of these boxes, if they don't apply to your change.
-->
*Please tick all that apply:*

- [ ] I have tested this change locally
- [ ] I have tested this change locally in all supported browsers
- [ ] This change will be visible to users
- [ ] I have added automated tests that cover this change
- [ ] I have ensured the change is gated by config
- [ ] This change was covered by a ship review
- [ ] This change was covered by a tech design
- [ ] Any dependent config has been merged

