### PR TITLE
ntp: Fixed animation jitter of customizer drawer

### DIFF
--- a/special-pages/pages/new-tab/app/components/App.js
+++ b/special-pages/pages/new-tab/app/components/App.js
@@ -61,20 +61,21 @@ export function App() {
                         </div>
                     </div>
                 </main>
-                <CustomizerMenuPositionedFixed>
-                    {customizerKind === 'menu' && <CustomizerMenu />}
-                    {customizerKind === 'drawer' && (
-                        <CustomizerButton
-                            buttonId={buttonId}
-                            menuId={drawerId}
-                            toggleMenu={toggle}
-                            buttonRef={buttonRef}
-                            isOpen={isOpen}
-                            kind={'drawer'}
-                            theme={main}
-                        />
-                    )}
-                </CustomizerMenuPositionedFixed>
+                <div data-theme={main}>
+                    <CustomizerMenuPositionedFixed>
+                        {customizerKind === 'menu' && <CustomizerMenu />}
+                        {customizerKind === 'drawer' && (
+                            <CustomizerButton
+                                buttonId={buttonId}
+                                menuId={drawerId}
+                                toggleMenu={toggle}
+                                buttonRef={buttonRef}
+                                isOpen={isOpen}
+                                kind={'drawer'}
+                            />
+                        )}
+                    </CustomizerMenuPositionedFixed>
+                </div>
                 {customizerKind === 'drawer' && (
                     <aside
                         class={cn(styles.aside, styles.asideLayout, styles.asideScroller)}

--- a/special-pages/pages/new-tab/app/components/App.js
+++ b/special-pages/pages/new-tab/app/components/App.js
@@ -1,10 +1,15 @@
 import { Fragment, h } from 'preact';
 import cn from 'classnames';
 import styles from './App.module.css';
-import { useCustomizerDrawerSettings, usePlatformName } from '../settings.provider.js';
+import { useCustomizerDrawerSettings, useCustomizerKind, usePlatformName } from '../settings.provider.js';
 import { WidgetList } from '../widget-list/WidgetList.js';
 import { useGlobalDropzone } from '../dropzone.js';
-import { Customizer, CustomizerButton, CustomizerMenuPositionedFixed, useContextMenu } from '../customizer/components/Customizer.js';
+import {
+    CustomizerMenu,
+    CustomizerButton,
+    CustomizerMenuPositionedFixed,
+    useContextMenu,
+} from '../customizer/components/CustomizerMenu.js';
 import { useDrawer, useDrawerControls } from './Drawer.js';
 import { CustomizerDrawer } from '../customizer/components/CustomizerDrawer.js';
 import { BackgroundConsumer } from './BackgroundProvider.js';
@@ -23,7 +28,7 @@ export function App() {
     const platformName = usePlatformName();
     const customizerDrawer = useCustomizerDrawerSettings();
 
-    const customizerKind = customizerDrawer.state === 'enabled' ? 'drawer' : 'menu';
+    const customizerKind = useCustomizerKind();
 
     useGlobalDropzone();
     useContextMenu();
@@ -41,6 +46,7 @@ export function App() {
     } = useDrawer(customizerDrawer.autoOpen ? 'visible' : 'hidden');
 
     const tabIndex = useComputed(() => (hidden.value ? -1 : 0));
+    const isOpen = useComputed(() => hidden.value === false);
     const { toggle } = useDrawerControls();
     const { main, browser } = useContext(CustomizerThemesContext);
 
@@ -54,19 +60,21 @@ export function App() {
                             <WidgetList />
                         </div>
                     </div>
-                    <CustomizerMenuPositionedFixed>
-                        {customizerKind === 'menu' && <Customizer />}
-                        {customizerKind === 'drawer' && (
-                            <CustomizerButton
-                                buttonId={buttonId}
-                                menuId={drawerId}
-                                toggleMenu={toggle}
-                                buttonRef={buttonRef}
-                                isOpen={false}
-                            />
-                        )}
-                    </CustomizerMenuPositionedFixed>
                 </main>
+                <CustomizerMenuPositionedFixed>
+                    {customizerKind === 'menu' && <CustomizerMenu />}
+                    {customizerKind === 'drawer' && (
+                        <CustomizerButton
+                            buttonId={buttonId}
+                            menuId={drawerId}
+                            toggleMenu={toggle}
+                            buttonRef={buttonRef}
+                            isOpen={isOpen}
+                            kind={'drawer'}
+                            theme={main}
+                        />
+                    )}
+                </CustomizerMenuPositionedFixed>
                 {customizerKind === 'drawer' && (
                     <aside
                         class={cn(styles.aside, styles.asideLayout, styles.asideScroller)}

--- a/special-pages/pages/new-tab/app/components/App.module.css
+++ b/special-pages/pages/new-tab/app/components/App.module.css
@@ -52,11 +52,14 @@ body[data-animate-background="true"] {
     color: var(--ntp-text-normal);
 }
 
+
+
 .mainLayout {
-    padding-right: 0;
-    transition: padding-right .3s;
+    will-change: transform;
+    transition: transform .3s;
+
     [data-drawer-visibility='visible'] & {
-        padding-right: var(--ntp-combined-width);
+        transform: translateX(calc(0px - var(--ntp-combined-width) / 2));
     }
 }
 
@@ -110,6 +113,7 @@ body[data-animate-background="true"] {
     right: 0;
     top: 0;
     z-index: 1;
+    will-change: transform;
     transform: translateX(100%);
     transition: transform .3s;
 

--- a/special-pages/pages/new-tab/app/customizer/components/BackgroundSection.js
+++ b/special-pages/pages/new-tab/app/customizer/components/BackgroundSection.js
@@ -93,6 +93,7 @@ function DefaultPanel({ checked, onClick }) {
                 aria-labelledby={id}
                 role="radio"
                 onClick={onClick}
+                tabindex={checked ? -1 : 0}
             >
                 {checked && <CircleCheck />}
             </button>
@@ -117,6 +118,7 @@ function ColorPanel(props) {
                 data-color-mode={props.color.colorScheme}
                 onClick={props.onClick}
                 aria-checked={props.checked}
+                tabindex={props.checked ? -1 : 0}
                 aria-labelledby={id}
                 role="radio"
                 style={{ background: props.color.hex }}
@@ -144,6 +146,7 @@ function GradientPanel(props) {
                 class={cn(styles.bgPanel, styles.dynamicIconColor)}
                 data-color-mode={props.gradient.colorScheme}
                 aria-checked={props.checked}
+                tabindex={props.checked ? -1 : 0}
                 aria-labelledby={id}
                 style={{
                     background: `url(${props.gradient.path})`,

--- a/special-pages/pages/new-tab/app/customizer/components/BrowserThemeSection.js
+++ b/special-pages/pages/new-tab/app/customizer/components/BrowserThemeSection.js
@@ -26,7 +26,7 @@ export function BrowserThemeSection(props) {
                     role="radio"
                     type="button"
                     aria-checked={current.value === 'light'}
-                    tabindex={0}
+                    tabindex={current.value === 'light' ? -1 : 0}
                     onClick={() => props.setTheme({ theme: 'light' })}
                 >
                     <span class="sr-only">{t('customizer_browser_theme_label', { type: 'light' })}</span>
@@ -39,7 +39,7 @@ export function BrowserThemeSection(props) {
                     role="radio"
                     type="button"
                     aria-checked={current.value === 'dark'}
-                    tabindex={0}
+                    tabindex={current.value === 'dark' ? -1 : 0}
                     onClick={() => props.setTheme({ theme: 'dark' })}
                 >
                     <span class="sr-only">{t('customizer_browser_theme_label', { type: 'dark' })}</span>
@@ -52,7 +52,7 @@ export function BrowserThemeSection(props) {
                     role="radio"
                     type="button"
                     aria-checked={current.value === 'system'}
-                    tabindex={0}
+                    tabindex={current.value === 'system' ? -1 : 0}
                     onClick={() => props.setTheme({ theme: 'system' })}
                 >
                     <span class="sr-only">{t('customizer_browser_theme_label', { type: 'system' })}</span>

--- a/special-pages/pages/new-tab/app/customizer/components/Customizer.examples.js
+++ b/special-pages/pages/new-tab/app/customizer/components/Customizer.examples.js
@@ -1,6 +1,6 @@
 import { h } from 'preact';
 import { noop } from '../../utils.js';
-import { CustomizerButton } from './Customizer.js';
+import { CustomizerButton } from './CustomizerMenu.js';
 import { EmbeddedVisibilityMenu, VisibilityMenu } from './VisibilityMenu.js';
 import { BackgroundSection } from './BackgroundSection.js';
 import { ColorSelection } from './ColorSelection.js';
@@ -66,7 +66,7 @@ export const customizerExamples = {
     'customizer-menu': {
         factory: () => (
             <MaxContent>
-                <CustomizerButton isOpen={true} />
+                <CustomizerButton isOpen={true} kind="menu" />
                 <br />
                 <VisibilityMenu
                     rows={[

--- a/special-pages/pages/new-tab/app/customizer/components/Customizer.module.css
+++ b/special-pages/pages/new-tab/app/customizer/components/Customizer.module.css
@@ -3,7 +3,7 @@
 }
 
 .lowerRightFixed {
-    position: fixed;
+    position: absolute;
     bottom: 1rem;
     right: 1rem;
 }
@@ -54,6 +54,16 @@
         [data-theme=dark] & {
             background-color: var(--color-white-at-24);
             border-color: var(--color-white-at-50);
+        }
+    }
+
+    &[data-kind="drawer"][aria-expanded="true"] {
+        visibility: hidden;
+    }
+
+    @media screen and (max-width: 800px) {
+        span {
+            display: none;
         }
     }
 }

--- a/special-pages/pages/new-tab/app/customizer/components/CustomizerDrawerInner.module.css
+++ b/special-pages/pages/new-tab/app/customizer/components/CustomizerDrawerInner.module.css
@@ -63,7 +63,7 @@
         opacity: .8;
     }
     &:focus-visible {
-        outline: 1px solid var(--ntp-focus-outline-color)
+        box-shadow: var(--focus-ring);
     }
 }
 .section {

--- a/special-pages/pages/new-tab/app/customizer/components/CustomizerMenu.js
+++ b/special-pages/pages/new-tab/app/customizer/components/CustomizerMenu.js
@@ -112,10 +112,9 @@ export function useContextMenu() {
  * @param {import("@preact/signals").Signal<boolean>|boolean} props.isOpen
  * @param {() => void} [props.toggleMenu]
  * @param {import("preact").Ref<HTMLButtonElement>} [props.buttonRef]
- * @param {import('@preact/signals').Signal<'light' | 'dark'>} [props.theme]
  * @param {"menu" | "drawer"} props.kind
  */
-export function CustomizerButton({ menuId, buttonId, isOpen, toggleMenu, buttonRef, kind, theme }) {
+export function CustomizerButton({ menuId, buttonId, isOpen, toggleMenu, buttonRef, kind }) {
     const { t } = useTypedTranslation();
     return (
         <button
@@ -126,7 +125,6 @@ export function CustomizerButton({ menuId, buttonId, isOpen, toggleMenu, buttonR
             aria-expanded={isOpen}
             aria-controls={menuId}
             data-kind={kind}
-            data-theme={theme}
             id={buttonId}
         >
             <CustomizeIcon />

--- a/special-pages/pages/new-tab/app/customizer/components/CustomizerMenu.js
+++ b/special-pages/pages/new-tab/app/customizer/components/CustomizerMenu.js
@@ -13,7 +13,7 @@ import { VisibilityMenu, VisibilityMenuPopover } from './VisibilityMenu.js';
 /**
  * Represents the NTP customizer. For now it's just the ability to toggle sections.
  */
-export function Customizer() {
+export function CustomizerMenu() {
     const { setIsOpen, buttonRef, dropdownRef, isOpen } = useDropdown();
     const [rowData, setRowData] = useState(/** @type {VisibilityRowData[]} */ ([]));
 
@@ -32,9 +32,9 @@ export function Customizer() {
         function handler() {
             setRowData(getItems());
         }
-        window.addEventListener(Customizer.UPDATE_EVENT, handler);
+        window.addEventListener(CustomizerMenu.UPDATE_EVENT, handler);
         return () => {
-            window.removeEventListener(Customizer.UPDATE_EVENT, handler);
+            window.removeEventListener(CustomizerMenu.UPDATE_EVENT, handler);
         };
     }, [isOpen]);
 
@@ -43,7 +43,14 @@ export function Customizer() {
 
     return (
         <div class={styles.root} ref={dropdownRef}>
-            <CustomizerButton buttonId={BUTTON_ID} menuId={MENU_ID} toggleMenu={toggleMenu} buttonRef={buttonRef} isOpen={isOpen} />
+            <CustomizerButton
+                buttonId={BUTTON_ID}
+                menuId={MENU_ID}
+                toggleMenu={toggleMenu}
+                buttonRef={buttonRef}
+                isOpen={isOpen}
+                kind={'menu'}
+            />
             <div id={MENU_ID} class={cn(styles.dropdownMenu, { [styles.show]: isOpen })} aria-labelledby={BUTTON_ID}>
                 <VisibilityMenuPopover>
                     <VisibilityMenu rows={rowData} />
@@ -53,8 +60,8 @@ export function Customizer() {
     );
 }
 
-Customizer.OPEN_EVENT = 'ntp-customizer-open';
-Customizer.UPDATE_EVENT = 'ntp-customizer-update';
+CustomizerMenu.OPEN_EVENT = 'ntp-customizer-open';
+CustomizerMenu.UPDATE_EVENT = 'ntp-customizer-update';
 
 export function getItems() {
     /** @type {VisibilityRowData[]} */
@@ -64,7 +71,7 @@ export function getItems() {
             next.push(incoming);
         },
     };
-    const event = new CustomEvent(Customizer.OPEN_EVENT, { detail });
+    const event = new CustomEvent(CustomizerMenu.OPEN_EVENT, { detail });
     window.dispatchEvent(event);
     next.sort((a, b) => a.index - b.index);
     return next;
@@ -102,20 +109,24 @@ export function useContextMenu() {
  * @param {object} props
  * @param {string} [props.menuId]
  * @param {string} [props.buttonId]
- * @param {boolean} props.isOpen
+ * @param {import("@preact/signals").Signal<boolean>|boolean} props.isOpen
  * @param {() => void} [props.toggleMenu]
  * @param {import("preact").Ref<HTMLButtonElement>} [props.buttonRef]
+ * @param {import('@preact/signals').Signal<'light' | 'dark'>} [props.theme]
+ * @param {"menu" | "drawer"} props.kind
  */
-export function CustomizerButton({ menuId, buttonId, isOpen, toggleMenu, buttonRef }) {
+export function CustomizerButton({ menuId, buttonId, isOpen, toggleMenu, buttonRef, kind, theme }) {
     const { t } = useTypedTranslation();
     return (
         <button
             ref={buttonRef}
-            className={styles.customizeButton}
+            class={styles.customizeButton}
             onClick={toggleMenu}
             aria-haspopup="true"
             aria-expanded={isOpen}
             aria-controls={menuId}
+            data-kind={kind}
+            data-theme={theme}
             id={buttonId}
         >
             <CustomizeIcon />
@@ -210,11 +221,11 @@ export function useCustomizer({ title, id, icon, toggle, visibility, index }) {
         const handler = (/** @type {CustomEvent<any>} */ e) => {
             e.detail.register({ title, id, icon, toggle, visibility, index });
         };
-        window.addEventListener(Customizer.OPEN_EVENT, handler);
-        return () => window.removeEventListener(Customizer.OPEN_EVENT, handler);
+        window.addEventListener(CustomizerMenu.OPEN_EVENT, handler);
+        return () => window.removeEventListener(CustomizerMenu.OPEN_EVENT, handler);
     }, [title, id, icon, toggle, visibility, index]);
 
     useEffect(() => {
-        window.dispatchEvent(new Event(Customizer.UPDATE_EVENT));
+        window.dispatchEvent(new Event(CustomizerMenu.UPDATE_EVENT));
     }, [visibility]);
 }

--- a/special-pages/pages/new-tab/app/customizer/components/VisibilityMenu.js
+++ b/special-pages/pages/new-tab/app/customizer/components/VisibilityMenu.js
@@ -11,7 +11,7 @@ import { CustomizerThemesContext } from '../CustomizerProvider.js';
 
 /**
  * @import { Widgets, WidgetConfigItem } from '../../../types/new-tab.js'
- * @import { VisibilityRowData, VisibilityRowState } from './Customizer.js'
+ * @import { VisibilityRowData, VisibilityRowState } from './CustomizerMenu.js'
  */
 
 /**

--- a/special-pages/pages/new-tab/app/customizer/components/VisibilityMenu.module.css
+++ b/special-pages/pages/new-tab/app/customizer/components/VisibilityMenu.module.css
@@ -24,7 +24,7 @@
 }
 
 .embedded {
-    font-size: var(--small-label-font-size);
+    font-size: var(--body-font-size);
     gap: 12px;
 }
 
@@ -34,22 +34,21 @@
     gap: 10px;
     white-space: nowrap;
     height: calc(28 * var(--px-in-rem));
-
-    > * {
-        min-width: 0;
-    }
-
-    label {
-        margin-left: auto;
-    }
 }
 
 .menuItemLabelEmbedded {
     white-space: normal;
     gap: 6px;
     height: auto;
-    > * {
-        min-width: auto;
+
+    /* push the input over to the RHS */
+    *:last-child {
+        margin-left: auto;
+    }
+
+    /* Apply a theme-specific focus ring on the switch **/
+    input:focus-visible + * {
+        box-shadow: var(--focus-ring)
     }
 }
 

--- a/special-pages/pages/new-tab/app/customizer/components/VisibilityMenuSection.js
+++ b/special-pages/pages/new-tab/app/customizer/components/VisibilityMenuSection.js
@@ -1,11 +1,11 @@
 import { useLayoutEffect, useState } from 'preact/hooks';
-import { Customizer, getItems } from './Customizer.js';
+import { CustomizerMenu, getItems } from './CustomizerMenu.js';
 import { EmbeddedVisibilityMenu } from './VisibilityMenu.js';
 import { h } from 'preact';
 
 export function VisibilityMenuSection() {
     const [rowData, setRowData] = useState(() => {
-        const items = /** @type {import("./Customizer.js").VisibilityRowData[]} */ (getItems());
+        const items = /** @type {import("./CustomizerMenu.js").VisibilityRowData[]} */ (getItems());
         return items;
     });
     useLayoutEffect(() => {
@@ -13,9 +13,9 @@ export function VisibilityMenuSection() {
             setRowData(getItems());
         }
 
-        window.addEventListener(Customizer.UPDATE_EVENT, handler);
+        window.addEventListener(CustomizerMenu.UPDATE_EVENT, handler);
         return () => {
-            window.removeEventListener(Customizer.UPDATE_EVENT, handler);
+            window.removeEventListener(CustomizerMenu.UPDATE_EVENT, handler);
         };
     }, []);
 

--- a/special-pages/pages/new-tab/app/customizer/customizer.md
+++ b/special-pages/pages/new-tab/app/customizer/customizer.md
@@ -139,7 +139,7 @@ title: Customizer
         "background": { "kind": "color", "value": "color01" }
       } 
       ```
-
+  
 - {@link "NewTab Messages".CustomizerSetThemeNotification `customizer_setTheme`}.
     - Sends {@link "NewTab Messages".CustomizerSetBackgroundNotify} whenever needed.
     - For example:
@@ -151,8 +151,7 @@ title: Customizer
 
 - {@link "NewTab Messages".CustomizerUploadNotification `customizer_upload`}.
     - Sent to trigger a file upload
-
-
+  
 - {@link "NewTab Messages".CustomizerDeleteImageNotification `customizer_deleteImage`}.
     - Sends {@link "NewTab Messages".CustomizerDeleteImageNotify} whenever needed.
     - For example:

--- a/special-pages/pages/new-tab/app/favorites/components/FavoritesCustomized.js
+++ b/special-pages/pages/new-tab/app/favorites/components/FavoritesCustomized.js
@@ -3,7 +3,7 @@ import { useContext } from 'preact/hooks';
 
 import { useTelemetry, useTypedTranslationWith } from '../../types.js';
 import { useVisibility } from '../../widget-list/widget-config.provider.js';
-import { useCustomizer } from '../../customizer/components/Customizer.js';
+import { useCustomizer } from '../../customizer/components/CustomizerMenu.js';
 
 import { FavoritesContext, FavoritesProvider } from './FavoritesProvider.js';
 import { PragmaticDND } from './PragmaticDND.js';

--- a/special-pages/pages/new-tab/app/index.js
+++ b/special-pages/pages/new-tab/app/index.js
@@ -156,6 +156,7 @@ async function getStrings(environment) {
 function installGlobalSideEffects(environment, settings) {
     document.body.dataset.platformName = settings.platform.name;
     document.body.dataset.display = environment.display;
+    document.body.dataset.animation = environment.urlParams.get('animation') || '';
 }
 
 /**

--- a/special-pages/pages/new-tab/app/privacy-stats/components/PrivacyStats.js
+++ b/special-pages/pages/new-tab/app/privacy-stats/components/PrivacyStats.js
@@ -7,7 +7,7 @@ import { PrivacyStatsContext, PrivacyStatsProvider } from '../PrivacyStatsProvid
 import { useVisibility } from '../../widget-list/widget-config.provider.js';
 import { viewTransition } from '../../utils.js';
 import { ShowHideButton } from '../../components/ShowHideButton.jsx';
-import { useCustomizer } from '../../customizer/components/Customizer.js';
+import { useCustomizer } from '../../customizer/components/CustomizerMenu.js';
 import { DDG_STATS_OTHER_COMPANY_IDENTIFIER } from '../constants.js';
 import { displayNameForCompany, sortStatsForDisplay } from '../privacy-stats.utils.js';
 import { useCustomizerDrawerSettings } from '../../settings.provider.js';

--- a/special-pages/pages/new-tab/app/privacy-stats/components/PrivacyStats.module.css
+++ b/special-pages/pages/new-tab/app/privacy-stats/components/PrivacyStats.module.css
@@ -41,6 +41,56 @@
     align-items: center;
     justify-content: center;
     padding-top: 0.5px;
+
+    [data-animation="heart02"] & {
+        animation: heart02 2s infinite;
+    }
+    [data-animation="heart01"] & {
+        animation: heart01 1.483s infinite cubic-bezier(0.67, 0, 0.33, 1);
+    }
+}
+
+@keyframes heart01 {
+    0% {
+        transform: scale(1);
+    }
+
+    4.5% { /* 4/89 frames */
+        transform: scale(1.25);
+    }
+
+    16.85% { /* 15/89 frames */
+        transform: scale(1);
+    }
+
+    23.6% { /* 21/89 frames */
+        transform: scale(1.1);
+    }
+
+    100% { /* 89/89 frames */
+        transform: scale(1);
+    }
+}
+
+@keyframes heart02 {
+    0% {
+        transform: scale(1);
+    }
+    5.6% {
+        transform: scale(1.2);
+    }
+    11.2% {
+        transform: scale(1);
+    }
+    22.4% {
+        transform: scale(1.1);
+    }
+    33.7% {
+        transform: scale(1);
+    }
+    100% {
+        transform: scale(1);
+    }
 }
 
 .title {

--- a/special-pages/pages/new-tab/app/settings.provider.js
+++ b/special-pages/pages/new-tab/app/settings.provider.js
@@ -19,3 +19,11 @@ export function usePlatformName() {
 export function useCustomizerDrawerSettings() {
     return useContext(SettingsContext).settings.customizerDrawer;
 }
+
+/**
+ * @returns {"menu" | "drawer"}
+ */
+export function useCustomizerKind() {
+    const settings = useContext(SettingsContext).settings;
+    return settings.customizerDrawer.state === 'enabled' ? 'drawer' : 'menu';
+}

--- a/special-pages/pages/new-tab/app/telemetry/Debug.js
+++ b/special-pages/pages/new-tab/app/telemetry/Debug.js
@@ -1,7 +1,7 @@
 import { h } from 'preact';
 import { useEffect, useRef, useState } from 'preact/hooks';
 import { useTelemetry } from '../types.js';
-import { useCustomizer } from '../customizer/components/Customizer.js';
+import { useCustomizer } from '../customizer/components/CustomizerMenu.js';
 import { Telemetry } from './telemetry.js';
 
 export function DebugCustomized({ index }) {


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/0/1201141132935289/1209119909341560/f
+ https://app.asana.com/0/1201141132935289/1209123210947312/f

## Description

- the main content now uses `translate` to animate over when the drawer is opened
- some other fixes related to the positioning of the customize button

## Testing Steps

- We're going to run through these changes over zoom.

## Checklist

<!--
  These questions are a friendly reminder to shipping code, if you're uncertain ask the AoR owners.
  It's also totally appropriate to not check some of these boxes, if they don't apply to your change.
-->
*Please tick all that apply:*

- [ ] I have tested this change locally
- [ ] I have tested this change locally in all supported browsers
- [ ] This change will be visible to users
- [ ] I have added automated tests that cover this change
- [ ] I have ensured the change is gated by config
- [ ] This change was covered by a ship review
- [ ] This change was covered by a tech design
- [ ] Any dependent config has been merged

