### PR TITLE
ntp: stats - don't show expansion controls without recent items

### DIFF
--- a/special-pages/pages/new-tab/app/privacy-stats/PrivacyStats.js
+++ b/special-pages/pages/new-tab/app/privacy-stats/PrivacyStats.js
@@ -109,18 +109,19 @@ export function Heading({ expansion, trackerCompanies, totalCount, onToggle, but
             </span>
             {none && <p className={styles.title}>{t('trackerStatsNoRecent')}</p>}
             {some && <p className={styles.title}>{alltimeTitle}</p>}
-            <span className={styles.expander}>
-                <ShowHideButton
-                    buttonAttrs={{
-                        ...buttonAttrs,
-                        hidden: trackerCompanies.length === 0,
-                        'aria-expanded': expansion === 'expanded',
-                        'aria-pressed': expansion === 'expanded',
-                    }}
-                    onClick={onToggle}
-                    text={expansion === 'expanded' ? t('trackerStatsHideLabel') : t('trackerStatsToggleLabel')}
-                />
-            </span>
+            {recent > 0 && (
+                <span className={styles.expander}>
+                    <ShowHideButton
+                        buttonAttrs={{
+                            ...buttonAttrs,
+                            'aria-expanded': expansion === 'expanded',
+                            'aria-pressed': expansion === 'expanded',
+                        }}
+                        onClick={onToggle}
+                        text={expansion === 'expanded' ? t('trackerStatsHideLabel') : t('trackerStatsToggleLabel')}
+                    />
+                </span>
+            )}
             <p className={styles.subtitle}>
                 {recent === 0 && t('trackerStatsNoActivity')}
                 {recent > 0 && recentTitle}

--- a/special-pages/pages/new-tab/app/privacy-stats/PrivacyStats.js
+++ b/special-pages/pages/new-tab/app/privacy-stats/PrivacyStats.js
@@ -137,10 +137,10 @@ export function Heading({ expansion, trackerCompanies, totalCount, onToggle, but
  */
 // eslint-disable-next-line no-redeclare
 export function Body({ trackerCompanies, listAttrs = {} }) {
-    const max = trackerCompanies[0]?.count ?? 0;
     const { t } = useTypedTranslation();
     const [formatter] = useState(() => new Intl.NumberFormat());
     const sorted = sortStatsForDisplay(trackerCompanies);
+    const max = sorted[0]?.count ?? 0;
 
     return (
         <ul {...listAttrs} class={styles.list} data-testid="CompanyList">

--- a/special-pages/pages/new-tab/app/privacy-stats/integration-tests/privacy-stats.spec.js
+++ b/special-pages/pages/new-tab/app/privacy-stats/integration-tests/privacy-stats.spec.js
@@ -5,7 +5,7 @@ test.describe('newtab privacy stats', () => {
     test('fetches config + stats', async ({ page }, workerInfo) => {
         const ntp = NewtabPage.create(page, workerInfo);
         await ntp.reducedMotion();
-        await ntp.openPage();
+        await ntp.openPage({ stats: 'few' });
 
         const calls1 = await ntp.mocks.waitForCallCount({ method: 'initialSetup', count: 1 });
         const calls2 = await ntp.mocks.waitForCallCount({ method: 'stats_getData', count: 1 });
@@ -22,5 +22,17 @@ test.describe('newtab privacy stats', () => {
         expect(await listItems.nth(2).textContent()).toBe('Amazon67');
         expect(await listItems.nth(3).textContent()).toBe('Google Ads2');
         expect(await listItems.nth(4).textContent()).toBe('Other210');
+
+        // show/hide
+        await page.getByLabel('Hide recent activity').click();
+        await page.getByLabel('Show recent activity').click();
+    });
+    test('hiding the expander when empty', async ({ page }, workerInfo) => {
+        const ntp = NewtabPage.create(page, workerInfo);
+        await ntp.reducedMotion();
+        await ntp.openPage({ stats: 'none' });
+        await page.getByText('No recent tracking activity').waitFor();
+        await expect(page.getByLabel('Hide recent activity')).not.toBeVisible();
+        await expect(page.getByLabel('Show recent activity')).not.toBeVisible();
     });
 });

--- a/special-pages/pages/new-tab/app/privacy-stats/integration-tests/privacy-stats.spec.js
+++ b/special-pages/pages/new-tab/app/privacy-stats/integration-tests/privacy-stats.spec.js
@@ -5,7 +5,7 @@ test.describe('newtab privacy stats', () => {
     test('fetches config + stats', async ({ page }, workerInfo) => {
         const ntp = NewtabPage.create(page, workerInfo);
         await ntp.reducedMotion();
-        await ntp.openPage({ stats: 'few' });
+        await ntp.openPage({ additional: { stats: 'few' } });
 
         const calls1 = await ntp.mocks.waitForCallCount({ method: 'initialSetup', count: 1 });
         const calls2 = await ntp.mocks.waitForCallCount({ method: 'stats_getData', count: 1 });
@@ -27,12 +27,40 @@ test.describe('newtab privacy stats', () => {
         await page.getByLabel('Hide recent activity').click();
         await page.getByLabel('Show recent activity').click();
     });
-    test('hiding the expander when empty', async ({ page }, workerInfo) => {
-        const ntp = NewtabPage.create(page, workerInfo);
-        await ntp.reducedMotion();
-        await ntp.openPage({ stats: 'none' });
-        await page.getByText('No recent tracking activity').waitFor();
-        await expect(page.getByLabel('Hide recent activity')).not.toBeVisible();
-        await expect(page.getByLabel('Show recent activity')).not.toBeVisible();
-    });
+    test(
+        'hiding the expander when empty',
+        {
+            annotation: {
+                type: 'issue',
+                description: 'https://app.asana.com/0/0/1208792040873366/f',
+            },
+        },
+        async ({ page }, workerInfo) => {
+            const ntp = NewtabPage.create(page, workerInfo);
+            await ntp.reducedMotion();
+            await ntp.openPage({ additional: { stats: 'none' } });
+            await page.getByText('No recent tracking activity').waitFor();
+            await expect(page.getByLabel('Hide recent activity')).not.toBeVisible();
+            await expect(page.getByLabel('Show recent activity')).not.toBeVisible();
+        },
+    );
+    test(
+        'bar width',
+        {
+            annotation: {
+                type: 'issue',
+                description: 'https://app.asana.com/0/0/1208800221025230/f',
+            },
+        },
+        async ({ page }, workerInfo) => {
+            const ntp = NewtabPage.create(page, workerInfo);
+            await ntp.reducedMotion();
+            await ntp.openPage({ additional: { stats: 'willUpdate', 'stats-update-count': '2' } });
+
+            //
+            // Checking the first + last bar widths due to a regression
+            await page.getByText('Google Ads5').locator('[style="width: 100%;"]').waitFor();
+            await page.getByText('Facebook1').locator('[style="width: 20%;"]').waitFor();
+        },
+    );
 });

--- a/special-pages/pages/new-tab/app/privacy-stats/mocks/stats.js
+++ b/special-pages/pages/new-tab/app/privacy-stats/mocks/stats.js
@@ -47,4 +47,29 @@ export const stats = {
         totalCount: 0,
         trackerCompanies: [],
     },
+    willUpdate: {
+        totalCount: 481_113,
+        trackerCompanies: [
+            {
+                displayName: 'Facebook',
+                count: 1,
+            },
+            {
+                displayName: 'Google',
+                count: 1,
+            },
+            {
+                displayName: DDG_STATS_OTHER_COMPANY_IDENTIFIER,
+                count: 1,
+            },
+            {
+                displayName: 'Amazon',
+                count: 1,
+            },
+            {
+                displayName: 'Google Ads',
+                count: 1,
+            },
+        ],
+    },
 };

--- a/special-pages/pages/new-tab/app/privacy-stats/privacy-stats.utils.js
+++ b/special-pages/pages/new-tab/app/privacy-stats/privacy-stats.utils.js
@@ -8,7 +8,7 @@ import { DDG_STATS_OTHER_COMPANY_IDENTIFIER } from './constants.js';
  * @return {TrackerCompany[]}
  */
 export function sortStatsForDisplay(stats) {
-    const sorted = stats.sort((a, b) => b.count - a.count);
+    const sorted = stats.slice().sort((a, b) => b.count - a.count);
     const other = sorted.findIndex((x) => x.displayName === DDG_STATS_OTHER_COMPANY_IDENTIFIER);
     if (other > -1) {
         const popped = sorted.splice(other, 1);

--- a/special-pages/pages/new-tab/integration-tests/new-tab.page.js
+++ b/special-pages/pages/new-tab/integration-tests/new-tab.page.js
@@ -58,11 +58,12 @@ export class NewtabPage {
      * @param {boolean} [params.willThrow] - Optional flag to simulate an exception
      * @param {string|number} [params.favorites] - Optional flag to preload a list of favorites
      * @param {string|string[]} [params.nextSteps] - Optional flag to load Next Steps cards
+     * @param {string} [params.stats] - Optional flag to load different data for the stats
      * @param {string} [params.rmf] - Optional flag to add certain rmf example
      * @param {string} [params.updateNotification] - Optional flag to point to display=components view with certain rmf example visible
      * @param {string} [params.platformName] - Optional parameters for opening the page.
      */
-    async openPage({ mode = 'debug', platformName, willThrow = false, favorites, nextSteps, rmf, updateNotification } = {}) {
+    async openPage({ mode = 'debug', stats, platformName, willThrow = false, favorites, nextSteps, rmf, updateNotification } = {}) {
         await this.mocks.install();
         const searchParams = new URLSearchParams({ mode, willThrow: String(willThrow) });
 
@@ -90,6 +91,10 @@ export class NewtabPage {
 
         if (updateNotification !== undefined) {
             searchParams.set('update-notification', updateNotification);
+        }
+
+        if (stats !== undefined) {
+            searchParams.set('stats', stats);
         }
 
         await this.page.goto('/new-tab' + '?' + searchParams.toString());

--- a/special-pages/pages/new-tab/integration-tests/new-tab.page.js
+++ b/special-pages/pages/new-tab/integration-tests/new-tab.page.js
@@ -58,12 +58,12 @@ export class NewtabPage {
      * @param {boolean} [params.willThrow] - Optional flag to simulate an exception
      * @param {string|number} [params.favorites] - Optional flag to preload a list of favorites
      * @param {string|string[]} [params.nextSteps] - Optional flag to load Next Steps cards
-     * @param {string} [params.stats] - Optional flag to load different data for the stats
+     * @param {Record<string, any>} [params.additional] - Optional map of key/values to add
      * @param {string} [params.rmf] - Optional flag to add certain rmf example
      * @param {string} [params.updateNotification] - Optional flag to point to display=components view with certain rmf example visible
      * @param {string} [params.platformName] - Optional parameters for opening the page.
      */
-    async openPage({ mode = 'debug', stats, platformName, willThrow = false, favorites, nextSteps, rmf, updateNotification } = {}) {
+    async openPage({ mode = 'debug', additional, platformName, willThrow = false, favorites, nextSteps, rmf, updateNotification } = {}) {
         await this.mocks.install();
         const searchParams = new URLSearchParams({ mode, willThrow: String(willThrow) });
 
@@ -93,8 +93,8 @@ export class NewtabPage {
             searchParams.set('update-notification', updateNotification);
         }
 
-        if (stats !== undefined) {
-            searchParams.set('stats', stats);
+        for (const [key, value] of Object.entries(additional || {})) {
+            searchParams.set(key, value);
         }
 
         await this.page.goto('/new-tab' + '?' + searchParams.toString());

--- a/special-pages/pages/new-tab/src/js/mock-transport.js
+++ b/special-pages/pages/new-tab/src/js/mock-transport.js
@@ -280,6 +280,10 @@ export function mockTransport() {
             const msg = /** @type {any} */ (_msg);
             switch (msg.method) {
                 case 'stats_getData': {
+                    const statsVariant = url.searchParams.get('stats');
+                    if (statsVariant && statsVariant in stats) {
+                        return Promise.resolve(stats[statsVariant]);
+                    }
                     return Promise.resolve(stats.few);
                 }
                 case 'stats_getConfig': {

--- a/special-pages/pages/new-tab/src/js/mock-transport.js
+++ b/special-pages/pages/new-tab/src/js/mock-transport.js
@@ -254,6 +254,33 @@ export function mockTransport() {
 
                     return () => controller.abort();
                 }
+                case 'stats_onDataUpdate': {
+                    const statsVariant = url.searchParams.get('stats');
+                    if (statsVariant !== 'willUpdate') return () => {};
+
+                    const count = url.searchParams.get('stats-update-count');
+                    const max = Math.min(parseInt(count || '0'), 10);
+                    if (max === 0) return () => {};
+
+                    let inc = 1;
+                    const int = setInterval(() => {
+                        if (inc === max) return clearInterval(int);
+                        const next = {
+                            ...stats.willUpdate,
+                            trackerCompanies: stats.willUpdate.trackerCompanies.map((x, index) => {
+                                return {
+                                    ...x,
+                                    count: x.count + inc * index,
+                                };
+                            }),
+                        };
+                        cb(next);
+                        inc++;
+                    }, 500);
+                    return () => {
+                        clearInterval(int);
+                    };
+                }
                 case 'favorites_onConfigUpdate': {
                     const controller = new AbortController();
                     channel.addEventListener(


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/0/1201141132935289/1208792040873365/f

## Description

- [x] Don't show expansion controls without recent items (+ add regression test)
- [x] Fix a regression around bar-width (+ add regression test)

## Testing Steps

- View the removal of expansion controls here https://deploy-preview-1243--content-scope-scripts.netlify.app/build/pages/new-tab/?stats=none
- View the bar-width fix here https://deploy-preview-1243--content-scope-scripts.netlify.app/build/pages/new-tab/?stats=willUpdate&stats-update-count=10


## Checklist

<!--
  These questions are a friendly reminder to shipping code, if you're uncertain ask the AoR owners.
  It's also totally appropriate to not check some of these boxes, if they don't apply to your change.
-->
*Please tick all that apply:*

- [ ] I have tested this change locally
- [ ] I have tested this change locally in all supported browsers
- [ ] This change will be visible to users
- [ ] I have added automated tests that cover this change
- [ ] I have ensured the change is gated by config
- [ ] This change was covered by a ship review
- [ ] This change was covered by a tech design
- [ ] Any dependent config has been merged

