### PR TITLE
ntp: update the title of the privacy stats widget when drawer is enabled

### DIFF
--- a/special-pages/pages/new-tab/app/customizer/integration-tests/customizer.page.js
+++ b/special-pages/pages/new-tab/app/customizer/integration-tests/customizer.page.js
@@ -358,4 +358,11 @@ export class CustomizerPage {
         // can only close after being opened
         await this.closesCustomizer();
     }
+
+    async hidesSection(label) {
+        const { page } = this.ntp;
+        await page.locator('aside').getByLabel(label).uncheck();
+        // await page.getByLabel('Toggle Blocked Tracking').check();
+        // await page.locator('aside').
+    }
 }

--- a/special-pages/pages/new-tab/app/customizer/integration-tests/customizer.spec.js
+++ b/special-pages/pages/new-tab/app/customizer/integration-tests/customizer.spec.js
@@ -249,6 +249,14 @@ test.describe('newtab customizer', () => {
         await cp.setsDarkTheme();
         await cp.darkThemeIsSelected();
     });
+    test('toggles section visibility', async ({ page }, workerInfo) => {
+        const ntp = NewtabPage.create(page, workerInfo);
+        const cp = new CustomizerPage(ntp);
+        await ntp.reducedMotion();
+        await ntp.openPage({ additional: { customizerDrawer: 'enabled', theme: 'light' } });
+        await cp.opensCustomizer();
+        await cp.hidesSection('Tracking Activity');
+    });
     test('opening settings', async ({ page }, workerInfo) => {
         const ntp = NewtabPage.create(page, workerInfo);
         const cp = new CustomizerPage(ntp);

--- a/special-pages/pages/new-tab/app/privacy-stats/components/PrivacyStats.js
+++ b/special-pages/pages/new-tab/app/privacy-stats/components/PrivacyStats.js
@@ -10,6 +10,7 @@ import { ShowHideButton } from '../../components/ShowHideButton.jsx';
 import { useCustomizer } from '../../customizer/components/Customizer.js';
 import { DDG_STATS_OTHER_COMPANY_IDENTIFIER } from '../constants.js';
 import { displayNameForCompany, sortStatsForDisplay } from '../privacy-stats.utils.js';
+import { useCustomizerDrawerSettings } from '../../settings.provider.js';
 
 /**
  * @import enStrings from "../strings.json"
@@ -208,10 +209,19 @@ export function PrivacyStatsBody({ trackerCompanies, listAttrs = {} }) {
  */
 export function PrivacyStatsCustomized() {
     const { t } = useTypedTranslationWith(/** @type {enStrings} */ ({}));
+    const drawer = useCustomizerDrawerSettings();
+
+    /**
+     * The menu title for the stats widget is changes when the menu is in the sidebar.
+     */
+    // prettier-ignore
+    const sectionTitle = drawer.state === 'enabled'
+        ? t('stats_menuTitle_v2')
+        : t('stats_menuTitle');
+
     const { visibility, id, toggle, index } = useVisibility();
 
-    const title = t('stats_menuTitle');
-    useCustomizer({ title, id, icon: 'shield', toggle, visibility: visibility.value, index });
+    useCustomizer({ title: sectionTitle, id, icon: 'shield', toggle, visibility: visibility.value, index });
 
     if (visibility.value === 'hidden') {
         return null;

--- a/special-pages/pages/new-tab/app/privacy-stats/strings.json
+++ b/special-pages/pages/new-tab/app/privacy-stats/strings.json
@@ -3,6 +3,10 @@
     "title": "Blocked Tracking Attempts",
     "note": "Used as a label in a customization menu"
   },
+  "stats_menuTitle_v2": {
+    "title": "Tracking Activity",
+    "note": "Used as a label in a customization menu"
+  },
   "stats_noActivity": {
     "title": "Blocked tracking attempts will appear here. Keep browsing to see how many we block.",
     "note": "Placeholder for when we cannot report any blocked trackers yet"

--- a/special-pages/pages/new-tab/public/locales/en/new-tab.json
+++ b/special-pages/pages/new-tab/public/locales/en/new-tab.json
@@ -45,6 +45,10 @@
     "title": "Blocked Tracking Attempts",
     "note": "Used as a label in a customization menu"
   },
+  "stats_menuTitle_v2": {
+    "title": "Tracking Activity",
+    "note": "Used as a label in a customization menu"
+  },
   "stats_noActivity": {
     "title": "Blocked tracking attempts will appear here. Keep browsing to see how many we block.",
     "note": "Placeholder for when we cannot report any blocked trackers yet"


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/0/1201141132935289/1209013497842933/f

## Description

Just a copy change - guarded behind the customizer drawer setting to allow it to be merged without affecting the existing title on Windows.

## Testing Steps

- Current: title of the section should NOT be updated 
  - https://deploy-preview-1363--content-scope-scripts.netlify.app/build/pages/new-tab
- NEW: title of the section should be updated in the sidebar
  - https://deploy-preview-1363--content-scope-scripts.netlify.app/build/pages/new-tab/?customizerDrawer=enabled

![New Tab Windows (3)](https://github.com/user-attachments/assets/9f7ec715-14db-4426-82c1-2efba0aaf224)

## Checklist


<!--
  These questions are a friendly reminder to shipping code, if you're uncertain ask the AoR owners.
  It's also totally appropriate to not check some of these boxes, if they don't apply to your change.
-->
*Please tick all that apply:*

- [ ] I have tested this change locally
- [ ] I have tested this change locally in all supported browsers
- [ ] This change will be visible to users
- [ ] I have added automated tests that cover this change
- [ ] I have ensured the change is gated by config
- [ ] This change was covered by a ship review
- [ ] This change was covered by a tech design
- [ ] Any dependent config has been merged

