### PR TITLE
ntp: per-widget error boundaries

### DIFF
--- a/special-pages/pages/new-tab/app/index.js
+++ b/special-pages/pages/new-tab/app/index.js
@@ -170,7 +170,8 @@ async function resolveEntryPoints(widgets, didCatch) {
  * @param {Record<string, any>} strings
  */
 function renderComponents(root, environment, settings, strings) {
-    render(
+    // eslint-disable-next-line no-labels,no-unused-labels
+    $INTEGRATION: render(
         <EnvironmentProvider debugState={environment.debugState} injectName={environment.injectName} willThrow={environment.willThrow}>
             <SettingsProvider settings={settings}>
                 <TranslationProvider translationObject={strings} fallback={strings} textLength={environment.textLength}>

--- a/special-pages/pages/new-tab/app/widget-list/WidgetList.js
+++ b/special-pages/pages/new-tab/app/widget-list/WidgetList.js
@@ -1,9 +1,11 @@
-import { Fragment, h } from 'preact';
+import { h } from 'preact';
 import { WidgetConfigContext, WidgetVisibilityProvider } from './widget-config.provider.js';
 import { useContext } from 'preact/hooks';
-import { Customizer, CustomizerMenuPositionedFixed } from '../customizer/components/Customizer';
-import { useEnv } from '../../../../shared/components/EnvironmentProvider.js';
-import { DebugCustomized } from '../telemetry/Debug.js';
+import { Customizer, CustomizerMenuPositionedFixed } from '../customizer/components/Customizer.js';
+import { useMessaging } from '../types.js';
+import { ErrorBoundary } from '../../../../shared/components/ErrorBoundary.js';
+import { Fallback } from '../../../../shared/components/Fallback/Fallback.jsx';
+import { Centered } from '../components/Layout.js';
 
 /**
  * @param {string} id
@@ -37,25 +39,53 @@ export async function widgetEntryPoint(id) {
 
 export function WidgetList() {
     const { widgets, widgetConfigItems, entryPoints } = useContext(WidgetConfigContext);
-    const { env } = useEnv();
+    const messaging = useMessaging();
+
+    /**
+     * @param {any} error
+     * @param {string} id
+     */
+    const didCatch = (error, id) => {
+        const message = error?.message || error?.error || 'unknown';
+        const composed = `Widget '${id}' threw an exception: ` + message;
+        messaging.reportPageException({ message: composed });
+    };
 
     return (
         <div>
             {widgets.map((widget, index) => {
                 const matchingConfig = widgetConfigItems.find((item) => item.id === widget.id);
                 const matchingEntryPoint = entryPoints[widget.id];
+                /**
+                 * If there's no config, it means the user does not control the visibility of the elements in question.
+                 */
                 if (!matchingConfig) {
-                    return <Fragment key={widget.id}>{matchingEntryPoint.factory?.()}</Fragment>;
-                }
-                return (
-                    <Fragment key={widget.id}>
-                        <WidgetVisibilityProvider visibility={matchingConfig.visibility} id={matchingConfig.id} index={index}>
+                    return (
+                        <ErrorBoundary key={widget.id} didCatch={(error) => didCatch(error, widget.id)} fallback={null}>
                             {matchingEntryPoint.factory?.()}
-                        </WidgetVisibilityProvider>
-                    </Fragment>
+                        </ErrorBoundary>
+                    );
+                }
+
+                /**
+                 * This section is for elements that the user controls the visibility of
+                 */
+                return (
+                    <WidgetVisibilityProvider key={widget.id} visibility={matchingConfig.visibility} id={matchingConfig.id} index={index}>
+                        <ErrorBoundary
+                            key={widget.id}
+                            didCatch={(error) => didCatch(error, widget.id)}
+                            fallback={
+                                <Centered>
+                                    <Fallback showDetails={true}>Widget id: {matchingConfig.id}</Fallback>
+                                </Centered>
+                            }
+                        >
+                            {matchingEntryPoint.factory?.()}
+                        </ErrorBoundary>
+                    </WidgetVisibilityProvider>
                 );
             })}
-            {env === 'development' && <DebugCustomized index={widgets.length} />}
             <CustomizerMenuPositionedFixed>
                 <Customizer />
             </CustomizerMenuPositionedFixed>

--- a/special-pages/shared/components/Fallback/Fallback.jsx
+++ b/special-pages/shared/components/Fallback/Fallback.jsx
@@ -4,12 +4,14 @@ import styles from './Fallback.module.css';
 /**
  * @param {object} props
  * @param {boolean} props.showDetails
+ * @param {import("preact").ComponentChild} [props.children]
  */
-export function Fallback({ showDetails }) {
+export function Fallback({ showDetails, children }) {
     return (
         <div class={styles.fallback}>
             <div>
                 <p>Something went wrong!</p>
+                {children}
                 {showDetails && (
                     <p>
                         Please check logs for a message called <code>reportPageException</code>


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/0/1201141132935289/1208795650288282/f

## Description


## Testing Steps

- Checkout this branch
- throw an exception from within a widget, like this
```diff
Index: special-pages/pages/new-tab/app/privacy-stats/PrivacyStats.js
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/special-pages/pages/new-tab/app/privacy-stats/PrivacyStats.js b/special-pages/pages/new-tab/app/privacy-stats/PrivacyStats.js
--- a/special-pages/pages/new-tab/app/privacy-stats/PrivacyStats.js	(revision b0b4b3f2912dd16f0b4e1b722d75aa03ed1a2034)
+++ b/special-pages/pages/new-tab/app/privacy-stats/PrivacyStats.js	(date 1732121450578)
@@ -142,6 +142,8 @@
     const sorted = sortStatsForDisplay(trackerCompanies);
     const max = sorted[0]?.count ?? 0;
 
+    throw new Error('oops!');
+
     return (
         <ul {...listAttrs} class={styles.list} data-testid="CompanyList">
             {sorted.map((company) => {

```
- Ensure the rest of the page still works (like favorites)
- Check the console, ensure the `reportPageException` was attempted (it'll be a warning like this:) 
<img width="776" alt="image" src="https://github.com/user-attachments/assets/cbee9eb0-6e9b-41bd-bfa7-39404bea3c5a">


## Checklist

<!--
  These questions are a friendly reminder to shipping code, if you're uncertain ask the AoR owners.
  It's also totally appropriate to not check some of these boxes, if they don't apply to your change.
-->
*Please tick all that apply:*

- [ ] I have tested this change locally
- [ ] I have tested this change locally in all supported browsers
- [ ] This change will be visible to users
- [ ] I have added automated tests that cover this change
- [ ] I have ensured the change is gated by config
- [ ] This change was covered by a ship review
- [ ] This change was covered by a tech design
- [ ] Any dependent config has been merged

