### PR TITLE
ntp: privacy stats ordering + translations

### DIFF
--- a/special-pages/messages/new-tab/examples/stats.js
+++ b/special-pages/messages/new-tab/examples/stats.js
@@ -4,9 +4,10 @@
 const privacyStatsData = {
     totalCount: 12345,
     trackerCompanies: [
-        { displayName: 'Tracker Co. A', count: 1234 },
-        { displayName: 'Tracker Co. B', count: 5678 },
         { displayName: 'Tracker Co. C', count: 91011 },
+        { displayName: 'Tracker Co. A', count: 1234 },
+        { displayName: '__other__', count: 89901 },
+        { displayName: 'Tracker Co. B', count: 5678 },
     ],
 };
 

--- a/special-pages/pages/new-tab/app/privacy-stats/PrivacyStats.js
+++ b/special-pages/pages/new-tab/app/privacy-stats/PrivacyStats.js
@@ -138,7 +138,7 @@ export function Body({ trackerCompanies, listAttrs = {} }) {
     const [formatter] = useState(() => new Intl.NumberFormat());
 
     return (
-        <ul {...listAttrs} class={styles.list}>
+        <ul {...listAttrs} class={styles.list} data-testid="CompanyList">
             {trackerCompanies.map((company) => {
                 const percentage = Math.min((company.count * 100) / max, 100);
                 const valueOrMin = Math.max(percentage, 10);

--- a/special-pages/pages/new-tab/app/privacy-stats/constants.js
+++ b/special-pages/pages/new-tab/app/privacy-stats/constants.js
@@ -1,0 +1,4 @@
+/**
+ * @module Privacy Stats Constants
+ */
+export const DDG_STATS_OTHER_COMPANY_IDENTIFIER = '__other__';

--- a/special-pages/pages/new-tab/app/privacy-stats/integration-tests/privacy-stats.spec.js
+++ b/special-pages/pages/new-tab/app/privacy-stats/integration-tests/privacy-stats.spec.js
@@ -14,5 +14,13 @@ test.describe('newtab privacy stats', () => {
         expect(calls1.length).toBe(1);
         expect(calls2.length).toBe(1);
         expect(calls3.length).toBe(1);
+
+        const listItems = page.getByTestId('CompanyList').locator('li');
+        expect(await listItems.count()).toBe(5);
+        expect(await listItems.nth(0).textContent()).toBe('Facebook310');
+        expect(await listItems.nth(1).textContent()).toBe('Google279');
+        expect(await listItems.nth(2).textContent()).toBe('Amazon67');
+        expect(await listItems.nth(3).textContent()).toBe('Google Ads2');
+        expect(await listItems.nth(4).textContent()).toBe('Other210');
     });
 });

--- a/special-pages/pages/new-tab/app/privacy-stats/mocks/stats.js
+++ b/special-pages/pages/new-tab/app/privacy-stats/mocks/stats.js
@@ -1,4 +1,7 @@
-// todo: add schema for types here.
+/**
+ * @import { PrivacyStatsData } from "../../../../../types/new-tab";
+ * @type {Record<string, PrivacyStatsData>}
+ */
 export const stats = {
     few: {
         totalCount: 481_113,
@@ -24,7 +27,6 @@ export const stats = {
                 count: 210,
             },
         ],
-        trackerCompaniesPeriod: 'last-day',
     },
     single: {
         totalCount: 481_113,
@@ -34,16 +36,13 @@ export const stats = {
                 count: 1,
             },
         ],
-        trackerCompaniesPeriod: 'last-day',
     },
     norecent: {
         totalCount: 481_113,
         trackerCompanies: [],
-        trackerCompaniesPeriod: 'last-day',
     },
     none: {
         totalCount: 0,
         trackerCompanies: [],
-        trackerCompaniesPeriod: 'last-day',
     },
 };

--- a/special-pages/pages/new-tab/app/privacy-stats/mocks/stats.js
+++ b/special-pages/pages/new-tab/app/privacy-stats/mocks/stats.js
@@ -1,3 +1,5 @@
+import { DDG_STATS_OTHER_COMPANY_IDENTIFIER } from '../constants.js';
+
 /**
  * @import { PrivacyStatsData } from "../../../../../types/new-tab";
  * @type {Record<string, PrivacyStatsData>}
@@ -15,16 +17,16 @@ export const stats = {
                 count: 279,
             },
             {
+                displayName: DDG_STATS_OTHER_COMPANY_IDENTIFIER,
+                count: 210,
+            },
+            {
                 displayName: 'Amazon',
                 count: 67,
             },
             {
                 displayName: 'Google Ads',
                 count: 2,
-            },
-            {
-                displayName: 'Other',
-                count: 210,
             },
         ],
     },

--- a/special-pages/pages/new-tab/app/privacy-stats/privacy-stats.md
+++ b/special-pages/pages/new-tab/app/privacy-stats/privacy-stats.md
@@ -30,6 +30,27 @@ title: Privacy Stats
       }
       ```
 
-## Examples:
-The following examples show the data types in JSON format:
+## Example:
+
+Note: The frontend will re-order the list based on the following two rules:
+
+* First, descending order, from the highest count to lowest
+* Second, the special entry `__other__` will always be placed at the end.
+
+So, the following input is fine, no need for the native side to put the list into any order 
+
+```json
+{
+  "totalCount": 12345,
+  "trackerCompanies": [
+    { "displayName": "__other__", "count": 89901 },
+    { "displayName": "Tracker Co. C", "count": 91011 },
+    { "displayName": "Tracker Co. A", "count": 1234 },
+    { "displayName": "Tracker Co. B", "count": 5678 }
+  ]
+}
+```
+
+The following examples show the data types in JSON format (these are type-checked, so can be replied upon)
 [messages/new-tab/examples/stats.js](../../../../messages/new-tab/examples/stats.js)
+

--- a/special-pages/pages/new-tab/app/privacy-stats/privacy-stats.utils.js
+++ b/special-pages/pages/new-tab/app/privacy-stats/privacy-stats.utils.js
@@ -1,0 +1,18 @@
+import { DDG_STATS_OTHER_COMPANY_IDENTIFIER } from './constants.js';
+
+/**
+ * Sort into descending order + place __other__ at the end.
+ *
+ * @import { TrackerCompany } from "../../../../types/new-tab"
+ * @param {TrackerCompany[]} stats
+ * @return {TrackerCompany[]}
+ */
+export function sortStatsForDisplay(stats) {
+    const sorted = stats.sort((a, b) => b.count - a.count);
+    const other = sorted.findIndex((x) => x.displayName === DDG_STATS_OTHER_COMPANY_IDENTIFIER);
+    if (other > -1) {
+        const popped = sorted.splice(other, 1);
+        sorted.push(popped[0]);
+    }
+    return sorted;
+}

--- a/special-pages/pages/new-tab/app/privacy-stats/unit-tests/stats-ordering.js
+++ b/special-pages/pages/new-tab/app/privacy-stats/unit-tests/stats-ordering.js
@@ -1,0 +1,48 @@
+import { describe, it } from 'node:test';
+import { deepEqual } from 'node:assert/strict';
+import { stats } from '../mocks/stats.js';
+import { sortStatsForDisplay } from '../privacy-stats.utils.js';
+
+/**
+ * @import { TrackerCompany } from "../../../../../types/new-tab"
+ */
+
+describe('stats re-ordering', () => {
+    it('orders based on count + places __other__ at the end of the list', () => {
+        /** @type {TrackerCompany[]} */
+        const input = stats.few.trackerCompanies;
+        const expected = [
+            { displayName: 'Facebook', count: 310 },
+            { displayName: 'Google', count: 279 },
+            { displayName: 'Amazon', count: 67 },
+            { displayName: 'Google Ads', count: 2 },
+            { displayName: '__other__', count: 210 },
+        ];
+        const actual = sortStatsForDisplay(input);
+        deepEqual(actual, expected);
+    });
+    it('orders when other is absent', () => {
+        /** @type {TrackerCompany[]} */
+        const input = [
+            { displayName: 'Google', count: 279 },
+            { displayName: 'Google Ads', count: 2 },
+            { displayName: 'Amazon', count: 67 },
+            { displayName: 'Facebook', count: 310 },
+        ];
+        const expected = [
+            { displayName: 'Facebook', count: 310 },
+            { displayName: 'Google', count: 279 },
+            { displayName: 'Amazon', count: 67 },
+            { displayName: 'Google Ads', count: 2 },
+        ];
+        const actual = sortStatsForDisplay(input);
+        deepEqual(actual, expected);
+    });
+    it('sorts a single item', () => {
+        /** @type {TrackerCompany[]} */
+        const input = [{ displayName: 'Google', count: 279 }];
+        const expected = [{ displayName: 'Google', count: 279 }];
+        const actual = sortStatsForDisplay(input);
+        deepEqual(actual, expected);
+    });
+});

--- a/special-pages/pages/new-tab/src/locales/en/newtab.json
+++ b/special-pages/pages/new-tab/src/locales/en/newtab.json
@@ -61,6 +61,10 @@
     "title": "Hide recent activity",
     "note": "The aria-label text for a toggle button that hides the detailed activity feed"
   },
+  "trackerStatsOtherCompanyName": {
+    "title": "Other",
+    "note": "A placeholder to represent an aggregated count of entries, not present in the rest of the list. For example, 'Other: 200', which would mean 200 entries excluding the ones already shown"
+  },
   "favorites_show_less": {
     "title": "Show less",
     "note": ""


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/0/1201141132935289/1208768291311536/f

## Description

- [x] let the FE sort the list of tracker stats just before displayed
- [x] use a special identifier `__other__` to signal which name should be translated by the frontend

## Testing Steps

- Check it still displays correctly on https://deploy-preview-1242--content-scope-scripts.netlify.app/build/pages/new-tab/

## Checklist

<!--
  These questions are a friendly reminder to shipping code, if you're uncertain ask the AoR owners.
  It's also totally appropriate to not check some of these boxes, if they don't apply to your change.
-->
*Please tick all that apply:*

- [x] I have tested this change locally
- [ ] I have tested this change locally in all supported browsers
- [x] This change will be visible to users
- [x] I have added automated tests that cover this change
- [ ] I have ensured the change is gated by config
- [ ] This change was covered by a ship review
- [ ] This change was covered by a tech design
- [ ] Any dependent config has been merged

