### PR TITLE
Remove XRay code and switch to main world content script in Firefox

### DIFF
--- a/injected/README.md
+++ b/injected/README.md
@@ -46,7 +46,7 @@ There are three stages that the content scope code is hooked into the platform:
 
 ### Platform specific integration details
 
-The [inject/](https://github.com/duckduckgo/content-scope-scripts/tree/main/inject) directory handles platform specific differences and is glue code into calling the contentScopeFeatures API.
+The [injected/entry-points/](https://github.com/duckduckgo/content-scope-scripts/tree/main/injected/entry-points) directory handles platform specific differences and is glue code into calling the contentScopeFeatures API.
 
 - In Firefox the code is loaded as a standard extension content script.
 - For Apple, Windows and Android the code is a UserScript that has some string replacements for properties and loads in as the page scope.

--- a/injected/entry-points/chrome-mv3.js
+++ b/injected/entry-points/chrome-mv3.js
@@ -21,14 +21,16 @@ load({
 });
 
 // @ts-expect-error https://app.asana.com/0/1201614831475344/1203979574128023/f
-window.addEventListener(secret, ({ detail: message }) => {
-    if (!message) return;
+window.addEventListener(secret, ({ detail: encodedMessage }) => {
+    if (!encodedMessage) return;
+    const message = JSON.parse(encodedMessage);
 
     switch (message.type) {
         case 'update':
             update(message);
             break;
         case 'register':
+            console.log('registered!', message);
             if (message.argumentsObject) {
                 message.argumentsObject.messageSecret = secret;
                 init(message.argumentsObject);

--- a/injected/entry-points/mozilla.js
+++ b/injected/entry-points/mozilla.js
@@ -1,96 +1,46 @@
 /**
- * @module Mozilla integration
+ * @module Mozilla MV2 main world integration
  */
 import { load, init, update } from '../src/content-scope-features.js';
 import { isTrackerOrigin } from '../src/trackers';
 import { computeLimitedSiteObject } from '../src/utils.js';
 
-const allowedMessages = [
-    'getClickToLoadState',
-    'getYouTubeVideoDetails',
-    'openShareFeedbackPage',
-    'addDebugFlag',
-    'setYoutubePreviewsEnabled',
-    'unblockClickToLoadContent',
-    'updateYouTubeCTLAddedFlag',
-    'updateFacebookCTLBreakageFlags',
-];
-const messageSecret = randomString();
+const secret = (crypto.getRandomValues(new Uint32Array(1))[0] / 2 ** 32).toString().replace('0.', '');
 
-function randomString() {
-    const num = crypto.getRandomValues(new Uint32Array(1))[0] / 2 ** 32;
-    return num.toString().replace('0.', '');
-}
+const trackerLookup = import.meta.trackerLookup;
 
-function initCode() {
-    const trackerLookup = import.meta.trackerLookup;
-    load({
-        platform: {
-            name: 'extension',
-        },
-        trackerLookup,
-        documentOriginIsTracker: isTrackerOrigin(trackerLookup),
-        site: computeLimitedSiteObject(),
-        // @ts-expect-error https://app.asana.com/0/1201614831475344/1203979574128023/f
-        bundledConfig: $BUNDLED_CONFIG$,
-    });
+load({
+    platform: {
+        name: 'extension',
+    },
+    trackerLookup,
+    documentOriginIsTracker: isTrackerOrigin(trackerLookup),
+    site: computeLimitedSiteObject(),
+    // @ts-expect-error https://app.asana.com/0/1201614831475344/1203979574128023/f
+    bundledConfig: $BUNDLED_CONFIG$,
+});
 
-    chrome.runtime.sendMessage(
-        {
-            messageType: 'registeredContentScript',
-            options: {
-                documentUrl: window.location.href,
-            },
-        },
-        (message) => {
-            // Background has disabled features
-            if (!message) {
-                return;
-            }
-            if (message.debug) {
-                window.addEventListener('message', (m) => {
-                    if (m.data.action && m.data.message) {
-                        chrome.runtime.sendMessage({
-                            messageType: 'debuggerMessage',
-                            options: m.data,
-                        });
-                    }
-                });
-            }
-            message.messageSecret = messageSecret;
-            init(message);
-        },
-    );
+// @ts-expect-error https://app.asana.com/0/1201614831475344/1203979574128023/f
+window.addEventListener(secret, ({ detail: encodedMessage }) => {
+    if (!encodedMessage) return;
+    const message = JSON.parse(encodedMessage);
 
-    chrome.runtime.onMessage.addListener((message) => {
-        // forward update messages to the embedded script
-        if (message && message.type === 'update') {
+    switch (message.type) {
+        case 'update':
             update(message);
-        }
-    });
+            break;
+        case 'register':
+            console.log('registered FF!', message);
+            if (message.argumentsObject) {
+                message.argumentsObject.messageSecret = secret;
+                init(message.argumentsObject);
+            }
+            break;
+    }
+});
 
-    window.addEventListener('sendMessageProxy' + messageSecret, (event) => {
-        event.stopImmediatePropagation();
-
-        if (!(event instanceof CustomEvent) || !event?.detail) {
-            return console.warn('no details in sendMessage proxy', event);
-        }
-
-        const messageType = event.detail?.messageType;
-        if (!allowedMessages.includes(messageType)) {
-            return console.warn('Ignoring invalid sendMessage messageType', messageType);
-        }
-
-        chrome.runtime.sendMessage(event.detail, (response) => {
-            const message = {
-                messageType: 'response',
-                responseMessageType: messageType,
-                response,
-            };
-
-            update(message);
-        });
-    });
-}
-
-initCode();
+window.dispatchEvent(
+    new CustomEvent('ddg-secret', {
+        detail: secret,
+    }),
+);

--- a/injected/scripts/entry-points.js
+++ b/injected/scripts/entry-points.js
@@ -60,12 +60,10 @@ const builds = {
 };
 
 async function initOther(injectScriptPath, platformName) {
-    const supportsMozProxies = platformName === 'firefox';
     const identName = `inject${camelcase(platformName)}`;
     const injectScript = await rollupScript({
         scriptPath: injectScriptPath,
         name: identName,
-        supportsMozProxies,
         platform: platformName,
     });
     const outputScript = injectScript;

--- a/injected/scripts/utils/build.js
+++ b/injected/scripts/utils/build.js
@@ -34,11 +34,10 @@ const prefixMessage = '/*! © DuckDuckGo ContentScopeScripts protections https:/
  * @param {string} params.platform
  * @param {string[]} [params.featureNames]
  * @param {string} [params.name]
- * @param {boolean} [params.supportsMozProxies]
  * @return {Promise<string>}
  */
 export async function rollupScript(params) {
-    const { scriptPath, platform, name, featureNames, supportsMozProxies = false } = params;
+    const { scriptPath, platform, name, featureNames } = params;
 
     const extensions = ['firefox', 'chrome', 'chrome-mv3'];
     const isExtension = extensions.includes(platform);
@@ -48,8 +47,6 @@ export async function rollupScript(params) {
         trackerLookup = trackerLookupData;
     }
     const suffixMessage = `/*# sourceURL=duckduckgo-privacy-protection.js?scope=${name} */`;
-    // The code is using a global, that we define here which means once tree shaken we get a browser specific output.
-    const mozProxies = supportsMozProxies;
     const plugins = [
         css(),
         svg({
@@ -61,8 +58,6 @@ export async function rollupScript(params) {
         replace({
             preventAssignment: true,
             values: {
-                // @ts-expect-error https://app.asana.com/0/1201614831475344/1203979574128023/f
-                mozProxies,
                 'import.meta.injectName': JSON.stringify(platform),
                 // To be replaced by the extension, but prevents tree shaking
                 'import.meta.trackerLookup': trackerLookup,

--- a/injected/src/globals.d.ts
+++ b/injected/src/globals.d.ts
@@ -1,8 +1,3 @@
-declare const mozProxies: boolean;
-declare function exportFunction(fn: () => unknown, desc: object, out: object): void;
-declare function exportFunction(fn: () => unknown, desc: object): void;
-declare function cloneInto(fn: object, desc: object, out: object): void;
-declare function cloneInto(fn: object, desc: object): void;
 declare namespace contentScopeFeatures {
     function init(args: object): void;
     function load(args: object): void;

--- a/injected/src/utils.js
+++ b/injected/src/utils.js
@@ -286,7 +286,7 @@ const functionMap = {
         debugger;
     },
 
-    noop: () => {},
+    noop: () => { },
 };
 
 /**
@@ -762,7 +762,7 @@ export function legacySendMessage(messageType, options) {
     // FF & Chrome
     return (
         originalWindowDispatchEvent &&
-        originalWindowDispatchEvent(createCustomEvent('sendMessageProxy' + messageSecret, { detail: { messageType, options } }))
+        originalWindowDispatchEvent(createCustomEvent('sendMessageProxy' + messageSecret, { detail: JSON.stringify({ messageType, options }) }))
     );
     // TBD other platforms
 }

--- a/injected/src/utils.js
+++ b/injected/src/utils.js
@@ -1,5 +1,4 @@
 /* eslint-disable no-redeclare, no-global-assign */
-/* global cloneInto, exportFunction, mozProxies */
 import { Set } from './captured-globals.js';
 
 // Only use globalThis for testing this breaks window.wrappedJSObject code in Firefox
@@ -22,25 +21,14 @@ export function getInjectionElement() {
     return document.head || document.documentElement;
 }
 
-// Tests don't define this variable so fallback to behave like chrome
-const hasMozProxies = typeof mozProxies !== 'undefined' ? mozProxies : false;
-
 /**
  * Creates a script element with the given code to avoid Firefox CSP restrictions.
  * @param {string} css
  * @returns {HTMLLinkElement | HTMLStyleElement}
  */
 export function createStyleElement(css) {
-    let style;
-    if (hasMozProxies) {
-        style = document.createElement('link');
-        style.href = 'data:text/css,' + encodeURIComponent(css);
-        style.setAttribute('rel', 'stylesheet');
-        style.setAttribute('type', 'text/css');
-    } else {
-        style = document.createElement('style');
-        style.innerText = css;
-    }
+    const style = document.createElement('style');
+    style.innerText = css;
     return style;
 }
 
@@ -434,30 +422,16 @@ export class DDGProxy {
             }
             return DDGReflect.get(target, prop, receiver);
         };
-        if (hasMozProxies) {
-            this._native = objectScope[property];
-            const handler = new globalObj.wrappedJSObject.Object();
-            handler.apply = exportFunction(outputHandler, globalObj);
-            handler.get = exportFunction(getMethod, globalObj);
-            // @ts-expect-error wrappedJSObject is not a property of objectScope
-            this.internal = new globalObj.wrappedJSObject.Proxy(objectScope.wrappedJSObject[property], handler);
-        } else {
-            this._native = objectScope[property];
-            const handler = {};
-            handler.apply = outputHandler;
-            handler.get = getMethod;
-            this.internal = new globalObj.Proxy(objectScope[property], handler);
-        }
+        this._native = objectScope[property];
+        const handler = {};
+        handler.apply = outputHandler;
+        handler.get = getMethod;
+        this.internal = new globalObj.Proxy(objectScope[property], handler);
     }
 
     // Actually apply the proxy to the native property
     overload() {
-        if (hasMozProxies) {
-            // @ts-expect-error wrappedJSObject is not a property of objectScope
-            exportFunction(this.internal, this.objectScope, { defineAs: this.property });
-        } else {
-            this.objectScope[this.property] = this.internal;
-        }
+        this.objectScope[this.property] = this.internal;
     }
 
     overloadDescriptor() {
@@ -500,17 +474,8 @@ export function postDebugMessage(feature, message, allowNonDebug = false) {
     });
 }
 
-export let DDGReflect;
-export let DDGPromise;
-
-// Exports for usage where we have to cross the xray boundary: https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Sharing_objects_with_page_scripts
-if (hasMozProxies) {
-    DDGPromise = globalObj.wrappedJSObject.Promise;
-    DDGReflect = globalObj.wrappedJSObject.Reflect;
-} else {
-    DDGPromise = globalObj.Promise;
-    DDGReflect = globalObj.Reflect;
-}
+export const DDGPromise = globalObj.Promise;
+export const DDGReflect = globalObj.Reflect;
 
 /**
  * @param {string | null} topLevelHostname
@@ -746,13 +711,6 @@ export function isPlatformSpecificFeature(featureName) {
 }
 
 export function createCustomEvent(eventName, eventDetail) {
-    // By default, Firefox protects the event detail Object from the page,
-    // leading to "Permission denied to access property" errors.
-    // See https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/Sharing_objects_with_page_scripts
-    if (hasMozProxies) {
-        eventDetail = cloneInto(eventDetail, window);
-    }
-
     // @ts-expect-error - possibly null
     return new OriginalCustomEvent(eventName, eventDetail);
 }

--- a/injected/unit-test/verify-artifacts.js
+++ b/injected/unit-test/verify-artifacts.js
@@ -33,7 +33,6 @@ const checks = {
         file: join(BUILD, 'chrome-mv3/inject.js'),
         tests: [
             { kind: 'maxFileSize', value: CSS_OUTPUT_SIZE },
-            { kind: 'containsString', text: 'cloneInto(', includes: false },
             { kind: 'containsString', text: '$TRACKER_LOOKUP$', includes: true },
         ],
     },
@@ -41,7 +40,6 @@ const checks = {
         file: join(BUILD, 'firefox/inject.js'),
         tests: [
             { kind: 'maxFileSize', value: CSS_OUTPUT_SIZE },
-            { kind: 'containsString', text: 'cloneInto(', includes: true },
             { kind: 'containsString', text: '$TRACKER_LOOKUP$', includes: true },
         ],
     },


### PR DESCRIPTION
**Asana Task/Github Issue:** <!-- Link to Asana Task/Github Issue -->
https://app.asana.com/0/1201614831475344/1207277833550158/f

## Description
Firefox now supports execution worlds for content scripts in their MV2 manifest. This allows us to remove xray code. See also https://github.com/duckduckgo/duckduckgo-privacy-extension/pull/2852
<!--
  Provide a terse summary of what the change is, detailed descriptions should belong in ship reviews or tech designs
-->

## Testing Steps

- <!-- Include simple steps on how to check this change is working. Write "N/A" if not applicable. -->

## Checklist

<!--
  These questions are a friendly reminder to shipping code, if you're uncertain ask the AoR owners.
  It's also totally appropriate to not check some of these boxes, if they don't apply to your change.
-->
*Please tick all that apply:*

- [ ] I have tested this change locally
- [ ] I have tested this change locally in all supported browsers
- [ ] This change will be visible to users
- [ ] I have added automated tests that cover this change
- [ ] I have ensured the change is gated by config
- [ ] This change was covered by a ship review
- [ ] This change was covered by a tech design
- [ ] Any dependent config has been merged

