### PR TITLE
Add API manipulation feature

### DIFF
--- a/injected/entry-points/integration.js
+++ b/injected/entry-points/integration.js
@@ -28,10 +28,70 @@ function generateConfig() {
             domain: topLevelUrl.hostname,
             isBroken: false,
             allowlisted: false,
-            enabledFeatures: ['fingerprintingCanvas', 'fingerprintingScreenSize', 'navigatorInterface', 'cookie'],
+            enabledFeatures: [
+                'apiManipulation',
+                'fingerprintingCanvas',
+                'fingerprintingScreenSize',
+                'navigatorInterface',
+                'cookie'
+            ],
         },
-        trackerLookup,
-    };
+        featureSettings: {
+            apiManipulation: {
+                "apiChanges": {
+                    "Navigator.prototype.joinAdInterestGroup": {
+                        "type": "remove"
+                    },
+                    "Navigator.prototype.leaveAdInterestGroup": {
+                        "type": "remove"
+                    },
+                    "Navigator.prototype.clearOriginJoinedAdInterestGroups": {
+                        "type": "remove"
+                    },
+                    "Navigator.prototype.updateAdInterestGroups": {
+                        "type": "remove"
+                    },
+                    "Navigator.prototype.createAuctionNonce": {
+                        "type": "remove"
+                    },
+                    "Navigator.prototype.runAdAuction": {
+                        "type": "remove"
+                    },
+                    "Navigator.prototype.adAuctionComponents": {
+                        "type": "remove"
+                    },
+                    "Navigator.prototype.deprecatedURNToURL": {
+                        "type": "remove"
+                    },
+                    "Navigator.prototype.deprecatedReplaceInURN": {
+                        "type": "remove"
+                    },
+                    "Navigator.prototype.getInterestGroupAdAuctionData": {
+                        "type": "remove"
+                    },
+                    "Navigator.prototype.createAdRequest": {
+                        "type": "remove"
+                    },
+                    "Navigator.prototype.finalizeAd": {
+                        "type": "remove"
+                    },
+                    "Navigator.prototype.canLoadAdAuctionFencedFrame": {
+                        "type": "remove"
+                    },
+                    "Navigator.prototype.deprecatedRunAdAuctionEnforcesKAnonymity": {
+                        "type": "remove"
+                    },
+                    "Navigator.prototype.protectedAudience": {
+                        "type": "wrapPropertyValue",
+                        "value": {
+                            "type": "undefined"
+                        }
+                    },
+                },
+            },
+        },
+        trackerLookup
+    }
 }
 
 /**

--- a/injected/entry-points/integration.js
+++ b/injected/entry-points/integration.js
@@ -28,61 +28,7 @@ function generateConfig() {
             domain: topLevelUrl.hostname,
             isBroken: false,
             allowlisted: false,
-            enabledFeatures: ['apiManipulation', 'fingerprintingCanvas', 'fingerprintingScreenSize', 'navigatorInterface', 'cookie'],
-        },
-        featureSettings: {
-            apiManipulation: {
-                apiChanges: {
-                    'Navigator.prototype.joinAdInterestGroup': {
-                        type: 'remove',
-                    },
-                    'Navigator.prototype.leaveAdInterestGroup': {
-                        type: 'remove',
-                    },
-                    'Navigator.prototype.clearOriginJoinedAdInterestGroups': {
-                        type: 'remove',
-                    },
-                    'Navigator.prototype.updateAdInterestGroups': {
-                        type: 'remove',
-                    },
-                    'Navigator.prototype.createAuctionNonce': {
-                        type: 'remove',
-                    },
-                    'Navigator.prototype.runAdAuction': {
-                        type: 'remove',
-                    },
-                    'Navigator.prototype.adAuctionComponents': {
-                        type: 'remove',
-                    },
-                    'Navigator.prototype.deprecatedURNToURL': {
-                        type: 'remove',
-                    },
-                    'Navigator.prototype.deprecatedReplaceInURN': {
-                        type: 'remove',
-                    },
-                    'Navigator.prototype.getInterestGroupAdAuctionData': {
-                        type: 'remove',
-                    },
-                    'Navigator.prototype.createAdRequest': {
-                        type: 'remove',
-                    },
-                    'Navigator.prototype.finalizeAd': {
-                        type: 'remove',
-                    },
-                    'Navigator.prototype.canLoadAdAuctionFencedFrame': {
-                        type: 'remove',
-                    },
-                    'Navigator.prototype.deprecatedRunAdAuctionEnforcesKAnonymity': {
-                        type: 'remove',
-                    },
-                    'Navigator.prototype.protectedAudience': {
-                        type: 'descriptor',
-                        getterValue: {
-                            type: 'undefined',
-                        },
-                    },
-                },
-            },
+            enabledFeatures: ['fingerprintingCanvas', 'fingerprintingScreenSize', 'navigatorInterface', 'cookie'],
         },
         trackerLookup,
     };

--- a/injected/entry-points/integration.js
+++ b/injected/entry-points/integration.js
@@ -28,70 +28,64 @@ function generateConfig() {
             domain: topLevelUrl.hostname,
             isBroken: false,
             allowlisted: false,
-            enabledFeatures: [
-                'apiManipulation',
-                'fingerprintingCanvas',
-                'fingerprintingScreenSize',
-                'navigatorInterface',
-                'cookie'
-            ],
+            enabledFeatures: ['apiManipulation', 'fingerprintingCanvas', 'fingerprintingScreenSize', 'navigatorInterface', 'cookie'],
         },
         featureSettings: {
             apiManipulation: {
-                "apiChanges": {
-                    "Navigator.prototype.joinAdInterestGroup": {
-                        "type": "remove"
+                apiChanges: {
+                    'Navigator.prototype.joinAdInterestGroup': {
+                        type: 'remove',
                     },
-                    "Navigator.prototype.leaveAdInterestGroup": {
-                        "type": "remove"
+                    'Navigator.prototype.leaveAdInterestGroup': {
+                        type: 'remove',
                     },
-                    "Navigator.prototype.clearOriginJoinedAdInterestGroups": {
-                        "type": "remove"
+                    'Navigator.prototype.clearOriginJoinedAdInterestGroups': {
+                        type: 'remove',
                     },
-                    "Navigator.prototype.updateAdInterestGroups": {
-                        "type": "remove"
+                    'Navigator.prototype.updateAdInterestGroups': {
+                        type: 'remove',
                     },
-                    "Navigator.prototype.createAuctionNonce": {
-                        "type": "remove"
+                    'Navigator.prototype.createAuctionNonce': {
+                        type: 'remove',
                     },
-                    "Navigator.prototype.runAdAuction": {
-                        "type": "remove"
+                    'Navigator.prototype.runAdAuction': {
+                        type: 'remove',
                     },
-                    "Navigator.prototype.adAuctionComponents": {
-                        "type": "remove"
+                    'Navigator.prototype.adAuctionComponents': {
+                        type: 'remove',
                     },
-                    "Navigator.prototype.deprecatedURNToURL": {
-                        "type": "remove"
+                    'Navigator.prototype.deprecatedURNToURL': {
+                        type: 'remove',
                     },
-                    "Navigator.prototype.deprecatedReplaceInURN": {
-                        "type": "remove"
+                    'Navigator.prototype.deprecatedReplaceInURN': {
+                        type: 'remove',
                     },
-                    "Navigator.prototype.getInterestGroupAdAuctionData": {
-                        "type": "remove"
+                    'Navigator.prototype.getInterestGroupAdAuctionData': {
+                        type: 'remove',
                     },
-                    "Navigator.prototype.createAdRequest": {
-                        "type": "remove"
+                    'Navigator.prototype.createAdRequest': {
+                        type: 'remove',
                     },
-                    "Navigator.prototype.finalizeAd": {
-                        "type": "remove"
+                    'Navigator.prototype.finalizeAd': {
+                        type: 'remove',
                     },
-                    "Navigator.prototype.canLoadAdAuctionFencedFrame": {
-                        "type": "remove"
+                    'Navigator.prototype.canLoadAdAuctionFencedFrame': {
+                        type: 'remove',
                     },
-                    "Navigator.prototype.deprecatedRunAdAuctionEnforcesKAnonymity": {
-                        "type": "remove"
+                    'Navigator.prototype.deprecatedRunAdAuctionEnforcesKAnonymity': {
+                        type: 'remove',
                     },
-                    "Navigator.prototype.protectedAudience": {
-                        "type": "wrapPropertyValue",
-                        "value": {
-                            "type": "undefined"
-                        }
+                    'Navigator.prototype.protectedAudience': {
+                        type: 'wrapPropertyValue',
+                        value: {
+                            type: 'undefined',
+                        },
                     },
                 },
             },
         },
-        trackerLookup
-    }
+        trackerLookup,
+    };
 }
 
 /**

--- a/injected/entry-points/integration.js
+++ b/injected/entry-points/integration.js
@@ -76,8 +76,8 @@ function generateConfig() {
                         type: 'remove',
                     },
                     'Navigator.prototype.protectedAudience': {
-                        type: 'wrapPropertyValue',
-                        value: {
+                        type: 'descriptor',
+                        getterValue: {
                             type: 'undefined',
                         },
                     },

--- a/injected/integration-test/pages.spec.js
+++ b/injected/integration-test/pages.spec.js
@@ -66,9 +66,9 @@ test.describe('Test integration pages', () => {
         await testPage(
             page,
             'api-manipulation/pages/apis.html',
-            `${process.cwd()}/integration-test/test-pages/api-manipulation/config/apis.json`
-        )
-    })
+            `${process.cwd()}/integration-test/test-pages/api-manipulation/config/apis.json`,
+        );
+    });
 
     test('Web compat shims correctness', async ({ page }) => {
         await testPage(page, 'webcompat/pages/shims.html', `${process.cwd()}/integration-test/test-pages/webcompat/config/shims.json`);

--- a/injected/integration-test/pages.spec.js
+++ b/injected/integration-test/pages.spec.js
@@ -62,7 +62,7 @@ test.describe('Test integration pages', () => {
         }
     }
 
-    test.only('Test manipulating APIs', async ({ page }) => {
+    test('Test manipulating APIs', async ({ page }) => {
         await testPage(
             page,
             'api-manipulation/pages/apis.html',

--- a/injected/integration-test/pages.spec.js
+++ b/injected/integration-test/pages.spec.js
@@ -62,6 +62,14 @@ test.describe('Test integration pages', () => {
         }
     }
 
+    test.only('Test manipulating APIs', async ({ page }) => {
+        await testPage(
+            page,
+            'api-manipulation/pages/apis.html',
+            `${process.cwd()}/integration-test/test-pages/api-manipulation/config/apis.json`
+        )
+    })
+
     test('Web compat shims correctness', async ({ page }) => {
         await testPage(page, 'webcompat/pages/shims.html', `${process.cwd()}/integration-test/test-pages/webcompat/config/shims.json`);
     });

--- a/injected/integration-test/test-pages/api-manipulation/config/apis.json
+++ b/injected/integration-test/test-pages/api-manipulation/config/apis.json
@@ -30,6 +30,54 @@
                             "type": "string",
                             "value": "newName"
                         }
+                    },
+                    "Navigator.prototype.joinAdInterestGroup": {
+                        "type": "remove"
+                    },
+                    "Navigator.prototype.leaveAdInterestGroup": {
+                        "type": "remove"
+                    },
+                    "Navigator.prototype.clearOriginJoinedAdInterestGroups": {
+                        "type": "remove"
+                    },
+                    "Navigator.prototype.updateAdInterestGroups": {
+                        "type": "remove"
+                    },
+                    "Navigator.prototype.createAuctionNonce": {
+                        "type": "remove"
+                    },
+                    "Navigator.prototype.runAdAuction": {
+                        "type": "remove"
+                    },
+                    "Navigator.prototype.adAuctionComponents": {
+                        "type": "remove"
+                    },
+                    "Navigator.prototype.deprecatedURNToURL": {
+                        "type": "remove"
+                    },
+                    "Navigator.prototype.deprecatedReplaceInURN": {
+                        "type": "remove"
+                    },
+                    "Navigator.prototype.getInterestGroupAdAuctionData": {
+                        "type": "remove"
+                    },
+                    "Navigator.prototype.createAdRequest": {
+                        "type": "remove"
+                    },
+                    "Navigator.prototype.finalizeAd": {
+                        "type": "remove"
+                    },
+                    "Navigator.prototype.canLoadAdAuctionFencedFrame": {
+                        "type": "remove"
+                    },
+                    "Navigator.prototype.deprecatedRunAdAuctionEnforcesKAnonymity": {
+                        "type": "remove"
+                    },
+                    "Navigator.prototype.protectedAudience": {
+                        "type": "descriptor",
+                        "getterValue": {
+                            "type": "undefined"
+                        }
                     }
                 }
             }

--- a/injected/integration-test/test-pages/api-manipulation/config/apis.json
+++ b/injected/integration-test/test-pages/api-manipulation/config/apis.json
@@ -10,6 +10,26 @@
                             "type": "number",
                             "value": 222
                         }
+                    },
+                    "Navigator.prototype.userAgent": {
+                        "type": "remove"
+                    },
+                    "Navigator.prototype.thisDoesNotExist": {
+                        "type": "remove"
+                    },
+                    "Navigator.prototype.newAPI": {
+                        "type": "descriptor",
+                        "getterValue": {
+                            "type": "number",
+                            "value": 222
+                        }
+                    },
+                    "window.name": {
+                        "type": "descriptor",
+                        "getterValue": {
+                            "type": "string",
+                            "value": "newName"
+                        }
                     }
                 }
             }

--- a/injected/integration-test/test-pages/api-manipulation/config/apis.json
+++ b/injected/integration-test/test-pages/api-manipulation/config/apis.json
@@ -5,8 +5,8 @@
             "settings": {
                 "apiChanges": {
                     "Navigator.prototype.hardwareConcurrency": {
-                        "type": "wrapPropertyValue",
-                        "value": {
+                        "type": "descriptor",
+                        "getterValue": {
                             "type": "number",
                             "value": 222
                         }

--- a/injected/integration-test/test-pages/api-manipulation/config/apis.json
+++ b/injected/integration-test/test-pages/api-manipulation/config/apis.json
@@ -1,0 +1,18 @@
+{
+    "features": {
+        "apiManipulation": {
+            "state": "enabled",
+            "settings": {
+                "apiChanges": {
+                    "Navigator.prototype.hardwareConcurrency": {
+                        "type": "wrapPropertyValue",
+                        "value": {
+                            "type": "number",
+                            "value": 222
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/injected/integration-test/test-pages/api-manipulation/index.html
+++ b/injected/integration-test/test-pages/api-manipulation/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width">
+    <title>API Interventions</title>
+    <link rel="stylesheet" href="../shared/style.css">
+</head>
+<body>
+    <p><a href="../../index.html">[Home]</a></p>
+    <ul>
+        <li><a href="./pages/apis.html">Message Handlers</a> - <a href="./config/apis.json">Config</a></li>
+    </ul>
+</body>
+</html>

--- a/injected/integration-test/test-pages/api-manipulation/pages/apis.html
+++ b/injected/integration-test/test-pages/api-manipulation/pages/apis.html
@@ -13,12 +13,46 @@
     <p>This page verifies that APIs get modified</p>
 
     <script>
-        test('Test APIs modified', async () => {
+        test('API removal', async () => {
             return [
+                {
+                    name: "APIs removal",
+                    result: navigator.userAgent,
+                    expected: undefined
+                },
+                {
+                    name: "New API definition deletion does nothing",
+                    result: navigator.thisDoesNotExist,
+                    expected: undefined
+                },
+            ];
+        });
+        test('Existing API modified', async () => {
+            return [
+                {
+                    name: "New API definition doesn't work",
+                    result: navigator.newAPI,
+                    expected: undefined
+                },
                 {
                     name: "APIs modified",
                     result: navigator.hardwareConcurrency,
                     expected: 222
+                },
+                {
+                    name: "Returns expected value",
+                    result: window.name,
+                    expected: "newName"
+                },
+                {
+                    name: "Defaults to configurable",
+                    result: Object.getOwnPropertyDescriptor(window, 'name').configurable,
+                    expected: true
+                },
+                {
+                    name: "Defaults to enumerable",
+                    result: Object.getOwnPropertyDescriptor(window, 'name').enumerable,
+                    expected: true
                 }
             ]
         });

--- a/injected/integration-test/test-pages/api-manipulation/pages/apis.html
+++ b/injected/integration-test/test-pages/api-manipulation/pages/apis.html
@@ -27,6 +27,7 @@
                 },
             ];
         });
+
         test('Existing API modified', async () => {
             return [
                 {
@@ -55,6 +56,37 @@
                     expected: true
                 }
             ]
+        });
+
+
+        test('Validate all expected APIs can be removed', async () => {
+            // These APIs might not exist in all browsers however we should ensure they are removed after the code runs
+            const result = []
+            const APIs = [
+                navigator.joinAdInterestGroup,
+                navigator.leaveAdInterestGroup,
+                navigator.clearOriginJoinedAdInterestGroups,
+                navigator.updateAdInterestGroups,
+                navigator.createAuctionNonce,
+                navigator.runAdAuction,
+                navigator.adAuctionComponents,
+                navigator.deprecatedURNToURL,
+                navigator.deprecatedReplaceInURN,
+                navigator.getInterestGroupAdAuctionData,
+                navigator.createAdRequest,
+                navigator.finalizeAd,
+                navigator.canLoadAdAuctionFencedFrame,
+                navigator.deprecatedRunAdAuctionEnforcesKAnonymity,
+                navigator.protectedAudience,
+            ]
+            APIs.forEach(api => {
+                result.push({
+                    name: `API ${api} removed`,
+                    result: api,
+                    expected: undefined
+                });
+            });
+            return result;
         });
 
         // eslint-disable-next-line no-undef

--- a/injected/integration-test/test-pages/api-manipulation/pages/apis.html
+++ b/injected/integration-test/test-pages/api-manipulation/pages/apis.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width">
+  <title>Webcompat shims</title>
+  <link rel="stylesheet" href="../../shared/style.css">
+</head>
+<body>
+    <script src="../../shared/utils.js"></script>
+    <p><a href="../index.html">[Webcompat shims]</a></p>
+
+    <p>This page verifies that APIs get modified</p>
+
+    <script>
+        test('Test APIs modified', async () => {
+            return [
+                {
+                    name: "APIs modified",
+                    result: navigator.hardwareConcurrency,
+                    expected: 222
+                }
+            ]
+        });
+
+        // eslint-disable-next-line no-undef
+        renderResults();
+    </script>
+</body>
+</html>

--- a/injected/src/captured-globals.js
+++ b/injected/src/captured-globals.js
@@ -13,3 +13,4 @@ export const Proxy = globalThis.Proxy;
 export const functionToString = Function.prototype.toString;
 export const TypeError = globalThis.TypeError;
 export const Symbol = globalThis.Symbol;
+export const hasOwnProperty = Object.prototype.hasOwnProperty;

--- a/injected/src/features.js
+++ b/injected/src/features.js
@@ -12,7 +12,7 @@ export const baseFeatures = /** @type {const} */ ([
     'elementHiding',
     'exceptionHandler',
     'apiManipulation',
-])
+]);
 
 const otherFeatures = /** @type {const} */ ([
     'clickToLoad',

--- a/injected/src/features.js
+++ b/injected/src/features.js
@@ -11,7 +11,8 @@ export const baseFeatures = /** @type {const} */ ([
     'navigatorInterface',
     'elementHiding',
     'exceptionHandler',
-]);
+    'apiManipulation',
+])
 
 const otherFeatures = /** @type {const} */ ([
     'clickToLoad',

--- a/injected/src/features/api-manipulation.js
+++ b/injected/src/features/api-manipulation.js
@@ -100,8 +100,9 @@ export default class ApiManipulation extends ContentFeature {
         if (getterValue) {
             this.wrapProperty(api, key, {
                 get: () => processAttr(getterValue, undefined),
-                enumerable: change.enumerable ?? true,
-                configurable: change.configurable ?? true,
+                // wrapProperty takes care of setting these values to the api[key] default values.
+                enumerable: change.enumerable,
+                configurable: change.configurable,
             });
         }
     }

--- a/injected/src/features/api-manipulation.js
+++ b/injected/src/features/api-manipulation.js
@@ -85,7 +85,7 @@ export default class ApiManipulation extends ContentFeature {
      */
     removeApiMethod(api, key) {
         try {
-            if (key in api) {
+            if (Object.prototype.hasOwnProperty.call(api, key)) {
                 delete api[key];
             }
         } catch (e) {}

--- a/injected/src/features/api-manipulation.js
+++ b/injected/src/features/api-manipulation.js
@@ -5,6 +5,8 @@
  * @module API manipulation
  */
 import ContentFeature from '../content-feature';
+// eslint-disable-next-line no-redeclare
+import { hasOwnProperty } from '../captured-globals';
 import { processAttr } from '../utils';
 
 /**
@@ -85,7 +87,7 @@ export default class ApiManipulation extends ContentFeature {
      */
     removeApiMethod(api, key) {
         try {
-            if (Object.prototype.hasOwnProperty.call(api, key)) {
+            if (hasOwnProperty.call(api, key)) {
                 delete api[key];
             }
         } catch (e) {}

--- a/injected/src/features/api-manipulation.js
+++ b/injected/src/features/api-manipulation.js
@@ -3,16 +3,13 @@ import { processAttr } from '../utils'
 
 export default class ApiManipulation extends ContentFeature {
     init () {
-        console.log('ApiManipulation.init()')
         const apiChanges = this.getFeatureSetting('apiChanges')
         if (apiChanges) {
             for (const scope in apiChanges) {
                 const change = apiChanges[scope]
-                console.log('ApiManipulation.init() scope:', scope, 'change:', change)
                 if (!this.checkIsValidAPIChange(change)) {
                     continue
                 }
-                console.log('ApiManipulation.init() valid scope:', scope, 'change:', change)
                 this.applyApiChange(scope, change)
             }
         }
@@ -80,11 +77,11 @@ export default class ApiManipulation extends ContentFeature {
      * @param {string} key
      */
     removeApiMethod (api, key) {
-        if (api[key]) {
-            try {
+        try {
+            if (key in api) {
                 delete api[key]
-            } catch (e) {
             }
+        } catch (e) {
         }
     }
 
@@ -96,8 +93,7 @@ export default class ApiManipulation extends ContentFeature {
      */
     wrapPropertyValue (api, key, change) {
         this.wrapProperty(api, key, {
-            value: processAttr(change.value, undefined),
-            writable: change.writable || false,
+            get: () => processAttr(change.value, undefined),
             enumerable: change.enumerable || false,
             configurable: change.configurable || false
         })

--- a/injected/src/features/api-manipulation.js
+++ b/injected/src/features/api-manipulation.js
@@ -103,10 +103,10 @@ export default class ApiManipulation extends ContentFeature {
             const descriptor = {
                 get: () => processAttr(getterValue, undefined),
             };
-            if (change.enumerable) {
+            if ('enumerable' in change) {
                 descriptor.enumerable = change.enumerable;
             }
-            if (change.configurable) {
+            if ('configurable' in change) {
                 descriptor.configurable = change.configurable;
             }
             this.wrapProperty(api, key, descriptor);

--- a/injected/src/features/api-manipulation.js
+++ b/injected/src/features/api-manipulation.js
@@ -27,17 +27,14 @@ export default class ApiManipulation extends ContentFeature {
         if (change.type === 'remove') {
             return true;
         }
-        if (change.type === 'wrapPropertyValue') {
-            if (change.writable && typeof change.writable !== 'boolean') {
-                return false;
-            }
+        if (change.type === 'descriptor') {
             if (change.enumerable && typeof change.enumerable !== 'boolean') {
                 return false;
             }
             if (change.configurable && typeof change.configurable !== 'boolean') {
                 return false;
             }
-            return typeof change.value !== 'undefined';
+            return typeof change.getterValue !== 'undefined';
         }
         return false;
     }
@@ -45,9 +42,8 @@ export default class ApiManipulation extends ContentFeature {
     // TODO move this to schema definition imported from the privacy-config
     /**
      * @typedef {Object} APIChange
-     * @property {"remove"|"wrapPropertyValue"} type
-     * @property {any} [value] - The value to set.
-     * @property {boolean} [writable] - Whether the property is writable.
+     * @property {"remove"|"descriptor"} type
+     * @property {any} [getterValue] - The value returned from a getter.
      * @property {boolean} [enumerable] - Whether the property is enumerable.
      * @property {boolean} [configurable] - Whether the property is configurable.
      */
@@ -66,8 +62,8 @@ export default class ApiManipulation extends ContentFeature {
         const [obj, key] = response;
         if (change.type === 'remove') {
             this.removeApiMethod(obj, key);
-        } else if (change.type === 'wrapPropertyValue') {
-            this.wrapPropertyValue(obj, key, change);
+        } else if (change.type === 'descriptor') {
+            this.wrapApiDescriptor(obj, key, change);
         }
     }
 
@@ -85,14 +81,14 @@ export default class ApiManipulation extends ContentFeature {
     }
 
     /**
-     * Wraps a property value with a value.
+     * Wraps a property with descriptor.
      * @param {object} api
      * @param {string} key
      * @param {APIChange} change
      */
-    wrapPropertyValue(api, key, change) {
+    wrapApiDescriptor(api, key, change) {
         this.wrapProperty(api, key, {
-            get: () => processAttr(change.value, undefined),
+            get: () => processAttr(change.getterValue, undefined),
             enumerable: change.enumerable || false,
             configurable: change.configurable || false,
         });

--- a/injected/src/features/api-manipulation.js
+++ b/injected/src/features/api-manipulation.js
@@ -1,16 +1,16 @@
-import ContentFeature from '../content-feature'
-import { processAttr } from '../utils'
+import ContentFeature from '../content-feature';
+import { processAttr } from '../utils';
 
 export default class ApiManipulation extends ContentFeature {
-    init () {
-        const apiChanges = this.getFeatureSetting('apiChanges')
+    init() {
+        const apiChanges = this.getFeatureSetting('apiChanges');
         if (apiChanges) {
             for (const scope in apiChanges) {
-                const change = apiChanges[scope]
+                const change = apiChanges[scope];
                 if (!this.checkIsValidAPIChange(change)) {
-                    continue
+                    continue;
                 }
-                this.applyApiChange(scope, change)
+                this.applyApiChange(scope, change);
             }
         }
     }
@@ -20,26 +20,26 @@ export default class ApiManipulation extends ContentFeature {
      * @param {any} change
      * @returns {change is APIChange}
      */
-    checkIsValidAPIChange (change) {
+    checkIsValidAPIChange(change) {
         if (typeof change !== 'object') {
-            return false
+            return false;
         }
         if (change.type === 'remove') {
-            return true
+            return true;
         }
         if (change.type === 'wrapPropertyValue') {
             if (change.writable && typeof change.writable !== 'boolean') {
-                return false
+                return false;
             }
             if (change.enumerable && typeof change.enumerable !== 'boolean') {
-                return false
+                return false;
             }
             if (change.configurable && typeof change.configurable !== 'boolean') {
-                return false
+                return false;
             }
-            return typeof change.value !== 'undefined'
+            return typeof change.value !== 'undefined';
         }
-        return false
+        return false;
     }
 
     // TODO move this to schema definition imported from the privacy-config
@@ -58,16 +58,16 @@ export default class ApiManipulation extends ContentFeature {
      * @param {APIChange} change
      * @returns {void}
      */
-    applyApiChange (scope, change) {
-        const response = this.getGlobalObject(scope)
+    applyApiChange(scope, change) {
+        const response = this.getGlobalObject(scope);
         if (!response) {
-            return
+            return;
         }
-        const [obj, key] = response
+        const [obj, key] = response;
         if (change.type === 'remove') {
-            this.removeApiMethod(obj, key)
+            this.removeApiMethod(obj, key);
         } else if (change.type === 'wrapPropertyValue') {
-            this.wrapPropertyValue(obj, key, change)
+            this.wrapPropertyValue(obj, key, change);
         }
     }
 
@@ -76,13 +76,12 @@ export default class ApiManipulation extends ContentFeature {
      * @param {object} api
      * @param {string} key
      */
-    removeApiMethod (api, key) {
+    removeApiMethod(api, key) {
         try {
             if (key in api) {
-                delete api[key]
+                delete api[key];
             }
-        } catch (e) {
-        }
+        } catch (e) {}
     }
 
     /**
@@ -91,12 +90,12 @@ export default class ApiManipulation extends ContentFeature {
      * @param {string} key
      * @param {APIChange} change
      */
-    wrapPropertyValue (api, key, change) {
+    wrapPropertyValue(api, key, change) {
         this.wrapProperty(api, key, {
             get: () => processAttr(change.value, undefined),
             enumerable: change.enumerable || false,
-            configurable: change.configurable || false
-        })
+            configurable: change.configurable || false,
+        });
     }
 
     /**
@@ -104,20 +103,20 @@ export default class ApiManipulation extends ContentFeature {
      * @param {string} scope the scope of the object to get to.
      * @returns {[object, string]|null} the object at the scope.
      */
-    getGlobalObject (scope) {
-        const parts = scope.split('.')
+    getGlobalObject(scope) {
+        const parts = scope.split('.');
         // get the last part of the scope
-        const lastPart = parts.pop()
+        const lastPart = parts.pop();
         if (!lastPart) {
-            return null
+            return null;
         }
-        let obj = window
+        let obj = window;
         for (const part of parts) {
-            obj = obj[part]
+            obj = obj[part];
             if (!obj) {
-                return null
+                return null;
             }
         }
-        return [obj, lastPart]
+        return [obj, lastPart];
     }
 }

--- a/injected/src/features/api-manipulation.js
+++ b/injected/src/features/api-manipulation.js
@@ -52,7 +52,7 @@ export default class ApiManipulation extends ContentFeature {
     /**
      * @typedef {Object} APIChange
      * @property {"remove"|"descriptor"} type
-     * @property {any} [getterValue] - The value returned from a getter.
+     * @property {import('../utils.js').ConfigSetting} [getterValue] - The value returned from a getter.
      * @property {boolean} [enumerable] - Whether the property is enumerable.
      * @property {boolean} [configurable] - Whether the property is configurable.
      */
@@ -96,11 +96,14 @@ export default class ApiManipulation extends ContentFeature {
      * @param {APIChange} change
      */
     wrapApiDescriptor(api, key, change) {
-        this.wrapProperty(api, key, {
-            get: () => processAttr(change.getterValue, undefined),
-            enumerable: change.enumerable || true,
-            configurable: change.configurable || true,
-        });
+        const getterValue = change.getterValue;
+        if (getterValue) {
+            this.wrapProperty(api, key, {
+                get: () => processAttr(getterValue, undefined),
+                enumerable: change.enumerable ?? true,
+                configurable: change.configurable ?? true,
+            });
+        }
     }
 
     /**

--- a/injected/src/features/api-manipulation.js
+++ b/injected/src/features/api-manipulation.js
@@ -1,6 +1,15 @@
+/**
+ * This feature allows remote configuration of APIs that exist within the DOM.
+ * We support removal of APIs and returning different values from getters.
+ *
+ * @module API manipulation
+ */
 import ContentFeature from '../content-feature';
 import { processAttr } from '../utils';
 
+/**
+ * @internal
+ */
 export default class ApiManipulation extends ContentFeature {
     init() {
         const apiChanges = this.getFeatureSetting('apiChanges');
@@ -89,8 +98,8 @@ export default class ApiManipulation extends ContentFeature {
     wrapApiDescriptor(api, key, change) {
         this.wrapProperty(api, key, {
             get: () => processAttr(change.getterValue, undefined),
-            enumerable: change.enumerable || false,
-            configurable: change.configurable || false,
+            enumerable: change.enumerable || true,
+            configurable: change.configurable || true,
         });
     }
 

--- a/injected/src/features/api-manipulation.js
+++ b/injected/src/features/api-manipulation.js
@@ -98,12 +98,16 @@ export default class ApiManipulation extends ContentFeature {
     wrapApiDescriptor(api, key, change) {
         const getterValue = change.getterValue;
         if (getterValue) {
-            this.wrapProperty(api, key, {
+            const descriptor = {
                 get: () => processAttr(getterValue, undefined),
-                // wrapProperty takes care of setting these values to the api[key] default values.
-                enumerable: change.enumerable,
-                configurable: change.configurable,
-            });
+            };
+            if (change.enumerable) {
+                descriptor.enumerable = change.enumerable;
+            }
+            if (change.configurable) {
+                descriptor.configurable = change.configurable;
+            }
+            this.wrapProperty(api, key, descriptor);
         }
     }
 

--- a/injected/src/features/api-manipulation.js
+++ b/injected/src/features/api-manipulation.js
@@ -49,6 +49,8 @@ export default class ApiManipulation extends ContentFeature {
     }
 
     // TODO move this to schema definition imported from the privacy-config
+    // Additionally remove checkIsValidAPIChange when this change happens.
+    // See: https://app.asana.com/0/1201614831475344/1208715421518231/f
     /**
      * @typedef {Object} APIChange
      * @property {"remove"|"descriptor"} type

--- a/injected/src/utils.js
+++ b/injected/src/utils.js
@@ -259,7 +259,7 @@ function isAppleSilicon() {
  * If a value contains a criteria that is a match for this environment then return that value.
  * Otherwise return the first value that doesn't have a criteria.
  *
- * @param {*[]} configSetting - Config setting which should contain a list of possible values
+ * @param {ConfigSetting[]} configSetting - Config setting which should contain a list of possible values
  * @returns {*|undefined} - The value from the list that best matches the criteria in the config
  */
 function processAttrByCriteria(configSetting) {
@@ -290,8 +290,17 @@ const functionMap = {
 };
 
 /**
+ * @typedef {object} ConfigSetting
+ * @property {'undefined' | 'number' | 'string' | 'function' | 'boolean' | 'null' | 'array' | 'object'} type
+ * @property {string} [functionName]
+ * @property {boolean | string | number} value
+ * @property {object} [criteria]
+ * @property {string} criteria.arch
+ */
+
+/**
  * Processes a structured config setting and returns the value according to its type
- * @param {*} configSetting
+ * @param {ConfigSetting} configSetting
  * @param {*} [defaultValue]
  * @returns
  */
@@ -324,6 +333,7 @@ export function processAttr(configSetting, defaultValue) {
                 return undefined;
             }
 
+            // All JSON expressable types are handled here
             return configSetting.value;
         default:
             return defaultValue;

--- a/injected/unit-test/features.js
+++ b/injected/unit-test/features.js
@@ -17,6 +17,7 @@ describe('Features definition', () => {
             'navigatorInterface',
             'elementHiding',
             'exceptionHandler',
+            'apiManipulation',
         ]);
     });
 });

--- a/typedoc.js
+++ b/typedoc.js
@@ -10,6 +10,7 @@ const config = {
         'injected/entry-points/mozilla.js',
         'injected/entry-points/windows.js',
         'injected/src/types/*.ts',
+        'injected/src/features/api-manipulation.js',
         'injected/src/features/duck-player.js',
         'injected/src/features/duckplayer/thumbnails.js',
         'injected/src/features/duckplayer/video-overlay.js',


### PR DESCRIPTION
**Asana Task/Github Issue:**  https://app.asana.com/0/481882893211075/1208706976317187/f

## Description

Adding the ability to modify DOM apis remotely through the config.

## Testing Steps

This is draft currently however the manual steps I've been taking are:
- Building the extension with `npm build`
- Then loading the extension with:
    - `web-ext run -s integration-test/extension/ -t chromium`
- Opening example.com and validating the APIs have been modified as expected based on: `injected/entry-points/integration.js`

**Note:** My expectation is to move all these modifications into a test and out of the sample extension so keep a track of that sample config changing for the test.

## Checklist

<!--
  These questions are a friendly reminder to shipping code, if you're uncertain ask the AoR owners.
  It's also totally appropriate to not check some of these boxes, if they don't apply to your change.
-->
*Please tick all that apply:*

- [ ] I have tested this change locally
- [ ] I have tested this change locally in all supported browsers
- [ ] This change will be visible to users
- [ ] I have added automated tests that cover this change
- [ ] I have ensured the change is gated by config
- [ ] This change was covered by a ship review
- [ ] This change was covered by a tech design
- [ ] Any dependent config has been merged

