### PR TITLE
ntp: display tweaks + stats show more fix

### DIFF
--- a/messaging/lib/messaging.types.d.ts
+++ b/messaging/lib/messaging.types.d.ts
@@ -20,6 +20,7 @@ interface Window {
     __playwright_01: {
         mockResponses: Record<string, import('../index.js').MessageResponse>;
         subscriptionEvents: import('../index.js').SubscriptionEvent[];
+        publishSubscriptionEvent?: (evt: import('../index.js').SubscriptionEvent) => void;
         mocks: {
             outgoing: UnstableMockCall[];
         };

--- a/messaging/lib/test-utils.mjs
+++ b/messaging/lib/test-utils.mjs
@@ -428,7 +428,7 @@ export function simulateSubscriptionMessage(params) {
             break;
         }
         case 'integration': {
-            if (!(params.name in window))
+            if (!('publishSubscriptionEvent' in window.__playwright_01))
                 throw new Error(
                     `subscription event '${subscriptionEvent.subscriptionName}' was not published because 'window.__playwright_01.publishSubscriptionEvent' was missing`,
                 );

--- a/messaging/lib/test-utils.mjs
+++ b/messaging/lib/test-utils.mjs
@@ -427,6 +427,14 @@ export function simulateSubscriptionMessage(params) {
             window[params.name](subscriptionEvent);
             break;
         }
+        case 'integration': {
+            if (!(params.name in window))
+                throw new Error(
+                    `subscription event '${subscriptionEvent.subscriptionName}' was not published because 'window.__playwright_01.publishSubscriptionEvent' was missing`,
+                );
+            window.__playwright_01.publishSubscriptionEvent?.(subscriptionEvent);
+            break;
+        }
         default:
             throw new Error('platform not supported yet: ' + params.injectName);
     }

--- a/special-pages/pages/new-tab/app/entry-points/privacyStats.js
+++ b/special-pages/pages/new-tab/app/entry-points/privacyStats.js
@@ -4,7 +4,7 @@ import { Centered } from '../components/Layout.js';
 
 export function factory() {
     return (
-        <Centered>
+        <Centered data-entry-point="privacyStats">
             <PrivacyStatsCustomized />
         </Centered>
     );

--- a/special-pages/pages/new-tab/app/mock-transport.js
+++ b/special-pages/pages/new-tab/app/mock-transport.js
@@ -279,7 +279,7 @@ export function mockTransport() {
                     if (updateMaxCount === 0) return () => {};
                     if (statsVariant === 'willUpdate') {
                         let inc = 1;
-                        let max = Math.min(updateMaxCount, 10);
+                        const max = Math.min(updateMaxCount, 10);
                         const int = setInterval(() => {
                             if (inc === max) return clearInterval(int);
                             const next = {
@@ -300,8 +300,8 @@ export function mockTransport() {
                     } else if (statsVariant === 'growing') {
                         const list = stats.many.trackerCompanies;
                         let index = 0;
-                        let max = Math.min(updateMaxCount, list.length);
-                        let int = setInterval(() => {
+                        const max = Math.min(updateMaxCount, list.length);
+                        const int = setInterval(() => {
                             if (index === max) return clearInterval(int);
                             console.log({ index, max });
                             cb({

--- a/special-pages/pages/new-tab/app/privacy-stats/components/PrivacyStats.js
+++ b/special-pages/pages/new-tab/app/privacy-stats/components/PrivacyStats.js
@@ -138,27 +138,23 @@ export function PrivacyStatsBody({ trackerCompanies, listAttrs = {} }) {
     const defaultRowMax = 5;
     const sorted = sortStatsForDisplay(trackerCompanies);
     const max = sorted[0]?.count ?? 0;
-    const [visible, setVisible] = useState(defaultRowMax);
-    const hasmore = sorted.length > visible;
+    const [expansion, setExpansion] = useState(/** @type {Expansion} */ ('collapsed'));
 
     const toggleListExpansion = () => {
-        if (hasmore) {
+        if (expansion === 'collapsed') {
             messaging.statsShowMore();
         } else {
             messaging.statsShowLess();
         }
-        if (visible === defaultRowMax) {
-            setVisible(sorted.length);
-        }
-        if (visible === sorted.length) {
-            setVisible(defaultRowMax);
-        }
+        setExpansion(expansion === 'collapsed' ? 'expanded' : 'collapsed');
     };
+
+    const rows = expansion === 'expanded' ? sorted : sorted.slice(0, defaultRowMax);
 
     return (
         <Fragment>
             <ul {...listAttrs} class={styles.list} data-testid="CompanyList">
-                {sorted.slice(0, visible).map((company) => {
+                {rows.map((company) => {
                     const percentage = Math.min((company.count * 100) / max, 100);
                     const valueOrMin = Math.max(percentage, 10);
                     const inlineStyles = {
@@ -191,11 +187,11 @@ export function PrivacyStatsBody({ trackerCompanies, listAttrs = {} }) {
                 <div class={styles.listExpander}>
                     <ShowHideButton
                         onClick={toggleListExpansion}
-                        text={hasmore ? t('ntp_show_more') : t('ntp_show_less')}
+                        text={expansion === 'collapsed' ? t('ntp_show_more') : t('ntp_show_less')}
                         showText={true}
                         buttonAttrs={{
-                            'aria-expanded': !hasmore,
-                            'aria-pressed': visible === sorted.length,
+                            'aria-expanded': expansion === 'expanded',
+                            'aria-pressed': expansion === 'expanded',
                         }}
                     />
                 </div>

--- a/special-pages/pages/new-tab/app/privacy-stats/components/PrivacyStats.js
+++ b/special-pages/pages/new-tab/app/privacy-stats/components/PrivacyStats.js
@@ -9,7 +9,7 @@ import { viewTransition } from '../../utils.js';
 import { ShowHideButton } from '../../components/ShowHideButton.jsx';
 import { useCustomizer } from '../../customizer/components/Customizer.js';
 import { DDG_STATS_OTHER_COMPANY_IDENTIFIER } from '../constants.js';
-import { sortStatsForDisplay } from '../privacy-stats.utils.js';
+import { displayNameForCompany, sortStatsForDisplay } from '../privacy-stats.utils.js';
 
 /**
  * @import enStrings from "../strings.json"
@@ -165,8 +165,7 @@ export function PrivacyStatsBody({ trackerCompanies, listAttrs = {} }) {
                         width: `${valueOrMin}%`,
                     };
                     const countText = formatter.format(company.count);
-                    // prettier-ignore
-                    const displayName = company.displayName
+                    const displayName = displayNameForCompany(company.displayName);
                     if (company.displayName === DDG_STATS_OTHER_COMPANY_IDENTIFIER) {
                         const otherText = t('stats_otherCount', { count: String(company.count) });
                         return (
@@ -178,7 +177,7 @@ export function PrivacyStatsBody({ trackerCompanies, listAttrs = {} }) {
                     return (
                         <li key={company.displayName} class={styles.row}>
                             <div class={styles.company}>
-                                <CompanyIcon displayName={company.displayName} />
+                                <CompanyIcon displayName={displayName} />
                                 <span class={styles.name}>{displayName}</span>
                             </div>
                             <span class={styles.count}>{countText}</span>

--- a/special-pages/pages/new-tab/app/privacy-stats/integration-tests/privacy-stats.page.js
+++ b/special-pages/pages/new-tab/app/privacy-stats/integration-tests/privacy-stats.page.js
@@ -21,6 +21,13 @@ export class PrivacyStatsPage {
         await this.ntp.mocks.simulateSubscriptionMessage('stats_onDataUpdate', next);
     }
 
+    /**
+     * @param {import("../../../../../types/new-tab.js").PrivacyStatsData} data
+     */
+    async receiveData(data) {
+        await this.ntp.mocks.simulateSubscriptionMessage('stats_onDataUpdate', data);
+    }
+
     context() {
         return this.page.locator('[data-entry-point="privacyStats"]');
     }

--- a/special-pages/pages/new-tab/app/privacy-stats/integration-tests/privacy-stats.page.js
+++ b/special-pages/pages/new-tab/app/privacy-stats/integration-tests/privacy-stats.page.js
@@ -1,0 +1,47 @@
+import { stats } from '../mocks/stats.js';
+import { expect } from '@playwright/test';
+
+export class PrivacyStatsPage {
+    /**
+     * @param {import("@playwright/test").Page} page
+     * @param {import("../../../integration-tests/new-tab.page.js").NewtabPage} ntp
+     */
+    constructor(page, ntp) {
+        this.page = page;
+        this.ntp = ntp;
+    }
+
+    /**
+     * @param {object} params
+     * @param {number} params.count
+     */
+    async receive({ count }) {
+        /** @type {import("../../../../../types/new-tab.js").PrivacyStatsData} */
+        const next = { totalCount: 0, trackerCompanies: stats.many.trackerCompanies.slice(0, count) };
+        await this.ntp.mocks.simulateSubscriptionMessage('stats_onDataUpdate', next);
+    }
+
+    context() {
+        return this.page.locator('[data-entry-point="privacyStats"]');
+    }
+
+    rows() {
+        return this.context().getByTestId('CompanyList').locator('li');
+    }
+
+    /**
+     * @param {number} count
+     */
+    async hasRows(count) {
+        const rows = this.rows();
+        expect(await rows.count()).toBe(count);
+    }
+
+    async showMoreSecondary() {
+        await this.context().getByLabel('Show More', { exact: true }).click();
+    }
+
+    async showLessSecondary() {
+        await this.context().getByLabel('Show Less', { exact: true }).click();
+    }
+}

--- a/special-pages/pages/new-tab/app/privacy-stats/integration-tests/privacy-stats.spec.js
+++ b/special-pages/pages/new-tab/app/privacy-stats/integration-tests/privacy-stats.spec.js
@@ -80,7 +80,44 @@ test.describe('newtab privacy stats', () => {
             await expect(page.getByLabel('Show recent activity')).not.toBeVisible();
         },
     );
+    test(
+        'bar width',
+        {
+            annotation: {
+                type: 'issue',
+                description: 'https://app.asana.com/0/0/1208800221025230/f',
+            },
+        },
+        async ({ page }, workerInfo) => {
+            const ntp = NewtabPage.create(page, workerInfo);
+            const psp = new PrivacyStatsPage(page, ntp);
+            await ntp.reducedMotion();
+            await ntp.openPage({ additional: { stats: 'none' } });
 
+            await psp.receiveData({
+                totalCount: 2,
+                trackerCompanies: [
+                    { displayName: 'Google', count: 1 },
+                    { displayName: 'Facebook', count: 1 },
+                ],
+            });
+
+            await page.getByText('Google1').locator('[style="width: 100%;"]').waitFor();
+            await page.getByText('Facebook1').locator('[style="width: 100%;"]').waitFor();
+
+            await psp.receiveData({
+                totalCount: 2,
+                trackerCompanies: [
+                    { displayName: 'Google', count: 5 },
+                    { displayName: 'Facebook', count: 1 },
+                ],
+            });
+
+            // Checking the first + last bar widths due to a regression
+            await page.getByText('Google5').locator('[style="width: 100%;"]').waitFor();
+            await page.getByText('Facebook1').locator('[style="width: 20%;"]').waitFor();
+        },
+    );
     test(
         'secondary expansion',
         {

--- a/special-pages/pages/new-tab/app/privacy-stats/mocks/stats.js
+++ b/special-pages/pages/new-tab/app/privacy-stats/mocks/stats.js
@@ -21,7 +21,7 @@ export const stats = {
                 count: 210,
             },
             {
-                displayName: 'Amazon',
+                displayName: 'Amazon.com',
                 count: 67,
             },
             {
@@ -63,7 +63,7 @@ export const stats = {
                 count: 1,
             },
             {
-                displayName: 'Amazon',
+                displayName: 'Amazon.com',
                 count: 1,
             },
             {

--- a/special-pages/pages/new-tab/app/privacy-stats/mocks/stats.js
+++ b/special-pages/pages/new-tab/app/privacy-stats/mocks/stats.js
@@ -72,6 +72,10 @@ export const stats = {
             },
         ],
     },
+    growing: {
+        totalCount: 0,
+        trackerCompanies: [],
+    },
     many: {
         totalCount: 890,
         trackerCompanies: [

--- a/special-pages/pages/new-tab/app/privacy-stats/privacy-stats.utils.js
+++ b/special-pages/pages/new-tab/app/privacy-stats/privacy-stats.utils.js
@@ -16,3 +16,15 @@ export function sortStatsForDisplay(stats) {
     }
     return sorted;
 }
+
+/**
+ * @param {string} companyName
+ */
+export function displayNameForCompany(companyName) {
+    return (
+        companyName
+            // remove any end sections followed by a '.' - this handles things like `Amazon.com` as a company name in the
+            // tracker radar dataset
+            .replace(/\.[a-z]+$/i, '')
+    );
+}


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/0/1201141132935289/1208864911781466/f
## Description

- [x] fixed an issue where the track-radar dataset has `Example.com`, but we only want to show 'Example'
- [x] fixed a bug where the `Show More` toggle would break if the list grew after initial expansion

## Testing Steps

- Check the 'Show More' toggle on this link https://deploy-preview-1288--content-scope-scripts.netlify.app/build/pages/new-tab/?stats=growing&stats-update-count=10

## Checklist

<!--
  These questions are a friendly reminder to shipping code, if you're uncertain ask the AoR owners.
  It's also totally appropriate to not check some of these boxes, if they don't apply to your change.
-->
*Please tick all that apply:*

- [ ] I have tested this change locally
- [ ] I have tested this change locally in all supported browsers
- [ ] This change will be visible to users
- [ ] I have added automated tests that cover this change
- [ ] I have ensured the change is gated by config
- [ ] This change was covered by a ship review
- [ ] This change was covered by a tech design
- [ ] Any dependent config has been merged

