### PR TITLE
ntp: remove bullet from update-notification notes

### DIFF
--- a/special-pages/pages/new-tab/app/update-notification/components/UpdateNotification.js
+++ b/special-pages/pages/new-tab/app/update-notification/components/UpdateNotification.js
@@ -53,7 +53,17 @@ export function WithNotes({ notes, version }) {
             <div id={id} class={styles.detailsContent}>
                 <ul class={styles.list}>
                     {notes.map((note, index) => {
-                        return <li key={note + index}>{note}</li>;
+                        /**
+                         * Note: Doing this here as a very specific 'view' concern
+                         * Note: using the `if` + `.slice` to avoid regex
+                         * Note: `.slice` is safe on `•` because it is a single Unicode character
+                         *       and is represented by a single UTF-16 code unit.
+                         */
+                        let trimmed = note.trim();
+                        if (trimmed.startsWith('•')) {
+                            trimmed = trimmed.slice(1).trim();
+                        }
+                        return <li key={note + index}>{trimmed}</li>;
                     })}
                 </ul>
             </div>

--- a/special-pages/pages/new-tab/app/update-notification/integration-tests/update-notification.spec.js
+++ b/special-pages/pages/new-tab/app/update-notification/integration-tests/update-notification.spec.js
@@ -27,7 +27,9 @@ test.describe('newtab update notifications', () => {
 
         await page.getByText("Browser Updated to version 1.91. See what's new in this release.").waitFor();
         await page.getByRole('link', { name: "what's new" }).click();
-        await page.getByText('Bug fixes and improvements').waitFor();
+        // this test was updated to add 'exact: true' which would fail if the bullet was not stripped
+        await page.getByText('Bug fixes and improvements', { exact: true }).waitFor();
+        await page.getByText('Optimized performance for faster load times', { exact: true }).waitFor();
         await page.getByRole('button', { name: 'Dismiss' }).click();
         await ntp.mocks.waitForCallCount({ method: 'updateNotification_dismiss', count: 1 });
     });

--- a/special-pages/pages/new-tab/app/update-notification/mocks/update-notification.data.js
+++ b/special-pages/pages/new-tab/app/update-notification/mocks/update-notification.data.js
@@ -10,7 +10,11 @@ export const updateNotificationExamples = {
     },
     populated: {
         content: {
-            notes: ['Bug fixes and improvements'],
+            // prettier-ignore
+            notes: [
+                '• Bug fixes and improvements',
+                'Optimized performance for faster load times'
+            ],
             version: '1.91',
         },
     },


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/0/1201141132935289/1208864032402433/f

## Description

- The native side splits the string before we get it, but the bullets remain. It's really a view concern so we're handling it on our side

## Testing Steps

- The updated tests explain the problem well.

## Checklist

<!--
  These questions are a friendly reminder to shipping code, if you're uncertain ask the AoR owners.
  It's also totally appropriate to not check some of these boxes, if they don't apply to your change.
-->
*Please tick all that apply:*

- [ ] I have tested this change locally
- [ ] I have tested this change locally in all supported browsers
- [ ] This change will be visible to users
- [ ] I have added automated tests that cover this change
- [ ] I have ensured the change is gated by config
- [ ] This change was covered by a ship review
- [ ] This change was covered by a tech design
- [ ] Any dependent config has been merged

