### PR TITLE
Add getInterestGroupAdAuctionData removal

### DIFF
--- a/injected/src/features/google-rejected.js
+++ b/injected/src/features/google-rejected.js
@@ -21,6 +21,12 @@ export default class GoogleRejected extends ContentFeature {
             if ('adAuctionComponents' in Navigator.prototype) {
                 delete Navigator.prototype.adAuctionComponents
             }
+            // https://github.com/WICG/privacy-preserving-ads/blob/main/API%20Details.md
+            if (this.getFeatureSetting('getInterestGroupAdAuctionData')) {
+                if ('getInterestGroupAdAuctionData' in Navigator.prototype) {
+                    delete Navigator.prototype.getInterestGroupAdAuctionData
+                
+            }
         } catch {
             // Throw away this exception, it's likely a confict with another extension
         }


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/0/0/1208626149160771/f

## Description

Conditionally removes the `getInterestGroupAdAuctionData` API as specified here: https://github.com/WICG/privacy-preserving-ads/blob/main/API%20Details.md

## Testing Steps

- <!-- Include simple steps on how to check this change is working. Write "N/A" if not applicable. -->

## Checklist

<!--
  These questions are a friendly reminder to shipping code, if you're uncertain ask the AoR owners.
  It's also totally appropriate to not check some of these boxes, if they don't apply to your change.
-->
*Please tick all that apply:*

- [ ] I have tested this change locally
- [ ] I have tested this change locally in all supported browsers
- [ ] This change will be visible to users
- [ ] I have added automated tests that cover this change
- [ ] I have ensured the change is gated by config
- [ ] This change was covered by a ship review
- [ ] This change was covered by a tech design
- [ ] Any dependent config has been merged

