### PR TITLE
removing test boilerplate

### DIFF
--- a/injected/integration-test/breakage-reporting.spec.js
+++ b/injected/integration-test/breakage-reporting.spec.js
@@ -1,69 +1,35 @@
 import { test, expect } from '@playwright/test';
-import { readFileSync } from 'fs';
-import {
-    mockWindowsMessaging,
-    readOutgoingMessages,
-    simulateSubscriptionMessage,
-    waitForCallCount,
-    wrapWindowsScripts,
-} from '@duckduckgo/messaging/lib/test-utils.mjs';
-import { perPlatform } from './type-helpers.mjs';
+import { ResultsCollector } from './page-objects/results-collector.js';
 
+const HTML = '/breakage-reporting/index.html';
+const CONFIG = './integration-test/test-pages/breakage-reporting/config/config.json';
 test('Breakage Reporting Feature', async ({ page }, testInfo) => {
-    const breakageFeature = BreakageReportingSpec.create(page, testInfo);
-    await breakageFeature.enabled();
+    const collector = ResultsCollector.create(page, testInfo.project.use);
+    await collector.load(HTML, CONFIG);
+
+    const breakageFeature = new BreakageReportingSpec(page);
     await breakageFeature.navigate();
 
-    await page.evaluate(simulateSubscriptionMessage, {
-        messagingContext: {
-            context: 'contentScopeScripts',
-            featureName: 'breakageReporting',
-            env: 'development',
-        },
-        name: 'getBreakageReportValues',
-        payload: {},
-        injectName: breakageFeature.build.name,
-    });
+    await collector.simulateSubscriptionMessage('breakageReporting', 'getBreakageReportValues', {});
+    await collector.waitForMessage('breakageReportResult');
+    const calls = await collector.outgoingMessages();
 
-    await page.waitForFunction(
-        waitForCallCount,
-        {
-            method: 'breakageReportResult',
-            count: 1,
-        },
-        { timeout: 5000, polling: 100 },
-    );
-    const calls = await page.evaluate(readOutgoingMessages);
     expect(calls.length).toBe(1);
-
-    const result = calls[0].payload.params;
-    expect(result.jsPerformance.length).toBe(1);
-    expect(result.jsPerformance[0]).toBeGreaterThan(0);
-    expect(result.referrer).toBe('http://localhost:3220/breakage-reporting/index.html');
+    const result = /** @type {import("@duckduckgo/messaging").NotificationMessage} */ (calls[0].payload);
+    expect(result.params?.jsPerformance.length).toBe(1);
+    expect(result.params?.jsPerformance[0]).toBeGreaterThan(0);
+    expect(result.params?.referrer).toBe('http://localhost:3220/breakage-reporting/index.html');
 });
 
 export class BreakageReportingSpec {
-    htmlPage = '/breakage-reporting/index.html';
-    config = './integration-test/test-pages/breakage-reporting/config/config.json';
     /**
      * @param {import("@playwright/test").Page} page
-     * @param {import("./type-helpers.mjs").Build} build
-     * @param {import("./type-helpers.mjs").PlatformInfo} platform
      */
-    constructor(page, build, platform) {
+    constructor(page) {
         this.page = page;
-        this.build = build;
-        this.platform = platform;
-    }
-
-    async enabled() {
-        const config = JSON.parse(readFileSync(this.config, 'utf8'));
-        await this.setup({ config });
     }
 
     async navigate() {
-        await this.page.goto(this.htmlPage);
-
         await this.page.evaluate(() => {
             window.location.href = '/breakage-reporting/pages/ref.html';
         });
@@ -86,47 +52,5 @@ export class BreakageReportingSpec {
             });
             return response;
         });
-    }
-
-    /**
-     * @param {object} params
-     * @param {Record<string, any>} params.config
-     * @return {Promise<void>}
-     */
-    async setup(params) {
-        const { config } = params;
-
-        // read the built file from disk and do replacements
-        const injectedJS = wrapWindowsScripts(this.build.artifact, {
-            $CONTENT_SCOPE$: config,
-            $USER_UNPROTECTED_DOMAINS$: [],
-            $USER_PREFERENCES$: {
-                platform: { name: 'windows' },
-                debug: true,
-            },
-        });
-
-        await this.page.addInitScript(mockWindowsMessaging, {
-            messagingContext: {
-                env: 'development',
-                context: 'contentScopeScripts',
-                featureName: 'n/a',
-            },
-            responses: {},
-        });
-
-        // attach the JS
-        await this.page.addInitScript(injectedJS);
-    }
-
-    /**
-     * Helper for creating an instance per platform
-     * @param {import("@playwright/test").Page} page
-     * @param {import("@playwright/test").TestInfo} testInfo
-     */
-    static create(page, testInfo) {
-        // Read the configuration object to determine which platform we're testing against
-        const { platformInfo, build } = perPlatform(testInfo.project.use);
-        return new BreakageReportingSpec(page, build, platformInfo);
     }
 }

--- a/injected/integration-test/broker-protection.spec.js
+++ b/injected/integration-test/broker-protection.spec.js
@@ -3,31 +3,31 @@ import { BrokerProtectionPage } from './page-objects/broker-protection.js';
 
 test.describe('Broker Protection communications', () => {
     test('sends an error when the action is not found', async ({ page }, workerInfo) => {
-        const dbp = BrokerProtectionPage.create(page, workerInfo);
+        const dbp = BrokerProtectionPage.create(page, workerInfo.project.use);
         await dbp.enabled();
         await dbp.navigatesTo('form.html');
         await dbp.receivesAction('action-not-found.json');
-        await dbp.waitForMessage('actionError');
+        await dbp.collector.waitForMessage('actionError');
     });
 
     test.describe('Executes invalid action and sends error message', () => {
         test('click element not on page', async ({ page }, workerInfo) => {
-            const dbp = BrokerProtectionPage.create(page, workerInfo);
+            const dbp = BrokerProtectionPage.create(page, workerInfo.project.use);
             await dbp.enabled();
             await dbp.navigatesTo('empty-form.html');
             await dbp.receivesAction('click.json');
-            const response = await dbp.waitForMessage('actionCompleted');
+            const response = await dbp.collector.waitForMessage('actionCompleted');
             dbp.isErrorMessage(response);
         });
     });
 
     test.describe('Profile extraction', () => {
         test('extract', async ({ page, baseURL }, workerInfo) => {
-            const dbp = BrokerProtectionPage.create(page, workerInfo);
+            const dbp = BrokerProtectionPage.create(page, workerInfo.project.use);
             await dbp.enabled();
             await dbp.navigatesTo('results.html');
             await dbp.receivesAction('extract.json');
-            const response = await dbp.waitForMessage('actionCompleted');
+            const response = await dbp.collector.waitForMessage('actionCompleted');
             dbp.isSuccessMessage(response);
             dbp.isExtractMatch(response[0].payload.params.result.success.response, [
                 {
@@ -48,11 +48,11 @@ test.describe('Broker Protection communications', () => {
             dbp.responseContainsMetadata(response[0].payload.params.result.success.meta);
         });
         test('extract with retry', async ({ page, baseURL }, workerInfo) => {
-            const dbp = BrokerProtectionPage.create(page, workerInfo);
+            const dbp = BrokerProtectionPage.create(page, workerInfo.project.use);
             await dbp.enabled();
             await dbp.navigatesTo('results.html?delay=2000');
             await dbp.receivesAction('extract.json');
-            const response = await dbp.waitForMessage('actionCompleted');
+            const response = await dbp.collector.waitForMessage('actionCompleted');
             dbp.isSuccessMessage(response);
             dbp.isExtractMatch(response[0].payload.params.result.success.response, [
                 {
@@ -74,11 +74,11 @@ test.describe('Broker Protection communications', () => {
         });
 
         test('extract multiple profiles', async ({ page, baseURL }, workerInfo) => {
-            const dbp = BrokerProtectionPage.create(page, workerInfo);
+            const dbp = BrokerProtectionPage.create(page, workerInfo.project.use);
             await dbp.enabled();
             await dbp.navigatesTo('results-multiple.html');
             await dbp.receivesAction('extract2.json');
-            const response = await dbp.waitForMessage('actionCompleted');
+            const response = await dbp.collector.waitForMessage('actionCompleted');
             dbp.isSuccessMessage(response);
             dbp.isExtractMatch(response[0].payload.params.result.success.response, [
                 {
@@ -132,11 +132,11 @@ test.describe('Broker Protection communications', () => {
         });
 
         test('extract profiles test 3', async ({ page, baseURL }, workerInfo) => {
-            const dbp = BrokerProtectionPage.create(page, workerInfo);
+            const dbp = BrokerProtectionPage.create(page, workerInfo.project.use);
             await dbp.enabled();
             await dbp.navigatesTo('results-alt.html');
             await dbp.receivesAction('extract3.json');
-            const response = await dbp.waitForMessage('actionCompleted');
+            const response = await dbp.collector.waitForMessage('actionCompleted');
             dbp.isSuccessMessage(response);
             dbp.isExtractMatch(response[0].payload.params.result.success.response, [
                 {
@@ -161,11 +161,11 @@ test.describe('Broker Protection communications', () => {
         });
 
         test('extract profiles test 4', async ({ page, baseURL }, workerInfo) => {
-            const dbp = BrokerProtectionPage.create(page, workerInfo);
+            const dbp = BrokerProtectionPage.create(page, workerInfo.project.use);
             await dbp.enabled();
             await dbp.navigatesTo('results-4.html');
             await dbp.receivesAction('extract4.json');
-            const response = await dbp.waitForMessage('actionCompleted');
+            const response = await dbp.collector.waitForMessage('actionCompleted');
             dbp.isSuccessMessage(response);
             dbp.isExtractMatch(response[0].payload.params.result.success.response, [
                 {
@@ -184,11 +184,11 @@ test.describe('Broker Protection communications', () => {
         });
 
         test('extract profiles test 5', async ({ page, baseURL }, workerInfo) => {
-            const dbp = BrokerProtectionPage.create(page, workerInfo);
+            const dbp = BrokerProtectionPage.create(page, workerInfo.project.use);
             await dbp.enabled();
             await dbp.navigatesTo('results-5.html');
             await dbp.receivesAction('extract5.json');
-            const response = await dbp.waitForMessage('actionCompleted');
+            const response = await dbp.collector.waitForMessage('actionCompleted');
             dbp.isSuccessMessage(response);
             dbp.isExtractMatch(response[0].payload.params.result.success.response, [
                 {
@@ -210,11 +210,11 @@ test.describe('Broker Protection communications', () => {
         });
 
         test('extract profile from irregular HTML 1', async ({ page, baseURL }, workerInfo) => {
-            const dbp = BrokerProtectionPage.create(page, workerInfo);
+            const dbp = BrokerProtectionPage.create(page, workerInfo.project.use);
             await dbp.enabled();
             await dbp.navigatesTo('results-irregular1.html');
             await dbp.receivesAction('extract-irregular1.json');
-            const response = await dbp.waitForMessage('actionCompleted');
+            const response = await dbp.collector.waitForMessage('actionCompleted');
             dbp.isSuccessMessage(response);
             dbp.isExtractMatch(response[0].payload.params.result.success.response, [
                 {
@@ -234,11 +234,11 @@ test.describe('Broker Protection communications', () => {
         });
 
         test('extract profile from irregular HTML 2', async ({ page, baseURL }, workerInfo) => {
-            const dbp = BrokerProtectionPage.create(page, workerInfo);
+            const dbp = BrokerProtectionPage.create(page, workerInfo.project.use);
             await dbp.enabled();
             await dbp.navigatesTo('results-irregular2.html');
             await dbp.receivesAction('extract-irregular2.json');
-            const response = await dbp.waitForMessage('actionCompleted');
+            const response = await dbp.collector.waitForMessage('actionCompleted');
             dbp.isSuccessMessage(response);
             dbp.isExtractMatch(response[0].payload.params.result.success.response, [
                 {
@@ -259,11 +259,11 @@ test.describe('Broker Protection communications', () => {
         });
 
         test('extract profile from irregular HTML 3', async ({ page, baseURL }, workerInfo) => {
-            const dbp = BrokerProtectionPage.create(page, workerInfo);
+            const dbp = BrokerProtectionPage.create(page, workerInfo.project.use);
             await dbp.enabled();
             await dbp.navigatesTo('results-irregular3.html');
             await dbp.receivesAction('extract-irregular3.json');
-            const response = await dbp.waitForMessage('actionCompleted');
+            const response = await dbp.collector.waitForMessage('actionCompleted');
             dbp.isSuccessMessage(response);
             dbp.isExtractMatch(response[0].payload.params.result.success.response, [
                 {
@@ -285,11 +285,11 @@ test.describe('Broker Protection communications', () => {
         });
 
         test('extracts profile and generates id', async ({ page }, workerInfo) => {
-            const dbp = BrokerProtectionPage.create(page, workerInfo);
+            const dbp = BrokerProtectionPage.create(page, workerInfo.project.use);
             await dbp.enabled();
             await dbp.navigatesTo('results.html');
             await dbp.receivesAction('extract-generate-id.json');
-            const response = await dbp.waitForMessage('actionCompleted');
+            const response = await dbp.collector.waitForMessage('actionCompleted');
             dbp.isSuccessMessage(response);
             dbp.isExtractMatch(response[0].payload.params.result.success.response, [
                 {
@@ -312,11 +312,11 @@ test.describe('Broker Protection communications', () => {
         test('returns an empty array when no profile selector matches but the no results selector is present', async ({
             page,
         }, workerInfo) => {
-            const dbp = BrokerProtectionPage.create(page, workerInfo);
+            const dbp = BrokerProtectionPage.create(page, workerInfo.project.use);
             await dbp.enabled();
             await dbp.navigatesTo('results-not-found.html');
             await dbp.receivesAction('results-not-found-valid.json');
-            const response = await dbp.waitForMessage('actionCompleted');
+            const response = await dbp.collector.waitForMessage('actionCompleted');
             dbp.isSuccessMessage(response);
             dbp.isExtractMatch(response[0].payload.params.result.success.response, []);
         });
@@ -324,128 +324,128 @@ test.describe('Broker Protection communications', () => {
         test('returns an error when no profile selector matches and the no results selector is not present', async ({
             page,
         }, workerInfo) => {
-            const dbp = BrokerProtectionPage.create(page, workerInfo);
+            const dbp = BrokerProtectionPage.create(page, workerInfo.project.use);
             await dbp.enabled();
             await dbp.navigatesTo('results.html');
             await dbp.receivesAction('results-not-found-invalid.json');
-            const response = await dbp.waitForMessage('actionCompleted');
+            const response = await dbp.collector.waitForMessage('actionCompleted');
             dbp.isErrorMessage(response);
         });
     });
     test.describe('Executes action and sends success message', () => {
         test('buildUrl', async ({ page }, workerInfo) => {
-            const dbp = BrokerProtectionPage.create(page, workerInfo);
+            const dbp = BrokerProtectionPage.create(page, workerInfo.project.use);
             await dbp.enabled();
             await dbp.navigatesTo('results.html');
             await dbp.receivesAction('navigate.json');
-            const response = await dbp.waitForMessage('actionCompleted');
+            const response = await dbp.collector.waitForMessage('actionCompleted');
             dbp.isSuccessMessage(response);
             dbp.isUrlMatch(response[0].payload.params.result.success.response);
         });
 
         test('fillForm', async ({ page }, workerInfo) => {
-            const dbp = BrokerProtectionPage.create(page, workerInfo);
+            const dbp = BrokerProtectionPage.create(page, workerInfo.project.use);
             await dbp.enabled();
             await dbp.navigatesTo('form.html');
             await dbp.receivesAction('fill-form.json');
-            const response = await dbp.waitForMessage('actionCompleted');
+            const response = await dbp.collector.waitForMessage('actionCompleted');
             dbp.isSuccessMessage(response);
             await dbp.isFormFilled();
         });
 
         test('click', async ({ page }, workerInfo) => {
-            const dbp = BrokerProtectionPage.create(page, workerInfo);
+            const dbp = BrokerProtectionPage.create(page, workerInfo.project.use);
             await dbp.enabled();
             await dbp.navigatesTo('form.html');
             await dbp.receivesAction('click.json');
-            const response = await dbp.waitForMessage('actionCompleted');
+            const response = await dbp.collector.waitForMessage('actionCompleted');
             dbp.isSuccessMessage(response);
         });
 
         test('clicking with parent selector (considering matching weight/score)', async ({ page }, workerInfo) => {
-            const dbp = BrokerProtectionPage.create(page, workerInfo);
+            const dbp = BrokerProtectionPage.create(page, workerInfo.project.use);
             await dbp.enabled();
             await dbp.navigatesTo('results-weighted.html');
             await dbp.receivesAction('click-weighted.json');
-            const response = await dbp.waitForMessage('actionCompleted');
+            const response = await dbp.collector.waitForMessage('actionCompleted');
 
             dbp.isSuccessMessage(response);
             await page.waitForURL((url) => url.hash === '#2', { timeout: 2000 });
         });
 
         test('clicking with parent selector (clicking the actual parent)', async ({ page }, workerInfo) => {
-            const dbp = BrokerProtectionPage.create(page, workerInfo);
+            const dbp = BrokerProtectionPage.create(page, workerInfo.project.use);
             await dbp.enabled();
             await dbp.navigatesTo('results-parent.html');
             await dbp.receivesAction('click-parent.json');
-            const response = await dbp.waitForMessage('actionCompleted');
+            const response = await dbp.collector.waitForMessage('actionCompleted');
 
             dbp.isSuccessMessage(response);
             await page.waitForURL((url) => url.hash === '#2', { timeout: 2000 });
         });
 
         test('click multiple targets', async ({ page }, workerInfo) => {
-            const dbp = BrokerProtectionPage.create(page, workerInfo);
+            const dbp = BrokerProtectionPage.create(page, workerInfo.project.use);
             await dbp.enabled();
             await dbp.navigatesTo('click-multiple.html');
             await dbp.receivesAction('click-multiple.json');
-            const response = await dbp.waitForMessage('actionCompleted');
+            const response = await dbp.collector.waitForMessage('actionCompleted');
 
             dbp.isSuccessMessage(response);
             await page.waitForURL((url) => url.hash === '#1-2', { timeout: 2000 });
         });
 
         test('getCaptchaInfo', async ({ page }, workerInfo) => {
-            const dbp = BrokerProtectionPage.create(page, workerInfo);
+            const dbp = BrokerProtectionPage.create(page, workerInfo.project.use);
             await dbp.enabled();
             await dbp.navigatesTo('captcha.html');
             await dbp.receivesAction('get-captcha.json');
-            const response = await dbp.waitForMessage('actionCompleted');
+            const response = await dbp.collector.waitForMessage('actionCompleted');
             dbp.isSuccessMessage(response);
             dbp.isCaptchaMatch(response[0].payload?.params.result.success.response);
         });
 
         test('getCaptchaInfo (hcaptcha)', async ({ page }, workerInfo) => {
-            const dbp = BrokerProtectionPage.create(page, workerInfo);
+            const dbp = BrokerProtectionPage.create(page, workerInfo.project.use);
             await dbp.enabled();
             await dbp.navigatesTo('captcha2.html');
             await dbp.receivesAction('get-captcha.json');
-            const response = await dbp.waitForMessage('actionCompleted');
+            const response = await dbp.collector.waitForMessage('actionCompleted');
             dbp.isSuccessMessage(response);
             dbp.isHCaptchaMatch(response[0].payload?.params.result.success.response);
         });
 
         test('remove query params from captcha url', async ({ page }, workerInfo) => {
-            const dbp = BrokerProtectionPage.create(page, workerInfo);
+            const dbp = BrokerProtectionPage.create(page, workerInfo.project.use);
             await dbp.enabled();
             await dbp.navigatesTo('captcha.html?fname=john&lname=smith');
             await dbp.receivesAction('get-captcha.json');
-            const response = await dbp.waitForMessage('actionCompleted');
+            const response = await dbp.collector.waitForMessage('actionCompleted');
             dbp.isSuccessMessage(response);
             dbp.isQueryParamRemoved(response[0].payload?.params.result.success.response);
         });
 
         test('solveCaptcha', async ({ page }, workerInfo) => {
-            const dbp = BrokerProtectionPage.create(page, workerInfo);
+            const dbp = BrokerProtectionPage.create(page, workerInfo.project.use);
             await dbp.enabled();
             await dbp.navigatesTo('captcha.html');
             await dbp.receivesAction('solve-captcha.json');
-            const response = await dbp.waitForMessage('actionCompleted');
+            const response = await dbp.collector.waitForMessage('actionCompleted');
             dbp.isSuccessMessage(response);
             await dbp.isCaptchaTokenFilled();
         });
 
         test('expectation', async ({ page }, workerInfo) => {
-            const dbp = BrokerProtectionPage.create(page, workerInfo);
+            const dbp = BrokerProtectionPage.create(page, workerInfo.project.use);
             await dbp.enabled();
             await dbp.navigatesTo('form.html');
             await dbp.receivesAction('expectation.json');
-            const response = await dbp.waitForMessage('actionCompleted');
+            const response = await dbp.collector.waitForMessage('actionCompleted');
             dbp.isSuccessMessage(response);
         });
 
         test('expectation: element exists', async ({ page }, workerInfo) => {
-            const dbp = BrokerProtectionPage.create(page, workerInfo);
+            const dbp = BrokerProtectionPage.create(page, workerInfo.project.use);
             await dbp.enabled();
             await dbp.navigatesTo('form.html');
 
@@ -469,29 +469,29 @@ test.describe('Broker Protection communications', () => {
                 },
             });
 
-            const response = await dbp.waitForMessage('actionCompleted');
+            const response = await dbp.collector.waitForMessage('actionCompleted');
             dbp.isSuccessMessage(response);
         });
     });
 
     test('expectation with actions', async ({ page }, workerInfo) => {
-        const dbp = BrokerProtectionPage.create(page, workerInfo);
+        const dbp = BrokerProtectionPage.create(page, workerInfo.project.use);
         await dbp.enabled();
         await dbp.navigatesTo('expectation-actions.html');
         await dbp.receivesAction('expectation-actions.json');
-        const response = await dbp.waitForMessage('actionCompleted');
+        const response = await dbp.collector.waitForMessage('actionCompleted');
 
         dbp.isSuccessMessage(response);
         await page.waitForURL((url) => url.hash === '#1', { timeout: 2000 });
     });
 
     test('expectation fails when failSilently is not present', async ({ page }, workerInfo) => {
-        const dbp = BrokerProtectionPage.create(page, workerInfo);
+        const dbp = BrokerProtectionPage.create(page, workerInfo.project.use);
         await dbp.enabled();
         await dbp.navigatesTo('expectation-actions.html');
         await dbp.receivesAction('expectation-actions-fail.json');
 
-        const response = await dbp.waitForMessage('actionCompleted');
+        const response = await dbp.collector.waitForMessage('actionCompleted');
         dbp.isErrorMessage(response);
 
         const currentUrl = page.url();
@@ -499,12 +499,12 @@ test.describe('Broker Protection communications', () => {
     });
 
     test('expectation succeeds when failSilently is present', async ({ page }, workerInfo) => {
-        const dbp = BrokerProtectionPage.create(page, workerInfo);
+        const dbp = BrokerProtectionPage.create(page, workerInfo.project.use);
         await dbp.enabled();
         await dbp.navigatesTo('expectation-actions.html');
         await dbp.receivesAction('expectation-actions-fail-silently.json');
 
-        const response = await dbp.waitForMessage('actionCompleted');
+        const response = await dbp.collector.waitForMessage('actionCompleted');
         dbp.isSuccessMessage(response);
 
         const currentUrl = page.url();
@@ -512,12 +512,12 @@ test.describe('Broker Protection communications', () => {
     });
 
     test('expectation succeeds but subaction fails should throw error', async ({ page }, workerInfo) => {
-        const dbp = BrokerProtectionPage.create(page, workerInfo);
+        const dbp = BrokerProtectionPage.create(page, workerInfo.project.use);
         await dbp.enabled();
         await dbp.navigatesTo('expectation-actions.html');
         await dbp.receivesAction('expectation-actions-subaction-fail.json');
 
-        const response = await dbp.waitForMessage('actionCompleted');
+        const response = await dbp.collector.waitForMessage('actionCompleted');
         dbp.isErrorMessage(response);
 
         const currentUrl = page.url();
@@ -526,7 +526,7 @@ test.describe('Broker Protection communications', () => {
 
     test.describe('retrying', () => {
         test('retrying a click', async ({ page }, workerInfo) => {
-            const dbp = BrokerProtectionPage.create(page, workerInfo);
+            const dbp = BrokerProtectionPage.create(page, workerInfo.project.use);
             await dbp.enabled();
             await dbp.navigatesTo('retry.html');
 
@@ -551,11 +551,11 @@ test.describe('Broker Protection communications', () => {
             });
             await page.getByRole('heading', { name: 'Retry' }).waitFor({ timeout: 5000 });
 
-            const response = await dbp.waitForMessage('actionCompleted');
+            const response = await dbp.collector.waitForMessage('actionCompleted');
             dbp.isSuccessMessage(response);
         });
         test('ensuring retry doesnt apply everywhere', async ({ page }, workerInfo) => {
-            const dbp = BrokerProtectionPage.create(page, workerInfo);
+            const dbp = BrokerProtectionPage.create(page, workerInfo.project.use);
             await dbp.enabled();
             await dbp.navigatesTo('retry.html');
 
@@ -574,7 +574,7 @@ test.describe('Broker Protection communications', () => {
                 },
             });
 
-            const response = await dbp.waitForMessage('actionCompleted');
+            const response = await dbp.collector.waitForMessage('actionCompleted');
             dbp.isErrorMessage(response);
         });
     });

--- a/injected/integration-test/harmful-apis.spec.js
+++ b/injected/integration-test/harmful-apis.spec.js
@@ -1,13 +1,20 @@
 import { test, expect } from '@playwright/test';
-import { readFileSync } from 'fs';
-import { mockWindowsMessaging, wrapWindowsScripts } from '@duckduckgo/messaging/lib/test-utils.mjs';
-import { perPlatform } from './type-helpers.mjs';
-import { windowsGlobalPolyfills } from './shared.mjs';
+import { ResultsCollector } from './page-objects/results-collector.js';
+
+const HTML = '/harmful-apis/index.html';
+const CONFIG = './integration-test/test-pages/harmful-apis/config/apis.json';
 
 test.skip('Harmful APIs protections', async ({ page }, testInfo) => {
-    const protection = HarmfulApisSpec.create(page, testInfo);
-    await protection.enabled();
-    const results = await protection.runTests();
+    const collector = ResultsCollector.create(page, testInfo.project.use);
+    await collector.load(HTML, CONFIG);
+
+    for (const button of await page.getByTestId('user-gesture-button').all()) {
+        await button.click();
+    }
+    const results = await collector.results(async () => {
+        await page.getByTestId('render-results').click();
+    });
+
     // note that if protections are disabled, the browser will show a device selection pop-up, which will never be dismissed
 
     [
@@ -32,92 +39,3 @@ test.skip('Harmful APIs protections', async ({ page }, testInfo) => {
         }
     });
 });
-
-export class HarmfulApisSpec {
-    htmlPage = '/harmful-apis/index.html';
-    config = './integration-test/test-pages/harmful-apis/config/apis.json';
-
-    /**
-     * @param {import("@playwright/test").Page} page
-     * @param {import("./type-helpers.mjs").Build} build
-     * @param {import("./type-helpers.mjs").PlatformInfo} platform
-     */
-    constructor(page, build, platform) {
-        this.page = page;
-        this.build = build;
-        this.platform = platform;
-    }
-
-    async enabled() {
-        await this.installPolyfills();
-        const config = JSON.parse(readFileSync(this.config, 'utf8'));
-        await this.setup({ config });
-        await this.page.goto(this.htmlPage);
-    }
-
-    async runTests() {
-        for (const button of await this.page.getByTestId('user-gesture-button').all()) {
-            await button.click();
-        }
-        const resultsPromise = this.page.evaluate(() => {
-            return new Promise((resolve) => {
-                window.addEventListener('results-ready', () => {
-                    // @ts-expect-error - this is added by the test framework
-                    resolve(window.results);
-                });
-            });
-        });
-        await this.page.getByTestId('render-results').click();
-        return await resultsPromise;
-    }
-
-    /**
-     * In CI, the global objects such as USB might not be installed on the
-     * version of chromium running there.
-     */
-    async installPolyfills() {
-        await this.page.addInitScript(windowsGlobalPolyfills);
-    }
-
-    /**
-     * @param {object} params
-     * @param {Record<string, any>} params.config
-     * @return {Promise<void>}
-     */
-    async setup(params) {
-        const { config } = params;
-
-        // read the built file from disk and do replacements
-        const injectedJS = wrapWindowsScripts(this.build.artifact, {
-            $CONTENT_SCOPE$: config,
-            $USER_UNPROTECTED_DOMAINS$: [],
-            $USER_PREFERENCES$: {
-                platform: { name: 'windows' },
-                debug: true,
-            },
-        });
-
-        await this.page.addInitScript(mockWindowsMessaging, {
-            messagingContext: {
-                env: 'development',
-                context: 'contentScopeScripts',
-                featureName: 'n/a',
-            },
-            responses: {},
-        });
-
-        // attach the JS
-        await this.page.addInitScript(injectedJS);
-    }
-
-    /**
-     * Helper for creating an instance per platform
-     * @param {import("@playwright/test").Page} page
-     * @param {import("@playwright/test").TestInfo} testInfo
-     */
-    static create(page, testInfo) {
-        // Read the configuration object to determine which platform we're testing against
-        const { platformInfo, build } = perPlatform(testInfo.project.use);
-        return new HarmfulApisSpec(page, build, platformInfo);
-    }
-}

--- a/injected/integration-test/helpers/harness.js
+++ b/injected/integration-test/helpers/harness.js
@@ -4,6 +4,7 @@ import { tmpdir } from 'os';
 import { join } from 'path';
 import { chromium, firefox } from '@playwright/test';
 import { fork } from 'node:child_process';
+import { polyfillProcessGlobals } from '../../unit-test/helpers/polyfill-process-globals.js';
 
 const DATA_DIR_PREFIX = 'ddg-temp-';
 
@@ -17,6 +18,7 @@ export function testContextForExtension(test) {
             const tmpDirPrefix = join(tmpdir(), DATA_DIR_PREFIX);
             const dataDir = mkdtempSync(tmpDirPrefix);
             const browserTypes = { chromium, firefox };
+            const cleanupGlobals = polyfillProcessGlobals();
 
             const launchOptions = {
                 devtools: true,
@@ -32,6 +34,9 @@ export function testContextForExtension(test) {
 
             // actually run the tests
             await use(context);
+
+            // clean up globals
+            cleanupGlobals();
 
             // clean up
             await context.close();

--- a/injected/integration-test/message-bridge-apple.spec.js
+++ b/injected/integration-test/message-bridge-apple.spec.js
@@ -49,7 +49,7 @@ test('message bridge when enabled (apple)', async ({ page }, testInfo) => {
     await isolated.simulateSubscriptionMessage('exampleFeature', 'onUpdate', { abc: 'def' });
 
     // get all results
-    const results = await pageWorld.runTests();
+    const results = await pageWorld.results();
     expect(results['Creating the bridge']).toStrictEqual([
         { name: 'bridge.notify', result: 'function', expected: 'function' },
         { name: 'bridge.request', result: 'function', expected: 'function' },
@@ -100,7 +100,7 @@ test('message bridge when disabled (apple)', async ({ page }, testInfo) => {
     expect(calls).toHaveLength(0);
 
     // get all results
-    const results = await pageWorld.runTests();
+    const results = await pageWorld.results();
     expect(results['Creating the bridge, but it is unavailable']).toStrictEqual([
         { name: 'error', result: 'Did not install Message Bridge', expected: 'Did not install Message Bridge' },
     ]);

--- a/injected/integration-test/page-objects/broker-protection.js
+++ b/injected/integration-test/page-objects/broker-protection.js
@@ -1,15 +1,7 @@
 import { expect } from '@playwright/test';
 import { readFileSync } from 'fs';
-import {
-    mockWebkitMessaging,
-    readOutgoingMessages,
-    waitForCallCount,
-    wrapWebkitScripts,
-    simulateSubscriptionMessage,
-    wrapWindowsScripts,
-    mockWindowsMessaging,
-} from '@duckduckgo/messaging/lib/test-utils.mjs';
 import { perPlatform } from '../type-helpers.mjs';
+import { ResultsCollector } from './results-collector.js';
 
 export class BrokerProtectionPage {
     /**
@@ -19,16 +11,12 @@ export class BrokerProtectionPage {
      */
     constructor(page, build, platform) {
         this.page = page;
-        this.build = build;
-        this.platform = platform;
-        page.on('console', (msg) => {
-            console.log(msg.type(), msg.text());
-        });
+        this.collector = new ResultsCollector(page, build, platform);
     }
 
     // Given the "overlays" feature is enabled
     async enabled() {
-        await this.setup({ config: loadConfig('enabled') });
+        await this.collector.setup({ config: loadConfig('enabled') });
     }
 
     /**
@@ -155,112 +143,11 @@ export class BrokerProtectionPage {
     }
 
     /**
-     * Simulate the native-side pushing an action into the client-side JS
-     *
-     * @param {'init-data.json'} action - add more action types here
-     * @return {Promise<void>}
-     */
-    async receivesData(action) {
-        const actionJson = JSON.parse(readFileSync('./integration-test/test-pages/broker-protection/data/' + action, 'utf8'));
-        await this.simulateSubscriptionMessage('onInit', actionJson);
-    }
-
-    async sendsReadyNotification() {
-        const calls = await this.waitForMessage('ready');
-        expect(calls).toMatchObject([
-            {
-                payload: {
-                    context: this.messagingContext.context,
-                    featureName: 'brokerProtection',
-                    method: 'ready',
-                    params: {},
-                },
-            },
-        ]);
-    }
-
-    /**
      * @param {string} name
      * @param {Record<string, any>} payload
      */
     async simulateSubscriptionMessage(name, payload) {
-        await this.page.evaluate(simulateSubscriptionMessage, {
-            messagingContext: this.messagingContext,
-            name,
-            payload,
-            injectName: this.build.name,
-        });
-    }
-
-    /**
-     * @return {import("@duckduckgo/messaging").MessagingContext}
-     */
-    get messagingContext() {
-        const context = this.build.name === 'apple-isolated' ? 'contentScopeScriptsIsolated' : 'contentScopeScripts';
-        return {
-            context,
-            featureName: 'brokerProtection',
-            env: 'development',
-        };
-    }
-
-    /**
-     * This is a bit involved, but verifies that the built artefact behaves as expected
-     * given a mocked messaging implementation
-     *
-     * @param {object} params
-     * @param {Record<string, any>} params.config
-     * @return {Promise<void>}
-     */
-    async setup(params) {
-        const { config } = params;
-
-        // read the built file from disk and do replacements
-        const wrapFn = this.build.switch({
-            'apple-isolated': () => wrapWebkitScripts,
-            windows: () => wrapWindowsScripts,
-        });
-
-        const injectedJS = wrapFn(this.build.artifact, {
-            $CONTENT_SCOPE$: config,
-            $USER_UNPROTECTED_DOMAINS$: [],
-            $USER_PREFERENCES$: {
-                platform: { name: this.platform.name },
-                debug: true,
-            },
-        });
-
-        const mockMessaging = this.build.switch({
-            'apple-isolated': () => mockWebkitMessaging,
-            windows: () => mockWindowsMessaging,
-        });
-
-        await this.page.addInitScript(mockMessaging, {
-            messagingContext: this.messagingContext,
-            responses: {
-                ready: {},
-            },
-        });
-
-        // attach the JS
-        await this.page.addInitScript(injectedJS);
-    }
-
-    /**
-     * @param {string} method
-     * @return {Promise<object>}
-     */
-    async waitForMessage(method) {
-        await this.page.waitForFunction(
-            waitForCallCount,
-            {
-                method,
-                count: 1,
-            },
-            { timeout: 5000, polling: 100 },
-        );
-        const calls = await this.page.evaluate(readOutgoingMessages);
-        return calls.filter((v) => v.payload.method === method);
+        await this.collector.simulateSubscriptionMessage('brokerProtection', name, payload);
     }
 
     /**
@@ -279,11 +166,11 @@ export class BrokerProtectionPage {
     /**
      * Helper for creating an instance per platform
      * @param {import("@playwright/test").Page} page
-     * @param {import("@playwright/test").TestInfo} testInfo
+     * @param {Record<string, any>} use
      */
-    static create(page, testInfo) {
+    static create(page, use) {
         // Read the configuration object to determine which platform we're testing against
-        const { platformInfo, build } = perPlatform(testInfo.project.use);
+        const { platformInfo, build } = perPlatform(use);
         return new BrokerProtectionPage(page, build, platformInfo);
     }
 }

--- a/injected/integration-test/type-helpers.mjs
+++ b/injected/integration-test/type-helpers.mjs
@@ -72,7 +72,17 @@ export class Build {
      */
     static supported(name) {
         /** @type {ImportMeta['injectName'][]} */
-        const items = ['apple', 'apple-isolated', 'windows', 'integration', 'android', 'android-autofill-password-import'];
+        const items = [
+            'apple',
+            'apple-isolated',
+            'windows',
+            'integration',
+            'android',
+            'android-autofill-password-import',
+            'chrome-mv3',
+            'chrome',
+            'firefox',
+        ];
         if (items.includes(name)) {
             return name;
         }
@@ -81,11 +91,14 @@ export class Build {
 }
 
 export class PlatformInfo {
+    /** @type {NonNullable<ImportMeta['platform']>} */
+    name;
     /**
      * @param {object} params
      * @param {ImportMeta['platform']} params.name
      */
     constructor(params) {
+        if (!params.name) throw new Error('unreachable - must provide .name');
         this.name = params.name;
     }
 
@@ -95,7 +108,7 @@ export class PlatformInfo {
      */
     static supported(name) {
         /** @type {ImportMeta['platform'][]} */
-        const items = ['macos', 'ios', 'windows', 'android'];
+        const items = ['macos', 'ios', 'windows', 'android', 'extension'];
         if (items.includes(name)) {
             return name;
         }
@@ -113,6 +126,7 @@ export class PlatformInfo {
 export function perPlatform(config) {
     // Read the configuration object to determine which platform we're testing against
     if (!('injectName' in config) || typeof config.injectName !== 'string') {
+        // Read the configuration object to determine which platform we're testing against
         throw new Error('unsupported project - missing `use.injectName`');
     }
 

--- a/injected/integration-test/webcompat.spec.js
+++ b/injected/integration-test/webcompat.spec.js
@@ -1,12 +1,12 @@
 import { test, expect } from '@playwright/test';
-import { readFileSync } from 'fs';
-import { mockWebkitMessaging, wrapWebkitScripts } from '@duckduckgo/messaging/lib/test-utils.mjs';
-import { perPlatform } from './type-helpers.mjs';
+import { ResultsCollector } from './page-objects/results-collector.js';
 
-test('web compat', async ({ page }, testInfo) => {
-    const webcompat = WebcompatSpec.create(page, testInfo);
-    await webcompat.enabled();
-    const results = await webcompat.collectResults();
+const HTML = '/webcompat/pages/message-handlers.html';
+const CONFIG = './integration-test/test-pages/webcompat/config/message-handlers.json';
+test('web compat message handlers', async ({ page }, testInfo) => {
+    const webcompat = ResultsCollector.create(page, testInfo.project.use);
+    await webcompat.load(HTML, CONFIG);
+    const results = await webcompat.results();
     expect(results).toMatchObject({
         'webkit.messageHandlers - polyfill prevents throw': [
             {
@@ -31,83 +31,3 @@ test('web compat', async ({ page }, testInfo) => {
         ],
     });
 });
-
-export class WebcompatSpec {
-    htmlPage = '/webcompat/pages/message-handlers.html';
-    config = './integration-test/test-pages/webcompat/config/message-handlers.json';
-
-    /**
-     * @param {import('@playwright/test').Page} page
-     * @param {import('./type-helpers.mjs').Build} build
-     * @param {import('./type-helpers.mjs').PlatformInfo} platform
-     */
-    constructor(page, build, platform) {
-        this.page = page;
-        this.build = build;
-        this.platform = platform;
-        page.on('console', (msg) => {
-            console.log(msg.type(), msg.text());
-        });
-    }
-
-    async enabled() {
-        const config = JSON.parse(readFileSync(this.config, 'utf8'));
-        await this.setup({ config });
-        await this.page.goto(this.htmlPage);
-    }
-
-    collectResults() {
-        return this.page.evaluate(() => {
-            return new Promise((resolve) => {
-                // @ts-expect-error - this is added by the test framework
-                if (window.results) return resolve(window.results);
-                window.addEventListener('results-ready', () => {
-                    // @ts-expect-error - this is added by the test framework
-                    resolve(window.results);
-                });
-            });
-        });
-    }
-
-    /**
-     * @param {object} params
-     * @param {Record<string, any>} params.config
-     * @return {Promise<void>}
-     */
-    async setup(params) {
-        const { config } = params;
-
-        // read the built file from disk and do replacements
-        const injectedJS = wrapWebkitScripts(this.build.artifact, {
-            $CONTENT_SCOPE$: config,
-            $USER_UNPROTECTED_DOMAINS$: [],
-            $USER_PREFERENCES$: {
-                platform: { name: 'windows' },
-                debug: true,
-            },
-        });
-
-        await this.page.addInitScript(mockWebkitMessaging, {
-            messagingContext: {
-                env: 'development',
-                context: 'contentScopeScripts',
-                featureName: 'n/a',
-            },
-            responses: {},
-        });
-
-        // attach the JS
-        await this.page.addInitScript(injectedJS);
-    }
-
-    /**
-     * Helper for creating an instance per platform
-     * @param {import('@playwright/test').Page} page
-     * @param {import('@playwright/test').TestInfo} testInfo
-     */
-    static create(page, testInfo) {
-        // Read the configuration object to determine which platform we're testing against
-        const { platformInfo, build } = perPlatform(testInfo.project.use);
-        return new WebcompatSpec(page, build, platformInfo);
-    }
-}

--- a/injected/integration-test/windows-permissions.spec.js
+++ b/injected/integration-test/windows-permissions.spec.js
@@ -1,90 +1,16 @@
 import { test, expect } from '@playwright/test';
-import { readFileSync } from 'fs';
-import { mockWindowsMessaging, wrapWindowsScripts } from '@duckduckgo/messaging/lib/test-utils.mjs';
-import { perPlatform } from './type-helpers.mjs';
-import { windowsGlobalPolyfills } from './shared.mjs';
+import { ResultsCollector } from './page-objects/results-collector.js';
+
+const HTML = '/permissions/index.html';
+const CONFIG = './integration-test/test-pages/permissions/config/permissions.json';
 
 test('Windows Permissions Usage', async ({ page }, testInfo) => {
-    const perms = WindowsPermissionsSpec.create(page, testInfo);
-    await perms.enabled();
-    const results = await page.evaluate(() => {
-        // @ts-expect-error - this is added by the test framework
-        return window.results['Disabled Windows Permissions'];
-    });
+    const perms = ResultsCollector.create(page, testInfo.project.use);
+    await perms.load(HTML, CONFIG);
+    const results = await perms.results();
+    const match = results['Disabled Windows Permissions'];
 
-    for (const result of results) {
+    for (const result of match) {
         expect(result.result).toEqual(result.expected);
     }
 });
-
-export class WindowsPermissionsSpec {
-    htmlPage = '/permissions/index.html';
-    config = './integration-test/test-pages/permissions/config/permissions.json';
-    /**
-     * @param {import("@playwright/test").Page} page
-     * @param {import("./type-helpers.mjs").Build} build
-     * @param {import("./type-helpers.mjs").PlatformInfo} platform
-     */
-    constructor(page, build, platform) {
-        this.page = page;
-        this.build = build;
-        this.platform = platform;
-    }
-
-    async enabled() {
-        await this.installPolyfills();
-        const config = JSON.parse(readFileSync(this.config, 'utf8'));
-        await this.setup({ config });
-        await this.page.goto(this.htmlPage);
-    }
-
-    /**
-     * In CI, the global objects such as USB might not be installed on the
-     * version of chromium running there.
-     */
-    async installPolyfills() {
-        await this.page.addInitScript(windowsGlobalPolyfills);
-    }
-
-    /**
-     * @param {object} params
-     * @param {Record<string, any>} params.config
-     * @return {Promise<void>}
-     */
-    async setup(params) {
-        const { config } = params;
-
-        // read the built file from disk and do replacements
-        const injectedJS = wrapWindowsScripts(this.build.artifact, {
-            $CONTENT_SCOPE$: config,
-            $USER_UNPROTECTED_DOMAINS$: [],
-            $USER_PREFERENCES$: {
-                platform: { name: 'windows' },
-                debug: true,
-            },
-        });
-
-        await this.page.addInitScript(mockWindowsMessaging, {
-            messagingContext: {
-                env: 'development',
-                context: 'contentScopeScripts',
-                featureName: 'n/a',
-            },
-            responses: {},
-        });
-
-        // attach the JS
-        await this.page.addInitScript(injectedJS);
-    }
-
-    /**
-     * Helper for creating an instance per platform
-     * @param {import("@playwright/test").Page} page
-     * @param {import("@playwright/test").TestInfo} testInfo
-     */
-    static create(page, testInfo) {
-        // Read the configuration object to determine which platform we're testing against
-        const { platformInfo, build } = perPlatform(testInfo.project.use);
-        return new WindowsPermissionsSpec(page, build, platformInfo);
-    }
-}

--- a/injected/src/globals.d.ts
+++ b/injected/src/globals.d.ts
@@ -14,7 +14,7 @@ declare namespace contentScopeFeatures {
  */
 interface ImportMeta {
     env: 'production' | 'development';
-    platform?: 'windows' | 'macos' | 'android' | 'ios';
+    platform?: 'windows' | 'macos' | 'android' | 'ios' | 'extension';
     // this represents the different build artifact names
     injectName?:
         | 'firefox'

--- a/injected/unit-test/helpers/polyfill-process-globals.js
+++ b/injected/unit-test/helpers/polyfill-process-globals.js
@@ -1,5 +1,9 @@
-export default function setup() {
-    // Pollyfill for globalThis methods needed in processConfig
+export function polyfillProcessGlobals() {
+    // Store original values to restore later
+    const originalDocument = globalThis.document;
+    const originalLocation = globalThis.location;
+
+    // Apply the patch
     globalThis.document = {
         referrer: 'http://localhost:8080',
         location: {
@@ -10,11 +14,18 @@ export default function setup() {
             },
         },
     };
+
     globalThis.location = {
         href: 'http://localhost:8080',
         // @ts-expect-error - ancestorOrigins is not defined in the type definition
         ancestorOrigins: {
             length: 0,
         },
+    };
+
+    // Return a cleanup function
+    return function cleanup() {
+        globalThis.document = originalDocument;
+        globalThis.location = originalLocation;
     };
 }

--- a/injected/unit-test/utils.js
+++ b/injected/unit-test/utils.js
@@ -1,5 +1,5 @@
 import { matchHostname, postDebugMessage, initStringExemptionLists, processConfig, satisfiesMinVersion } from '../src/utils.js';
-import polyfillProcessGlobals from './helpers/pollyfil-for-process-globals.js';
+import { polyfillProcessGlobals } from './helpers/polyfill-process-globals.js';
 
 polyfillProcessGlobals();
 

--- a/messaging/lib/test-utils.mjs
+++ b/messaging/lib/test-utils.mjs
@@ -12,7 +12,8 @@
  * Install a mock interface for windows messaging
  * @param {{
  *  messagingContext: import('../index.js').MessagingContext,
- *  responses: Record<string, any>
+ *  responses: Record<string, any>,
+ *  messageCallback: 'messageCallback',
  * }} params
  */
 export function mockWindowsMessaging(params) {
@@ -113,6 +114,7 @@ export function mockWindowsMessaging(params) {
  * @param {{
  *  messagingContext: import('../index.js').MessagingContext,
  *  responses: Record<string, any>
+ *  messageCallback: string,
  * }} params
  */
 export function mockWebkitMessaging(params) {

--- a/special-pages/pages/new-tab/integration-tests/new-tab.page.js
+++ b/special-pages/pages/new-tab/integration-tests/new-tab.page.js
@@ -22,7 +22,7 @@ export class NewtabPage {
             env: 'development',
         });
         this.page.on('console', console.log);
-        // default mocks - just enough to render the first page without error
+        if (this.platform.name === 'extension') throw new Error('unreachable - not supported in extension platform');
         this.mocks.defaultResponses({
             requestSetAsDefault: {},
             requestImport: {},

--- a/special-pages/tests/page-objects/mocks.js
+++ b/special-pages/tests/page-objects/mocks.js
@@ -43,12 +43,14 @@ export class Mocks {
                 await this.page.addInitScript(mockWindowsMessaging, {
                     messagingContext: this.messagingContext,
                     responses: this._defaultResponses,
+                    messageCallback: 'messageCallback',
                 });
             },
             apple: async () => {
                 await this.page.addInitScript(mockWebkitMessaging, {
                     messagingContext: this.messagingContext,
                     responses: this._defaultResponses,
+                    messageCallback: 'messageCallback',
                 });
             },
             android: async () => {
@@ -62,6 +64,7 @@ export class Mocks {
                 await this.page.addInitScript(mockWindowsMessaging, {
                     messagingContext: this.messagingContext,
                     responses: this._defaultResponses,
+                    messageCallback: 'messageCallback',
                 });
             },
         });


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/0/72649045549333/1208697693265964/f

## Description

- [x] for tests in `injected` - there is now 1 blessed way to create a ResultsCollector, removing a bunch of boilerplate.

```js
test('Test manipulating APIs', async ({ page }, testInfo) => {
    // create the collector, using the test runner info - this handles the per-platform config
    const collector = ResultsCollector.create(page, testInfo.project.use);

    // call .load to load a HTML test page with a given config file
    await collector.load(
        '/api-manipulation/pages/apis.html', 
        './integration-test/test-pages/api-manipulation/config/apis.json');

    // collect the results
    const results = await collector.results();
    
    // process results
    console.log(results);
});
```

- [x] You can alter userPreferences too, with the following API

```js
test('Test manipulating APIs', async ({ page }, testInfo) => {
    const collector = ResultsCollector
        .create(page, testInfo.project.use)
        .withUserPreferences({ sessionKey: "abc" });
  
    // use as before
    await collector.load(html, config)
    const results = await collector.results();
    
});
```

## Testing Steps

- n/a

## Checklist

<!--
  These questions are a friendly reminder to shipping code, if you're uncertain ask the AoR owners.
  It's also totally appropriate to not check some of these boxes, if they don't apply to your change.
-->
*Please tick all that apply:*

- [ ] I have tested this change locally
- [ ] I have tested this change locally in all supported browsers
- [ ] This change will be visible to users
- [ ] I have added automated tests that cover this change
- [ ] I have ensured the change is gated by config
- [ ] This change was covered by a ship review
- [ ] This change was covered by a tech design
- [ ] Any dependent config has been merged

