### PR TITLE
feat: Add confirmation to Mac Next Steps card

### DIFF
--- a/special-pages/pages/new-tab/app/components/Icons.js
+++ b/special-pages/pages/new-tab/app/components/Icons.js
@@ -82,3 +82,23 @@ export function Cross() {
         </svg>
     );
 }
+
+export function CheckColor() {
+    return (
+        <svg fill="none" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
+            <path fill="#4CBA3C" d="M15.5 8a7.5 7.5 0 1 1-15 0 7.5 7.5 0 0 1 15 0" />
+            <path
+                fill="#fff"
+                fill-rule="evenodd"
+                d="M11.844 5.137a.5.5 0 0 1 .019.707l-4.5 4.75a.5.5 0 0 1-.733-.008l-2.5-2.75a.5.5 0 0 1 .74-.672l2.138 2.351 4.129-4.359a.5.5 0 0 1 .707-.019"
+                clip-rule="evenodd"
+            />
+            <path
+                fill="#288419"
+                fill-rule="evenodd"
+                d="M8 1a7 7 0 1 0 0 14A7 7 0 0 0 8 1M0 8a8 8 0 1 1 16 0A8 8 0 0 1 0 8"
+                clip-rule="evenodd"
+            />
+        </svg>
+    );
+}

--- a/special-pages/pages/new-tab/app/next-steps/components/NextSteps.module.css
+++ b/special-pages/pages/new-tab/app/next-steps/components/NextSteps.module.css
@@ -47,6 +47,7 @@
     font-size: calc(11 * var(--px-in-rem));
     line-height: calc(14 * var(--px-in-rem));
     color: var(--ntp-color-primary);
+    text-wrap: wrap; /* needed for some languages */
 
     &.supressActiveStateForSwitch {
         opacity: 1;
@@ -84,7 +85,7 @@
 
     @media screen and (prefers-color-scheme: dark) {
         &.supressActiveStateForSwitch {
-            /* outline: 1px solid yellow; */
+
             &:active {
                 background-color: var(--color-black-at-9);
             }

--- a/special-pages/pages/new-tab/app/next-steps/components/NextSteps.module.css
+++ b/special-pages/pages/new-tab/app/next-steps/components/NextSteps.module.css
@@ -48,6 +48,16 @@
     line-height: calc(14 * var(--px-in-rem));
     color: var(--ntp-color-primary);
 
+    &.supressActiveStateForSwitch {
+        opacity: 1;
+        transition: opacity .3s ease-out;
+
+        &:active {
+            background-color: var(--color-black-at-6);
+            opacity: 0;
+        }
+    }
+
     &:hover {
         background-color: var(--color-black-at-6);
         cursor: pointer;
@@ -73,6 +83,13 @@
     }
 
     @media screen and (prefers-color-scheme: dark) {
+        &.supressActiveStateForSwitch {
+            /* outline: 1px solid yellow; */
+            &:active {
+                background-color: var(--color-black-at-9);
+            }
+        }
+
         &:hover:not(:active) {
             background-color: var(--color-black-at-9);
         }
@@ -92,8 +109,11 @@
 .confirmation {
     display: flex;
     align-items: center;
-    transition: all .2s;
-    padding-bottom: var(--sp-1);
+    transition: all .2s ease-in;
+    font-size: calc(11 * var(--px-in-rem));
+    line-height: calc(14 * var(--px-in-rem));
+    padding-bottom: calc(5 * var(--px-in-rem));
+
     svg {
         height: 1rem;
         width: 1rem;
@@ -101,7 +121,7 @@
     }
 
     p {
-        font-weight: 700;
+        font-weight: 600;
         font-size: calc(11 * var(--px-in-rem));
     }
 }

--- a/special-pages/pages/new-tab/app/next-steps/components/NextSteps.module.css
+++ b/special-pages/pages/new-tab/app/next-steps/components/NextSteps.module.css
@@ -113,15 +113,16 @@
     transition: all .2s ease-in;
     font-size: calc(11 * var(--px-in-rem));
     line-height: calc(14 * var(--px-in-rem));
-    padding-bottom: calc(5 * var(--px-in-rem));
-
+    min-height: 26px;
+    
     svg {
         height: 1rem;
         width: 1rem;
         margin-right: var(--sp-2);
     }
-
+    
     p {
+        max-width: 8rem;
         font-weight: 600;
         font-size: calc(11 * var(--px-in-rem));
     }

--- a/special-pages/pages/new-tab/app/next-steps/components/NextSteps.module.css
+++ b/special-pages/pages/new-tab/app/next-steps/components/NextSteps.module.css
@@ -49,7 +49,8 @@
     color: var(--ntp-color-primary);
     text-wrap: wrap; /* needed for some languages */
 
-    &.supressActiveStateForSwitch {
+    /* the active state created an awkward flash, adding transition out */
+    &.supressActiveStateForSwitchToConfirmationText {
         opacity: 1;
         transition: opacity .3s ease-out;
 
@@ -84,8 +85,7 @@
     }
 
     @media screen and (prefers-color-scheme: dark) {
-        &.supressActiveStateForSwitch {
-
+        &.supressActiveStateForSwitchToConfirmationText {
             &:active {
                 background-color: var(--color-black-at-9);
             }

--- a/special-pages/pages/new-tab/app/next-steps/components/NextSteps.module.css
+++ b/special-pages/pages/new-tab/app/next-steps/components/NextSteps.module.css
@@ -89,6 +89,23 @@
     }
 }
 
+.confirmation {
+    display: flex;
+    align-items: center;
+    transition: all .2s;
+    padding-bottom: var(--sp-1);
+    svg {
+        height: 1rem;
+        width: 1rem;
+        margin-right: var(--sp-2);
+    }
+
+    p {
+        font-weight: 700;
+        font-size: calc(11 * var(--px-in-rem));
+    }
+}
+
 .dismissBtn {
     position: absolute;
     top: 0.5rem;

--- a/special-pages/pages/new-tab/app/next-steps/components/NextSteps.module.css
+++ b/special-pages/pages/new-tab/app/next-steps/components/NextSteps.module.css
@@ -111,8 +111,6 @@
     display: flex;
     align-items: center;
     transition: all .2s ease-in;
-    font-size: calc(11 * var(--px-in-rem));
-    line-height: calc(14 * var(--px-in-rem));
     min-height: 26px;
     
     svg {
@@ -122,9 +120,10 @@
     }
     
     p {
-        max-width: 8rem;
-        font-weight: 600;
         font-size: calc(11 * var(--px-in-rem));
+        line-height: calc(14 * var(--px-in-rem));
+        font-weight: 600;
+        max-width: 8rem;
     }
 }
 

--- a/special-pages/pages/new-tab/app/next-steps/components/NextStepsCard.js
+++ b/special-pages/pages/new-tab/app/next-steps/components/NextStepsCard.js
@@ -3,6 +3,8 @@ import styles from './NextSteps.module.css';
 import { DismissButton } from '../../components/DismissButton';
 import { variants } from '../nextsteps.data';
 import { useTypedTranslationWith } from '../../types';
+import { CheckColor } from '../../components/Icons';
+import { useState } from 'preact/hooks';
 
 /**
  * @param {object} props
@@ -14,14 +16,30 @@ import { useTypedTranslationWith } from '../../types';
 export function NextStepsCard({ type, dismiss, action }) {
     const { t } = useTypedTranslationWith(/** @type {import("../strings.json")} */ ({}));
     const message = variants[type]?.(t);
+    const [showMacConfirmation, setShowMacConfirmation] = useState(false);
+
+    const handleClick = () => {
+        if (message.id !== 'addAppToDockMac') {
+            return action(message.id);
+        }
+        action(message.id);
+        setShowMacConfirmation(true);
+    };
     return (
         <div class={styles.card}>
             <img src={`./icons/${message.icon}-128.svg`} alt="" class={styles.icon} />
             <h3 class={styles.title}>{message.title}</h3>
             <p class={styles.description}>{message.summary}</p>
-            <button class={styles.btn} onClick={() => action(message.id)}>
-                {message.actionText}
-            </button>
+            {message.id === 'addAppToDockMac' && !!showMacConfirmation ? (
+                <div class={styles.confirmation}>
+                    <CheckColor />
+                    <p>Added to Dock!</p>
+                </div>
+            ) : (
+                <button class={styles.btn} onClick={handleClick}>
+                    {message.actionText}
+                </button>
+            )}
 
             <DismissButton className={styles.dismissBtn} onClick={() => dismiss(message.id)} />
         </div>

--- a/special-pages/pages/new-tab/app/next-steps/components/NextStepsCard.js
+++ b/special-pages/pages/new-tab/app/next-steps/components/NextStepsCard.js
@@ -1,4 +1,6 @@
 import { h } from 'preact';
+import cn from 'classnames';
+
 import styles from './NextSteps.module.css';
 import { DismissButton } from '../../components/DismissButton';
 import { variants } from '../nextsteps.data';
@@ -16,27 +18,29 @@ import { useState } from 'preact/hooks';
 export function NextStepsCard({ type, dismiss, action }) {
     const { t } = useTypedTranslationWith(/** @type {import("../strings.json")} */ ({}));
     const message = variants[type]?.(t);
-    const [showMacConfirmation, setShowMacConfirmation] = useState(false);
+    const [showConfirmation, setShowConfirmation] = useState(false);
+    const hasConfirmationState = message.id === 'addAppToDockMac';
 
     const handleClick = () => {
-        if (message.id !== 'addAppToDockMac') {
+        if (!hasConfirmationState) {
             return action(message.id);
         }
+
         action(message.id);
-        setShowMacConfirmation(true);
+        setShowConfirmation(true);
     };
     return (
         <div class={styles.card}>
             <img src={`./icons/${message.icon}-128.svg`} alt="" class={styles.icon} />
             <h3 class={styles.title}>{message.title}</h3>
             <p class={styles.description}>{message.summary}</p>
-            {message.id === 'addAppToDockMac' && !!showMacConfirmation ? (
+            {hasConfirmationState && !!showConfirmation ? (
                 <div class={styles.confirmation}>
                     <CheckColor />
                     <p>Added to Dock!</p>
                 </div>
             ) : (
-                <button class={styles.btn} onClick={handleClick}>
+                <button class={cn(styles.btn, hasConfirmationState && styles.supressActiveStateForSwitch)} onClick={handleClick}>
                     {message.actionText}
                 </button>
             )}

--- a/special-pages/pages/new-tab/app/next-steps/components/NextStepsCard.js
+++ b/special-pages/pages/new-tab/app/next-steps/components/NextStepsCard.js
@@ -1,12 +1,12 @@
 import { h } from 'preact';
 import cn from 'classnames';
 
-import styles from './NextSteps.module.css';
-import { DismissButton } from '../../components/DismissButton';
-import { variants } from '../nextsteps.data';
-import { useTypedTranslationWith } from '../../types';
-import { CheckColor } from '../../components/Icons';
 import { useState } from 'preact/hooks';
+import { DismissButton } from '../../components/DismissButton';
+import { CheckColor } from '../../components/Icons';
+import { useTypedTranslationWith } from '../../types';
+import { variants } from '../nextsteps.data';
+import styles from './NextSteps.module.css';
 
 /**
  * @param {object} props

--- a/special-pages/pages/new-tab/app/next-steps/components/NextStepsCard.js
+++ b/special-pages/pages/new-tab/app/next-steps/components/NextStepsCard.js
@@ -5,7 +5,7 @@ import { useState } from 'preact/hooks';
 import { DismissButton } from '../../components/DismissButton';
 import { CheckColor } from '../../components/Icons';
 import { useTypedTranslationWith } from '../../types';
-import { variants } from '../nextsteps.data';
+import { variants, additionalCardStates } from '../nextsteps.data';
 import styles from './NextSteps.module.css';
 
 /**
@@ -19,7 +19,7 @@ export function NextStepsCard({ type, dismiss, action }) {
     const { t } = useTypedTranslationWith(/** @type {import("../strings.json")} */ ({}));
     const message = variants[type]?.(t);
     const [showConfirmation, setShowConfirmation] = useState(false);
-    const hasConfirmationState = message.id === 'addAppToDockMac';
+    const hasConfirmationState = additionalCardStates.hasConfirmationText(message.id);
 
     const handleClick = () => {
         if (!hasConfirmationState) {
@@ -40,7 +40,10 @@ export function NextStepsCard({ type, dismiss, action }) {
                     <p>{message.confirmationText}</p>
                 </div>
             ) : (
-                <button class={cn(styles.btn, hasConfirmationState && styles.supressActiveStateForSwitch)} onClick={handleClick}>
+                <button
+                    class={cn(styles.btn, hasConfirmationState && styles.supressActiveStateForSwitchToConfirmationText)}
+                    onClick={handleClick}
+                >
                     {message.actionText}
                 </button>
             )}

--- a/special-pages/pages/new-tab/app/next-steps/components/NextStepsCard.js
+++ b/special-pages/pages/new-tab/app/next-steps/components/NextStepsCard.js
@@ -37,7 +37,7 @@ export function NextStepsCard({ type, dismiss, action }) {
             {hasConfirmationState && !!showConfirmation ? (
                 <div class={styles.confirmation}>
                     <CheckColor />
-                    <p>Added to Dock!</p>
+                    <p>{message.confirmationText}</p>
                 </div>
             ) : (
                 <button class={cn(styles.btn, hasConfirmationState && styles.supressActiveStateForSwitch)} onClick={handleClick}>

--- a/special-pages/pages/new-tab/app/next-steps/components/NextStepsGroup.js
+++ b/special-pages/pages/new-tab/app/next-steps/components/NextStepsGroup.js
@@ -1,11 +1,11 @@
 import { h } from 'preact';
 import cn from 'classnames';
-import styles from './NextSteps.module.css';
-import { useTypedTranslationWith } from '../../types';
-import { NextStepsCard } from './NextStepsCard';
-import { otherText } from '../nextsteps.data';
-import { ShowHideButton } from '../../components/ShowHideButton';
 import { useId } from 'preact/hooks';
+import { ShowHideButton } from '../../components/ShowHideButton';
+import { useTypedTranslationWith } from '../../types';
+import { otherText } from '../nextsteps.data';
+import styles from './NextSteps.module.css';
+import { NextStepsCard } from './NextStepsCard';
 
 /**
  * @import enStrings from '../strings.json';

--- a/special-pages/pages/new-tab/app/next-steps/integrations-tests/next-steps.spec.js
+++ b/special-pages/pages/new-tab/app/next-steps/integrations-tests/next-steps.spec.js
@@ -64,7 +64,7 @@ test.describe('newtab NextSteps cards', () => {
         await ntp.reducedMotion();
         await ntp.openPage({ nextSteps: ['addAppToDockMac', 'defaultApp'] });
         await page.getByRole('button', { name: 'Add to Dock' }).click();
-        await page.pause();
+
         await expect(page.getByText('Added to Dock!')).toBeVisible();
         await expect(page.getByRole('button', { name: 'Add to Dock' })).not.toBeVisible();
     });

--- a/special-pages/pages/new-tab/app/next-steps/integrations-tests/next-steps.spec.js
+++ b/special-pages/pages/new-tab/app/next-steps/integrations-tests/next-steps.spec.js
@@ -58,4 +58,14 @@ test.describe('newtab NextSteps cards', () => {
         await page.getByRole('button', { name: 'Try DuckPlayer' }).click();
         await ntp.mocks.waitForCallCount({ method: 'nextSteps_action', count: 1 });
     });
+
+    test('shows a confirmation state', async ({ page }, workerInfo) => {
+        const ntp = NewtabPage.create(page, workerInfo);
+        await ntp.reducedMotion();
+        await ntp.openPage({ nextSteps: ['addAppToDockMac', 'defaultApp'] });
+        await page.getByRole('button', { name: 'Add to Dock' }).click();
+        await page.pause();
+        await expect(page.getByText('Added to Dock!')).toBeVisible();
+        await expect(page.getByRole('button', { name: 'Add to Dock' })).not.toBeVisible();
+    });
 });

--- a/special-pages/pages/new-tab/app/next-steps/nextsteps.data.js
+++ b/special-pages/pages/new-tab/app/next-steps/nextsteps.data.js
@@ -71,6 +71,7 @@ export const otherText = {
     nextSteps_sectionTitle: (t) => t('nextSteps_sectionTitle'),
 };
 
+/** @type {string[]} cardsWithConfirmationText */
 const cardsWithConfirmationText = ['addAppToDockMac'];
 
 export const additionalCardStates = {

--- a/special-pages/pages/new-tab/app/next-steps/nextsteps.data.js
+++ b/special-pages/pages/new-tab/app/next-steps/nextsteps.data.js
@@ -50,6 +50,7 @@ export const variants = {
         title: t('nextSteps_addAppDockMac_title'),
         summary: t('nextSteps_addAppDockMac_summary'),
         actionText: t('nextSteps_addAppDockMac_actionText'),
+        confirmationText: t('nextSteps_addAppDockMac_confirmationText'),
     }),
     /** @param {(translationId: keyof enStrings) => string} t */
     pinAppToTaskbarWindows: (t) => ({

--- a/special-pages/pages/new-tab/app/next-steps/nextsteps.data.js
+++ b/special-pages/pages/new-tab/app/next-steps/nextsteps.data.js
@@ -70,3 +70,9 @@ export const otherText = {
     /** @param {(translationId: keyof enStrings) => string} t */
     nextSteps_sectionTitle: (t) => t('nextSteps_sectionTitle'),
 };
+
+const cardsWithConfirmationText = ['addAppToDockMac'];
+
+export const additionalCardStates = {
+    hasConfirmationText: (/** @type {keyof variants} */ variantId) => cardsWithConfirmationText.includes(variantId),
+};


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/0/1208403786889309/1208892824152048/f

## Description
- Adds handling for a confirmation state in the NextStepsCard, to handle the MacOS NTP use-case with “addAppToDockMac"

## Testing Steps
- [Visit here](https://deploy-preview-1300--content-scope-scripts.netlify.app/build/pages/new-tab/?next-steps=addAppToDockMac&next-steps=blockCookies)
- Click the action button in the Add App to Dock NextStepsCard. Should switch to text and icon saying “Added App to Dock!"
- Clicking the action button in the Cookies NextStepCard should do nothing

## Checklist

<!--
  These questions are a friendly reminder to shipping code, if you're uncertain ask the AoR owners.
  It's also totally appropriate to not check some of these boxes, if they don't apply to your change.
-->
*Please tick all that apply:*

- [ ] I have tested this change locally
- [ ] I have tested this change locally in all supported browsers
- [ ] This change will be visible to users
- [ ] I have added automated tests that cover this change
- [ ] I have ensured the change is gated by config
- [ ] This change was covered by a ship review
- [ ] This change was covered by a tech design
- [ ] Any dependent config has been merged

