### PR TITLE
Only export core types from messaging

### DIFF
--- a/injected/entry-points/android.js
+++ b/injected/entry-points/android.js
@@ -4,7 +4,7 @@
 import { load, init } from '../src/content-scope-features.js'
 import { processConfig, isGloballyDisabled } from './../src/utils'
 import { isTrackerOrigin } from '../src/trackers'
-import { AndroidMessagingConfig } from '../../messaging/index.js'
+import { AndroidMessagingConfig } from '../../messaging/lib/android.js'
 
 function initCode () {
     // @ts-expect-error https://app.asana.com/0/1201614831475344/1203979574128023/f

--- a/injected/entry-points/apple.js
+++ b/injected/entry-points/apple.js
@@ -4,7 +4,8 @@
 import { load, init } from '../src/content-scope-features.js'
 import { processConfig, isGloballyDisabled } from './../src/utils'
 import { isTrackerOrigin } from '../src/trackers'
-import { WebkitMessagingConfig, TestTransportConfig } from '../../messaging/index.js'
+import { TestTransportConfig } from '../../messaging/index.js'
+import { WebkitMessagingConfig } from '../../messaging/lib/webkit.js'
 
 function initCode () {
     // @ts-expect-error https://app.asana.com/0/1201614831475344/1203979574128023/f

--- a/injected/entry-points/windows.js
+++ b/injected/entry-points/windows.js
@@ -4,7 +4,7 @@
 import { load, init } from '../src/content-scope-features.js'
 import { processConfig, isGloballyDisabled, windowsSpecificFeatures } from './../src/utils'
 import { isTrackerOrigin } from '../src/trackers'
-import { WindowsMessagingConfig } from '../../messaging/index.js'
+import { WindowsMessagingConfig } from '../../messaging/lib/windows.js'
 
 function initCode () {
     // @ts-expect-error https://app.asana.com/0/1201614831475344/1203979574128023/f

--- a/injected/src/content-feature.js
+++ b/injected/src/content-feature.js
@@ -3,7 +3,7 @@ import { immutableJSONPatch } from 'immutable-json-patch'
 import { PerformanceMonitor } from './performance.js'
 import { defineProperty, shimInterface, shimProperty, wrapMethod, wrapProperty, wrapToString } from './wrapper-utils.js'
 import { Proxy, Reflect } from './captured-globals.js'
-import { Messaging, MessagingContext } from '../../messaging/index.js'
+import { MessagingContext } from '../../messaging/index.js'
 import { extensionConstructMessagingConfig } from './sendmessage-transport.js'
 
 /**
@@ -125,7 +125,7 @@ export default class ContentFeature {
             if (this.platform?.name !== 'extension') throw new Error('Only extension messaging supported, all others should be passed in')
             messagingConfig = extensionConstructMessagingConfig()
         }
-        this._messaging = new Messaging(messagingContext, messagingConfig)
+        this._messaging = messagingConfig.intoMessaging(messagingContext)
         return this._messaging
     }
 

--- a/injected/src/features/click-to-load.js
+++ b/injected/src/features/click-to-load.js
@@ -1,4 +1,3 @@
-import { Messaging, TestTransportConfig, WebkitMessagingConfig } from '../../../messaging/index.js'
 import { createCustomEvent, originalWindowDispatchEvent } from '../utils.js'
 import { logoImg, loadingImages, closeIcon, facebookLogo } from './click-to-load/ctl-assets.js'
 import { getStyles, getConfig } from './click-to-load/ctl-config.js'
@@ -7,6 +6,7 @@ import ContentFeature from '../content-feature.js'
 import { DDGCtlPlaceholderBlockedElement } from './click-to-load/components/ctl-placeholder-blocked.js'
 import { DDGCtlLoginButton } from './click-to-load/components/ctl-login-button.js'
 import { registerCustomElements } from './click-to-load/components'
+import { TestTransportConfig } from '@duckduckgo/messaging'
 
 /**
  * @typedef {'darkMode' | 'lightMode' | 'loginMode' | 'cancelMode'} displayMode
@@ -2019,16 +2019,10 @@ export default class ClickToLoad extends ContentFeature {
         if (this.platform.name === 'android' || this.platform.name === 'extension') {
             this._clickToLoadMessagingTransport = new SendMessageMessagingTransport()
             const config = new TestTransportConfig(this._clickToLoadMessagingTransport)
-            this._messaging = new Messaging(this.messagingContext, config)
+            this._messaging = config.intoMessaging(this.messagingContext)
             return this._messaging
         } else if (this.platform.name === 'ios' || this.platform.name === 'macos') {
-            const config = new WebkitMessagingConfig({
-                secret: '',
-                hasModernWebkitAPI: true,
-                webkitMessageHandlerNames: ['contentScopeScriptsIsolated']
-            })
-            this._messaging = new Messaging(this.messagingContext, config)
-            return this._messaging
+            return this.messaging
         } else {
             throw new Error('Messaging not supported yet on platform: ' + this.name)
         }

--- a/injected/unit-test/messaging.js
+++ b/injected/unit-test/messaging.js
@@ -1,5 +1,4 @@
 import {
-    Messaging,
     MessagingContext,
     TestTransportConfig,
     RequestMessage, NotificationMessage, Subscription, MessageResponse, SubscriptionEvent
@@ -82,7 +81,7 @@ describe('Android', () => {
             featureName,
             env: 'development'
         })
-        const messaging = new Messaging(messageContextA, config)
+        const messaging = config.intoMessaging(messageContextA)
         return { messaging }
     }
     it('sends notification to 1 feature', () => {
@@ -232,7 +231,7 @@ function createMessaging () {
         env: 'development'
     })
 
-    const messaging = new Messaging(messagingContext, testTransportConfig)
+    const messaging = testTransportConfig.intoMessaging(messagingContext)
 
     return { transport, messaging }
 }

--- a/messaging/lib/android.js
+++ b/messaging/lib/android.js
@@ -6,13 +6,16 @@
  *
  */
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-import { MessagingTransport, MessageResponse, SubscriptionEvent } from '../index.js'
+import { Messaging, MessagingTransport } from '../index.js'
 import { isResponseFor, isSubscriptionEventFor } from '../schema.js'
 
 /**
  * @typedef {import('../index.js').Subscription} Subscription
  * @typedef {import('../index.js').MessagingContext} MessagingContext
  * @typedef {import('../index.js').RequestMessage} RequestMessage
+ * @typedef {import('../index.js').SubscriptionEvent} SubscriptionEvent
+ * @typedef {import('../index.js').MessageResponse} MessageResponse
+ * @typedef {import('../index.js').IntoMessaging} IntoMessaging
  * @typedef {import('../index.js').NotificationMessage} NotificationMessage
  */
 
@@ -171,6 +174,7 @@ export class AndroidMessagingTransport {
  *     }
  * }
  * ```
+ * @implements IntoMessaging
  */
 export class AndroidMessagingConfig {
     /** @type {(json: string, secret: string) => void} */
@@ -208,6 +212,14 @@ export class AndroidMessagingConfig {
          * Assign the incoming handler method to the global object.
          */
         this._assignHandlerMethod()
+    }
+
+    /**
+     * @param {MessagingContext} context
+     * @return {Messaging}
+     */
+    intoMessaging (context) {
+        return new Messaging(context, new AndroidMessagingTransport(this, context))
     }
 
     /**

--- a/messaging/lib/examples/android.example.js
+++ b/messaging/lib/examples/android.example.js
@@ -1,4 +1,4 @@
-import { Messaging, MessagingContext } from '../../index.js'
+import { MessagingContext } from '../../index.js'
 import { AndroidMessagingConfig } from '../android.js'
 
 /**
@@ -30,7 +30,7 @@ const messagingContext = new MessagingContext({
 /**
  * And then send notifications!
  */
-const messaging = new Messaging(messagingContext, config)
+const messaging = config.intoMessaging(messagingContext)
 messaging.notify('helloWorld')
 
 /**
@@ -63,8 +63,8 @@ const messagingContext2 = { ...messagingContext1, featureName: 'duckPlayer' }
 /**
  * Now, each feature has its own isolated messaging...
  */
-const messaging1 = new Messaging(messagingContext, config)
+const messaging1 = config.intoMessaging(messagingContext1)
 messaging1.notify('helloWorld')
 
-const messaging2 = new Messaging(messagingContext2, config)
+const messaging2 = config.intoMessaging(messagingContext2)
 messaging2.notify('getUserValues')

--- a/messaging/lib/examples/test.example.js
+++ b/messaging/lib/examples/test.example.js
@@ -1,4 +1,4 @@
-import { Messaging, MessagingContext, TestTransportConfig } from '../../index.js'
+import { MessagingContext, TestTransportConfig } from '../../index.js'
 
 /**
  * Creates an ad-hoc messaging transport on the fly - useful for testing
@@ -36,7 +36,7 @@ const messagingContext = new MessagingContext({
 /**
  * And then send notifications!
  */
-const messaging = new Messaging(messagingContext, config)
+const messaging = config.intoMessaging(messagingContext)
 messaging.notify('helloWorld')
 
 /**

--- a/messaging/lib/examples/webkit.example.js
+++ b/messaging/lib/examples/webkit.example.js
@@ -1,4 +1,5 @@
-import { Messaging, MessagingContext, WebkitMessagingConfig } from '../../index.js'
+import { MessagingContext } from '../../index.js'
+import { WebkitMessagingConfig } from '../webkit.js'
 
 /**
  * Configuration for WebkitMessaging
@@ -21,7 +22,7 @@ const messagingContext = new MessagingContext({
 /**
  * With config + context, now create an instance:
  */
-const messaging = new Messaging(messagingContext, config)
+const messaging = config.intoMessaging(messagingContext)
 
 /**
  * send notifications (fire and forget)

--- a/messaging/lib/examples/windows.example.js
+++ b/messaging/lib/examples/windows.example.js
@@ -1,5 +1,5 @@
 import { WindowsMessagingConfig } from '../windows.js'
-import { Messaging, MessagingContext } from '../../index.js'
+import { MessagingContext } from '../../index.js'
 
 /**
  * These 3 required methods that get assigned by the Native side.
@@ -32,7 +32,7 @@ const messagingContext = new MessagingContext({
 /**
  * And then send notifications!
  */
-const messaging = new Messaging(messagingContext, config)
+const messaging = config.intoMessaging(messagingContext)
 messaging.notify('helloWorld')
 
 /**

--- a/messaging/lib/webkit.js
+++ b/messaging/lib/webkit.js
@@ -7,7 +7,7 @@
  * part of the message handling, see {@link WebkitMessagingTransport} for details.
  */
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-import { MessagingTransport, MissingHandler } from '../index.js'
+import { MessagingTransport, MissingHandler, Messaging } from '../index.js'
 import { isResponseFor, isSubscriptionEventFor } from '../schema.js'
 
 /**
@@ -317,6 +317,9 @@ export class WebkitMessagingTransport {
  * Please see {@link WebkitMessagingTransport} for details on how messages are sent/received
  *
  * [Example](./examples/webkit.example.js)
+ *
+ * @import { IntoMessaging, MessagingContext } from "../index.js"
+ * @implements IntoMessaging
  */
 export class WebkitMessagingConfig {
     /**
@@ -353,6 +356,14 @@ export class WebkitMessagingConfig {
          * messages.
          */
         this.secret = params.secret
+    }
+
+    /**
+     * @param {MessagingContext} context
+     * @return {Messaging}
+     */
+    intoMessaging (context) {
+        return new Messaging(context, new WebkitMessagingTransport(this, context))
     }
 }
 

--- a/messaging/lib/windows.js
+++ b/messaging/lib/windows.js
@@ -7,7 +7,7 @@
  *
  */
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-import { MessagingTransport, NotificationMessage, RequestMessage } from '../index.js'
+import { MessagingTransport, NotificationMessage, RequestMessage, Messaging } from '../index.js'
 
 /**
  * An implementation of {@link MessagingTransport} for Windows
@@ -204,6 +204,8 @@ export class WindowsMessagingTransport {
  *
  * [Example](./examples/windows.example.js)
  *
+ * @import { IntoMessaging, MessagingContext } from "../index.js"
+ * @implements IntoMessaging
  */
 export class WindowsMessagingConfig {
     /**
@@ -220,6 +222,14 @@ export class WindowsMessagingConfig {
          * @type {'windows'}
          */
         this.platform = 'windows'
+    }
+
+    /**
+     * @param {MessagingContext} context
+     * @return {Messaging}
+     */
+    intoMessaging (context) {
+        return new Messaging(context, new WindowsMessagingTransport(this, context))
     }
 }
 

--- a/special-pages/shared/create-special-page-messaging.js
+++ b/special-pages/shared/create-special-page-messaging.js
@@ -1,11 +1,13 @@
 import {
-    AndroidMessagingConfig,
     Messaging,
     MessagingContext,
-    TestTransportConfig,
-    WebkitMessagingConfig,
-    WindowsMessagingConfig
+    TestTransport,
+    TestTransportConfig
 } from '@duckduckgo/messaging'
+
+import { WindowsMessagingConfig } from '@duckduckgo/messaging/lib/windows.js'
+import { WebkitMessagingConfig } from '@duckduckgo/messaging/lib/webkit.js'
+import { AndroidMessagingConfig } from '@duckduckgo/messaging/lib/android.js'
 
 /**
  * @param {object} opts
@@ -33,14 +35,14 @@ export function createSpecialPageMessaging (opts) {
                     removeEventListener: window.chrome.webview.removeEventListener
                 }
             })
-            return new Messaging(messageContext, opts)
+            return opts.intoMessaging(messageContext)
         } else if (opts.injectName === 'apple') {
             const opts = new WebkitMessagingConfig({
                 hasModernWebkitAPI: true,
                 secret: '',
                 webkitMessageHandlerNames: ['specialPages']
             })
-            return new Messaging(messageContext, opts)
+            return opts.intoMessaging(messageContext)
         } else if (opts.injectName === 'android') {
             const opts = new AndroidMessagingConfig({
                 messageSecret: 'duckduckgo-android-messaging-secret',
@@ -49,7 +51,7 @@ export function createSpecialPageMessaging (opts) {
                 target: globalThis,
                 debug: true
             })
-            return new Messaging(messageContext, opts)
+            return opts.intoMessaging(messageContext)
         }
     } catch (e) {
         console.error('could not access handlers for %s, falling back to mock interface', opts.injectName)
@@ -88,5 +90,5 @@ export function createSpecialPageMessaging (opts) {
         }
     })
 
-    return new Messaging(messageContext, fallback)
+    return new Messaging(messageContext, new TestTransport(fallback, messageContext))
 }


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/0/1201614831475344/1208567543316316/f

## Description

Alter the messaging API to prevent having to import all implementations (and them ending up in resulting bundles)

> [!NOTE]
> This doesn't improve special pages just yet, but it is a big improvement for the injected side

## Testing Steps

- If all the automated tests pass, we have a very high level of confidence.

## Checklist

<!--
  These questions are a friendly reminder to shipping code, if you're uncertain ask the AoR owners.
  It's also totally appropriate to not check some of these boxes, if they don't apply to your change.
-->
*Please tick all that apply:*

- [ ] I have tested this change locally
- [ ] I have tested this change locally in all supported browsers
- [ ] This change will be visible to users
- [ ] I have added automated tests that cover this change
- [ ] I have ensured the change is gated by config
- [ ] This change was covered by a ship review
- [ ] This change was covered by a tech design
- [ ] Any dependent config has been merged

