### PR TITLE
ntp: virtual list for favorites

### DIFF
--- a/special-pages/index.mjs
+++ b/special-pages/index.mjs
@@ -19,10 +19,42 @@ const DEBUG = Boolean(args.debug);
 
 export const support = {
     /** @type {Partial<Record<ImportMeta['injectName'], string[]>>} */
+    duckplayer: {
+        integration: ['copy', 'build-js'],
+        windows: ['copy', 'build-js'],
+        apple: ['copy', 'build-js', 'inline-html'],
+        android: ['copy', 'build-js'],
+    },
+    /** @type {Partial<Record<ImportMeta['injectName'], string[]>>} */
+    errorpage: {
+        integration: ['copy'],
+        apple: ['copy', 'inline-html'],
+    },
+    /** @type {Partial<Record<ImportMeta['injectName'], string[]>>} */
+    onboarding: {
+        integration: ['copy', 'build-js'],
+        windows: ['copy', 'build-js'],
+        apple: ['copy', 'build-js'],
+    },
+    /** @type {Partial<Record<ImportMeta['injectName'], string[]>>} */
+    example: {
+        integration: ['copy', 'build-js'],
+    },
+    /** @type {Partial<Record<ImportMeta['injectName'], string[]>>} */
+    'release-notes': {
+        integration: ['copy', 'build-js'],
+        apple: ['copy', 'build-js'],
+    },
+    /** @type {Partial<Record<ImportMeta['injectName'], string[]>>} */
+    'special-error': {
+        integration: ['copy', 'build-js'],
+        apple: ['copy', 'build-js', 'inline-html'],
+    },
+    /** @type {Partial<Record<ImportMeta['injectName'], string[]>>} */
     'new-tab': {
         integration: ['copy', 'build-js'],
-        // windows: ['copy', 'build-js'],
-        // apple: ['copy', 'build-js'],
+        windows: ['copy', 'build-js'],
+        apple: ['copy', 'build-js'],
     },
 };
 

--- a/special-pages/index.mjs
+++ b/special-pages/index.mjs
@@ -19,42 +19,10 @@ const DEBUG = Boolean(args.debug);
 
 export const support = {
     /** @type {Partial<Record<ImportMeta['injectName'], string[]>>} */
-    duckplayer: {
-        integration: ['copy', 'build-js'],
-        windows: ['copy', 'build-js'],
-        apple: ['copy', 'build-js', 'inline-html'],
-        android: ['copy', 'build-js'],
-    },
-    /** @type {Partial<Record<ImportMeta['injectName'], string[]>>} */
-    errorpage: {
-        integration: ['copy'],
-        apple: ['copy', 'inline-html'],
-    },
-    /** @type {Partial<Record<ImportMeta['injectName'], string[]>>} */
-    onboarding: {
-        integration: ['copy', 'build-js'],
-        windows: ['copy', 'build-js'],
-        apple: ['copy', 'build-js'],
-    },
-    /** @type {Partial<Record<ImportMeta['injectName'], string[]>>} */
-    example: {
-        integration: ['copy', 'build-js'],
-    },
-    /** @type {Partial<Record<ImportMeta['injectName'], string[]>>} */
-    'release-notes': {
-        integration: ['copy', 'build-js'],
-        apple: ['copy', 'build-js'],
-    },
-    /** @type {Partial<Record<ImportMeta['injectName'], string[]>>} */
-    'special-error': {
-        integration: ['copy', 'build-js'],
-        apple: ['copy', 'build-js', 'inline-html'],
-    },
-    /** @type {Partial<Record<ImportMeta['injectName'], string[]>>} */
     'new-tab': {
         integration: ['copy', 'build-js'],
-        windows: ['copy', 'build-js'],
-        apple: ['copy', 'build-js'],
+        // windows: ['copy', 'build-js'],
+        // apple: ['copy', 'build-js'],
     },
 };
 

--- a/special-pages/pages/new-tab/app/favorites/components/Favorites.js
+++ b/special-pages/pages/new-tab/app/favorites/components/Favorites.js
@@ -170,15 +170,17 @@ function VirtualizedGridRows({ WIDGET_ID, rowHeight, favorites, expansion, openF
     const subsetOfRowsToRender = expansion === 'collapsed'
         // if it's collapsed, just 1 row to show (the first one)
         ? [rows[0]]
-        // otherwise select the window between start/end
+        // otherwise, select the window between start/end
         : rows.slice(start, end);
 
     //
-    const inline_height = expansion === 'collapsed' ? rowHeight : rows.length * rowHeight;
+    const container_height = expansion === 'collapsed' ? rowHeight : rows.length * rowHeight;
+    const dropped = document.documentElement.dataset.dropped;
+
     return (
         <div
             className={styles.grid}
-            style={{ height: inline_height + 'px' }}
+            style={{ height: container_height + 'px' }}
             id={WIDGET_ID}
             ref={safeAreaRef}
             onContextMenu={getContextMenuHandler(openContextMenu)}
@@ -187,7 +189,7 @@ function VirtualizedGridRows({ WIDGET_ID, rowHeight, favorites, expansion, openF
             {subsetOfRowsToRender.map((items, index) => {
                 const top_offset = (start + index) * rowHeight;
                 const keyed = `-${start + index}-`;
-                return <TileRow key={keyed} items={items} top_offset={top_offset} add={add} />;
+                return <TileRow key={keyed} dropped={dropped} items={items} top_offset={top_offset} add={add} />;
             })}
         </div>
     );

--- a/special-pages/pages/new-tab/app/favorites/components/Favorites.js
+++ b/special-pages/pages/new-tab/app/favorites/components/Favorites.js
@@ -212,9 +212,9 @@ function VirtualizedGridRows({ WIDGET_ID, rowHeight, favorites, expansion, openF
         >
             {rows.length === 0 && <TileRow key={'empty-rows'} items={[]} topOffset={0} add={add} />}
             {rows.length > 0 &&
-                subsetOfRowsToRender.map((items, index) => {
-                    const topOffset = (start + index) * rowHeight;
-                    const keyed = `-${start + index}-`;
+                subsetOfRowsToRender.map((items, rowIndex) => {
+                    const topOffset = (start + rowIndex) * rowHeight;
+                    const keyed = `-${start + rowIndex}-`;
                     return <TileRow key={keyed} dropped={dropped} items={items} topOffset={topOffset} add={add} />;
                 })}
         </div>
@@ -231,7 +231,7 @@ function getContextMenuHandler(openContextMenu) {
     return (event) => {
         let target = /** @type {HTMLElement|null} */ (event.target);
         while (target && target !== event.currentTarget) {
-            if (typeof target.dataset.id === 'string') {
+            if (typeof target.dataset.id === 'string' && 'href' in target && typeof target.href === 'string') {
                 event.preventDefault();
                 event.stopImmediatePropagation();
                 return openContextMenu(target.dataset.id);
@@ -243,6 +243,9 @@ function getContextMenuHandler(openContextMenu) {
 }
 
 /**
+ * Following a click on a favorite, walk up the DOM from the clicked
+ * element to find the <a>. This is done to prevent needing a click handler
+ * on every element.
  * @param {(id: string, url: string, target: OpenTarget) => void} openFavorite
  * @param {ImportMeta['platform']} platformName
  */

--- a/special-pages/pages/new-tab/app/favorites/components/Favorites.js
+++ b/special-pages/pages/new-tab/app/favorites/components/Favorites.js
@@ -142,16 +142,16 @@ function VirtualizedGridRows({ WIDGET_ID, rowHeight, favorites, expansion, openF
         if (!safeAreaRef.current) return console.warn('cannot access ref');
         if (!gridOffset.current) return console.warn('cannot access ref');
         const offset = gridOffset.current;
-        let end = window.scrollY + window.innerHeight - offset;
+        const end = window.scrollY + window.innerHeight - offset;
         let start;
         if (offset > window.scrollY) {
             start = 0;
         } else {
             start = window.scrollY - offset;
         }
-        let start_index = Math.floor(start / rowHeight);
-        let end_index = Math.min(Math.ceil(end / rowHeight), rows.length);
-        setVisibleRange({ start: start_index, end: end_index });
+        const startIndex = Math.floor(start / rowHeight);
+        const endIndex = Math.min(Math.ceil(end / rowHeight), rows.length);
+        setVisibleRange({ start: startIndex, end: endIndex });
     }
 
     useLayoutEffect(() => {
@@ -213,9 +213,9 @@ function VirtualizedGridRows({ WIDGET_ID, rowHeight, favorites, expansion, openF
             {rows.length === 0 && <TileRow key={'empty-rows'} items={[]} topOffset={0} add={add} />}
             {rows.length > 0 &&
                 subsetOfRowsToRender.map((items, index) => {
-                    const top_offset = (start + index) * rowHeight;
+                    const topOffset = (start + index) * rowHeight;
                     const keyed = `-${start + index}-`;
-                    return <TileRow key={keyed} dropped={dropped} items={items} topOffset={top_offset} add={add} />;
+                    return <TileRow key={keyed} dropped={dropped} items={items} topOffset={topOffset} add={add} />;
                 })}
         </div>
     );

--- a/special-pages/pages/new-tab/app/favorites/components/Favorites.js
+++ b/special-pages/pages/new-tab/app/favorites/components/Favorites.js
@@ -17,6 +17,11 @@ import { TileRow } from './TileRow.js';
  */
 export const FavoritesMemo = memo(Favorites);
 export const ROW_CAPACITY = 6;
+/**
+ * Note: These values MUST match exactly what's defined in the CSS.
+ */
+const ITEM_HEIGHT = 98;
+const ROW_GAP = 8;
 
 /**
  * Favorites Grid.
@@ -38,8 +43,6 @@ export function Favorites({ gridRef, favorites, expansion, toggle, openContextMe
     const TOGGLE_ID = useId();
 
     const hiddenCount = expansion === 'collapsed' ? favorites.length - ROW_CAPACITY : 0;
-    const ITEM_HEIGHT = 98;
-    const ROW_GAP = 8;
     const rowHeight = ITEM_HEIGHT + ROW_GAP;
     const canToggleExpansion = favorites.length >= ROW_CAPACITY;
 
@@ -80,7 +83,10 @@ export function Favorites({ gridRef, favorites, expansion, toggle, openContextMe
 }
 
 /**
- * Favorites Grid.
+ * Favorites Grid. This will take a list of Favorites, split it into chunks (rows)
+ * and then layout the rows based on an offset from the top of the container.
+ *
+ * Doing this means we can just render the items in the current viewport
  *
  * @param {object} props
  * @param {string} props.WIDGET_ID
@@ -92,6 +98,9 @@ export function Favorites({ gridRef, favorites, expansion, toggle, openContextMe
  * @param {() => void} props.add
  */
 function VirtualizedGridRows({ WIDGET_ID, rowHeight, favorites, expansion, openFavorite, openContextMenu, add }) {
+    const platformName = usePlatformName();
+
+    // convert the list of favorites into chunks of length ROW_CAPACITY
     const rows = useMemo(() => {
         const chunked = [];
         let inner = [];
@@ -109,17 +118,26 @@ function VirtualizedGridRows({ WIDGET_ID, rowHeight, favorites, expansion, openF
         return chunked;
     }, [favorites]);
 
-    const platformName = usePlatformName();
+    // get a ref for the favorites' grid, this will allow it to receive drop events,
+    // and the ref can also be used for reading the offset (eg: if other elements are above it)
     const safeAreaRef = /** @type {import("preact").RefObject<HTMLDivElement>} */ (useDropzoneSafeArea());
-    const [{ start, end }, setSlice] = useState({ start: 0, end: 1 });
+
+    // set the start/end indexes of the elements
+    const [{ start, end }, setVisibleRange] = useState({ start: 0, end: 1 });
+
+    // hold a mutable value that we update on resize
     const gridOffset = useRef(0);
 
+    // When called, make the expensive call to `getBoundingClientRect` to determine the offset of
+    // the grid wrapper.
     function updateGlobals() {
-        if (!safeAreaRef.current) return console.warn('cannot access curren');
+        if (!safeAreaRef.current) return;
         const rec = safeAreaRef.current.getBoundingClientRect();
         gridOffset.current = rec.y + window.scrollY;
     }
 
+    // decide which the start/end indexes should be, based on scroll position.
+    // NOTE: this is called on scroll, so must not incur expensive checks/measurements - math only!
     function setVisibleRows() {
         if (!safeAreaRef.current) return console.warn('cannot access ref');
         if (!gridOffset.current) return console.warn('cannot access ref');
@@ -133,7 +151,7 @@ function VirtualizedGridRows({ WIDGET_ID, rowHeight, favorites, expansion, openF
         }
         let start_index = Math.floor(start / rowHeight);
         let end_index = Math.min(Math.ceil(end / rowHeight), rows.length);
-        setSlice({ start: start_index, end: end_index });
+        setVisibleRange({ start: start_index, end: end_index });
     }
 
     useLayoutEffect(() => {
@@ -166,34 +184,38 @@ function VirtualizedGridRows({ WIDGET_ID, rowHeight, favorites, expansion, openF
         };
     }, [rows.length]);
 
+    // now, we decide which items to show based on the widget expansion
     // prettier-ignore
     const subsetOfRowsToRender = expansion === 'collapsed'
-        // if it's collapsed, just 1 row to show (the first one)
+        // if it's 'collapsed', just 1 row to show (the first one)
         ? [rows[0]]
         // otherwise, select the window between start/end
-        // the extra '1' is the additional row to render offscreen - this helps
-        // with keyboard focus
+        // the '+ 1' is an additional row to render offscreen - which helps with keyboard navigation.
         : rows.slice(start, end + 1);
 
     //
-    const container_height = expansion === 'collapsed' ? rowHeight : rows.length * rowHeight;
+    const containerHeight = expansion === 'collapsed' ? rowHeight : rows.length * rowHeight;
+
+    // read a global property on <html> to determine if an element was recently dropped.
+    // this is used for animation (the pulse) - it's easier this way because the act of dropping
+    // a tile can cause it to render inside a different row, meaning the `key` is invalidated and so the dom-node is recreated
     const dropped = document.documentElement.dataset.dropped;
 
     return (
         <div
             className={styles.grid}
-            style={{ height: container_height + 'px' }}
+            style={{ height: containerHeight + 'px' }}
             id={WIDGET_ID}
             ref={safeAreaRef}
             onContextMenu={getContextMenuHandler(openContextMenu)}
             onClick={getOnClickHandler(openFavorite, platformName)}
         >
-            {rows.length === 0 && <TileRow key={'empty-rows'} items={[]} top_offset={0} add={add} />}
+            {rows.length === 0 && <TileRow key={'empty-rows'} items={[]} topOffset={0} add={add} />}
             {rows.length > 0 &&
                 subsetOfRowsToRender.map((items, index) => {
                     const top_offset = (start + index) * rowHeight;
                     const keyed = `-${start + index}-`;
-                    return <TileRow key={keyed} dropped={dropped} items={items} top_offset={top_offset} add={add} />;
+                    return <TileRow key={keyed} dropped={dropped} items={items} topOffset={top_offset} add={add} />;
                 })}
         </div>
     );

--- a/special-pages/pages/new-tab/app/favorites/components/Favorites.js
+++ b/special-pages/pages/new-tab/app/favorites/components/Favorites.js
@@ -171,7 +171,9 @@ function VirtualizedGridRows({ WIDGET_ID, rowHeight, favorites, expansion, openF
         // if it's collapsed, just 1 row to show (the first one)
         ? [rows[0]]
         // otherwise, select the window between start/end
-        : rows.slice(start, end);
+        // the extra '1' is the additional row to render offscreen - this helps
+        // with keyboard focus
+        : rows.slice(start, end + 1);
 
     //
     const container_height = expansion === 'collapsed' ? rowHeight : rows.length * rowHeight;
@@ -186,11 +188,13 @@ function VirtualizedGridRows({ WIDGET_ID, rowHeight, favorites, expansion, openF
             onContextMenu={getContextMenuHandler(openContextMenu)}
             onClick={getOnClickHandler(openFavorite, platformName)}
         >
-            {subsetOfRowsToRender.map((items, index) => {
-                const top_offset = (start + index) * rowHeight;
-                const keyed = `-${start + index}-`;
-                return <TileRow key={keyed} dropped={dropped} items={items} top_offset={top_offset} add={add} />;
-            })}
+            {rows.length === 0 && <TileRow key={'empty-rows'} items={[]} top_offset={0} add={add} />}
+            {rows.length > 0 &&
+                subsetOfRowsToRender.map((items, index) => {
+                    const top_offset = (start + index) * rowHeight;
+                    const keyed = `-${start + index}-`;
+                    return <TileRow key={keyed} dropped={dropped} items={items} top_offset={top_offset} add={add} />;
+                })}
         </div>
     );
 }

--- a/special-pages/pages/new-tab/app/favorites/components/Favorites.module.css
+++ b/special-pages/pages/new-tab/app/favorites/components/Favorites.module.css
@@ -34,10 +34,14 @@
 .grid {
     grid-area: grid;
     display: grid;
-    grid-template-columns: repeat(6, 1fr);
-    align-items: start;
-    grid-row-gap: 0.5rem;
+    position: relative;
     margin-left: -0.75rem;
     margin-right: -0.75rem;
 }
 
+.gridRow {
+    display: grid;
+    grid-template-columns: repeat(6, 1fr);
+    align-items: start;
+    position: absolute;
+}

--- a/special-pages/pages/new-tab/app/favorites/components/FavoritesProvider.js
+++ b/special-pages/pages/new-tab/app/favorites/components/FavoritesProvider.js
@@ -46,6 +46,10 @@ export const FavoritesContext = createContext({
     add: () => {
         throw new Error('must implement add');
     },
+    /** @type {(cb: (data: FavoritesConfig) => void) => void} */
+    onConfigChanged: (cb) => {
+        throw new Error('must implement add');
+    },
 });
 
 export const FavoritesDispatchContext = createContext(/** @type {import("preact/hooks").Dispatch<Events>} */ ({}));
@@ -107,8 +111,21 @@ export function FavoritesProvider({ children }) {
         service.current.add();
     }, [service]);
 
+    /** @type {(cb: (data: FavoritesConfig) => void) => void} */
+    const onConfigChanged = useCallback(
+        (cb) => {
+            if (!service.current) return;
+            return service.current.onConfig((event) => {
+                if (event.source === 'manual') {
+                    cb(event.data);
+                }
+            });
+        },
+        [service],
+    );
+
     return (
-        <FavoritesContext.Provider value={{ state, toggle, favoritesDidReOrder, openFavorite, openContextMenu, add }}>
+        <FavoritesContext.Provider value={{ state, toggle, favoritesDidReOrder, openFavorite, openContextMenu, add, onConfigChanged }}>
             <FavoritesDispatchContext.Provider value={dispatch}>{children}</FavoritesDispatchContext.Provider>
         </FavoritesContext.Provider>
     );

--- a/special-pages/pages/new-tab/app/favorites/components/PragmaticDND.js
+++ b/special-pages/pages/new-tab/app/favorites/components/PragmaticDND.js
@@ -135,7 +135,13 @@ function useGridState(favorites, itemsDidReOrder, instanceId) {
                         axis: 'horizontal',
                     });
 
+                    // mark an element as dropped globally.
+                    // todo: not happy with this, but it's working for launch.
                     document.documentElement.dataset.dropped = String(startId);
+                    setTimeout(() => {
+                        document.documentElement.dataset.dropped = '';
+                    }, 0);
+
                     itemsDidReOrder({
                         list: reorderedList,
                         id: startId,

--- a/special-pages/pages/new-tab/app/favorites/components/PragmaticDND.js
+++ b/special-pages/pages/new-tab/app/favorites/components/PragmaticDND.js
@@ -1,6 +1,5 @@
 import { h, createContext } from 'preact';
 import { useContext, useEffect, useRef, useState } from 'preact/hooks';
-import { flushSync } from 'preact/compat';
 
 import { monitorForElements, draggable, dropTargetForElements } from '@atlaskit/pragmatic-drag-and-drop/element/adapter';
 import { extractClosestEdge, attachClosestEdge } from '@atlaskit/pragmatic-drag-and-drop-hitbox/closest-edge';
@@ -136,33 +135,13 @@ function useGridState(favorites, itemsDidReOrder, instanceId) {
                         axis: 'horizontal',
                     });
 
-                    flushSync(() => {
-                        try {
-                            itemsDidReOrder({
-                                list: reorderedList,
-                                id: startId,
-                                fromIndex: startIndex,
-                                targetIndex,
-                            });
-                        } catch (e) {
-                            console.error('did catch', e);
-                        }
+                    document.documentElement.dataset.dropped = String(startId);
+                    itemsDidReOrder({
+                        list: reorderedList,
+                        id: startId,
+                        fromIndex: startIndex,
+                        targetIndex,
                     });
-
-                    const htmlElem = source.element;
-
-                    const pulseAnimation = htmlElem.animate(
-                        [{ transform: 'scale(1)' }, { transform: 'scale(1.1)' }, { transform: 'scale(1)' }],
-                        {
-                            duration: 500, // duration in milliseconds
-                            iterations: 1, // run the animation once
-                            easing: 'ease-in-out', // easing function
-                        },
-                    );
-
-                    pulseAnimation.onfinish = () => {
-                        // additional actions can be placed here or handle the end of the animation if needed
-                    };
                 },
             }),
         );

--- a/special-pages/pages/new-tab/app/favorites/components/Tile.js
+++ b/special-pages/pages/new-tab/app/favorites/components/Tile.js
@@ -1,6 +1,6 @@
 import { h } from 'preact';
 import cn from 'classnames';
-import { useEffect, useId, useState } from 'preact/hooks';
+import { useId } from 'preact/hooks';
 import { memo } from 'preact/compat';
 import styles from './Tile.module.css';
 import { urlToColor } from '../color.js';

--- a/special-pages/pages/new-tab/app/favorites/components/Tile.js
+++ b/special-pages/pages/new-tab/app/favorites/components/Tile.js
@@ -20,34 +20,8 @@ import { useItemState } from './PragmaticDND.js';
  * @param {number|null|undefined} props.faviconMax
  * @param {number} props.index
  */
-function Tile({ url, faviconSrc, faviconMax, index, title, id }) {
+export function Tile_({ url, faviconSrc, faviconMax, index, title, id }) {
     const { state, ref } = useItemState(url, id);
-    const [visible, setVisible] = useState(true);
-
-    useEffect(() => {
-        if (!ref) return;
-        if (state.type !== 'idle') return;
-        let elem = ref.current;
-        if (!elem) return;
-        /** @type {IntersectionObserver | null} */
-        let o = new IntersectionObserver(
-            (entries) => {
-                const last = entries[entries.length - 1];
-                requestAnimationFrame(() => {
-                    setVisible(last.isIntersecting);
-                });
-            },
-            { threshold: [0] },
-        );
-        o.observe(elem);
-        return () => {
-            if (elem) {
-                o?.unobserve(elem);
-            }
-            o = null;
-            elem = null;
-        };
-    }, [id, state.type]);
 
     return (
         <a
@@ -61,14 +35,7 @@ function Tile({ url, faviconSrc, faviconMax, index, title, id }) {
             ref={ref}
         >
             <div class={cn(styles.icon, styles.draggable)}>
-                {visible && (
-                    <ImageLoader
-                        faviconSrc={faviconSrc || 'n/a'}
-                        faviconMax={faviconMax || DDG_DEFAULT_ICON_SIZE}
-                        title={title}
-                        url={url}
-                    />
-                )}
+                <ImageLoader faviconSrc={faviconSrc || 'n/a'} faviconMax={faviconMax || DDG_DEFAULT_ICON_SIZE} title={title} url={url} />
             </div>
             <div class={styles.text}>{title}</div>
             {state.type === 'is-dragging-over' && state.closestEdge ? <div class={styles.dropper} data-edge={state.closestEdge} /> : null}
@@ -76,7 +43,7 @@ function Tile({ url, faviconSrc, faviconMax, index, title, id }) {
     );
 }
 
-export const TileMemo = memo(Tile);
+export const Tile = memo(Tile_);
 
 /**
  * Loads and displays an image for a given webpage.
@@ -118,7 +85,6 @@ function ImageLoader({ faviconSrc, faviconMax, title, url }) {
     return (
         <img
             src={src}
-            loading="lazy"
             className={styles.favicon}
             alt={`favicon for ${title}`}
             onLoad={imgLoaded}

--- a/special-pages/pages/new-tab/app/favorites/components/Tile.js
+++ b/special-pages/pages/new-tab/app/favorites/components/Tile.js
@@ -19,8 +19,9 @@ import { useItemState } from './PragmaticDND.js';
  * @param {string|null|undefined} props.faviconSrc
  * @param {number|null|undefined} props.faviconMax
  * @param {number} props.index
+ * @param {boolean} props.dropped
  */
-export function Tile_({ url, faviconSrc, faviconMax, index, title, id }) {
+export function Tile_({ url, faviconSrc, faviconMax, index, title, id, dropped }) {
     const { state, ref } = useItemState(url, id);
 
     return (
@@ -31,6 +32,7 @@ export function Tile_({ url, faviconSrc, faviconMax, index, title, id }) {
             href={url}
             data-id={id}
             data-index={index}
+            data-dropped={String(dropped)}
             data-edge={'closestEdge' in state && state.closestEdge}
             ref={ref}
         >

--- a/special-pages/pages/new-tab/app/favorites/components/Tile.module.css
+++ b/special-pages/pages/new-tab/app/favorites/components/Tile.module.css
@@ -12,6 +12,19 @@
     &:focus-visible .icon {
         box-shadow: var(--focus-ring);
     }
+
+    &[data-dropped="true"] {
+        animation-name: pulse;
+        animation-duration: 500ms;
+        animation-fill-mode: forwards;
+        animation-timing-function: ease-in-out;
+    }
+}
+
+@keyframes pulse {
+    0% { scale: 1 }
+    50% { scale: 1.2 }
+    100% { scale: 1 }
 }
 
 .icon {
@@ -50,12 +63,6 @@
     background-repeat: no-repeat;
     background-size: contain;
     pointer-events: none;
-    opacity: 0;
-    transition: opacity .3s;
-
-    &[data-loaded] {
-        opacity: 1;
-    }
 
     &[data-loaded][data-did-try-fallback] {
         border-radius: var(--border-radius-md);

--- a/special-pages/pages/new-tab/app/favorites/components/TileRow.js
+++ b/special-pages/pages/new-tab/app/favorites/components/TileRow.js
@@ -5,11 +5,15 @@ import { memo } from 'preact/compat';
 import { ROW_CAPACITY } from './Favorites.js';
 
 /**
- * Represents a row of tiles with optional placeholders to fill empty spaces in the first  row.
+ * @typedef {import('../../../../../types/new-tab.js').Favorite} Favorite
+ */
+
+/**
+ * Represents a row of tiles with optional placeholders to fill empty spaces in the first row.
  * @param {object} props - An object containing parameters for the TileRow_ function.
  * @param {number} props.topOffset - The top offset position of the row.
- * @param {Array} props.items - An array of items to be displayed as tiles in the row.
- * @param {()=>void} props.add - A function to be called when a new item is added to the row.
+ * @param {Favorite[]} props.items - An array of items to be displayed as tiles in the row.
+ * @param {() => void} props.add - A function to be called when a new item is added to the row.
  * @param {string} [props.dropped] - The ID of the item that has been dropped (if one exists)
  */
 function TileRow_({ topOffset, items, add, dropped }) {
@@ -30,12 +34,15 @@ function TileRow_({ topOffset, items, add, dropped }) {
                     />
                 );
             })}
-            {Array.from({ length: fillers }).map((_, index) => {
-                if (index === 0) {
-                    return <PlusIconMemo key="placeholder-plus" onClick={add} />;
-                }
-                return <Placeholder key={`placeholder-${index}`} />;
-            })}
+            {fillers > 0 &&
+                Array.from({ length: fillers }).map((_, fillerIndex) => {
+                    // first is always the + button
+                    if (fillerIndex === 0) {
+                        return <PlusIconMemo key="placeholder-plus" onClick={add} />;
+                    }
+
+                    return <Placeholder key={`placeholder-${fillerIndex}`} />;
+                })}
         </ul>
     );
 }

--- a/special-pages/pages/new-tab/app/favorites/components/TileRow.js
+++ b/special-pages/pages/new-tab/app/favorites/components/TileRow.js
@@ -4,7 +4,15 @@ import { h } from 'preact';
 import { memo } from 'preact/compat';
 import { ROW_CAPACITY } from './Favorites.js';
 
-function TileRow_({ top_offset, items, add }) {
+/**
+ * Represents a row of tiles with optional placeholders to fill empty spaces in the first  row.
+ * @param {object} props - An object containing parameters for the TileRow_ function.
+ * @param {number} props.top_offset - The top offset position of the row.
+ * @param {Array} props.items - An array of items to be displayed as tiles in the row.
+ * @param {()=>void} props.add - A function to be called when a new item is added to the row.
+ * @param {string} [props.dropped] - The ID of the item that has been dropped (if one exists)
+ */
+function TileRow_({ top_offset, items, add, dropped }) {
     const fillers = ROW_CAPACITY - items.length;
     return (
         <ul className={styles.gridRow} style={{ top: top_offset + 'px' }}>
@@ -18,6 +26,7 @@ function TileRow_({ top_offset, items, add }) {
                         key={item.id + item.favicon?.src + item.favicon?.maxAvailableSize}
                         id={item.id}
                         index={index}
+                        dropped={dropped === item.id}
                     />
                 );
             })}

--- a/special-pages/pages/new-tab/app/favorites/components/TileRow.js
+++ b/special-pages/pages/new-tab/app/favorites/components/TileRow.js
@@ -11,8 +11,8 @@ import { ROW_CAPACITY } from './Favorites.js';
 /**
  * Represents a row of tiles with optional placeholders to fill empty spaces in the first row.
  * @param {object} props - An object containing parameters for the TileRow_ function.
- * @param {number} props.topOffset - The top offset position of the row.
- * @param {Favorite[]} props.items - An array of items to be displayed as tiles in the row.
+ * @param {number} props.topOffset - The top offset position of the row (relative to the container)
+ * @param {Favorite[]} props.items - An array of favorites to be displayed as tiles in the row.
  * @param {() => void} props.add - A function to be called when a new item is added to the row.
  * @param {string} [props.dropped] - The ID of the item that has been dropped (if one exists)
  */
@@ -36,11 +36,12 @@ function TileRow_({ topOffset, items, add, dropped }) {
             })}
             {fillers > 0 &&
                 Array.from({ length: fillers }).map((_, fillerIndex) => {
-                    // first is always the + button
+                    // first is always the + (plus) button
                     if (fillerIndex === 0) {
                         return <PlusIconMemo key="placeholder-plus" onClick={add} />;
                     }
 
+                    // for all the rest, just fill the row with dotted outlines
                     return <Placeholder key={`placeholder-${fillerIndex}`} />;
                 })}
         </ul>

--- a/special-pages/pages/new-tab/app/favorites/components/TileRow.js
+++ b/special-pages/pages/new-tab/app/favorites/components/TileRow.js
@@ -1,0 +1,34 @@
+import styles from './Favorites.module.css';
+import { Placeholder, PlusIconMemo, Tile } from './Tile.js';
+import { h } from 'preact';
+import { memo } from 'preact/compat';
+import { ROW_CAPACITY } from './Favorites.js';
+
+function TileRow_({ top_offset, items, add }) {
+    const fillers = ROW_CAPACITY - items.length;
+    return (
+        <ul className={styles.gridRow} style={{ top: top_offset + 'px' }}>
+            {items.map((item, index) => {
+                return (
+                    <Tile
+                        url={item.url}
+                        faviconSrc={item.favicon?.src}
+                        faviconMax={item.favicon?.maxAvailableSize}
+                        title={item.title}
+                        key={item.id + item.favicon?.src + item.favicon?.maxAvailableSize}
+                        id={item.id}
+                        index={index}
+                    />
+                );
+            })}
+            {Array.from({ length: fillers }).map((_, index) => {
+                if (index === 0) {
+                    return <PlusIconMemo key="placeholder-plus" onClick={add} />;
+                }
+                return <Placeholder key={`placeholder-${index}`} />;
+            })}
+        </ul>
+    );
+}
+
+export const TileRow = memo(TileRow_);

--- a/special-pages/pages/new-tab/app/favorites/components/TileRow.js
+++ b/special-pages/pages/new-tab/app/favorites/components/TileRow.js
@@ -7,15 +7,15 @@ import { ROW_CAPACITY } from './Favorites.js';
 /**
  * Represents a row of tiles with optional placeholders to fill empty spaces in the first  row.
  * @param {object} props - An object containing parameters for the TileRow_ function.
- * @param {number} props.top_offset - The top offset position of the row.
+ * @param {number} props.topOffset - The top offset position of the row.
  * @param {Array} props.items - An array of items to be displayed as tiles in the row.
  * @param {()=>void} props.add - A function to be called when a new item is added to the row.
  * @param {string} [props.dropped] - The ID of the item that has been dropped (if one exists)
  */
-function TileRow_({ top_offset, items, add, dropped }) {
+function TileRow_({ topOffset, items, add, dropped }) {
     const fillers = ROW_CAPACITY - items.length;
     return (
-        <ul className={styles.gridRow} style={{ top: top_offset + 'px' }}>
+        <ul className={styles.gridRow} style={{ top: topOffset + 'px' }}>
             {items.map((item, index) => {
                 return (
                     <Tile

--- a/special-pages/pages/new-tab/app/favorites/mocks/MockFavoritesProvider.js
+++ b/special-pages/pages/new-tab/app/favorites/mocks/MockFavoritesProvider.js
@@ -65,8 +65,13 @@ export function MockFavoritesProvider({ data = favorites.many, config = DEFAULT_
         console.log('noop add', ...args);
     };
 
+    const onConfigChanged = () => {
+        /* no-op */
+        return () => {};
+    };
+
     return (
-        <FavoritesContext.Provider value={{ state, toggle, favoritesDidReOrder, openContextMenu, openFavorite, add }}>
+        <FavoritesContext.Provider value={{ state, toggle, favoritesDidReOrder, openContextMenu, openFavorite, add, onConfigChanged }}>
             <FavoritesDispatchContext.Provider value={dispatch}>{children}</FavoritesDispatchContext.Provider>
         </FavoritesContext.Provider>
     );

--- a/special-pages/pages/new-tab/app/favorites/mocks/favorites.data.js
+++ b/special-pages/pages/new-tab/app/favorites/mocks/favorites.data.js
@@ -234,7 +234,7 @@ export function gen(count = 1000) {
             const out = {
                 id: `id-many-${index}`,
                 url: `https://${alpha[index % 7]}.example.com?id=${index}`,
-                title: `Example ${index}`,
+                title: `Example ${index + 1}`,
                 favicon: { src: joined, maxAvailableSize: 64 },
             };
 


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/0/1201141132935289/1208792034336660/f

## Description

- [x] only render the rows of favorites that are visible
  - this addresses a major pain-point from our native desktop browsers
- [x] when expanded, defer rendering children until the main thread is free
  - this means users on the very slowest devices still get an instant feedback on click 

## Example
Part of this PR is optimizing the expand/collapse action of the favorites list. On slow devices this can cause over a second of input delay since the act of rendering a screen full of favorites can be an expensive main-thread-blocking operation.

To combat this problem, I separated the expand/collapse action from the rendering of the actual tiles, which had the following impact: 💪🏻 

**BEFORE** (20x CPU slowdown)
<img width="647" alt="Screenshot 2024-11-26 at 10 13 02 AM" src="https://github.com/user-attachments/assets/5ac5d3f5-0653-441f-a2b9-9781e9902597">

**AFTER** (20x CPU slowdown)

<img width="540" alt="Screenshot 2024-11-26 at 10 22 32 AM" src="https://github.com/user-attachments/assets/b2bc679c-f9c8-4342-abb6-1c551ba79190">



## TODO:
- [x] add some perf metrics to explain the change

## Testing Steps

- https://deploy-preview-1269--content-scope-scripts.netlify.app/build/pages/new-tab/?favorites=100
- Verify that the page works as expected with showing/hiding along with drag+drop

## Checklist

<!--
  These questions are a friendly reminder to shipping code, if you're uncertain ask the AoR owners.
  It's also totally appropriate to not check some of these boxes, if they don't apply to your change.
-->
*Please tick all that apply:*

- [x] I have tested this change locally
- [x] I have tested this change locally in all supported browsers
- [ ] This change will be visible to users
- [ ] I have added automated tests that cover this change
- [ ] I have ensured the change is gated by config
- [ ] This change was covered by a ship review
- [ ] This change was covered by a tech design
- [ ] Any dependent config has been merged

