### PR TITLE
extract mocks into mock-transport

### DIFF
--- a/special-pages/pages/release-notes/src/js/index.js
+++ b/special-pages/pages/release-notes/src/js/index.js
@@ -18,7 +18,7 @@ import { init } from '../../app/index'
 import { createSpecialPageMessaging } from '../../../../shared/create-special-page-messaging'
 import { Environment } from '../../../../shared/environment'
 import { createTypedMessages } from '@duckduckgo/messaging'
-import { mockTransport } from "./mock-transport.js";
+import { mockTransport } from './mock-transport.js'
 
 /**
  * This describes the messages that will be sent to the native layer,

--- a/special-pages/pages/release-notes/src/js/mock-transport.js
+++ b/special-pages/pages/release-notes/src/js/mock-transport.js
@@ -44,9 +44,9 @@ export function mockTransport () {
         },
         subscribe (_msg, callback) {
             window.__playwright_01?.mocks?.outgoing?.push?.({ payload: structuredClone(_msg) })
-            /** @type {import('../../../../types/release-notes').ReleaseNotesMessages['subscriptions']} */
-            const msg = /** @type {any} */(_msg)
-            switch (msg.subscriptionEvent) {
+            /** @type {import('../../../../types/release-notes').ReleaseNotesMessages['subscriptions']['subscriptionEvent']} */
+            const subscription = /** @type {any} */(_msg.subscriptionName)
+            switch (subscription) {
             case 'onUpdate': {
                 const searchParams = new URLSearchParams(window.location.search)
                 let stateId = searchParams.get('stateId')

--- a/special-pages/pages/release-notes/src/js/mock-transport.js
+++ b/special-pages/pages/release-notes/src/js/mock-transport.js
@@ -1,0 +1,81 @@
+import { TestTransportConfig } from "@duckduckgo/messaging";
+import { sampleData } from '../../app/sampleData'
+
+/**
+ * @typedef {import('../../../../types/release-notes').UpdateMessage} UpdateMessage
+ */
+
+export function mockTransport () {
+    /**
+     * Allows for sample data overrides. Overrides can be combined. Ex:
+     *
+     * ?stateId=updateReady&manualUpdate
+     * ?stateId=loaded&noPrivacyPro
+     * ?stateId=updateReady&manualUpdate&noPrivacyPro
+     *
+     * @type {Record<string, Partial<UpdateMessage>>}
+     */
+    const dataOverrides = {
+        manualUpdate: {
+            automaticUpdate: false
+        },
+        noPrivacyPro: {
+            releaseNotesPrivacyPro: undefined
+        }
+    }
+
+    return new TestTransportConfig({
+        notify(msg) {
+
+        },
+        request(_msg) {
+            window.__playwright_01?.mocks?.outgoing?.push?.({ payload: structuredClone(_msg) })
+            /** @type {import('../../../../types/release-notes').ReleaseNotesMessages['requests']} */
+            const msg = /** @type {any} */(_msg)
+            switch (msg.method) {
+                case "initialSetup": {
+                    return Promise.resolve({
+                        env: 'development',
+                        locale: 'en'
+                    })
+                }
+                default: return Promise.resolve(null)
+            }
+        },
+        subscribe(_msg, callback) {
+            window.__playwright_01?.mocks?.outgoing?.push?.({ payload: structuredClone(_msg) })
+            /** @type {import('../../../../types/release-notes').ReleaseNotesMessages['subscriptions']} */
+            const msg = /** @type {any} */(_msg)
+            switch (msg.subscriptionEvent) {
+                case "onUpdate": {
+                    const searchParams = new URLSearchParams(window.location.search)
+                    let stateId = searchParams.get('stateId')
+                    if (!stateId || !sampleData[stateId]) {
+                        stateId = 'loading'
+                    }
+                    let updateData = sampleData[stateId]
+
+                    Object.entries(dataOverrides).forEach(([key, value]) => {
+                        if (searchParams.has(key)) {
+                            updateData = { ...updateData, ...value }
+                        }
+                    })
+
+                    callback(sampleData.loading)
+
+                    const timer = setTimeout(() => {
+                        callback(updateData)
+                    }, 1000)
+
+                    return () => {
+                        clearTimeout(timer)
+                    }
+                }
+            }
+
+            return () => {
+                // any cleanup
+            }
+        }
+    })
+}

--- a/special-pages/pages/release-notes/src/js/mock-transport.js
+++ b/special-pages/pages/release-notes/src/js/mock-transport.js
@@ -1,4 +1,4 @@
-import { TestTransportConfig } from "@duckduckgo/messaging";
+import { TestTransportConfig } from '@duckduckgo/messaging'
 import { sampleData } from '../../app/sampleData'
 
 /**
@@ -25,52 +25,52 @@ export function mockTransport () {
     }
 
     return new TestTransportConfig({
-        notify(msg) {
-
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        notify (_msg) {
         },
-        request(_msg) {
+        request (_msg) {
             window.__playwright_01?.mocks?.outgoing?.push?.({ payload: structuredClone(_msg) })
             /** @type {import('../../../../types/release-notes').ReleaseNotesMessages['requests']} */
             const msg = /** @type {any} */(_msg)
             switch (msg.method) {
-                case "initialSetup": {
-                    return Promise.resolve({
-                        env: 'development',
-                        locale: 'en'
-                    })
-                }
-                default: return Promise.resolve(null)
+            case 'initialSetup': {
+                return Promise.resolve({
+                    env: 'development',
+                    locale: 'en'
+                })
+            }
+            default: return Promise.resolve(null)
             }
         },
-        subscribe(_msg, callback) {
+        subscribe (_msg, callback) {
             window.__playwright_01?.mocks?.outgoing?.push?.({ payload: structuredClone(_msg) })
             /** @type {import('../../../../types/release-notes').ReleaseNotesMessages['subscriptions']} */
             const msg = /** @type {any} */(_msg)
             switch (msg.subscriptionEvent) {
-                case "onUpdate": {
-                    const searchParams = new URLSearchParams(window.location.search)
-                    let stateId = searchParams.get('stateId')
-                    if (!stateId || !sampleData[stateId]) {
-                        stateId = 'loading'
-                    }
-                    let updateData = sampleData[stateId]
-
-                    Object.entries(dataOverrides).forEach(([key, value]) => {
-                        if (searchParams.has(key)) {
-                            updateData = { ...updateData, ...value }
-                        }
-                    })
-
-                    callback(sampleData.loading)
-
-                    const timer = setTimeout(() => {
-                        callback(updateData)
-                    }, 1000)
-
-                    return () => {
-                        clearTimeout(timer)
-                    }
+            case 'onUpdate': {
+                const searchParams = new URLSearchParams(window.location.search)
+                let stateId = searchParams.get('stateId')
+                if (!stateId || !sampleData[stateId]) {
+                    stateId = 'loading'
                 }
+                let updateData = sampleData[stateId]
+
+                Object.entries(dataOverrides).forEach(([key, value]) => {
+                    if (searchParams.has(key)) {
+                        updateData = { ...updateData, ...value }
+                    }
+                })
+
+                callback(sampleData.loading)
+
+                const timer = setTimeout(() => {
+                    callback(updateData)
+                }, 1000)
+
+                return () => {
+                    clearTimeout(timer)
+                }
+            }
             }
 
             return () => {


### PR DESCRIPTION
**Asana Task/Github Issue:** n/a

## Description

This change ensures the mock transport code is stripped from the production build. It's also a more powerful pattern going forward since it's mocking exactly the boundary and nothing else.

## Testing Steps

- <!-- Include simple steps on how to check this change is working. Write "N/A" if not applicable. -->

## Checklist

<!--
  These questions are a friendly reminder to shipping code, if you're uncertain ask the AoR owners.
  It's also totally appropriate to not check some of these boxes, if they don't apply to your change.
-->
*Please tick all that apply:*

- [ ] I have tested this change locally
- [ ] I have tested this change locally in all supported browsers
- [ ] This change will be visible to users
- [ ] I have added automated tests that cover this change
- [ ] I have ensured the change is gated by config
- [ ] This change was covered by a ship review
- [ ] This change was covered by a tech design
- [ ] Any dependent config has been merged

