### PR TITLE
ntp: fix favorites container when expanded+few items

### DIFF
--- a/special-pages/pages/new-tab/app/favorites/components/Favorites.js
+++ b/special-pages/pages/new-tab/app/favorites/components/Favorites.js
@@ -122,7 +122,11 @@ function VirtualizedGridRows({ WIDGET_ID, rowHeight, favorites, expansion, openF
     // get a ref for the favorites' grid, this will allow it to receive drop events,
     // and the ref can also be used for reading the offset (eg: if other elements are above it)
     const safeAreaRef = /** @type {import("preact").RefObject<HTMLDivElement>} */ (useDropzoneSafeArea());
-    const containerHeight = expansion === 'collapsed' ? rowHeight : rows.length * rowHeight;
+
+    // prettier-ignore
+    const containerHeight = expansion === 'collapsed' || rows.length === 0
+        ? rowHeight
+        : rows.length * rowHeight;
 
     return (
         <div


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/0/0/1208922171943499/f

## Description

- The height of the container was broken if the native side's state is both 'expanded' + has no favorites
  - this should not technically occur, and could be fixed on the native side, but it's an easy thing for us to guard against.

## Testing Steps

- first, visit https://deploy-preview-1306--content-scope-scripts.netlify.app/build/pages/new-tab/?favorites=10
- expand the favorites list
- then, go to https://deploy-preview-1306--content-scope-scripts.netlify.app/build/pages/new-tab/?favorites=0 to simulate having no favorites 
- the height of the container should look correct

Should look like this:

<img width="564" alt="image" src="https://github.com/user-attachments/assets/d3977207-b886-4029-b0e6-00a5d3c5bf55">

And not this:

<img width="562" alt="image" src="https://github.com/user-attachments/assets/89e2593c-e3b5-48f3-8cb8-c51477904ea9">



## Checklist

<!--
  These questions are a friendly reminder to shipping code, if you're uncertain ask the AoR owners.
  It's also totally appropriate to not check some of these boxes, if they don't apply to your change.
-->
*Please tick all that apply:*

- [ ] I have tested this change locally
- [ ] I have tested this change locally in all supported browsers
- [ ] This change will be visible to users
- [ ] I have added automated tests that cover this change
- [ ] I have ensured the change is gated by config
- [ ] This change was covered by a ship review
- [ ] This change was covered by a tech design
- [ ] Any dependent config has been merged

