### PR TITLE
fix: randomUUID is absent in non-secure contexts

### DIFF
--- a/injected/src/captured-globals.js
+++ b/injected/src/captured-globals.js
@@ -23,4 +23,4 @@ export const Promise = globalThis.Promise;
 export const String = globalThis.String;
 export const Map = globalThis.Map;
 export const Error = globalThis.Error;
-export const randomUUID = globalThis.crypto?.randomUUID.bind(globalThis.crypto);
+export const randomUUID = globalThis.crypto?.randomUUID?.bind(globalThis.crypto);


### PR DESCRIPTION
**Asana Task/Github Issue:** Task/Issue URL:  https://app.asana.com/0/0/1208815620119693/f

## Description

- [x] Property access for `crypto.randomUUID` fails in insecure contexts
- [x] Tested E2E in https://github.com/duckduckgo/Android/pull/5299

## Checklist

<!--
  These questions are a friendly reminder to shipping code, if you're uncertain ask the AoR owners.
  It's also totally appropriate to not check some of these boxes, if they don't apply to your change.
-->
*Please tick all that apply:*

- [x] I have tested this change locally
- [x] I have tested this change locally in all supported browsers
- [ ] This change will be visible to users
- [ ] I have added automated tests that cover this change
- [ ] I have ensured the change is gated by config
- [ ] This change was covered by a ship review
- [ ] This change was covered by a tech design
- [ ] Any dependent config has been merged

