### PR TITLE
Fixes skip link position when debugging

### DIFF
--- a/special-pages/pages/onboarding/app/components/App2.js
+++ b/special-pages/pages/onboarding/app/components/App2.js
@@ -67,9 +67,9 @@ export function App2({ children }) {
                         <SingleStep />
                     </BeforeAfterProvider>
                 </ErrorBoundary>
-                {children}
             </div>
             {(step.id === 'welcome' || step.id === 'getStarted') && <Hiker />}
+            {children}
         </main>
     );
 }


### PR DESCRIPTION
## Description

As reported by Jonathan L, skip link for version v3 isn’t working. Turns out it’s nested in the `<main>` element, which places it in the wrong position in the page (red square in image below)

<img width="604" alt="image" src="https://github.com/user-attachments/assets/d9e2e9c2-32cd-4f45-8c43-5d0226072fb8">

## Testing Steps

- Visit the [preview link](https://deploy-preview-1224--content-scope-scripts.netlify.app/build/pages/onboarding/?order=v3) or run locally with query param `?order=v3`
- Open the console
- Click 5 times on the bottom left of the page
- Confirm that a `dismissToAddressBar` notification is dispatched

## Checklist

<!--
  These questions are a friendly reminder to shipping code, if you're uncertain ask the AoR owners.
  It's also totally appropriate to not check some of these boxes, if they don't apply to your change.
-->
*Please tick all that apply:*

- [ ] I have tested this change locally
- [ ] I have tested this change locally in all supported browsers
- [ ] This change will be visible to users
- [ ] I have added automated tests that cover this change
- [ ] I have ensured the change is gated by config
- [ ] This change was covered by a ship review
- [ ] This change was covered by a tech design
- [ ] Any dependent config has been merged

