### PR TITLE
Switch to using ts direct from privacy config

### DIFF
--- a/injected/package.json
+++ b/injected/package.json
@@ -38,6 +38,7 @@
   },
   "devDependencies": {
     "@canvas/image-data": "^1.0.0",
+    "@duckduckgo/privacy-configuration": "github:duckduckgo/privacy-configuration#main",
     "@fingerprintjs/fingerprintjs": "^4.5.1",
     "@rollup/plugin-commonjs": "^28.0.1",
     "@rollup/plugin-node-resolve": "^15.3.0",
@@ -46,7 +47,6 @@
     "@types/jasmine": "^5.1.4",
     "@types/node": "^22.8.7",
     "@typescript-eslint/eslint-plugin": "^6.9.1",
-    "@duckduckgo/privacy-configuration": "github:duckduckgo/privacy-configuration#1729260354597",
     "fast-check": "^3.23.1",
     "jasmine": "^5.4.0",
     "minimist": "^1.2.8",

--- a/injected/package.json
+++ b/injected/package.json
@@ -46,7 +46,7 @@
     "@types/jasmine": "^5.1.4",
     "@types/node": "^22.8.7",
     "@typescript-eslint/eslint-plugin": "^6.9.1",
-    "config-builder": "github:duckduckgo/privacy-configuration#1729260354597",
+    "@duckduckgo/privacy-configuration": "github:duckduckgo/privacy-configuration#1729260354597",
     "fast-check": "^3.23.1",
     "jasmine": "^5.4.0",
     "minimist": "^1.2.8",

--- a/injected/scripts/bundleTrackers.mjs
+++ b/injected/scripts/bundleTrackers.mjs
@@ -4,6 +4,10 @@ import { parseArgs, write } from '../../scripts/script-utils.js';
 
 const tdsUrl = 'https://staticcdn.duckduckgo.com/trackerblocking/v4/tds.json';
 const resp = await fetch(tdsUrl);
+/**
+ * Ignore 'unknown' type for now.
+ * @type any
+ */
 const tds = await resp.json();
 
 // Build a trie of tracker domains, starting with the broadest subdomain. Leaves are set to 1 to indicate success

--- a/injected/scripts/types.mjs
+++ b/injected/scripts/types.mjs
@@ -1,13 +1,8 @@
 import { cwd, isLaunchFile } from '../../scripts/script-utils.js';
-import { dirname, join } from 'node:path';
-import { createRequire } from 'node:module';
+import { join } from 'node:path';
 import { buildTypes } from '../../types-generator/build-types.mjs';
 
 const injectRoot = join(cwd(import.meta.url), '..');
-
-// eslint-disable-next-line no-redeclare
-const require = createRequire(import.meta.url);
-const configBuilderRoot = dirname(require.resolve('config-builder'));
 
 /** @type {Record<string, import('../../types-generator/build-types.mjs').Mapping>} */
 const injectSchemaMapping = {
@@ -16,20 +11,6 @@ const injectSchemaMapping = {
      *  - `schema` should be an absolute path to a valid JSON Schema document
      *  - `types` should be an absolute path to the output file
      */
-    'Webcompat Settings': {
-        schema: join(configBuilderRoot, 'tests/schemas/webcompat-settings.json'),
-        types: join(injectRoot, 'src/types/webcompat-settings.d.ts'),
-        // todo: fix this on windows.
-        exclude: process.platform === 'win32',
-        kind: 'settings',
-    },
-    'Duckplayer Settings': {
-        schema: join(configBuilderRoot, 'tests/schemas/duckplayer-settings.json'),
-        types: join(injectRoot, 'src/types/duckplayer-settings.d.ts'),
-        // todo: fix this on windows.
-        exclude: process.platform === 'win32',
-        kind: 'settings',
-    },
     'Schema Messages': {
         schemaDir: join(injectRoot, 'src/messages'),
         typesDir: join(injectRoot, 'src/types'),

--- a/injected/src/features/duck-player.js
+++ b/injected/src/features/duck-player.js
@@ -67,7 +67,7 @@ export default class DuckPlayerFeature extends ContentFeature {
 
         /**
          * Just the 'overlays' part of the settings object.
-         * @type {import("../types/duckplayer-settings.js").DuckPlayerSettings['overlays']}
+         * @type {import("@duckduckgo/privacy-configuration/schema/features/duckplayer").DuckPlayerSettings['overlays']}
          */
         const overlaySettings = this.getFeatureSetting('overlays');
         const overlaysEnabled = overlaySettings?.youtube?.state === 'enabled';
@@ -114,7 +114,7 @@ export default class DuckPlayerFeature extends ContentFeature {
 }
 
 /**
- * @typedef {Omit<import("../types/duckplayer-settings").YouTubeOverlay, "state">} OverlaysFeatureSettings
+ * @typedef {Omit<import("@duckduckgo/privacy-configuration/schema/features/duckplayer").DuckPlayerSettings['overlays']['youtube'], "state">} OverlaysFeatureSettings
  */
 
 // for docs generation

--- a/injected/src/features/web-compat.js
+++ b/injected/src/features/web-compat.js
@@ -571,7 +571,7 @@ export class WebCompat extends ContentFeature {
      * Support for modifying localStorage entries
      */
     modifyLocalStorage() {
-        /** @type {import('../types//webcompat-settings').WebCompatSettings['modifyLocalStorage']} */
+        /** @type {import('@duckduckgo/privacy-configuration/schema/features/webcompat').WebCompatSettings['modifyLocalStorage']} */
         const settings = this.getFeatureSetting('modifyLocalStorage');
 
         if (!settings || !settings.changes) return;
@@ -587,7 +587,7 @@ export class WebCompat extends ContentFeature {
      * Support for proxying `window.webkit.messageHandlers`
      */
     messageHandlersFix() {
-        /** @type {import('../types//webcompat-settings').WebCompatSettings['messageHandlers']} */
+        /** @type {import('@duckduckgo/privacy-configuration/schema/features/webcompat').WebCompatSettings['messageHandlers']} */
         const settings = this.getFeatureSetting('messageHandlers');
 
         // Do nothing if `messageHandlers` is absent

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,7 @@
       },
       "devDependencies": {
         "@canvas/image-data": "^1.0.0",
-        "@duckduckgo/privacy-configuration": "github:duckduckgo/privacy-configuration#1729260354597",
+        "@duckduckgo/privacy-configuration": "github:duckduckgo/privacy-configuration#main",
         "@fingerprintjs/fingerprintjs": "^4.5.1",
         "@rollup/plugin-commonjs": "^28.0.1",
         "@rollup/plugin-node-resolve": "^15.3.0",
@@ -53,6 +53,16 @@
         "rollup": "^4.24.4",
         "rollup-plugin-import-css": "^3.5.6",
         "rollup-plugin-svg-import": "^3.0.0"
+      }
+    },
+    "injected/node_modules/@duckduckgo/privacy-configuration": {
+      "version": "1.0.0",
+      "resolved": "git+ssh://git@github.com/duckduckgo/privacy-configuration.git#85e0456d121473e4ece926a656792a5faf3f026e",
+      "dev": true,
+      "license": "Apache 2.0",
+      "dependencies": {
+        "node-fetch": "^3.3.2",
+        "tldts": "^6.1.52"
       }
     },
     "injected/node_modules/@eslint/js": {
@@ -250,6 +260,24 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "injected/node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "dev": true,
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
       }
     },
     "messaging": {
@@ -549,36 +577,6 @@
     "node_modules/@duckduckgo/messaging": {
       "resolved": "messaging",
       "link": true
-    },
-    "node_modules/@duckduckgo/privacy-configuration": {
-      "name": "config-builder",
-      "version": "1.0.0",
-      "resolved": "git+ssh://git@github.com/duckduckgo/privacy-configuration.git#207bcafcd8d67d0530569f7efcf84463194b999b",
-      "dev": true,
-      "license": "Apache 2.0",
-      "dependencies": {
-        "node-fetch": "^3.3.2",
-        "tldts": "^6.1.52"
-      }
-    },
-    "node_modules/@duckduckgo/privacy-configuration/node_modules/node-fetch": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
-      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "data-uri-to-buffer": "^4.0.0",
-        "fetch-blob": "^3.1.4",
-        "formdata-polyfill": "^4.0.10"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/node-fetch"
-      }
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.24.0",
@@ -8440,28 +8438,6 @@
     "@duckduckgo/messaging": {
       "version": "file:messaging"
     },
-    "@duckduckgo/privacy-configuration": {
-      "version": "git+ssh://git@github.com/duckduckgo/privacy-configuration.git#207bcafcd8d67d0530569f7efcf84463194b999b",
-      "dev": true,
-      "from": "@duckduckgo/privacy-configuration@github:duckduckgo/privacy-configuration#1729260354597",
-      "requires": {
-        "node-fetch": "^3.3.2",
-        "tldts": "^6.1.52"
-      },
-      "dependencies": {
-        "node-fetch": {
-          "version": "3.3.2",
-          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
-          "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
-          "dev": true,
-          "requires": {
-            "data-uri-to-buffer": "^4.0.0",
-            "fetch-blob": "^3.1.4",
-            "formdata-polyfill": "^4.0.10"
-          }
-        }
-      }
-    },
     "@esbuild/aix-ppc64": {
       "version": "0.24.0",
       "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.24.0.tgz",
@@ -11312,7 +11288,7 @@
       "version": "file:injected",
       "requires": {
         "@canvas/image-data": "^1.0.0",
-        "@duckduckgo/privacy-configuration": "github:duckduckgo/privacy-configuration#1729260354597",
+        "@duckduckgo/privacy-configuration": "github:duckduckgo/privacy-configuration#main",
         "@fingerprintjs/fingerprintjs": "^4.5.1",
         "@rollup/plugin-commonjs": "^28.0.1",
         "@rollup/plugin-node-resolve": "^15.3.0",
@@ -11333,6 +11309,15 @@
         "sjcl": "^1.0.8"
       },
       "dependencies": {
+        "@duckduckgo/privacy-configuration": {
+          "version": "git+ssh://git@github.com/duckduckgo/privacy-configuration.git#85e0456d121473e4ece926a656792a5faf3f026e",
+          "dev": true,
+          "from": "@duckduckgo/privacy-configuration@github:duckduckgo/privacy-configuration#main",
+          "requires": {
+            "node-fetch": "^3.3.2",
+            "tldts": "^6.1.52"
+          }
+        },
         "@eslint/js": {
           "version": "8.57.1",
           "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.57.1.tgz",
@@ -11455,6 +11440,17 @@
           "peer": true,
           "requires": {
             "is-glob": "^4.0.3"
+          }
+        },
+        "node-fetch": {
+          "version": "3.3.2",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+          "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+          "dev": true,
+          "requires": {
+            "data-uri-to-buffer": "^4.0.0",
+            "fetch-blob": "^3.1.4",
+            "formdata-polyfill": "^4.0.10"
           }
         }
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,6 +38,7 @@
       },
       "devDependencies": {
         "@canvas/image-data": "^1.0.0",
+        "@duckduckgo/privacy-configuration": "github:duckduckgo/privacy-configuration#1729260354597",
         "@fingerprintjs/fingerprintjs": "^4.5.1",
         "@rollup/plugin-commonjs": "^28.0.1",
         "@rollup/plugin-node-resolve": "^15.3.0",
@@ -46,7 +47,6 @@
         "@types/jasmine": "^5.1.4",
         "@types/node": "^22.8.7",
         "@typescript-eslint/eslint-plugin": "^6.9.1",
-        "config-builder": "github:duckduckgo/privacy-configuration#1729260354597",
         "fast-check": "^3.23.1",
         "jasmine": "^5.4.0",
         "minimist": "^1.2.8",
@@ -549,6 +549,36 @@
     "node_modules/@duckduckgo/messaging": {
       "resolved": "messaging",
       "link": true
+    },
+    "node_modules/@duckduckgo/privacy-configuration": {
+      "name": "config-builder",
+      "version": "1.0.0",
+      "resolved": "git+ssh://git@github.com/duckduckgo/privacy-configuration.git#207bcafcd8d67d0530569f7efcf84463194b999b",
+      "dev": true,
+      "license": "Apache 2.0",
+      "dependencies": {
+        "node-fetch": "^3.3.2",
+        "tldts": "^6.1.52"
+      }
+    },
+    "node_modules/@duckduckgo/privacy-configuration/node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
+      }
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.24.0",
@@ -2873,43 +2903,6 @@
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true
     },
-    "node_modules/config-builder": {
-      "version": "1.0.0",
-      "resolved": "git+ssh://git@github.com/duckduckgo/privacy-configuration.git#207bcafcd8d67d0530569f7efcf84463194b999b",
-      "dev": true,
-      "license": "Apache 2.0",
-      "dependencies": {
-        "node-fetch": "^3.3.2",
-        "tldts": "^6.1.52"
-      }
-    },
-    "node_modules/config-builder/node_modules/data-uri-to-buffer": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
-      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
-      "dev": true,
-      "engines": {
-        "node": ">= 12"
-      }
-    },
-    "node_modules/config-builder/node_modules/node-fetch": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
-      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
-      "dev": true,
-      "dependencies": {
-        "data-uri-to-buffer": "^4.0.0",
-        "fetch-blob": "^3.1.4",
-        "formdata-polyfill": "^4.0.10"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/node-fetch"
-      }
-    },
     "node_modules/corser": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/corser/-/corser-2.0.1.tgz",
@@ -2995,6 +2988,16 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/data-view-buffer": {
@@ -8437,6 +8440,28 @@
     "@duckduckgo/messaging": {
       "version": "file:messaging"
     },
+    "@duckduckgo/privacy-configuration": {
+      "version": "git+ssh://git@github.com/duckduckgo/privacy-configuration.git#207bcafcd8d67d0530569f7efcf84463194b999b",
+      "dev": true,
+      "from": "@duckduckgo/privacy-configuration@github:duckduckgo/privacy-configuration#1729260354597",
+      "requires": {
+        "node-fetch": "^3.3.2",
+        "tldts": "^6.1.52"
+      },
+      "dependencies": {
+        "node-fetch": {
+          "version": "3.3.2",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+          "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+          "dev": true,
+          "requires": {
+            "data-uri-to-buffer": "^4.0.0",
+            "fetch-blob": "^3.1.4",
+            "formdata-polyfill": "^4.0.10"
+          }
+        }
+      }
+    },
     "@esbuild/aix-ppc64": {
       "version": "0.24.0",
       "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.24.0.tgz",
@@ -9901,34 +9926,6 @@
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true
     },
-    "config-builder": {
-      "version": "git+ssh://git@github.com/duckduckgo/privacy-configuration.git#207bcafcd8d67d0530569f7efcf84463194b999b",
-      "dev": true,
-      "from": "config-builder@github:duckduckgo/privacy-configuration#1729260354597",
-      "requires": {
-        "node-fetch": "^3.3.2",
-        "tldts": "^6.1.52"
-      },
-      "dependencies": {
-        "data-uri-to-buffer": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
-          "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
-          "dev": true
-        },
-        "node-fetch": {
-          "version": "3.3.2",
-          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
-          "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
-          "dev": true,
-          "requires": {
-            "data-uri-to-buffer": "^4.0.0",
-            "fetch-blob": "^3.1.4",
-            "formdata-polyfill": "^4.0.10"
-          }
-        }
-      }
-    },
     "corser": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/corser/-/corser-2.0.1.tgz",
@@ -9978,6 +9975,12 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
       "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
+      "dev": true
+    },
+    "data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
       "dev": true
     },
     "data-view-buffer": {
@@ -11309,6 +11312,7 @@
       "version": "file:injected",
       "requires": {
         "@canvas/image-data": "^1.0.0",
+        "@duckduckgo/privacy-configuration": "github:duckduckgo/privacy-configuration#1729260354597",
         "@fingerprintjs/fingerprintjs": "^4.5.1",
         "@rollup/plugin-commonjs": "^28.0.1",
         "@rollup/plugin-node-resolve": "^15.3.0",
@@ -11317,7 +11321,6 @@
         "@types/jasmine": "^5.1.4",
         "@types/node": "^22.8.7",
         "@typescript-eslint/eslint-plugin": "^6.9.1",
-        "config-builder": "github:duckduckgo/privacy-configuration#1729260354597",
         "fast-check": "^3.23.1",
         "immutable-json-patch": "^6.0.1",
         "jasmine": "^5.4.0",


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/0/481882893211075/1208516641945153/f

## Description

Switches us over to using the TS from the privacy-configuration repo.

Needs: https://github.com/duckduckgo/privacy-configuration/pull/2444/files and https://github.com/duckduckgo/privacy-configuration/pull/2439

Draft as the config changes still need review, this was to ensure there's no issues on our side.
/cc @sammacbeth  and @shakyShane 

## Testing Steps

- <!-- Include simple steps on how to check this change is working. Write "N/A" if not applicable. -->

## Checklist

<!--
  These questions are a friendly reminder to shipping code, if you're uncertain ask the AoR owners.
  It's also totally appropriate to not check some of these boxes, if they don't apply to your change.
-->
*Please tick all that apply:*

- [ ] I have tested this change locally
- [ ] I have tested this change locally in all supported browsers
- [ ] This change will be visible to users
- [ ] I have added automated tests that cover this change
- [ ] I have ensured the change is gated by config
- [ ] This change was covered by a ship review
- [ ] This change was covered by a tech design
- [ ] Any dependent config has been merged

