### PR TITLE
Special error page - malware support - translations

### DIFF
--- a/special-pages/pages/special-error/public/locales/bg/special-error.json
+++ b/special-pages/pages/special-error/public/locales/bg/special-error.json
@@ -10,22 +10,34 @@
   },
   "advancedButton" : {
     "title" : "Разширени",
-    "note" : "Button shown in an error page that warns users of security risks on a website due to Phishing issues. The buttons allows the user to see advanced options on click."
+    "note" : "Button shown in an error page that warns users of security risks on a website due to Phishing or Malware issues. The buttons allows the user to see advanced options on click."
   },
   "advancedEllipsisButton" : {
     "title" : "Разширени...",
-    "note" : "Button shown in an error page that warns users of security risks on a website due to Phishing issues. The buttons allows the user to see advanced options on click. This button contains a trailing ellipsis."
+    "note" : "Button shown in an error page that warns users of security risks on a website due to Phishing or Malware issues. The buttons allows the user to see advanced options on click. This button contains a trailing ellipsis."
   },
   "leaveSiteButton" : {
     "title" : "Напускане на този сайт",
-    "note" : "Button shown in an error page that warns users of security risks on a website due to Phishing issues. The buttons allows the user to leave the website and navigate to previous page."
+    "note" : "Button shown in an error page that warns users of security risks on a website due to Phishing or Malware issues. The buttons allows the user to leave the website and navigate to previous page."
   },
   "visitSiteButton" : {
     "title" : "Поемане на риска и отваряне на сайта",
-    "note" : "Button shown in an error page that warns users of security risks on a website due to Phishing issues. The buttons allows the user to visit the website anyway despite the risks."
+    "note" : "Button shown in an error page that warns users of security risks on a website due to Phishing or Malware issues. The buttons allows the user to visit the website anyway despite the risks."
+  },
+  "malwarePageHeading" : {
+    "title" : "Предупреждение: Този сайт може да изложи личната ви информация на риск",
+    "note" : "Title shown in an error page that warn users of security risks on a website due to malware distribution"
+  },
+  "malwareWarningText" : {
+    "title" : "DuckDuckGo блокира тази страница, защото тя може да разпространява зловреден софтуер, който да компрометира устройството ви или да открадне личната ви информация. <a>Научете повече</a>",
+    "note" : "Error description shown in an error page that warns users of security risks on a website due to malware distribution."
+  },
+  "malwareAdvancedInfoHeading" : {
+    "title" : "Ако смятате, че този уебсайт е безопасен, можете да <a>съобщите за грешка</a>. Все пак можете да посетите уебсайта на свой собствен риск.",
+    "note" : "Title of the Advanced info section shown in an error page that warns users of security risks on a website due to malware distribution."
   },
   "phishingPageHeading" : {
-    "title" : "Предупреждение: Този сайт излага вашата лична информация на риск",
+    "title" : "Предупреждение: Този сайт може да изложи личната ви информация на риск",
     "note" : "Title shown in an error page that warn users of security risks on a website due to Phishing issues"
   },
   "phishingWarningText" : {
@@ -33,16 +45,8 @@
     "note" : "Error description shown in an error page that warns users of security risks on a website due to Phishing issues."
   },
   "phishingAdvancedInfoHeading" : {
-    "title" : "DuckDuckGo ви предупреждава, когато даден уебсайт е маркиран като злонамерен.",
-    "note" : "Title of the Advanced info section shown in an error page that warns users of security risks on a website due to Phishing issues."
-  },
-  "phishingAdvancedInfoText_1" : {
-    "title" : "Показват се предупреждения за уебсайтове, за които е съобщено, че са измамни. Измамните уебсайтове се опитват да ви подмамят да повярвате, че са легитимни уебсайтове, на които имате доверие. Ако разбирате рисковете, можете да продължите въпреки това.",
-    "note" : "Body of the text of the Advanced info shown in an error page that warns users of security risks on a website due to Phishing issues."
-  },
-  "phishingAdvancedInfoText_2" : {
-    "title" : "За повече информация вижте нашата <a>помощна страница за защита от фишинг и злонамерен софтуер</a>.",
-    "note" : "A call-to-action to read more on our help pages for phishing and malware protection."
+    "title" : "Ако смятате, че този уебсайт е безопасен, можете да <a>съобщите за грешка</a>. Все пак можете да посетите уебсайта на свой собствен риск.",
+    "note" : "Title of the Advanced info section shown in an error page that warns users of security risks on a website due to malware distribution."
   },
   "sslPageHeading" : {
     "title" : "Предупреждение: Този сайт може да не е сигурен",

--- a/special-pages/pages/special-error/public/locales/cs/special-error.json
+++ b/special-pages/pages/special-error/public/locales/cs/special-error.json
@@ -10,22 +10,34 @@
   },
   "advancedButton" : {
     "title" : "Pokročilé",
-    "note" : "Button shown in an error page that warns users of security risks on a website due to Phishing issues. The buttons allows the user to see advanced options on click."
+    "note" : "Button shown in an error page that warns users of security risks on a website due to Phishing or Malware issues. The buttons allows the user to see advanced options on click."
   },
   "advancedEllipsisButton" : {
     "title" : "Pokročilé...",
-    "note" : "Button shown in an error page that warns users of security risks on a website due to Phishing issues. The buttons allows the user to see advanced options on click. This button contains a trailing ellipsis."
+    "note" : "Button shown in an error page that warns users of security risks on a website due to Phishing or Malware issues. The buttons allows the user to see advanced options on click. This button contains a trailing ellipsis."
   },
   "leaveSiteButton" : {
     "title" : "Opustit tuhle stránku",
-    "note" : "Button shown in an error page that warns users of security risks on a website due to Phishing issues. The buttons allows the user to leave the website and navigate to previous page."
+    "note" : "Button shown in an error page that warns users of security risks on a website due to Phishing or Malware issues. The buttons allows the user to leave the website and navigate to previous page."
   },
   "visitSiteButton" : {
     "title" : "Přijmout riziko a přejít na stránku",
-    "note" : "Button shown in an error page that warns users of security risks on a website due to Phishing issues. The buttons allows the user to visit the website anyway despite the risks."
+    "note" : "Button shown in an error page that warns users of security risks on a website due to Phishing or Malware issues. The buttons allows the user to visit the website anyway despite the risks."
+  },
+  "malwarePageHeading" : {
+    "title" : "Pozor: Tahle stránka může vystavit tvoje osobní údaje riziku",
+    "note" : "Title shown in an error page that warn users of security risks on a website due to malware distribution"
+  },
+  "malwareWarningText" : {
+    "title" : "Služba DuckDuckGo tuhle stránku zablokovala, protože může šířit malware, jehož cílem je narušit zabezpečení zařízení nebo odcizit osobní údaje. <a>Přečti si další informace</a>.",
+    "note" : "Error description shown in an error page that warns users of security risks on a website due to malware distribution."
+  },
+  "malwareAdvancedInfoHeading" : {
+    "title" : "Pokud věříš, že je tahle stránka bezpečná, můžeš <a>nahlásit chybu</a>. Můžeš taky stránku navštívit na vlastní nebezpečí.",
+    "note" : "Title of the Advanced info section shown in an error page that warns users of security risks on a website due to malware distribution."
   },
   "phishingPageHeading" : {
-    "title" : "Pozor: Tahle stránka vystavuje tvoje osobní údaje riziku",
+    "title" : "Pozor: Tahle stránka může vystavit tvoje osobní údaje riziku",
     "note" : "Title shown in an error page that warn users of security risks on a website due to Phishing issues"
   },
   "phishingWarningText" : {
@@ -33,16 +45,8 @@
     "note" : "Error description shown in an error page that warns users of security risks on a website due to Phishing issues."
   },
   "phishingAdvancedInfoHeading" : {
-    "title" : "DuckDuckGo tě upozorní, když je web označený jako škodlivý.",
-    "note" : "Title of the Advanced info section shown in an error page that warns users of security risks on a website due to Phishing issues."
-  },
-  "phishingAdvancedInfoText_1" : {
-    "title" : "Varování se zobrazuje u webových stránek, které jsou nahlášené jako podvodné. Podvodné webové stránky se tě snaží oklamat a přesvědčit, že jde o legitimní webové stránky, kterým důvěřuješ. Pokud rozumíš tomu, o jaká rizika může jít, klidně pokračuj dál.",
-    "note" : "Body of the text of the Advanced info shown in an error page that warns users of security risks on a website due to Phishing issues."
-  },
-  "phishingAdvancedInfoText_2" : {
-    "title" : "Další informace najdeš na <a>stránce nápovědy, která se týká ochrany před phishingem a malwarem</a>.",
-    "note" : "A call-to-action to read more on our help pages for phishing and malware protection."
+    "title" : "Pokud věříš, že je tahle stránka bezpečná, můžeš <a>nahlásit chybu</a>. Můžeš taky stránku navštívit na vlastní nebezpečí.",
+    "note" : "Title of the Advanced info section shown in an error page that warns users of security risks on a website due to malware distribution."
   },
   "sslPageHeading" : {
     "title" : "Pozor: Tenhle web může být nezabezpečený",

--- a/special-pages/pages/special-error/public/locales/da/special-error.json
+++ b/special-pages/pages/special-error/public/locales/da/special-error.json
@@ -10,22 +10,34 @@
   },
   "advancedButton" : {
     "title" : "Avanceret",
-    "note" : "Button shown in an error page that warns users of security risks on a website due to Phishing issues. The buttons allows the user to see advanced options on click."
+    "note" : "Button shown in an error page that warns users of security risks on a website due to Phishing or Malware issues. The buttons allows the user to see advanced options on click."
   },
   "advancedEllipsisButton" : {
     "title" : "Avanceret...",
-    "note" : "Button shown in an error page that warns users of security risks on a website due to Phishing issues. The buttons allows the user to see advanced options on click. This button contains a trailing ellipsis."
+    "note" : "Button shown in an error page that warns users of security risks on a website due to Phishing or Malware issues. The buttons allows the user to see advanced options on click. This button contains a trailing ellipsis."
   },
   "leaveSiteButton" : {
     "title" : "Forlad dette websted",
-    "note" : "Button shown in an error page that warns users of security risks on a website due to Phishing issues. The buttons allows the user to leave the website and navigate to previous page."
+    "note" : "Button shown in an error page that warns users of security risks on a website due to Phishing or Malware issues. The buttons allows the user to leave the website and navigate to previous page."
   },
   "visitSiteButton" : {
     "title" : "Accepter risiko og besøg webstedet",
-    "note" : "Button shown in an error page that warns users of security risks on a website due to Phishing issues. The buttons allows the user to visit the website anyway despite the risks."
+    "note" : "Button shown in an error page that warns users of security risks on a website due to Phishing or Malware issues. The buttons allows the user to visit the website anyway despite the risks."
+  },
+  "malwarePageHeading" : {
+    "title" : "Advarsel: Denne side kan udgøre en risiko for dine personlige oplysninger",
+    "note" : "Title shown in an error page that warn users of security risks on a website due to malware distribution"
+  },
+  "malwareWarningText" : {
+    "title" : "DuckDuckGo har blokeret denne side, fordi den muligvis distribuerer malware, der er designet til at kompromittere din enhed eller stjæle dine personlige oplysninger. <a>Få mere at vide</a>",
+    "note" : "Error description shown in an error page that warns users of security risks on a website due to malware distribution."
+  },
+  "malwareAdvancedInfoHeading" : {
+    "title" : "Hvis du mener, at dette websted er sikkert, kan du <a>anmelde en fejl</a>. Du kan stadig besøge webstedet på eget ansvar.",
+    "note" : "Title of the Advanced info section shown in an error page that warns users of security risks on a website due to malware distribution."
   },
   "phishingPageHeading" : {
-    "title" : "Advarsel: Denne side udgør en risiko for dine personlige oplysninger",
+    "title" : "Advarsel: Denne side kan udgøre en risiko for dine personlige oplysninger",
     "note" : "Title shown in an error page that warn users of security risks on a website due to Phishing issues"
   },
   "phishingWarningText" : {
@@ -33,16 +45,8 @@
     "note" : "Error description shown in an error page that warns users of security risks on a website due to Phishing issues."
   },
   "phishingAdvancedInfoHeading" : {
-    "title" : "DuckDuckGo advarer dig, når et websted er blevet markeret som ondsindet.",
-    "note" : "Title of the Advanced info section shown in an error page that warns users of security risks on a website due to Phishing issues."
-  },
-  "phishingAdvancedInfoText_1" : {
-    "title" : "Advarsler vises for websteder, der er rapporteret at være vildledende. Vildledende websteder forsøger at narre dig til at tro, at de er legitime websteder, som du har tillid til. Hvis du forstår de risici, der er forbundet med det, kan du fortsætte alligevel.",
-    "note" : "Body of the text of the Advanced info shown in an error page that warns users of security risks on a website due to Phishing issues."
-  },
-  "phishingAdvancedInfoText_2" : {
-    "title" : "Se vores <a>hjælpeside om beskyttelse mod phishing og malware</a> for at få flere oplysninger.",
-    "note" : "A call-to-action to read more on our help pages for phishing and malware protection."
+    "title" : "Hvis du mener, at dette websted er sikkert, kan du <a>anmelde en fejl</a>. Du kan stadig besøge webstedet på eget ansvar.",
+    "note" : "Title of the Advanced info section shown in an error page that warns users of security risks on a website due to malware distribution."
   },
   "sslPageHeading" : {
     "title" : "Advarsel: Denne side kan være usikker",

--- a/special-pages/pages/special-error/public/locales/de/special-error.json
+++ b/special-pages/pages/special-error/public/locales/de/special-error.json
@@ -10,22 +10,34 @@
   },
   "advancedButton" : {
     "title" : "Erweitert",
-    "note" : "Button shown in an error page that warns users of security risks on a website due to Phishing issues. The buttons allows the user to see advanced options on click."
+    "note" : "Button shown in an error page that warns users of security risks on a website due to Phishing or Malware issues. The buttons allows the user to see advanced options on click."
   },
   "advancedEllipsisButton" : {
     "title" : "Erweitert ...",
-    "note" : "Button shown in an error page that warns users of security risks on a website due to Phishing issues. The buttons allows the user to see advanced options on click. This button contains a trailing ellipsis."
+    "note" : "Button shown in an error page that warns users of security risks on a website due to Phishing or Malware issues. The buttons allows the user to see advanced options on click. This button contains a trailing ellipsis."
   },
   "leaveSiteButton" : {
     "title" : "Diese Website verlassen",
-    "note" : "Button shown in an error page that warns users of security risks on a website due to Phishing issues. The buttons allows the user to leave the website and navigate to previous page."
+    "note" : "Button shown in an error page that warns users of security risks on a website due to Phishing or Malware issues. The buttons allows the user to leave the website and navigate to previous page."
   },
   "visitSiteButton" : {
     "title" : "Risiko akzeptieren und Website besuchen",
-    "note" : "Button shown in an error page that warns users of security risks on a website due to Phishing issues. The buttons allows the user to visit the website anyway despite the risks."
+    "note" : "Button shown in an error page that warns users of security risks on a website due to Phishing or Malware issues. The buttons allows the user to visit the website anyway despite the risks."
+  },
+  "malwarePageHeading" : {
+    "title" : "Warnung: Diese Seite könnte deine persönlichen Daten gefährden",
+    "note" : "Title shown in an error page that warn users of security risks on a website due to malware distribution"
+  },
+  "malwareWarningText" : {
+    "title" : "DuckDuckGo hat diese Seite blockiert, weil sie möglicherweise Malware verbreitet, die darauf abzielt, dein Gerät zu kompromittieren oder deine persönlichen Daten zu stehlen. <a>Mehr erfahren</a>",
+    "note" : "Error description shown in an error page that warns users of security risks on a website due to malware distribution."
+  },
+  "malwareAdvancedInfoHeading" : {
+    "title" : "Wenn du glaubst, dass diese Website sicher ist, kannst du <a>einen Fehler melden</a>. Du kannst die Website weiterhin auf eigenes Risiko besuchen.",
+    "note" : "Title of the Advanced info section shown in an error page that warns users of security risks on a website due to malware distribution."
   },
   "phishingPageHeading" : {
-    "title" : "Warnung: Diese Seite gefährdet deine persönlichen Daten",
+    "title" : "Warnung: Diese Seite könnte deine persönlichen Daten gefährden",
     "note" : "Title shown in an error page that warn users of security risks on a website due to Phishing issues"
   },
   "phishingWarningText" : {
@@ -33,16 +45,8 @@
     "note" : "Error description shown in an error page that warns users of security risks on a website due to Phishing issues."
   },
   "phishingAdvancedInfoHeading" : {
-    "title" : "DuckDuckGo warnt dich, wenn eine Website als bösartig gekennzeichnet wurde.",
-    "note" : "Title of the Advanced info section shown in an error page that warns users of security risks on a website due to Phishing issues."
-  },
-  "phishingAdvancedInfoText_1" : {
-    "title" : "Es werden Warnungen für Websites angezeigt, die als betrügerisch gemeldet wurden. Betrügerische Websites versuchen dir vorzugaukeln, dass es sich um seriöse Websites handelt, denen du vertraust. Wenn du dir über die damit verbundenen Risiken im Klaren bist, kannst du trotzdem fortfahren.",
-    "note" : "Body of the text of the Advanced info shown in an error page that warns users of security risks on a website due to Phishing issues."
-  },
-  "phishingAdvancedInfoText_2" : {
-    "title" : "Weitere Informationen findest du auf unserer <a>Hilfeseite zum Schutz vor Phishing und Malware</a>.",
-    "note" : "A call-to-action to read more on our help pages for phishing and malware protection."
+    "title" : "Wenn du glaubst, dass diese Website sicher ist, kannst du <a>einen Fehler melden</a>. Du kannst die Website weiterhin auf eigenes Risiko besuchen.",
+    "note" : "Title of the Advanced info section shown in an error page that warns users of security risks on a website due to malware distribution."
   },
   "sslPageHeading" : {
     "title" : "Warnung: Diese Website ist möglicherweise unsicher",

--- a/special-pages/pages/special-error/public/locales/el/special-error.json
+++ b/special-pages/pages/special-error/public/locales/el/special-error.json
@@ -10,22 +10,34 @@
   },
   "advancedButton" : {
     "title" : "Προχωρημένο",
-    "note" : "Button shown in an error page that warns users of security risks on a website due to Phishing issues. The buttons allows the user to see advanced options on click."
+    "note" : "Button shown in an error page that warns users of security risks on a website due to Phishing or Malware issues. The buttons allows the user to see advanced options on click."
   },
   "advancedEllipsisButton" : {
     "title" : "Σύνθετες ρυθμίσεις...",
-    "note" : "Button shown in an error page that warns users of security risks on a website due to Phishing issues. The buttons allows the user to see advanced options on click. This button contains a trailing ellipsis."
+    "note" : "Button shown in an error page that warns users of security risks on a website due to Phishing or Malware issues. The buttons allows the user to see advanced options on click. This button contains a trailing ellipsis."
   },
   "leaveSiteButton" : {
     "title" : "Αποχωρήστε από τον ιστότοπο αυτόν",
-    "note" : "Button shown in an error page that warns users of security risks on a website due to Phishing issues. The buttons allows the user to leave the website and navigate to previous page."
+    "note" : "Button shown in an error page that warns users of security risks on a website due to Phishing or Malware issues. The buttons allows the user to leave the website and navigate to previous page."
   },
   "visitSiteButton" : {
     "title" : "Αποδεχτείτε τον κίνδυνο και επισκεφτείτε τον ιστότοπο",
-    "note" : "Button shown in an error page that warns users of security risks on a website due to Phishing issues. The buttons allows the user to visit the website anyway despite the risks."
+    "note" : "Button shown in an error page that warns users of security risks on a website due to Phishing or Malware issues. The buttons allows the user to visit the website anyway despite the risks."
+  },
+  "malwarePageHeading" : {
+    "title" : "Προειδοποίηση: Αυτός ο ιστότοπος μπορεί να θέσει σε κίνδυνο τα προσωπικά στοιχεία σας",
+    "note" : "Title shown in an error page that warn users of security risks on a website due to malware distribution"
+  },
+  "malwareWarningText" : {
+    "title" : "Το DuckDuckGo μπλόκαρε αυτήν τη σελίδα επειδή μπορεί να διανέμει κακόβουλο λογισμικό, το οποίο έχει σχεδιαστεί για να θέσει σε κίνδυνο τη συσκευή σας ή να υποκλέψει τα προσωπικά στοιχεία σας. <a>Μάθετε περισσότερα</a>",
+    "note" : "Error description shown in an error page that warns users of security risks on a website due to malware distribution."
+  },
+  "malwareAdvancedInfoHeading" : {
+    "title" : "Εάν πιστεύετε ότι αυτός ο ιστότοπος είναι ασφαλής, μπορείτε να <a>αναφέρετε ένα σφάλμα</a>. Μπορείτε ακόμα να επισκεφθείτε τον ιστότοπο, με δική σας ευθύνη.",
+    "note" : "Title of the Advanced info section shown in an error page that warns users of security risks on a website due to malware distribution."
   },
   "phishingPageHeading" : {
-    "title" : "Προειδοποίηση: Ο ιστότοπος αυτός θέτει σε κίνδυνο τα προσωπικά στοιχεία σας",
+    "title" : "Προειδοποίηση: Αυτός ο ιστότοπος μπορεί να θέσει σε κίνδυνο τα προσωπικά στοιχεία σας",
     "note" : "Title shown in an error page that warn users of security risks on a website due to Phishing issues"
   },
   "phishingWarningText" : {
@@ -33,16 +45,8 @@
     "note" : "Error description shown in an error page that warns users of security risks on a website due to Phishing issues."
   },
   "phishingAdvancedInfoHeading" : {
-    "title" : "Το DuckDuckGo σάς προειδοποιεί όταν ένας ιστότοπος έχει επισημανθεί ως κακόβουλος.",
-    "note" : "Title of the Advanced info section shown in an error page that warns users of security risks on a website due to Phishing issues."
-  },
-  "phishingAdvancedInfoText_1" : {
-    "title" : "Εμφανίζονται προειδοποιήσεις για ιστότοπους που έχουν αναφερθεί ότι είναι παραπλανητικοί. Οι παραπλανητικοί ιστότοποι προσπαθούν να σας εξαπατήσουν ώστε να πιστέψετε πως είναι νόμιμοι ιστότοποι που εμπιστεύεστε. Εάν κατανοείτε τους κινδύνους που ενέχει, μπορείτε να συνεχίσετε εάν το επιθυμείτε.",
-    "note" : "Body of the text of the Advanced info shown in an error page that warns users of security risks on a website due to Phishing issues."
-  },
-  "phishingAdvancedInfoText_2" : {
-    "title" : "Για περισσότερες πληροφορίες, ανατρέξτε στη <a>σελίδα βοήθειας για Προστασία από ηλεκτρονικό ψάρεμα και κακόβουλο λογισμικό</a>.",
-    "note" : "A call-to-action to read more on our help pages for phishing and malware protection."
+    "title" : "Εάν πιστεύετε ότι αυτός ο ιστότοπος είναι ασφαλής, μπορείτε να <a>αναφέρετε ένα σφάλμα</a>. Μπορείτε ακόμα να επισκεφθείτε τον ιστότοπο, με δική σας ευθύνη.",
+    "note" : "Title of the Advanced info section shown in an error page that warns users of security risks on a website due to malware distribution."
   },
   "sslPageHeading" : {
     "title" : "Προειδοποίηση: Αυτός ο ιστότοπος ενδέχεται να μην είναι ασφαλής",

--- a/special-pages/pages/special-error/public/locales/es/special-error.json
+++ b/special-pages/pages/special-error/public/locales/es/special-error.json
@@ -10,22 +10,34 @@
   },
   "advancedButton" : {
     "title" : "Avanzado",
-    "note" : "Button shown in an error page that warns users of security risks on a website due to Phishing issues. The buttons allows the user to see advanced options on click."
+    "note" : "Button shown in an error page that warns users of security risks on a website due to Phishing or Malware issues. The buttons allows the user to see advanced options on click."
   },
   "advancedEllipsisButton" : {
     "title" : "Avanzadas...",
-    "note" : "Button shown in an error page that warns users of security risks on a website due to Phishing issues. The buttons allows the user to see advanced options on click. This button contains a trailing ellipsis."
+    "note" : "Button shown in an error page that warns users of security risks on a website due to Phishing or Malware issues. The buttons allows the user to see advanced options on click. This button contains a trailing ellipsis."
   },
   "leaveSiteButton" : {
     "title" : "Salir de este sitio",
-    "note" : "Button shown in an error page that warns users of security risks on a website due to Phishing issues. The buttons allows the user to leave the website and navigate to previous page."
+    "note" : "Button shown in an error page that warns users of security risks on a website due to Phishing or Malware issues. The buttons allows the user to leave the website and navigate to previous page."
   },
   "visitSiteButton" : {
     "title" : "Aceptar el riesgo y visitar el sitio",
-    "note" : "Button shown in an error page that warns users of security risks on a website due to Phishing issues. The buttons allows the user to visit the website anyway despite the risks."
+    "note" : "Button shown in an error page that warns users of security risks on a website due to Phishing or Malware issues. The buttons allows the user to visit the website anyway despite the risks."
+  },
+  "malwarePageHeading" : {
+    "title" : "Advertencia: este sitio puede poner en riesgo tu información personal",
+    "note" : "Title shown in an error page that warn users of security risks on a website due to malware distribution"
+  },
+  "malwareWarningText" : {
+    "title" : "DuckDuckGo ha bloqueado esta página porque podría estar distribuyendo malware diseñado para comprometer tu dispositivo o robar tu información personal. <a>Más información</a>",
+    "note" : "Error description shown in an error page that warns users of security risks on a website due to malware distribution."
+  },
+  "malwareAdvancedInfoHeading" : {
+    "title" : "Si crees que este sitio web es seguro, puedes <a>informar de un error</a>. Puedes seguir visitando el sitio web por tu cuenta y riesgo.",
+    "note" : "Title of the Advanced info section shown in an error page that warns users of security risks on a website due to malware distribution."
   },
   "phishingPageHeading" : {
-    "title" : "Advertencia: este sitio pone en riesgo tu información personal",
+    "title" : "Advertencia: este sitio puede poner en riesgo tu información personal",
     "note" : "Title shown in an error page that warn users of security risks on a website due to Phishing issues"
   },
   "phishingWarningText" : {
@@ -33,16 +45,8 @@
     "note" : "Error description shown in an error page that warns users of security risks on a website due to Phishing issues."
   },
   "phishingAdvancedInfoHeading" : {
-    "title" : "DuckDuckGo te avisa cuando un sitio web ha sido marcado como malicioso.",
-    "note" : "Title of the Advanced info section shown in an error page that warns users of security risks on a website due to Phishing issues."
-  },
-  "phishingAdvancedInfoText_1" : {
-    "title" : "Se muestran advertencias para los sitios web que se han denunciado como engañosos. Los sitios web engañosos intentan engañarte haciéndote creer que son sitios web legítimos en los que confías. Si entiendes los riesgos involucrados, puedes continuar de todos modos.",
-    "note" : "Body of the text of the Advanced info shown in an error page that warns users of security risks on a website due to Phishing issues."
-  },
-  "phishingAdvancedInfoText_2" : {
-    "title" : "Consulta nuestra <a>página de ayuda Protección contra phishing y malware</a> para obtener más información.",
-    "note" : "A call-to-action to read more on our help pages for phishing and malware protection."
+    "title" : "Si crees que este sitio web es seguro, puedes <a>informar de un error</a>. Puedes seguir visitando el sitio web por tu cuenta y riesgo.",
+    "note" : "Title of the Advanced info section shown in an error page that warns users of security risks on a website due to malware distribution."
   },
   "sslPageHeading" : {
     "title" : "Advertencia: este sitio puede ser inseguro",

--- a/special-pages/pages/special-error/public/locales/et/special-error.json
+++ b/special-pages/pages/special-error/public/locales/et/special-error.json
@@ -10,22 +10,34 @@
   },
   "advancedButton" : {
     "title" : "Täiustatud",
-    "note" : "Button shown in an error page that warns users of security risks on a website due to Phishing issues. The buttons allows the user to see advanced options on click."
+    "note" : "Button shown in an error page that warns users of security risks on a website due to Phishing or Malware issues. The buttons allows the user to see advanced options on click."
   },
   "advancedEllipsisButton" : {
     "title" : "Täpsemad...",
-    "note" : "Button shown in an error page that warns users of security risks on a website due to Phishing issues. The buttons allows the user to see advanced options on click. This button contains a trailing ellipsis."
+    "note" : "Button shown in an error page that warns users of security risks on a website due to Phishing or Malware issues. The buttons allows the user to see advanced options on click. This button contains a trailing ellipsis."
   },
   "leaveSiteButton" : {
     "title" : "Lahku sellelt saidilt",
-    "note" : "Button shown in an error page that warns users of security risks on a website due to Phishing issues. The buttons allows the user to leave the website and navigate to previous page."
+    "note" : "Button shown in an error page that warns users of security risks on a website due to Phishing or Malware issues. The buttons allows the user to leave the website and navigate to previous page."
   },
   "visitSiteButton" : {
     "title" : "Nõustu riskiga ja külasta saiti",
-    "note" : "Button shown in an error page that warns users of security risks on a website due to Phishing issues. The buttons allows the user to visit the website anyway despite the risks."
+    "note" : "Button shown in an error page that warns users of security risks on a website due to Phishing or Malware issues. The buttons allows the user to visit the website anyway despite the risks."
+  },
+  "malwarePageHeading" : {
+    "title" : "Hoiatus! See sait võib teie isikuandmed ohtu seada",
+    "note" : "Title shown in an error page that warn users of security risks on a website due to malware distribution"
+  },
+  "malwareWarningText" : {
+    "title" : "DuckDuckGo blokeeris selle saidi, kuna see võib levitada pahavara, mis on loodud teie seadme kahjustamiseks või teie isikuandmete varastamiseks. <a>Vaata lähemalt</a>",
+    "note" : "Error description shown in an error page that warns users of security risks on a website due to malware distribution."
+  },
+  "malwareAdvancedInfoHeading" : {
+    "title" : "Kui arvate, et see veebisait on turvaline, võite <a>teatada veast</a>. Võite siiski külastada veebisaiti omal vastutusel.",
+    "note" : "Title of the Advanced info section shown in an error page that warns users of security risks on a website due to malware distribution."
   },
   "phishingPageHeading" : {
-    "title" : "Hoiatus! See sait seab sinu isikuandmed ohtu",
+    "title" : "Hoiatus! See sait võib teie isikuandmed ohtu seada",
     "note" : "Title shown in an error page that warn users of security risks on a website due to Phishing issues"
   },
   "phishingWarningText" : {
@@ -33,16 +45,8 @@
     "note" : "Error description shown in an error page that warns users of security risks on a website due to Phishing issues."
   },
   "phishingAdvancedInfoHeading" : {
-    "title" : "DuckDuckGo hoiatab sind, kui veebisait on märgitud pahatahtlikuks.",
-    "note" : "Title of the Advanced info section shown in an error page that warns users of security risks on a website due to Phishing issues."
-  },
-  "phishingAdvancedInfoText_1" : {
-    "title" : "Hoiatusi kuvatakse veebisaitide kohta, mille kohta on teatatud, et need on petlikud. Petlikud veebisaidid püüavad sind petta ja näida legitiimsete veebisaitidena, mida usaldad. Kui mõistad kaasnevaid riske, võid ikkagi jätkata.",
-    "note" : "Body of the text of the Advanced info shown in an error page that warns users of security risks on a website due to Phishing issues."
-  },
-  "phishingAdvancedInfoText_2" : {
-    "title" : "Lisateavet leiad meie <a>andmepüügi ja pahavara kaitse abilehelt</a>.",
-    "note" : "A call-to-action to read more on our help pages for phishing and malware protection."
+    "title" : "Kui arvate, et see veebisait on turvaline, võite <a>teatada veast</a>. Võite siiski külastada veebisaiti omal vastutusel.",
+    "note" : "Title of the Advanced info section shown in an error page that warns users of security risks on a website due to malware distribution."
   },
   "sslPageHeading" : {
     "title" : "Hoiatus: see sait võib olla ebaturvaline",

--- a/special-pages/pages/special-error/public/locales/fi/special-error.json
+++ b/special-pages/pages/special-error/public/locales/fi/special-error.json
@@ -10,22 +10,34 @@
   },
   "advancedButton" : {
     "title" : "Lisäasetukset",
-    "note" : "Button shown in an error page that warns users of security risks on a website due to Phishing issues. The buttons allows the user to see advanced options on click."
+    "note" : "Button shown in an error page that warns users of security risks on a website due to Phishing or Malware issues. The buttons allows the user to see advanced options on click."
   },
   "advancedEllipsisButton" : {
     "title" : "Lisäasetukset...",
-    "note" : "Button shown in an error page that warns users of security risks on a website due to Phishing issues. The buttons allows the user to see advanced options on click. This button contains a trailing ellipsis."
+    "note" : "Button shown in an error page that warns users of security risks on a website due to Phishing or Malware issues. The buttons allows the user to see advanced options on click. This button contains a trailing ellipsis."
   },
   "leaveSiteButton" : {
     "title" : "Poistu sivustolta",
-    "note" : "Button shown in an error page that warns users of security risks on a website due to Phishing issues. The buttons allows the user to leave the website and navigate to previous page."
+    "note" : "Button shown in an error page that warns users of security risks on a website due to Phishing or Malware issues. The buttons allows the user to leave the website and navigate to previous page."
   },
   "visitSiteButton" : {
     "title" : "Hyväksy riski ja mene sivustolle",
-    "note" : "Button shown in an error page that warns users of security risks on a website due to Phishing issues. The buttons allows the user to visit the website anyway despite the risks."
+    "note" : "Button shown in an error page that warns users of security risks on a website due to Phishing or Malware issues. The buttons allows the user to visit the website anyway despite the risks."
+  },
+  "malwarePageHeading" : {
+    "title" : "Varoitus: Tämä sivusto saattaa vaarantaa henkilötietosi",
+    "note" : "Title shown in an error page that warn users of security risks on a website due to malware distribution"
+  },
+  "malwareWarningText" : {
+    "title" : "DuckDuckGo esti tämän sivun, koska se saattaa levittää haittaohjelmia, jotka voivat vaarantaa laitteesi tai varastaa henkilökohtaisia tietojasi. <a>Lue lisää</a>",
+    "note" : "Error description shown in an error page that warns users of security risks on a website due to malware distribution."
+  },
+  "malwareAdvancedInfoHeading" : {
+    "title" : "Jos uskot, että tämä verkkosivusto on turvallinen, voit <a>ilmoittaa virheestä</a>. Voit silti vierailla verkkosivustolla omalla vastuullasi.",
+    "note" : "Title of the Advanced info section shown in an error page that warns users of security risks on a website due to malware distribution."
   },
   "phishingPageHeading" : {
-    "title" : "Varoitus: Tämä sivusto vaarantaa henkilötietosi",
+    "title" : "Varoitus: Tämä sivusto saattaa vaarantaa henkilötietosi",
     "note" : "Title shown in an error page that warn users of security risks on a website due to Phishing issues"
   },
   "phishingWarningText" : {
@@ -33,16 +45,8 @@
     "note" : "Error description shown in an error page that warns users of security risks on a website due to Phishing issues."
   },
   "phishingAdvancedInfoHeading" : {
-    "title" : "DuckDuckGo varoittaa sinua, jos verkkosivusto on merkitty haitalliseksi.",
-    "note" : "Title of the Advanced info section shown in an error page that warns users of security risks on a website due to Phishing issues."
-  },
-  "phishingAdvancedInfoText_1" : {
-    "title" : "Varoitukset näkyvät verkkosivustoilla, joiden on raportoitu olevan harhaanjohtavia. Huijaussivustot yrittävät saada sinut uskomaan, että ne ovat laillisia ja luotettavia verkkosivustoja. Jos ymmärrät sivuston riskit, voit jatkaa.",
-    "note" : "Body of the text of the Advanced info shown in an error page that warns users of security risks on a website due to Phishing issues."
-  },
-  "phishingAdvancedInfoText_2" : {
-    "title" : "Katso lisätietoja <a>tietojenkalastelua ja haittaohjelmasuojausta koskevalta ohjesivulta</a>.",
-    "note" : "A call-to-action to read more on our help pages for phishing and malware protection."
+    "title" : "Jos uskot, että tämä verkkosivusto on turvallinen, voit <a>ilmoittaa virheestä</a>. Voit silti vierailla verkkosivustolla omalla vastuullasi.",
+    "note" : "Title of the Advanced info section shown in an error page that warns users of security risks on a website due to malware distribution."
   },
   "sslPageHeading" : {
     "title" : "Varoitus: Tämä sivusto ei välttämättä ole turvallinen",

--- a/special-pages/pages/special-error/public/locales/fr/special-error.json
+++ b/special-pages/pages/special-error/public/locales/fr/special-error.json
@@ -10,22 +10,34 @@
   },
   "advancedButton" : {
     "title" : "Options avancées",
-    "note" : "Button shown in an error page that warns users of security risks on a website due to Phishing issues. The buttons allows the user to see advanced options on click."
+    "note" : "Button shown in an error page that warns users of security risks on a website due to Phishing or Malware issues. The buttons allows the user to see advanced options on click."
   },
   "advancedEllipsisButton" : {
     "title" : "Options avancées…",
-    "note" : "Button shown in an error page that warns users of security risks on a website due to Phishing issues. The buttons allows the user to see advanced options on click. This button contains a trailing ellipsis."
+    "note" : "Button shown in an error page that warns users of security risks on a website due to Phishing or Malware issues. The buttons allows the user to see advanced options on click. This button contains a trailing ellipsis."
   },
   "leaveSiteButton" : {
     "title" : "Quitter ce site",
-    "note" : "Button shown in an error page that warns users of security risks on a website due to Phishing issues. The buttons allows the user to leave the website and navigate to previous page."
+    "note" : "Button shown in an error page that warns users of security risks on a website due to Phishing or Malware issues. The buttons allows the user to leave the website and navigate to previous page."
   },
   "visitSiteButton" : {
     "title" : "Accepter le risque et visiter le site",
-    "note" : "Button shown in an error page that warns users of security risks on a website due to Phishing issues. The buttons allows the user to visit the website anyway despite the risks."
+    "note" : "Button shown in an error page that warns users of security risks on a website due to Phishing or Malware issues. The buttons allows the user to visit the website anyway despite the risks."
+  },
+  "malwarePageHeading" : {
+    "title" : "Attention : ce site peut faire courir un risque à vos informations personnelles",
+    "note" : "Title shown in an error page that warn users of security risks on a website due to malware distribution"
+  },
+  "malwareWarningText" : {
+    "title" : "DuckDuckGo a bloqué cette page car elle pourrait diffuser des logiciels malveillants conçus pour compromettre votre appareil ou voler vos informations personnelles. <a>En savoir plus</a>",
+    "note" : "Error description shown in an error page that warns users of security risks on a website due to malware distribution."
+  },
+  "malwareAdvancedInfoHeading" : {
+    "title" : "Si vous pensez que ce site Web est sûr, vous pouvez <a>signaler une erreur</a>. La visite du site Web se fera à vos risques et périls.",
+    "note" : "Title of the Advanced info section shown in an error page that warns users of security risks on a website due to malware distribution."
   },
   "phishingPageHeading" : {
-    "title" : "Attention : ce site fait courir un risque à vos informations personnelles",
+    "title" : "Attention : ce site peut faire courir un risque à vos informations personnelles",
     "note" : "Title shown in an error page that warn users of security risks on a website due to Phishing issues"
   },
   "phishingWarningText" : {
@@ -33,16 +45,8 @@
     "note" : "Error description shown in an error page that warns users of security risks on a website due to Phishing issues."
   },
   "phishingAdvancedInfoHeading" : {
-    "title" : "DuckDuckGo vous avertit lorsqu'un site Web a été signalé comme étant malveillant.",
-    "note" : "Title of the Advanced info section shown in an error page that warns users of security risks on a website due to Phishing issues."
-  },
-  "phishingAdvancedInfoText_1" : {
-    "title" : "Des avertissements sont affichés pour les sites Web signalés comme étant trompeurs. Les sites Web trompeurs tentent de vous faire croire qu'ils sont des sites Web légitimes en lesquels vous avez confiance. Si vous comprenez les risques encourus, vous pouvez décider de poursuivre malgré tout.",
-    "note" : "Body of the text of the Advanced info shown in an error page that warns users of security risks on a website due to Phishing issues."
-  },
-  "phishingAdvancedInfoText_2" : {
-    "title" : "Consultez notre <a>page d’aide sur la protection contre le phishing et les logiciels malveillants</a> pour en savoir plus.",
-    "note" : "A call-to-action to read more on our help pages for phishing and malware protection."
+    "title" : "Si vous pensez que ce site Web est sûr, vous pouvez <a>signaler une erreur</a>. La visite du site Web se fera à vos risques et périls.",
+    "note" : "Title of the Advanced info section shown in an error page that warns users of security risks on a website due to malware distribution."
   },
   "sslPageHeading" : {
     "title" : "Avertissement : ce site n'est peut-être pas sécurisé",

--- a/special-pages/pages/special-error/public/locales/hr/special-error.json
+++ b/special-pages/pages/special-error/public/locales/hr/special-error.json
@@ -10,22 +10,34 @@
   },
   "advancedButton" : {
     "title" : "Napredno",
-    "note" : "Button shown in an error page that warns users of security risks on a website due to Phishing issues. The buttons allows the user to see advanced options on click."
+    "note" : "Button shown in an error page that warns users of security risks on a website due to Phishing or Malware issues. The buttons allows the user to see advanced options on click."
   },
   "advancedEllipsisButton" : {
     "title" : "Napredno...",
-    "note" : "Button shown in an error page that warns users of security risks on a website due to Phishing issues. The buttons allows the user to see advanced options on click. This button contains a trailing ellipsis."
+    "note" : "Button shown in an error page that warns users of security risks on a website due to Phishing or Malware issues. The buttons allows the user to see advanced options on click. This button contains a trailing ellipsis."
   },
   "leaveSiteButton" : {
     "title" : "Napusti ovo web-mjesto",
-    "note" : "Button shown in an error page that warns users of security risks on a website due to Phishing issues. The buttons allows the user to leave the website and navigate to previous page."
+    "note" : "Button shown in an error page that warns users of security risks on a website due to Phishing or Malware issues. The buttons allows the user to leave the website and navigate to previous page."
   },
   "visitSiteButton" : {
     "title" : "Prihvati rizik i posjeti web-mjesto",
-    "note" : "Button shown in an error page that warns users of security risks on a website due to Phishing issues. The buttons allows the user to visit the website anyway despite the risks."
+    "note" : "Button shown in an error page that warns users of security risks on a website due to Phishing or Malware issues. The buttons allows the user to visit the website anyway despite the risks."
+  },
+  "malwarePageHeading" : {
+    "title" : "Upozorenje: ovo web-mjesto može ugroziti tvoje osobne podatke",
+    "note" : "Title shown in an error page that warn users of security risks on a website due to malware distribution"
+  },
+  "malwareWarningText" : {
+    "title" : "DuckDuckGo je blokirao ovu stranicu jer možda širi zlonamjerni softver izrađen da ugrozi tvoj uređaj ili ukrade tvoje osobne podatke. <a>Saznaj više</a>",
+    "note" : "Error description shown in an error page that warns users of security risks on a website due to malware distribution."
+  },
+  "malwareAdvancedInfoHeading" : {
+    "title" : "Ako vjeruješ da je ovo web-mjesto sigurno, možeš <a>prijaviti pogrešku</a>. Još uvijek možeš posjetiti web-mjesto na vlastitu odgovornost.",
+    "note" : "Title of the Advanced info section shown in an error page that warns users of security risks on a website due to malware distribution."
   },
   "phishingPageHeading" : {
-    "title" : "Upozorenje: ovo web-mjesto ugrožava tvoje osobne podatke",
+    "title" : "Upozorenje: ovo web-mjesto može ugroziti tvoje osobne podatke",
     "note" : "Title shown in an error page that warn users of security risks on a website due to Phishing issues"
   },
   "phishingWarningText" : {
@@ -33,16 +45,8 @@
     "note" : "Error description shown in an error page that warns users of security risks on a website due to Phishing issues."
   },
   "phishingAdvancedInfoHeading" : {
-    "title" : "DuckDuckGo te upozorava kada je web-mjesto označeno kao zlonamjerno.",
-    "note" : "Title of the Advanced info section shown in an error page that warns users of security risks on a website due to Phishing issues."
-  },
-  "phishingAdvancedInfoText_1" : {
-    "title" : "Upozorenja se prikazuju za web-mjesta za koje je prijavljeno da su obmanjujuća. Obmanjujuća web-mjesta pokušavaju te prevariti u smislu da povjerujete kako se radi o stvarnim web-mjestima kojima se može vjerovati. Ako razumiješ rizike, svejedno možeš nastaviti.",
-    "note" : "Body of the text of the Advanced info shown in an error page that warns users of security risks on a website due to Phishing issues."
-  },
-  "phishingAdvancedInfoText_2" : {
-    "title" : "Više informacija potraži na našoj <a>stranici pomoći za zaštitu od krađe identiteta i zlonamjernog softvera</a> .",
-    "note" : "A call-to-action to read more on our help pages for phishing and malware protection."
+    "title" : "Ako vjeruješ da je ovo web-mjesto sigurno, možeš <a>prijaviti pogrešku</a>. Još uvijek možeš posjetiti web-mjesto na vlastitu odgovornost.",
+    "note" : "Title of the Advanced info section shown in an error page that warns users of security risks on a website due to malware distribution."
   },
   "sslPageHeading" : {
     "title" : "Upozorenje: ova stranica može biti nesigurna",

--- a/special-pages/pages/special-error/public/locales/hu/special-error.json
+++ b/special-pages/pages/special-error/public/locales/hu/special-error.json
@@ -10,22 +10,34 @@
   },
   "advancedButton" : {
     "title" : "Haladó",
-    "note" : "Button shown in an error page that warns users of security risks on a website due to Phishing issues. The buttons allows the user to see advanced options on click."
+    "note" : "Button shown in an error page that warns users of security risks on a website due to Phishing or Malware issues. The buttons allows the user to see advanced options on click."
   },
   "advancedEllipsisButton" : {
     "title" : "Speciális…",
-    "note" : "Button shown in an error page that warns users of security risks on a website due to Phishing issues. The buttons allows the user to see advanced options on click. This button contains a trailing ellipsis."
+    "note" : "Button shown in an error page that warns users of security risks on a website due to Phishing or Malware issues. The buttons allows the user to see advanced options on click. This button contains a trailing ellipsis."
   },
   "leaveSiteButton" : {
     "title" : "Webhely elhagyása",
-    "note" : "Button shown in an error page that warns users of security risks on a website due to Phishing issues. The buttons allows the user to leave the website and navigate to previous page."
+    "note" : "Button shown in an error page that warns users of security risks on a website due to Phishing or Malware issues. The buttons allows the user to leave the website and navigate to previous page."
   },
   "visitSiteButton" : {
     "title" : "Kockázat elfogadása és a webhely megnyitása",
-    "note" : "Button shown in an error page that warns users of security risks on a website due to Phishing issues. The buttons allows the user to visit the website anyway despite the risks."
+    "note" : "Button shown in an error page that warns users of security risks on a website due to Phishing or Malware issues. The buttons allows the user to visit the website anyway despite the risks."
+  },
+  "malwarePageHeading" : {
+    "title" : "Figyelmeztetés: Ez a webhely veszélyt jelenthet a személyes adataidra",
+    "note" : "Title shown in an error page that warn users of security risks on a website due to malware distribution"
+  },
+  "malwareWarningText" : {
+    "title" : "A DuckDuckGo blokkolta ezt az oldalt, mert lehetséges, hogy olyan rosszindulatú programokat terjeszt, amelyek veszélyeztethetik az eszközöd biztonságát vagy ellophatják a személyes adataidat. <a>További részletek</a>",
+    "note" : "Error description shown in an error page that warns users of security risks on a website due to malware distribution."
+  },
+  "malwareAdvancedInfoHeading" : {
+    "title" : "Ha úgy gondolod, hogy ez a weboldal biztonságos, <a>tegyél hibabejelentést</a>. A weboldalt továbbra is saját felelősségedre látogathatod.",
+    "note" : "Title of the Advanced info section shown in an error page that warns users of security risks on a website due to malware distribution."
   },
   "phishingPageHeading" : {
-    "title" : "Figyelmeztetés: Ez a webhely veszélyezteti a személyes adataidat",
+    "title" : "Figyelmeztetés: Ez a webhely veszélyt jelenthet a személyes adataidra",
     "note" : "Title shown in an error page that warn users of security risks on a website due to Phishing issues"
   },
   "phishingWarningText" : {
@@ -33,16 +45,8 @@
     "note" : "Error description shown in an error page that warns users of security risks on a website due to Phishing issues."
   },
   "phishingAdvancedInfoHeading" : {
-    "title" : "A DuckDuckGo figyelmeztet, ha egy webhely rosszindulatúként van megjelölve.",
-    "note" : "Title of the Advanced info section shown in an error page that warns users of security risks on a website due to Phishing issues."
-  },
-  "phishingAdvancedInfoText_1" : {
-    "title" : "A megtévesztőként bejelentett webhelyek esetén figyelmeztetés jelenik meg. A megtévesztő webhelyek megpróbálnak becsapni, hogy legitim, megbízható webhelynek hidd őket. Ha tisztában vagy a kockázatokkal, akkor ennek ellenére folytathatod.",
-    "note" : "Body of the text of the Advanced info shown in an error page that warns users of security risks on a website due to Phishing issues."
-  },
-  "phishingAdvancedInfoText_2" : {
-    "title" : "További információért olvasd el az <a>Adathalászat és rosszindulatú programok elleni védelem súgóoldalunkat</a>.",
-    "note" : "A call-to-action to read more on our help pages for phishing and malware protection."
+    "title" : "Ha úgy gondolod, hogy ez a weboldal biztonságos, <a>tegyél hibabejelentést</a>. A weboldalt továbbra is saját felelősségedre látogathatod.",
+    "note" : "Title of the Advanced info section shown in an error page that warns users of security risks on a website due to malware distribution."
   },
   "sslPageHeading" : {
     "title" : "Figyelmeztetés: Lehet, hogy ez a webhely nem biztonságos",

--- a/special-pages/pages/special-error/public/locales/it/special-error.json
+++ b/special-pages/pages/special-error/public/locales/it/special-error.json
@@ -10,22 +10,34 @@
   },
   "advancedButton" : {
     "title" : "Avanzate",
-    "note" : "Button shown in an error page that warns users of security risks on a website due to Phishing issues. The buttons allows the user to see advanced options on click."
+    "note" : "Button shown in an error page that warns users of security risks on a website due to Phishing or Malware issues. The buttons allows the user to see advanced options on click."
   },
   "advancedEllipsisButton" : {
     "title" : "Avanzate...",
-    "note" : "Button shown in an error page that warns users of security risks on a website due to Phishing issues. The buttons allows the user to see advanced options on click. This button contains a trailing ellipsis."
+    "note" : "Button shown in an error page that warns users of security risks on a website due to Phishing or Malware issues. The buttons allows the user to see advanced options on click. This button contains a trailing ellipsis."
   },
   "leaveSiteButton" : {
     "title" : "Esci da questo sito",
-    "note" : "Button shown in an error page that warns users of security risks on a website due to Phishing issues. The buttons allows the user to leave the website and navigate to previous page."
+    "note" : "Button shown in an error page that warns users of security risks on a website due to Phishing or Malware issues. The buttons allows the user to leave the website and navigate to previous page."
   },
   "visitSiteButton" : {
     "title" : "Accetta il rischio e visita il sito",
-    "note" : "Button shown in an error page that warns users of security risks on a website due to Phishing issues. The buttons allows the user to visit the website anyway despite the risks."
+    "note" : "Button shown in an error page that warns users of security risks on a website due to Phishing or Malware issues. The buttons allows the user to visit the website anyway despite the risks."
+  },
+  "malwarePageHeading" : {
+    "title" : "Attenzione: questo sito potrebbe mettere a rischio i tuoi dati personali",
+    "note" : "Title shown in an error page that warn users of security risks on a website due to malware distribution"
+  },
+  "malwareWarningText" : {
+    "title" : "DuckDuckGo ha bloccato questa pagina perché potrebbe distribuire malware progettato per compromettere il tuo dispositivo o rubare le tue informazioni personali. <a>Ulteriori informazioni</a>",
+    "note" : "Error description shown in an error page that warns users of security risks on a website due to malware distribution."
+  },
+  "malwareAdvancedInfoHeading" : {
+    "title" : "Se ritieni che questo sito web sia sicuro, puoi <a>segnalare un errore</a>. Puoi comunque visitare il sito web a tuo rischio e pericolo.",
+    "note" : "Title of the Advanced info section shown in an error page that warns users of security risks on a website due to malware distribution."
   },
   "phishingPageHeading" : {
-    "title" : "Attenzione: questo sito mette a rischio i tuoi dati personali",
+    "title" : "Attenzione: questo sito potrebbe mettere a rischio i tuoi dati personali",
     "note" : "Title shown in an error page that warn users of security risks on a website due to Phishing issues"
   },
   "phishingWarningText" : {
@@ -33,16 +45,8 @@
     "note" : "Error description shown in an error page that warns users of security risks on a website due to Phishing issues."
   },
   "phishingAdvancedInfoHeading" : {
-    "title" : "DuckDuckGo ti avvisa quando un sito web è stato contrassegnato come dannoso.",
-    "note" : "Title of the Advanced info section shown in an error page that warns users of security risks on a website due to Phishing issues."
-  },
-  "phishingAdvancedInfoText_1" : {
-    "title" : "Vengono visualizzati avvisi per i siti web segnalati come ingannevoli. Questi siti cercano di ingannarti facendogli credere di essere siti web legittimi di cui puoi fidarti. Se ne comprendi i rischi, puoi comunque continuare.",
-    "note" : "Body of the text of the Advanced info shown in an error page that warns users of security risks on a website due to Phishing issues."
-  },
-  "phishingAdvancedInfoText_2" : {
-    "title" : "Per maggiori informazioni, consulta la nostra <a>pagina di aiuto sulla protezione da phishing e malware</a>.",
-    "note" : "A call-to-action to read more on our help pages for phishing and malware protection."
+    "title" : "Se ritieni che questo sito web sia sicuro, puoi <a>segnalare un errore</a>. Puoi comunque visitare il sito web a tuo rischio e pericolo.",
+    "note" : "Title of the Advanced info section shown in an error page that warns users of security risks on a website due to malware distribution."
   },
   "sslPageHeading" : {
     "title" : "Attenzione: questo sito potrebbe non essere sicuro",

--- a/special-pages/pages/special-error/public/locales/lt/special-error.json
+++ b/special-pages/pages/special-error/public/locales/lt/special-error.json
@@ -10,22 +10,34 @@
   },
   "advancedButton" : {
     "title" : "Išplėstinė",
-    "note" : "Button shown in an error page that warns users of security risks on a website due to Phishing issues. The buttons allows the user to see advanced options on click."
+    "note" : "Button shown in an error page that warns users of security risks on a website due to Phishing or Malware issues. The buttons allows the user to see advanced options on click."
   },
   "advancedEllipsisButton" : {
     "title" : "Išplėstinė informacija...",
-    "note" : "Button shown in an error page that warns users of security risks on a website due to Phishing issues. The buttons allows the user to see advanced options on click. This button contains a trailing ellipsis."
+    "note" : "Button shown in an error page that warns users of security risks on a website due to Phishing or Malware issues. The buttons allows the user to see advanced options on click. This button contains a trailing ellipsis."
   },
   "leaveSiteButton" : {
     "title" : "Išeiti iš šios svetainės",
-    "note" : "Button shown in an error page that warns users of security risks on a website due to Phishing issues. The buttons allows the user to leave the website and navigate to previous page."
+    "note" : "Button shown in an error page that warns users of security risks on a website due to Phishing or Malware issues. The buttons allows the user to leave the website and navigate to previous page."
   },
   "visitSiteButton" : {
     "title" : "Priimti riziką ir apsilankyti svetainėje",
-    "note" : "Button shown in an error page that warns users of security risks on a website due to Phishing issues. The buttons allows the user to visit the website anyway despite the risks."
+    "note" : "Button shown in an error page that warns users of security risks on a website due to Phishing or Malware issues. The buttons allows the user to visit the website anyway despite the risks."
+  },
+  "malwarePageHeading" : {
+    "title" : "Įspėjimas: ši svetainė gali kelti pavojų jūsų asmeninei informacijai",
+    "note" : "Title shown in an error page that warn users of security risks on a website due to malware distribution"
+  },
+  "malwareWarningText" : {
+    "title" : "„DuckDuckGo“ užblokavo šį puslapį, nes jame gali būti platinama kenkėjiška programinė įranga, kuria siekiama pakenkti jūsų įrenginiui arba pavogti jūsų asmeninę informaciją. <a>Sužinokite daugiau</a>",
+    "note" : "Error description shown in an error page that warns users of security risks on a website due to malware distribution."
+  },
+  "malwareAdvancedInfoHeading" : {
+    "title" : "Jei manote, kad ši svetainė yra saugi, galite <a>pranešti apie klaidą</a>. Vis dar galite apsilankyti svetainėje savo rizika.",
+    "note" : "Title of the Advanced info section shown in an error page that warns users of security risks on a website due to malware distribution."
   },
   "phishingPageHeading" : {
-    "title" : "Įspėjimas: ši svetainė kelia pavojų jūsų asmeninei informacijai",
+    "title" : "Įspėjimas: ši svetainė gali kelti pavojų jūsų asmeninei informacijai",
     "note" : "Title shown in an error page that warn users of security risks on a website due to Phishing issues"
   },
   "phishingWarningText" : {
@@ -33,16 +45,8 @@
     "note" : "Error description shown in an error page that warns users of security risks on a website due to Phishing issues."
   },
   "phishingAdvancedInfoHeading" : {
-    "title" : "„DuckDuckGo“ įspėja jus, kai svetainė buvo pažymėta kaip kenkėjiška.",
-    "note" : "Title of the Advanced info section shown in an error page that warns users of security risks on a website due to Phishing issues."
-  },
-  "phishingAdvancedInfoText_1" : {
-    "title" : "Įspėjimai rodomi apie svetaines, kurios, kaip pranešta, yra apgaulingos. Apgaulingos svetainės bando jus apgauti manyti, kad jos yra teisėtos svetainės, kuriomis pasitikite. Jei suprantate susijusią riziką, bet kuriuo atveju galite tęsti.",
-    "note" : "Body of the text of the Advanced info shown in an error page that warns users of security risks on a website due to Phishing issues."
-  },
-  "phishingAdvancedInfoText_2" : {
-    "title" : "Daugiau informacijos rasite mūsų <a>pagalbos puslapyje „Phishing and Malware Protection“ (Apsauga nuo sukčiavimo ir kenkėjiškų programų)</a>.",
-    "note" : "A call-to-action to read more on our help pages for phishing and malware protection."
+    "title" : "Jei manote, kad ši svetainė yra saugi, galite <a>pranešti apie klaidą</a>. Vis dar galite apsilankyti svetainėje savo rizika.",
+    "note" : "Title of the Advanced info section shown in an error page that warns users of security risks on a website due to malware distribution."
   },
   "sslPageHeading" : {
     "title" : "Įspėjimas: ši svetainė gali būti nesaugi",

--- a/special-pages/pages/special-error/public/locales/lv/special-error.json
+++ b/special-pages/pages/special-error/public/locales/lv/special-error.json
@@ -10,22 +10,34 @@
   },
   "advancedButton" : {
     "title" : "Detalizēti",
-    "note" : "Button shown in an error page that warns users of security risks on a website due to Phishing issues. The buttons allows the user to see advanced options on click."
+    "note" : "Button shown in an error page that warns users of security risks on a website due to Phishing or Malware issues. The buttons allows the user to see advanced options on click."
   },
   "advancedEllipsisButton" : {
     "title" : "Detalizēti...",
-    "note" : "Button shown in an error page that warns users of security risks on a website due to Phishing issues. The buttons allows the user to see advanced options on click. This button contains a trailing ellipsis."
+    "note" : "Button shown in an error page that warns users of security risks on a website due to Phishing or Malware issues. The buttons allows the user to see advanced options on click. This button contains a trailing ellipsis."
   },
   "leaveSiteButton" : {
     "title" : "Pamest šo vietni",
-    "note" : "Button shown in an error page that warns users of security risks on a website due to Phishing issues. The buttons allows the user to leave the website and navigate to previous page."
+    "note" : "Button shown in an error page that warns users of security risks on a website due to Phishing or Malware issues. The buttons allows the user to leave the website and navigate to previous page."
   },
   "visitSiteButton" : {
     "title" : "Pieņemt risku un apmeklēt vietni",
-    "note" : "Button shown in an error page that warns users of security risks on a website due to Phishing issues. The buttons allows the user to visit the website anyway despite the risks."
+    "note" : "Button shown in an error page that warns users of security risks on a website due to Phishing or Malware issues. The buttons allows the user to visit the website anyway despite the risks."
+  },
+  "malwarePageHeading" : {
+    "title" : "Brīdinājums: Šī vietne var apdraudēt tavu personisko informāciju.",
+    "note" : "Title shown in an error page that warn users of security risks on a website due to malware distribution"
+  },
+  "malwareWarningText" : {
+    "title" : "DuckDuckGo bloķēja šo lapu, jo tajā, iespējams, tiek izplatīta ļaunprātīga programmatūra, kas paredzēta, lai apdraudētu tavu ierīci vai nozagtu tavu personisko informāciju. <a>Uzzināt vairāk</a>",
+    "note" : "Error description shown in an error page that warns users of security risks on a website due to malware distribution."
+  },
+  "malwareAdvancedInfoHeading" : {
+    "title" : "Ja uzskati, ka šī vietne ir droša, vari <a>ziņot par kļūdu</a>. Tu joprojām vari apmeklēt šo vietni, apzinoties savu risku.",
+    "note" : "Title of the Advanced info section shown in an error page that warns users of security risks on a website due to malware distribution."
   },
   "phishingPageHeading" : {
-    "title" : "Brīdinājums: Šī vietne apdraud tavu personisko informāciju",
+    "title" : "Brīdinājums: Šī vietne var apdraudēt tavu personisko informāciju",
     "note" : "Title shown in an error page that warn users of security risks on a website due to Phishing issues"
   },
   "phishingWarningText" : {
@@ -33,16 +45,8 @@
     "note" : "Error description shown in an error page that warns users of security risks on a website due to Phishing issues."
   },
   "phishingAdvancedInfoHeading" : {
-    "title" : "DuckDuckGo brīdina, ja vietne ir atzīmēta kā ļaunprātīga.",
-    "note" : "Title of the Advanced info section shown in an error page that warns users of security risks on a website due to Phishing issues."
-  },
-  "phishingAdvancedInfoText_1" : {
-    "title" : "Tiek parādīti brīdinājumi par vietnēm, par kurām ziņots, ka tās ir maldinošas. Krāpnieciskās vietnes cenšas maldināt, liekot noticēt, ka tās ir īstas vietnes, kurām tu uzticies. Ja saproti ar to saistītos riskus, vari tomēr turpināt.",
-    "note" : "Body of the text of the Advanced info shown in an error page that warns users of security risks on a website due to Phishing issues."
-  },
-  "phishingAdvancedInfoText_2" : {
-    "title" : "Lai iegūtu vairāk informācijas, skatiet mūsu <a>palīdzības lapu par aizsardzību pret pikšķerēšanu un ļaunprātīgu programmatūru</a>.",
-    "note" : "A call-to-action to read more on our help pages for phishing and malware protection."
+    "title" : "Ja uzskati, ka šī vietne ir droša, vari <a>ziņot par kļūdu</a>. Tu joprojām vari apmeklēt šo vietni, apzinoties savu risku.",
+    "note" : "Title of the Advanced info section shown in an error page that warns users of security risks on a website due to malware distribution."
   },
   "sslPageHeading" : {
     "title" : "Brīdinājums: šī vietne var būt nedroša",

--- a/special-pages/pages/special-error/public/locales/nb/special-error.json
+++ b/special-pages/pages/special-error/public/locales/nb/special-error.json
@@ -10,22 +10,34 @@
   },
   "advancedButton" : {
     "title" : "Avansert",
-    "note" : "Button shown in an error page that warns users of security risks on a website due to Phishing issues. The buttons allows the user to see advanced options on click."
+    "note" : "Button shown in an error page that warns users of security risks on a website due to Phishing or Malware issues. The buttons allows the user to see advanced options on click."
   },
   "advancedEllipsisButton" : {
     "title" : "Avansert ...",
-    "note" : "Button shown in an error page that warns users of security risks on a website due to Phishing issues. The buttons allows the user to see advanced options on click. This button contains a trailing ellipsis."
+    "note" : "Button shown in an error page that warns users of security risks on a website due to Phishing or Malware issues. The buttons allows the user to see advanced options on click. This button contains a trailing ellipsis."
   },
   "leaveSiteButton" : {
     "title" : "Forlat dette nettstedet",
-    "note" : "Button shown in an error page that warns users of security risks on a website due to Phishing issues. The buttons allows the user to leave the website and navigate to previous page."
+    "note" : "Button shown in an error page that warns users of security risks on a website due to Phishing or Malware issues. The buttons allows the user to leave the website and navigate to previous page."
   },
   "visitSiteButton" : {
     "title" : "Godta risikoen og gå til nettstedet",
-    "note" : "Button shown in an error page that warns users of security risks on a website due to Phishing issues. The buttons allows the user to visit the website anyway despite the risks."
+    "note" : "Button shown in an error page that warns users of security risks on a website due to Phishing or Malware issues. The buttons allows the user to visit the website anyway despite the risks."
+  },
+  "malwarePageHeading" : {
+    "title" : "Advarsel: Dette nettstedet kan sette personopplysningene dine i fare",
+    "note" : "Title shown in an error page that warn users of security risks on a website due to malware distribution"
+  },
+  "malwareWarningText" : {
+    "title" : "DuckDuckGo blokkerte denne siden fordi det er mulig at den distribuerer skadelig programvare som er laget for å kompromittere enheten din eller stjele personopplysningene dine. <a>Finn ut mer</a>",
+    "note" : "Error description shown in an error page that warns users of security risks on a website due to malware distribution."
+  },
+  "malwareAdvancedInfoHeading" : {
+    "title" : "Hvis du mener at dette nettstedet er trygt, kan du <a>rapportere en feil</a>. Du kan fortsatt besøke nettstedet på egen risiko.",
+    "note" : "Title of the Advanced info section shown in an error page that warns users of security risks on a website due to malware distribution."
   },
   "phishingPageHeading" : {
-    "title" : "Advarsel: Dette nettstedet utgjør en risiko for personopplysningene dine",
+    "title" : "Advarsel: Dette nettstedet kan sette personopplysningene dine i fare",
     "note" : "Title shown in an error page that warn users of security risks on a website due to Phishing issues"
   },
   "phishingWarningText" : {
@@ -33,16 +45,8 @@
     "note" : "Error description shown in an error page that warns users of security risks on a website due to Phishing issues."
   },
   "phishingAdvancedInfoHeading" : {
-    "title" : "DuckDuckGo advarer deg når et nettsted er flagget som skadelig.",
-    "note" : "Title of the Advanced info section shown in an error page that warns users of security risks on a website due to Phishing issues."
-  },
-  "phishingAdvancedInfoText_1" : {
-    "title" : "Advarsler vises for nettsteder som er rapportert som villedende. Villedende nettsteder prøver å lure deg til å tro at de er legitime nettsteder du stoler på. Hvis du forstår denne risikoen, kan du fortsette likevel.",
-    "note" : "Body of the text of the Advanced info shown in an error page that warns users of security risks on a website due to Phishing issues."
-  },
-  "phishingAdvancedInfoText_2" : {
-    "title" : "Se <a>hjelpesiden vår om beskyttelse mot phishing og skadelig programvare</a> for å få mer informasjon.",
-    "note" : "A call-to-action to read more on our help pages for phishing and malware protection."
+    "title" : "Hvis du mener at dette nettstedet er trygt, kan du <a>rapportere en feil</a>. Du kan besøke nettstedet på egen risiko.",
+    "note" : "Title of the Advanced info section shown in an error page that warns users of security risks on a website due to malware distribution."
   },
   "sslPageHeading" : {
     "title" : "Advarsel: Dette nettstedet kan være usikkert",

--- a/special-pages/pages/special-error/public/locales/nl/special-error.json
+++ b/special-pages/pages/special-error/public/locales/nl/special-error.json
@@ -10,22 +10,34 @@
   },
   "advancedButton" : {
     "title" : "Geavanceerd",
-    "note" : "Button shown in an error page that warns users of security risks on a website due to Phishing issues. The buttons allows the user to see advanced options on click."
+    "note" : "Button shown in an error page that warns users of security risks on a website due to Phishing or Malware issues. The buttons allows the user to see advanced options on click."
   },
   "advancedEllipsisButton" : {
     "title" : "Geavanceerd...",
-    "note" : "Button shown in an error page that warns users of security risks on a website due to Phishing issues. The buttons allows the user to see advanced options on click. This button contains a trailing ellipsis."
+    "note" : "Button shown in an error page that warns users of security risks on a website due to Phishing or Malware issues. The buttons allows the user to see advanced options on click. This button contains a trailing ellipsis."
   },
   "leaveSiteButton" : {
     "title" : "Deze website verlaten",
-    "note" : "Button shown in an error page that warns users of security risks on a website due to Phishing issues. The buttons allows the user to leave the website and navigate to previous page."
+    "note" : "Button shown in an error page that warns users of security risks on a website due to Phishing or Malware issues. The buttons allows the user to leave the website and navigate to previous page."
   },
   "visitSiteButton" : {
     "title" : "Risico accepteren en site bezoeken",
-    "note" : "Button shown in an error page that warns users of security risks on a website due to Phishing issues. The buttons allows the user to visit the website anyway despite the risks."
+    "note" : "Button shown in an error page that warns users of security risks on a website due to Phishing or Malware issues. The buttons allows the user to visit the website anyway despite the risks."
+  },
+  "malwarePageHeading" : {
+    "title" : "Opgelet: Deze site vormt mogelijk een risico voor je persoonlijke gegevens",
+    "note" : "Title shown in an error page that warn users of security risks on a website due to malware distribution"
+  },
+  "malwareWarningText" : {
+    "title" : "DuckDuckGo heeft deze pagina geblokkeerd omdat deze mogelijk malware verspreidt om je apparaat te beschadigen of je persoonlijke gegevens te stelen. <a>Meer informatie</a>",
+    "note" : "Error description shown in an error page that warns users of security risks on a website due to malware distribution."
+  },
+  "malwareAdvancedInfoHeading" : {
+    "title" : "Je kunt <a>een fout melden</a> als je denkt dat deze website veilig is. Je kunt de website nog steeds bezoeken op eigen risico.",
+    "note" : "Title of the Advanced info section shown in an error page that warns users of security risks on a website due to malware distribution."
   },
   "phishingPageHeading" : {
-    "title" : "Waarschuwing: Deze site vormt een risico voor je persoonlijke gegevens",
+    "title" : "Opgelet: deze site vormt mogelijk een risico voor je persoonlijke gegevens",
     "note" : "Title shown in an error page that warn users of security risks on a website due to Phishing issues"
   },
   "phishingWarningText" : {
@@ -33,16 +45,8 @@
     "note" : "Error description shown in an error page that warns users of security risks on a website due to Phishing issues."
   },
   "phishingAdvancedInfoHeading" : {
-    "title" : "DuckDuckGo waarschuwt je wanneer een website als schadelijk is gemarkeerd.",
-    "note" : "Title of the Advanced info section shown in an error page that warns users of security risks on a website due to Phishing issues."
-  },
-  "phishingAdvancedInfoText_1" : {
-    "title" : "Er worden waarschuwingen weergegeven voor websites waarvan is gemeld dat ze misleidend zijn. Misleidende websites proberen je wijs te maken dat het legitieme websites zijn die je vertrouwt. Je kunt doorgaan als je de risico's begrijpt.",
-    "note" : "Body of the text of the Advanced info shown in an error page that warns users of security risks on a website due to Phishing issues."
-  },
-  "phishingAdvancedInfoText_2" : {
-    "title" : "Zie onze <a>hulppagina over bescherming tegen phishing en malware</a> voor meer informatie.",
-    "note" : "A call-to-action to read more on our help pages for phishing and malware protection."
+    "title" : "Je kunt <a>een fout melden</a> als je denkt dat deze website veilig is. Je kunt de website nog steeds bezoeken op eigen risico.",
+    "note" : "Title of the Advanced info section shown in an error page that warns users of security risks on a website due to malware distribution."
   },
   "sslPageHeading" : {
     "title" : "Waarschuwing: Deze website is mogelijk onveilig",

--- a/special-pages/pages/special-error/public/locales/pl/special-error.json
+++ b/special-pages/pages/special-error/public/locales/pl/special-error.json
@@ -10,22 +10,34 @@
   },
   "advancedButton" : {
     "title" : "Zaawansowane",
-    "note" : "Button shown in an error page that warns users of security risks on a website due to Phishing issues. The buttons allows the user to see advanced options on click."
+    "note" : "Button shown in an error page that warns users of security risks on a website due to Phishing or Malware issues. The buttons allows the user to see advanced options on click."
   },
   "advancedEllipsisButton" : {
     "title" : "Zaawansowane...",
-    "note" : "Button shown in an error page that warns users of security risks on a website due to Phishing issues. The buttons allows the user to see advanced options on click. This button contains a trailing ellipsis."
+    "note" : "Button shown in an error page that warns users of security risks on a website due to Phishing or Malware issues. The buttons allows the user to see advanced options on click. This button contains a trailing ellipsis."
   },
   "leaveSiteButton" : {
     "title" : "Opuść tę stronę",
-    "note" : "Button shown in an error page that warns users of security risks on a website due to Phishing issues. The buttons allows the user to leave the website and navigate to previous page."
+    "note" : "Button shown in an error page that warns users of security risks on a website due to Phishing or Malware issues. The buttons allows the user to leave the website and navigate to previous page."
   },
   "visitSiteButton" : {
     "title" : "Zaakceptuj ryzyko i odwiedź witrynę",
-    "note" : "Button shown in an error page that warns users of security risks on a website due to Phishing issues. The buttons allows the user to visit the website anyway despite the risks."
+    "note" : "Button shown in an error page that warns users of security risks on a website due to Phishing or Malware issues. The buttons allows the user to visit the website anyway despite the risks."
+  },
+  "malwarePageHeading" : {
+    "title" : "Ostrzeżenie: ta strona może narazić Twoje dane osobowe na ryzyko",
+    "note" : "Title shown in an error page that warn users of security risks on a website due to malware distribution"
+  },
+  "malwareWarningText" : {
+    "title" : "Ta strona została zablokowana przez DuckDuckGo, ponieważ może rozpowszechniać złośliwe oprogramowanie, którego celem jest naruszenie bezpieczeństwa urządzenia lub kradzież danych osobowych. <a>Dowiedz się więcej</a>",
+    "note" : "Error description shown in an error page that warns users of security risks on a website due to malware distribution."
+  },
+  "malwareAdvancedInfoHeading" : {
+    "title" : "Jeśli uważasz, że ta strona jest bezpieczna, możesz <a>zgłosić błąd</a>. Możesz odwiedzić tę stronę internetową na własne ryzyko.",
+    "note" : "Title of the Advanced info section shown in an error page that warns users of security risks on a website due to malware distribution."
   },
   "phishingPageHeading" : {
-    "title" : "Ostrzeżenie: ta strona naraża Twoje dane osobowe na ryzyko",
+    "title" : "Ostrzeżenie: ta strona może narazić Twoje dane osobowe na ryzyko",
     "note" : "Title shown in an error page that warn users of security risks on a website due to Phishing issues"
   },
   "phishingWarningText" : {
@@ -33,16 +45,8 @@
     "note" : "Error description shown in an error page that warns users of security risks on a website due to Phishing issues."
   },
   "phishingAdvancedInfoHeading" : {
-    "title" : "DuckDuckGo ostrzega, gdy strona internetowa została oznaczona jako złośliwa.",
-    "note" : "Title of the Advanced info section shown in an error page that warns users of security risks on a website due to Phishing issues."
-  },
-  "phishingAdvancedInfoText_1" : {
-    "title" : "Ostrzeżenia są wyświetlane w przypadku witryn internetowych, które uznano za wprowadzające w błąd. Witryny wprowadzające w błąd próbują przekonać użytkownika, że są legalnymi i zaufanymi stronami. Jeśli rozumiesz związane z tym ryzyko, możesz kontynuować.",
-    "note" : "Body of the text of the Advanced info shown in an error page that warns users of security risks on a website due to Phishing issues."
-  },
-  "phishingAdvancedInfoText_2" : {
-    "title" : "Więcej informacji znajdziesz na naszej <a>stronie pomocy dotyczącej ochrony przed wyłudzaniem informacji oraz złośliwym oprogramowaniem</a>.",
-    "note" : "A call-to-action to read more on our help pages for phishing and malware protection."
+    "title" : "Jeśli uważasz, że ta strona jest bezpieczna, możesz <a>zgłosić błąd</a>. Możesz odwiedzić tę stronę internetową na własne ryzyko.",
+    "note" : "Title of the Advanced info section shown in an error page that warns users of security risks on a website due to malware distribution."
   },
   "sslPageHeading" : {
     "title" : "Ostrzeżenie: ta witryna może być niebezpieczna",

--- a/special-pages/pages/special-error/public/locales/pt/special-error.json
+++ b/special-pages/pages/special-error/public/locales/pt/special-error.json
@@ -10,22 +10,34 @@
   },
   "advancedButton" : {
     "title" : "Avançado",
-    "note" : "Button shown in an error page that warns users of security risks on a website due to Phishing issues. The buttons allows the user to see advanced options on click."
+    "note" : "Button shown in an error page that warns users of security risks on a website due to Phishing or Malware issues. The buttons allows the user to see advanced options on click."
   },
   "advancedEllipsisButton" : {
-    "title" : "Avançadas…",
-    "note" : "Button shown in an error page that warns users of security risks on a website due to Phishing issues. The buttons allows the user to see advanced options on click. This button contains a trailing ellipsis."
+    "title" : "Avançado…",
+    "note" : "Button shown in an error page that warns users of security risks on a website due to Phishing or Malware issues. The buttons allows the user to see advanced options on click. This button contains a trailing ellipsis."
   },
   "leaveSiteButton" : {
     "title" : "Deixar este site",
-    "note" : "Button shown in an error page that warns users of security risks on a website due to Phishing issues. The buttons allows the user to leave the website and navigate to previous page."
+    "note" : "Button shown in an error page that warns users of security risks on a website due to Phishing or Malware issues. The buttons allows the user to leave the website and navigate to previous page."
   },
   "visitSiteButton" : {
     "title" : "Aceitar o risco e visitar o site",
-    "note" : "Button shown in an error page that warns users of security risks on a website due to Phishing issues. The buttons allows the user to visit the website anyway despite the risks."
+    "note" : "Button shown in an error page that warns users of security risks on a website due to Phishing or Malware issues. The buttons allows the user to visit the website anyway despite the risks."
+  },
+  "malwarePageHeading" : {
+    "title" : "Aviso: este site pode pôr em risco as tuas informações pessoais",
+    "note" : "Title shown in an error page that warn users of security risks on a website due to malware distribution"
+  },
+  "malwareWarningText" : {
+    "title" : "O DuckDuckGo bloqueou esta página porque pode estar a distribuir malware projetado para comprometer o teu dispositivo ou roubar as tuas informações pessoais. <a>Sabe mais</a>",
+    "note" : "Error description shown in an error page that warns users of security risks on a website due to malware distribution."
+  },
+  "malwareAdvancedInfoHeading" : {
+    "title" : "Se considerares que este site é seguro, podes <a>denunciar um erro</a>. Mesmo assim, podes visitar o site por tua conta e risco.",
+    "note" : "Title of the Advanced info section shown in an error page that warns users of security risks on a website due to malware distribution."
   },
   "phishingPageHeading" : {
-    "title" : "Aviso: este site põe em risco as tuas informações pessoais",
+    "title" : "Aviso: este site pode pôr em risco as tuas informações pessoais",
     "note" : "Title shown in an error page that warn users of security risks on a website due to Phishing issues"
   },
   "phishingWarningText" : {
@@ -33,16 +45,8 @@
     "note" : "Error description shown in an error page that warns users of security risks on a website due to Phishing issues."
   },
   "phishingAdvancedInfoHeading" : {
-    "title" : "O DuckDuckGo avisa-te quando um site foi sinalizado como malicioso.",
-    "note" : "Title of the Advanced info section shown in an error page that warns users of security risks on a website due to Phishing issues."
-  },
-  "phishingAdvancedInfoText_1" : {
-    "title" : "Os avisos são mostrados para sites indicados como fraudulentos. Os sites fraudulentos tentam fazer-te crer que são sites legítimos em que confias. Se compreendes os riscos envolvidos, podes continuar.",
-    "note" : "Body of the text of the Advanced info shown in an error page that warns users of security risks on a website due to Phishing issues."
-  },
-  "phishingAdvancedInfoText_2" : {
-    "title" : "Consulta a nossa <a>página de ajuda sobre Proteção contra phishing e malware</a> para obteres mais informações.",
-    "note" : "A call-to-action to read more on our help pages for phishing and malware protection."
+    "title" : "Se considerares que este site é seguro, podes <a>denunciar um erro</a>. Mesmo assim, podes visitar o site por tua conta e risco.",
+    "note" : "Title of the Advanced info section shown in an error page that warns users of security risks on a website due to malware distribution."
   },
   "sslPageHeading" : {
     "title" : "Aviso: este site pode ser inseguro",

--- a/special-pages/pages/special-error/public/locales/ro/special-error.json
+++ b/special-pages/pages/special-error/public/locales/ro/special-error.json
@@ -10,22 +10,34 @@
   },
   "advancedButton" : {
     "title" : "Avansat",
-    "note" : "Button shown in an error page that warns users of security risks on a website due to Phishing issues. The buttons allows the user to see advanced options on click."
+    "note" : "Button shown in an error page that warns users of security risks on a website due to Phishing or Malware issues. The buttons allows the user to see advanced options on click."
   },
   "advancedEllipsisButton" : {
     "title" : "Avansat...",
-    "note" : "Button shown in an error page that warns users of security risks on a website due to Phishing issues. The buttons allows the user to see advanced options on click. This button contains a trailing ellipsis."
+    "note" : "Button shown in an error page that warns users of security risks on a website due to Phishing or Malware issues. The buttons allows the user to see advanced options on click. This button contains a trailing ellipsis."
   },
   "leaveSiteButton" : {
     "title" : "Părăsește acest site",
-    "note" : "Button shown in an error page that warns users of security risks on a website due to Phishing issues. The buttons allows the user to leave the website and navigate to previous page."
+    "note" : "Button shown in an error page that warns users of security risks on a website due to Phishing or Malware issues. The buttons allows the user to leave the website and navigate to previous page."
   },
   "visitSiteButton" : {
     "title" : "Acceptă riscul și accesează site-ul",
-    "note" : "Button shown in an error page that warns users of security risks on a website due to Phishing issues. The buttons allows the user to visit the website anyway despite the risks."
+    "note" : "Button shown in an error page that warns users of security risks on a website due to Phishing or Malware issues. The buttons allows the user to visit the website anyway despite the risks."
+  },
+  "malwarePageHeading" : {
+    "title" : "Avertizare: acest site ar putea pune în pericol informațiile tale personale",
+    "note" : "Title shown in an error page that warn users of security risks on a website due to malware distribution"
+  },
+  "malwareWarningText" : {
+    "title" : "DuckDuckGo a blocat această pagină deoarece este posibil să distribuie programe rău intenționate, menite să-ți compromită dispozitivul sau să-ți fure datele cu caracter personal. <a>Află mai multe</a>",
+    "note" : "Error description shown in an error page that warns users of security risks on a website due to malware distribution."
+  },
+  "malwareAdvancedInfoHeading" : {
+    "title" : "Dacă crezi că acest site este sigur, poți <a>să raportezi o eroare</a>. Poți vizita în continuare site-ul pe propriul risc.",
+    "note" : "Title of the Advanced info section shown in an error page that warns users of security risks on a website due to malware distribution."
   },
   "phishingPageHeading" : {
-    "title" : "Avertizare: acest site prezintă un risc pentru informațiile tale personale",
+    "title" : "Avertizare: acest site ți-ar putea pune în pericol datele cu caracter personal",
     "note" : "Title shown in an error page that warn users of security risks on a website due to Phishing issues"
   },
   "phishingWarningText" : {
@@ -33,16 +45,8 @@
     "note" : "Error description shown in an error page that warns users of security risks on a website due to Phishing issues."
   },
   "phishingAdvancedInfoHeading" : {
-    "title" : "DuckDuckGo te avertizează când un site a fost semnalat ca rău intenționat.",
-    "note" : "Title of the Advanced info section shown in an error page that warns users of security risks on a website due to Phishing issues."
-  },
-  "phishingAdvancedInfoText_1" : {
-    "title" : "Sunt afișate avertizări pentru site-urile care au fost raportate ca fiind înșelătoare. Site-urile înșelătoare încearcă să te păcălească și să te facă să crezi că sunt site-uri legitime în care poți avea încredere. Dacă înțelegi riscurile implicate, poți continua oricum.",
-    "note" : "Body of the text of the Advanced info shown in an error page that warns users of security risks on a website due to Phishing issues."
-  },
-  "phishingAdvancedInfoText_2" : {
-    "title" : "Pentru mai multe informații, consultă <a>pagina noastră de ajutor pentru protecție împotriva phishingului și a programelor rău intenționate</a>.",
-    "note" : "A call-to-action to read more on our help pages for phishing and malware protection."
+    "title" : "Dacă crezi că acest site este sigur, poți <a>să raportezi o eroare</a>. Poți vizita în continuare site-ul pe propriul risc.",
+    "note" : "Title of the Advanced info section shown in an error page that warns users of security risks on a website due to malware distribution."
   },
   "sslPageHeading" : {
     "title" : "Avertisment: acest site poate fi nesigur",

--- a/special-pages/pages/special-error/public/locales/ru/special-error.json
+++ b/special-pages/pages/special-error/public/locales/ru/special-error.json
@@ -10,22 +10,34 @@
   },
   "advancedButton" : {
     "title" : "Дополнительно",
-    "note" : "Button shown in an error page that warns users of security risks on a website due to Phishing issues. The buttons allows the user to see advanced options on click."
+    "note" : "Button shown in an error page that warns users of security risks on a website due to Phishing or Malware issues. The buttons allows the user to see advanced options on click."
   },
   "advancedEllipsisButton" : {
     "title" : "Дополнительно...",
-    "note" : "Button shown in an error page that warns users of security risks on a website due to Phishing issues. The buttons allows the user to see advanced options on click. This button contains a trailing ellipsis."
+    "note" : "Button shown in an error page that warns users of security risks on a website due to Phishing or Malware issues. The buttons allows the user to see advanced options on click. This button contains a trailing ellipsis."
   },
   "leaveSiteButton" : {
     "title" : "Покинуть сайт",
-    "note" : "Button shown in an error page that warns users of security risks on a website due to Phishing issues. The buttons allows the user to leave the website and navigate to previous page."
+    "note" : "Button shown in an error page that warns users of security risks on a website due to Phishing or Malware issues. The buttons allows the user to leave the website and navigate to previous page."
   },
   "visitSiteButton" : {
     "title" : "Принять риск и перейти на сайт",
-    "note" : "Button shown in an error page that warns users of security risks on a website due to Phishing issues. The buttons allows the user to visit the website anyway despite the risks."
+    "note" : "Button shown in an error page that warns users of security risks on a website due to Phishing or Malware issues. The buttons allows the user to visit the website anyway despite the risks."
+  },
+  "malwarePageHeading" : {
+    "title" : "Внимание! Потенциальная угроза личным данным",
+    "note" : "Title shown in an error page that warn users of security risks on a website due to malware distribution"
+  },
+  "malwareWarningText" : {
+    "title" : "DuckDuckGo заблокировал эту страницу: возможно, она распространяет вредоносное ПО для взлома устройств или кражи личной информации. <a>Подробнее...</a>",
+    "note" : "Error description shown in an error page that warns users of security risks on a website due to malware distribution."
+  },
+  "malwareAdvancedInfoHeading" : {
+    "title" : "Если вы уверены в безопасности этого сайта, можете <a>сообщить нам об ошибке</a>. Решив посетить его, вы принимаете на себя все связанные с этим риски.",
+    "note" : "Title of the Advanced info section shown in an error page that warns users of security risks on a website due to malware distribution."
   },
   "phishingPageHeading" : {
-    "title" : "Внимание! Личные данные под угрозой",
+    "title" : "Осторожно! Потенциальная угроза личным данным",
     "note" : "Title shown in an error page that warn users of security risks on a website due to Phishing issues"
   },
   "phishingWarningText" : {
@@ -33,16 +45,8 @@
     "note" : "Error description shown in an error page that warns users of security risks on a website due to Phishing issues."
   },
   "phishingAdvancedInfoHeading" : {
-    "title" : "DuckDuckGo предупредит вас, если сайт был отмечен как вредоносный.",
-    "note" : "Title of the Advanced info section shown in an error page that warns users of security risks on a website due to Phishing issues."
-  },
-  "phishingAdvancedInfoText_1" : {
-    "title" : "Предупреждением сопровождаются мошеннические сайты, на которые поступили жалобы. Такие сайты пытаются выдать себя за настоящие, которым доверяют пользователи. Если вы осознаете связанные риски, можете продолжить.",
-    "note" : "Body of the text of the Advanced info shown in an error page that warns users of security risks on a website due to Phishing issues."
-  },
-  "phishingAdvancedInfoText_2" : {
-    "title" : "Подробности — на нашей <a>справочной странице о защите от фишинга и вредоносного ПО</a>.",
-    "note" : "A call-to-action to read more on our help pages for phishing and malware protection."
+    "title" : "Если вы уверены в безопасности этого сайта, можете <a>сообщить нам об ошибке</a>. Решив посетить его, вы принимаете на себя все связанные с этим риски.",
+    "note" : "Title of the Advanced info section shown in an error page that warns users of security risks on a website due to malware distribution."
   },
   "sslPageHeading" : {
     "title" : "Внимание! Возможно, сайт небезопасен",

--- a/special-pages/pages/special-error/public/locales/sk/special-error.json
+++ b/special-pages/pages/special-error/public/locales/sk/special-error.json
@@ -10,22 +10,34 @@
   },
   "advancedButton" : {
     "title" : "Pokročilé",
-    "note" : "Button shown in an error page that warns users of security risks on a website due to Phishing issues. The buttons allows the user to see advanced options on click."
+    "note" : "Button shown in an error page that warns users of security risks on a website due to Phishing or Malware issues. The buttons allows the user to see advanced options on click."
   },
   "advancedEllipsisButton" : {
     "title" : "Pokročilé...",
-    "note" : "Button shown in an error page that warns users of security risks on a website due to Phishing issues. The buttons allows the user to see advanced options on click. This button contains a trailing ellipsis."
+    "note" : "Button shown in an error page that warns users of security risks on a website due to Phishing or Malware issues. The buttons allows the user to see advanced options on click. This button contains a trailing ellipsis."
   },
   "leaveSiteButton" : {
     "title" : "Opustiť túto stránku",
-    "note" : "Button shown in an error page that warns users of security risks on a website due to Phishing issues. The buttons allows the user to leave the website and navigate to previous page."
+    "note" : "Button shown in an error page that warns users of security risks on a website due to Phishing or Malware issues. The buttons allows the user to leave the website and navigate to previous page."
   },
   "visitSiteButton" : {
     "title" : "Akceptovať riziko a navštíviť stránku",
-    "note" : "Button shown in an error page that warns users of security risks on a website due to Phishing issues. The buttons allows the user to visit the website anyway despite the risks."
+    "note" : "Button shown in an error page that warns users of security risks on a website due to Phishing or Malware issues. The buttons allows the user to visit the website anyway despite the risks."
+  },
+  "malwarePageHeading" : {
+    "title" : "Upozornenie: Táto stránka môže ohroziť tvoje osobné údaje",
+    "note" : "Title shown in an error page that warn users of security risks on a website due to malware distribution"
+  },
+  "malwareWarningText" : {
+    "title" : "DuckDuckGo zablokoval túto stránku, pretože môže šíriť škodlivý softvér určený na ohrozenie tvojho zariadenia alebo krádež tvojich osobných údajov. <a>Zistiť viac</a>",
+    "note" : "Error description shown in an error page that warns users of security risks on a website due to malware distribution."
+  },
+  "malwareAdvancedInfoHeading" : {
+    "title" : "Ak si myslíš, že táto webová stránka je bezpečná, môžeš <a>nahlásiť chybu</a>. Webovú stránku môžeš stále navštíviť na vlastné riziko.",
+    "note" : "Title of the Advanced info section shown in an error page that warns users of security risks on a website due to malware distribution."
   },
   "phishingPageHeading" : {
-    "title" : "Upozornenie: Táto stránka ohrozuje vaše osobné údaje",
+    "title" : "Upozornenie: Táto stránka môže ohroziť tvoje osobné údaje",
     "note" : "Title shown in an error page that warn users of security risks on a website due to Phishing issues"
   },
   "phishingWarningText" : {
@@ -33,16 +45,8 @@
     "note" : "Error description shown in an error page that warns users of security risks on a website due to Phishing issues."
   },
   "phishingAdvancedInfoHeading" : {
-    "title" : "Ak bola webová stránka označená ako škodlivá, DuckDuckGo vás na to upozorní.",
-    "note" : "Title of the Advanced info section shown in an error page that warns users of security risks on a website due to Phishing issues."
-  },
-  "phishingAdvancedInfoText_1" : {
-    "title" : "Upozornenia sa zobrazujú pre webové lokality, ktoré boli nahlásené ako nekalé. Nekalé webové lokality sa vás snažia oklamať a presvedčiť vás, že ide o legitímne webové lokality, ktorým dôverujete. Ak rozumiete rizikám, ktoré s tým súvisia, môžete napriek tomu pokračovať.",
-    "note" : "Body of the text of the Advanced info shown in an error page that warns users of security risks on a website due to Phishing issues."
-  },
-  "phishingAdvancedInfoText_2" : {
-    "title" : "Viac informácií nájdete v časti <a>Pomocník ohľadom ochrany pred phishingom a malvérom.</a>",
-    "note" : "A call-to-action to read more on our help pages for phishing and malware protection."
+    "title" : "Ak si myslíš, že táto webová stránka je bezpečná, môžeš <a>nahlásiť chybu</a>. Webovú stránku môžeš stále navštíviť na vlastné riziko.",
+    "note" : "Title of the Advanced info section shown in an error page that warns users of security risks on a website due to malware distribution."
   },
   "sslPageHeading" : {
     "title" : "Varovanie: Táto stránka môže byť nezabezpečená",

--- a/special-pages/pages/special-error/public/locales/sl/special-error.json
+++ b/special-pages/pages/special-error/public/locales/sl/special-error.json
@@ -10,22 +10,34 @@
   },
   "advancedButton" : {
     "title" : "Napredno",
-    "note" : "Button shown in an error page that warns users of security risks on a website due to Phishing issues. The buttons allows the user to see advanced options on click."
+    "note" : "Button shown in an error page that warns users of security risks on a website due to Phishing or Malware issues. The buttons allows the user to see advanced options on click."
   },
   "advancedEllipsisButton" : {
     "title" : "Napredno ...",
-    "note" : "Button shown in an error page that warns users of security risks on a website due to Phishing issues. The buttons allows the user to see advanced options on click. This button contains a trailing ellipsis."
+    "note" : "Button shown in an error page that warns users of security risks on a website due to Phishing or Malware issues. The buttons allows the user to see advanced options on click. This button contains a trailing ellipsis."
   },
   "leaveSiteButton" : {
     "title" : "Zapustite to spletno mesto",
-    "note" : "Button shown in an error page that warns users of security risks on a website due to Phishing issues. The buttons allows the user to leave the website and navigate to previous page."
+    "note" : "Button shown in an error page that warns users of security risks on a website due to Phishing or Malware issues. The buttons allows the user to leave the website and navigate to previous page."
   },
   "visitSiteButton" : {
     "title" : "Sprejmite tveganje in obiščite spletno mesto",
-    "note" : "Button shown in an error page that warns users of security risks on a website due to Phishing issues. The buttons allows the user to visit the website anyway despite the risks."
+    "note" : "Button shown in an error page that warns users of security risks on a website due to Phishing or Malware issues. The buttons allows the user to visit the website anyway despite the risks."
+  },
+  "malwarePageHeading" : {
+    "title" : "Opozorilo: to spletno mesto lahko ogrozi vaše osebne podatke",
+    "note" : "Title shown in an error page that warn users of security risks on a website due to malware distribution"
+  },
+  "malwareWarningText" : {
+    "title" : "DuckDuckGo je blokiral to stran, ker morda distribuira zlonamerno programsko opremo, namenjeno ogrožanju vaše naprave ali kraji vaših osebnih podatkov. <a>Preberite več o tem</a>",
+    "note" : "Error description shown in an error page that warns users of security risks on a website due to malware distribution."
+  },
+  "malwareAdvancedInfoHeading" : {
+    "title" : "Če menite, da je to spletno mesto varno, lahko <a>prijavite napako</a>. Spletno mesto lahko še vedno obiščete na lastno odgovornost.",
+    "note" : "Title of the Advanced info section shown in an error page that warns users of security risks on a website due to malware distribution."
   },
   "phishingPageHeading" : {
-    "title" : "Opozorilo: To spletno mesto ogroža vaše osebne podatke",
+    "title" : "Opozorilo: to spletno mesto lahko ogrozi vaše osebne podatke",
     "note" : "Title shown in an error page that warn users of security risks on a website due to Phishing issues"
   },
   "phishingWarningText" : {
@@ -33,16 +45,8 @@
     "note" : "Error description shown in an error page that warns users of security risks on a website due to Phishing issues."
   },
   "phishingAdvancedInfoHeading" : {
-    "title" : "DuckDuckGo vas opozori, kadar je bilo spletno mesto označeno kot zlonamerno.",
-    "note" : "Title of the Advanced info section shown in an error page that warns users of security risks on a website due to Phishing issues."
-  },
-  "phishingAdvancedInfoText_1" : {
-    "title" : "Opozorila so prikazana za spletne strani, za katere je bilo sporočeno, da so zavajajoče. Zavajajoča spletna mesta vas poskušajo preslepiti, da so legitimna spletna mesta, ki jim zaupate. Če razumete vsa tveganja, lahko vseeno nadaljujete.",
-    "note" : "Body of the text of the Advanced info shown in an error page that warns users of security risks on a website due to Phishing issues."
-  },
-  "phishingAdvancedInfoText_2" : {
-    "title" : "Za več informacij glejte našo <a>stran s pomočjo za zaščito pred lažnim predstavljanjem in zlonamerno programsko opremo</a> .",
-    "note" : "A call-to-action to read more on our help pages for phishing and malware protection."
+    "title" : "Če menite, da je to spletno mesto varno, lahko <a>prijavite napako</a>. Spletno mesto lahko še vedno obiščete na lastno odgovornost.",
+    "note" : "Title of the Advanced info section shown in an error page that warns users of security risks on a website due to malware distribution."
   },
   "sslPageHeading" : {
     "title" : "Opozorilo: To spletno mesto je morda nevarno",

--- a/special-pages/pages/special-error/public/locales/sv/special-error.json
+++ b/special-pages/pages/special-error/public/locales/sv/special-error.json
@@ -10,22 +10,34 @@
   },
   "advancedButton" : {
     "title" : "Avancerat",
-    "note" : "Button shown in an error page that warns users of security risks on a website due to Phishing issues. The buttons allows the user to see advanced options on click."
+    "note" : "Button shown in an error page that warns users of security risks on a website due to Phishing or Malware issues. The buttons allows the user to see advanced options on click."
   },
   "advancedEllipsisButton" : {
     "title" : "Avancerat ...",
-    "note" : "Button shown in an error page that warns users of security risks on a website due to Phishing issues. The buttons allows the user to see advanced options on click. This button contains a trailing ellipsis."
+    "note" : "Button shown in an error page that warns users of security risks on a website due to Phishing or Malware issues. The buttons allows the user to see advanced options on click. This button contains a trailing ellipsis."
   },
   "leaveSiteButton" : {
     "title" : "Lämna denna webbplats",
-    "note" : "Button shown in an error page that warns users of security risks on a website due to Phishing issues. The buttons allows the user to leave the website and navigate to previous page."
+    "note" : "Button shown in an error page that warns users of security risks on a website due to Phishing or Malware issues. The buttons allows the user to leave the website and navigate to previous page."
   },
   "visitSiteButton" : {
     "title" : "Acceptera risken och besök webbplatsen",
-    "note" : "Button shown in an error page that warns users of security risks on a website due to Phishing issues. The buttons allows the user to visit the website anyway despite the risks."
+    "note" : "Button shown in an error page that warns users of security risks on a website due to Phishing or Malware issues. The buttons allows the user to visit the website anyway despite the risks."
+  },
+  "malwarePageHeading" : {
+    "title" : "Varning: Den här webbplatsen kan utsätta din personliga information för risker",
+    "note" : "Title shown in an error page that warn users of security risks on a website due to malware distribution"
+  },
+  "malwareWarningText" : {
+    "title" : "DuckDuckGo har blockerat den här sidan eftersom den kan distribuera skadlig programvara avsedd att göra intrång på din enhet eller stjäla din personliga information. <a>Läs mer</a>",
+    "note" : "Error description shown in an error page that warns users of security risks on a website due to malware distribution."
+  },
+  "malwareAdvancedInfoHeading" : {
+    "title" : "Om du tror att den här webbplatsen är säker kan du <a>rapportera ett fel</a>. Du kan fortfarande besöka webbplatsen på egen risk.",
+    "note" : "Title of the Advanced info section shown in an error page that warns users of security risks on a website due to malware distribution."
   },
   "phishingPageHeading" : {
-    "title" : "Varning: Den här webbplatsen utsätter din personliga information för risker",
+    "title" : "Varning: Den här webbplatsen kan utsätta din personliga information för risker",
     "note" : "Title shown in an error page that warn users of security risks on a website due to Phishing issues"
   },
   "phishingWarningText" : {
@@ -33,16 +45,8 @@
     "note" : "Error description shown in an error page that warns users of security risks on a website due to Phishing issues."
   },
   "phishingAdvancedInfoHeading" : {
-    "title" : "DuckDuckGo varnar dig när en webbplats har flaggats som skadlig.",
-    "note" : "Title of the Advanced info section shown in an error page that warns users of security risks on a website due to Phishing issues."
-  },
-  "phishingAdvancedInfoText_1" : {
-    "title" : "Varningar visas för webbplatser som har rapporterats som bedrägliga. Bedrägliga webbplatser försöker lura dig så att du tror att de är legitima webbplatser som du litar på. Om du förstår riskerna kan du fortsätta ändå.",
-    "note" : "Body of the text of the Advanced info shown in an error page that warns users of security risks on a website due to Phishing issues."
-  },
-  "phishingAdvancedInfoText_2" : {
-    "title" : "Mer information finns på vår <a>hjälpsida för skydd mot nätfiske och skadlig programvara.</a>",
-    "note" : "A call-to-action to read more on our help pages for phishing and malware protection."
+    "title" : "Om du tror att den här webbplatsen är säker kan du <a>rapportera ett fel</a>. Du kan fortfarande besöka webbplatsen på egen risk.",
+    "note" : "Title of the Advanced info section shown in an error page that warns users of security risks on a website due to malware distribution."
   },
   "sslPageHeading" : {
     "title" : "Varning: Denna webbplats kan vara osäker",

--- a/special-pages/pages/special-error/public/locales/tr/special-error.json
+++ b/special-pages/pages/special-error/public/locales/tr/special-error.json
@@ -10,22 +10,34 @@
   },
   "advancedButton" : {
     "title" : "Gelişmiş",
-    "note" : "Button shown in an error page that warns users of security risks on a website due to Phishing issues. The buttons allows the user to see advanced options on click."
+    "note" : "Button shown in an error page that warns users of security risks on a website due to Phishing or Malware issues. The buttons allows the user to see advanced options on click."
   },
   "advancedEllipsisButton" : {
     "title" : "Gelişmiş...",
-    "note" : "Button shown in an error page that warns users of security risks on a website due to Phishing issues. The buttons allows the user to see advanced options on click. This button contains a trailing ellipsis."
+    "note" : "Button shown in an error page that warns users of security risks on a website due to Phishing or Malware issues. The buttons allows the user to see advanced options on click. This button contains a trailing ellipsis."
   },
   "leaveSiteButton" : {
     "title" : "Bu Siteden Ayrılın",
-    "note" : "Button shown in an error page that warns users of security risks on a website due to Phishing issues. The buttons allows the user to leave the website and navigate to previous page."
+    "note" : "Button shown in an error page that warns users of security risks on a website due to Phishing or Malware issues. The buttons allows the user to leave the website and navigate to previous page."
   },
   "visitSiteButton" : {
     "title" : "Riski Kabul Edin ve Siteyi Ziyaret Edin",
-    "note" : "Button shown in an error page that warns users of security risks on a website due to Phishing issues. The buttons allows the user to visit the website anyway despite the risks."
+    "note" : "Button shown in an error page that warns users of security risks on a website due to Phishing or Malware issues. The buttons allows the user to visit the website anyway despite the risks."
+  },
+  "malwarePageHeading" : {
+    "title" : "Uyarı: Bu site kişisel bilgilerinizi riske atabilir",
+    "note" : "Title shown in an error page that warn users of security risks on a website due to malware distribution"
+  },
+  "malwareWarningText" : {
+    "title" : "Cihazınızı tehlikeye atmak veya kişisel bilgilerinizi çalmak için tasarlanmış kötü amaçlı yazılım dağıtıyor olabileceğinden, DuckDuckGo bu sayfayı engelledi. <a>Daha fazla bilgi</a>",
+    "note" : "Error description shown in an error page that warns users of security risks on a website due to malware distribution."
+  },
+  "malwareAdvancedInfoHeading" : {
+    "title" : "Bu web sitesinin güvenli olduğuna inanıyorsanız <a>bir hata bildirebilirsiniz</a>. Riski göze alabiliyorsanız web sitesini yine de ziyaret edebilirsiniz.",
+    "note" : "Title of the Advanced info section shown in an error page that warns users of security risks on a website due to malware distribution."
   },
   "phishingPageHeading" : {
-    "title" : "Uyarı: Bu site kişisel bilgilerinizi riske atıyor",
+    "title" : "Uyarı: Bu site kişisel bilgilerinizi riske atabilir",
     "note" : "Title shown in an error page that warn users of security risks on a website due to Phishing issues"
   },
   "phishingWarningText" : {
@@ -33,16 +45,8 @@
     "note" : "Error description shown in an error page that warns users of security risks on a website due to Phishing issues."
   },
   "phishingAdvancedInfoHeading" : {
-    "title" : "DuckDuckGo, bir web sitesi kötü amaçlı olarak işaretlendiğinde sizi uyarır.",
-    "note" : "Title of the Advanced info section shown in an error page that warns users of security risks on a website due to Phishing issues."
-  },
-  "phishingAdvancedInfoText_1" : {
-    "title" : "Aldatıcı olduğu bildirilen web siteleri için uyarılar gösterilmektedir. Aldatıcı web siteleri, güvendiğiniz meşru web siteleri olduklarına inanmanız için sizi kandırmaya çalışır. Riskleri anlıyorsanız, yine de devam edebilirsiniz.",
-    "note" : "Body of the text of the Advanced info shown in an error page that warns users of security risks on a website due to Phishing issues."
-  },
-  "phishingAdvancedInfoText_2" : {
-    "title" : "Daha fazla bilgi için <a>Kimlik Avı ve Kötü Amaçlı Yazılım Koruması yardım sayfamızı</a> inceleyin.",
-    "note" : "A call-to-action to read more on our help pages for phishing and malware protection."
+    "title" : "Bu web sitesinin güvenli olduğuna inanıyorsanız <a>bir hata bildirebilirsiniz</a>. Riski göze alabiliyorsanız web sitesini yine de ziyaret edebilirsiniz.",
+    "note" : "Title of the Advanced info section shown in an error page that warns users of security risks on a website due to malware distribution."
   },
   "sslPageHeading" : {
     "title" : "Uyarı: Bu site güvenli olmayabilir",


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/0/1206594217596623/1208958530747145/f

## Description

Translations for phishing and malware error page

## Testing Steps

1. Visit the [preview](https://deploy-preview-1337--content-scope-scripts.netlify.app/build/pages/special-error/?locale=pt&errorId=malware) (change the locale parameter to any supported language)
2. Confirm that the malware error page does not show any English strings 
<img width="548" alt="image" src="https://github.com/user-attachments/assets/7eb5a202-dd30-4708-9b94-360f85217090" />
 

## Checklist

<!--
  These questions are a friendly reminder to shipping code, if you're uncertain ask the AoR owners.
  It's also totally appropriate to not check some of these boxes, if they don't apply to your change.
-->
*Please tick all that apply:*

- [ ] I have tested this change locally
- [ ] I have tested this change locally in all supported browsers
- [ ] This change will be visible to users
- [ ] I have added automated tests that cover this change
- [ ] I have ensured the change is gated by config
- [ ] This change was covered by a ship review
- [ ] This change was covered by a tech design
- [ ] Any dependent config has been merged

