### PR TITLE
ntp: support multiple release-note lists

### DIFF
--- a/special-pages/pages/new-tab/app/entry-points/updateNotification.js
+++ b/special-pages/pages/new-tab/app/entry-points/updateNotification.js
@@ -4,8 +4,10 @@ import { UpdateNotificationProvider } from '../update-notification/UpdateNotific
 
 export function factory() {
     return (
-        <UpdateNotificationProvider data-entry-point="updateNotification">
-            <UpdateNotificationConsumer />
-        </UpdateNotificationProvider>
+        <div data-entry-point="updateNotification">
+            <UpdateNotificationProvider>
+                <UpdateNotificationConsumer />
+            </UpdateNotificationProvider>
+        </div>
     );
 }

--- a/special-pages/pages/new-tab/app/mock-transport.js
+++ b/special-pages/pages/new-tab/app/mock-transport.js
@@ -490,11 +490,11 @@ export function mockTransport() {
                     let updateNotification = { content: null };
                     const isDelayed = url.searchParams.has('update-notification-delay');
 
-                    if (!isDelayed && url.searchParams.get('update-notification') === 'empty') {
-                        updateNotification = updateNotificationExamples.empty;
-                    }
-                    if (!isDelayed && url.searchParams.get('update-notification') === 'populated') {
-                        updateNotification = updateNotificationExamples.populated;
+                    if (!isDelayed && url.searchParams.has('update-notification')) {
+                        const value = url.searchParams.get('update-notification');
+                        if (value && value in updateNotificationExamples) {
+                            updateNotification = updateNotificationExamples[value];
+                        }
                     }
 
                     /** @type {import('../types/new-tab.ts').InitialSetupResponse} */

--- a/special-pages/pages/new-tab/app/update-notification/components/UpdateNotification.module.css
+++ b/special-pages/pages/new-tab/app/update-notification/components/UpdateNotification.module.css
@@ -56,13 +56,17 @@
 }
 
 .detailsContent {
-    padding-inline: var(--sp-2);
-    margin-top: var(--sp-2);
+    margin-top: var(--sp-4);
     text-align: left;
+    max-width: 380px; /* just a value that looks below it's centered heading */
+    margin-left: auto;
+    margin-right: auto;
 }
-
+.title {
+    padding: 0.5rem 0;
+}
 .list {
-    margin-left: var(--sp-20);
+    margin-left: 1.5rem;
     li {
         list-style: disc
     }

--- a/special-pages/pages/new-tab/app/update-notification/integration-tests/update-notification.spec.js
+++ b/special-pages/pages/new-tab/app/update-notification/integration-tests/update-notification.spec.js
@@ -33,4 +33,21 @@ test.describe('newtab update notifications', () => {
         await page.getByRole('button', { name: 'Dismiss' }).click();
         await ntp.mocks.waitForCallCount({ method: 'updateNotification_dismiss', count: 1 });
     });
+    test('handles multiple lists', async ({ page }, workerInfo) => {
+        const ntp = NewtabPage.create(page, workerInfo);
+        await ntp.reducedMotion();
+        await ntp.openPage({ updateNotification: 'multipleSections' });
+        await page.getByRole('link', { name: "what's new" }).click();
+        await expect(page.locator('[data-entry-point="updateNotification"]')).toMatchAriaSnapshot(`
+        - group:
+          - list:
+            - listitem: We're excited to introduce a new browsing feature - Fire Windows. These special windows work the same way as normal windows, except they isolate your activity from other browsing data and self-destruct when closed. This means you can use a Fire Window to browse without saving local history or to sign into a site with a different account. You can open a new Fire Window anytime from the Fire Button menu.
+            - listitem: Try the new bookmark management view that opens in a tab for more robust bookmark organization.
+          - paragraph: For Privacy Pro subscribers
+          - list:
+            - listitem: VPN notifications are now available to help communicate VPN status.
+            - listitem: Some apps aren't compatible with VPNs. You can now exclude these apps to use them while connected to the VPN.
+            - listitem: Visit https://duckduckgo.com/pro for more information.
+        `);
+    });
 });

--- a/special-pages/pages/new-tab/app/update-notification/mocks/update-notification.data.js
+++ b/special-pages/pages/new-tab/app/update-notification/mocks/update-notification.data.js
@@ -18,4 +18,18 @@ export const updateNotificationExamples = {
             version: '1.91',
         },
     },
+    multipleSections: {
+        content: {
+            // prettier-ignore
+            notes: [
+                `• We're excited to introduce a new browsing feature - Fire Windows. These special windows work the same way as normal windows, except they isolate your activity from other browsing data and self-destruct when closed. This means you can use a Fire Window to browse without saving local history or to sign into a site with a different account. You can open a new Fire Window anytime from the Fire Button menu.`,
+                `• Try the new bookmark management view that opens in a tab for more robust bookmark organization.`,
+                `For Privacy Pro subscribers`,
+                `• VPN notifications are now available to help communicate VPN status.`,
+                `• Some apps aren't compatible with VPNs. You can now exclude these apps to use them while connected to the VPN.`,
+                `• Visit https://duckduckgo.com/pro for more information.`,
+            ],
+            version: '0.98.4',
+        },
+    },
 };


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/0/1207414201589134/1209114169882239/f
## Description

- Support for separate lists - this is a temporary measure until windows supports the shared releases notes.

## Testing Steps

- Check the display here: https://deploy-preview-1385--content-scope-scripts.netlify.app/build/pages/new-tab/?update-notification=multipleSections

## Checklist

<!--
  These questions are a friendly reminder to shipping code, if you're uncertain ask the AoR owners.
  It's also totally appropriate to not check some of these boxes, if they don't apply to your change.
-->
*Please tick all that apply:*

- [ ] I have tested this change locally
- [ ] I have tested this change locally in all supported browsers
- [ ] This change will be visible to users
- [ ] I have added automated tests that cover this change
- [ ] I have ensured the change is gated by config
- [ ] This change was covered by a ship review
- [ ] This change was covered by a tech design
- [ ] Any dependent config has been merged

