### PR TITLE
Onboarding: waiting for import status on macOS

### DIFF
--- a/special-pages/pages/onboarding/app/index.js
+++ b/special-pages/pages/onboarding/app/index.js
@@ -14,6 +14,7 @@ import { TranslationProvider } from '../../../shared/components/TranslationsProv
 import { SettingsProvider } from './components/SettingsProvider';
 import enStrings from '../src/locales/en/onboarding.json';
 import { stepDefinitions as stepDefinitionsV3 } from './components/v3/data';
+import { mockTransport } from '../src/js/mock-transport';
 
 const baseEnvironment = new Environment().withInjectName(document.documentElement.dataset.platform).withEnv(import.meta.env);
 
@@ -22,6 +23,14 @@ const messaging = createSpecialPageMessaging({
     injectName: baseEnvironment.injectName,
     env: baseEnvironment.env,
     pageName: 'onboarding',
+    mockTransport: () => {
+        // only in integration environments
+        if (baseEnvironment.injectName !== 'integration') return null;
+        let mock = null;
+
+        mock = mockTransport();
+        return mock;
+    },
 });
 
 const onboarding = new OnboardingMessages(messaging, baseEnvironment.injectName);

--- a/special-pages/pages/onboarding/app/messages.js
+++ b/special-pages/pages/onboarding/app/messages.js
@@ -52,15 +52,6 @@ export class OnboardingMessages {
      * @returns {Promise<InitResponse>}
      */
     async init() {
-        if (this.injectName === 'integration') {
-            return {
-                stepDefinitions: {},
-                exclude: [],
-                order: 'v3',
-                locale: 'en',
-                env: 'development',
-            };
-        }
         return await this.messaging.request('init');
     }
 

--- a/special-pages/pages/onboarding/src/js/mock-transport.js
+++ b/special-pages/pages/onboarding/src/js/mock-transport.js
@@ -1,0 +1,52 @@
+import { TestTransportConfig } from '@duckduckgo/messaging';
+
+/**
+ * @typedef {import('../../../../types/release-notes').UpdateMessage} UpdateMessage
+ */
+
+export function mockTransport() {
+    return new TestTransportConfig({
+        notify(_msg) {
+            window.__playwright_01?.mocks?.outgoing?.push?.({ payload: structuredClone(_msg) });
+            const msg = /** @type {any} */ (_msg);
+            switch (msg.method) {
+                default: {
+                    console.warn('unhandled notification', msg);
+                }
+            }
+        },
+        request(_msg) {
+            window.__playwright_01?.mocks?.outgoing?.push?.({ payload: structuredClone(_msg) });
+            const msg = /** @type {any} */ (_msg);
+            switch (msg.method) {
+                case 'init': {
+                    return Promise.resolve({
+                        stepDefinitions: {},
+                        exclude: [],
+                        order: 'v3',
+                        locale: 'en',
+                        env: 'development',
+                    });
+                }
+                case 'requestImport':
+                case 'requestSetAsDefault':
+                case 'requestDockOptIn': {
+                    return Promise.resolve({
+                        enabled: true,
+                    });
+                }
+                default:
+                    return Promise.resolve(null);
+            }
+        },
+        subscribe(_msg, callback) {
+            window.__playwright_01?.mocks?.outgoing?.push?.({ payload: structuredClone(_msg) });
+
+            callback(null);
+
+            return () => {
+                // any cleanup
+            };
+        },
+    });
+}

--- a/special-pages/tests/onboarding.spec.js
+++ b/special-pages/tests/onboarding.spec.js
@@ -230,6 +230,25 @@ test.describe('onboarding', () => {
                 // ▶️ Then I can choose to import afterwards
                 await onboarding.importUserData();
             });
+            test('When the import step has failed on macOS', async ({ page }, workerInfo) => {
+                test.skip(workerInfo.project.name !== 'macos');
+
+                const onboarding = OnboardingPage.create(page, workerInfo);
+                onboarding.withMockData({
+                    init: {
+                        stepDefinitions: null,
+                        order: 'v3',
+                    },
+                    requestImport: { enabled: false },
+                });
+
+                await onboarding.reducedMotion();
+                await onboarding.openPage({ env: 'app', page: 'systemSettings' });
+                await onboarding.skippedCurrent();
+
+                // ▶️ Then I can still see the import button
+                await onboarding.importUserDataFailedGracefully();
+            });
         });
         test.describe('Given I am on the customize step', () => {
             test('Then I can see additional information about the steps', async ({ page }, workerInfo) => {

--- a/special-pages/tests/page-objects/onboarding.js
+++ b/special-pages/tests/page-objects/onboarding.js
@@ -27,7 +27,7 @@ export class OnboardingPage {
         this.defaultResponses = {
             requestSetAsDefault: {},
             requestDockOptIn: {},
-            requestImport: {},
+            requestImport: { enabled: true },
             stepCompleted: {},
             reportPageException: {},
             init: {
@@ -48,6 +48,13 @@ export class OnboardingPage {
         this.mocks.defaultResponses({
             ...this.defaultResponses,
             init: data,
+        });
+    }
+
+    withMockData(data) {
+        this.mocks.defaultResponses({
+            ...this.defaultResponses,
+            ...data,
         });
     }
 
@@ -173,6 +180,23 @@ export class OnboardingPage {
         const { page } = this;
         await page.getByRole('button', { name: 'Import' }).click();
         await page.getByRole('img', { name: 'Completed Action' }).waitFor();
+        const calls = await this.mocks.outgoing({ names: ['requestImport'] });
+        expect(calls).toMatchObject([
+            {
+                payload: {
+                    context: 'specialPages',
+                    featureName: 'onboarding',
+                    method: 'requestImport',
+                    params: {},
+                },
+            },
+        ]);
+    }
+
+    async importUserDataFailedGracefully() {
+        const { page } = this;
+        await page.getByRole('button', { name: 'Import Now', exact: true }).click();
+        await page.getByRole('button', { name: 'Import', exact: true }).waitFor();
         const calls = await this.mocks.outgoing({ names: ['requestImport'] });
         expect(calls).toMatchObject([
             {


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/0/72649045549333/1208592742896624/f
## Description

When choosing to import data during onboarding, wait for response from macOS on whether import was successful 

## Testing Steps

- Follow the steps here https://github.com/duckduckgo/macos-browser/pull/3485

OR

- Run the preview locally then set the mockTransport to return `{ enabled: false }` on `requestImport` to simulate a failed import. You should see the import button persist when that’s the case (same behavior as skipping the import step). 

## Checklist

<!--
  These questions are a friendly reminder to shipping code, if you're uncertain ask the AoR owners.
  It's also totally appropriate to not check some of these boxes, if they don't apply to your change.
-->
*Please tick all that apply:*

- [x] I have tested this change locally
- [x] I have tested this change locally in all supported browsers
- [x] This change will be visible to users
- [x] I have added automated tests that cover this change
- [ ] I have ensured the change is gated by config
- [ ] This change was covered by a ship review
- [ ] This change was covered by a tech design
- [ ] Any dependent config has been merged

