### PR TITLE
ntp: ensure cross-window sections collapse

### DIFF
--- a/special-pages/pages/new-tab/app/favorites/components/Favorites.js
+++ b/special-pages/pages/new-tab/app/favorites/components/Favorites.js
@@ -23,7 +23,7 @@ export const ROW_CAPACITY = 6;
 /**
  * Note: These values MUST match exactly what's defined in the CSS.
  */
-const ITEM_HEIGHT = 90;
+const ITEM_HEIGHT = 96;
 const ROW_GAP = 8;
 
 /**

--- a/special-pages/pages/new-tab/app/favorites/components/FavoritesProvider.js
+++ b/special-pages/pages/new-tab/app/favorites/components/FavoritesProvider.js
@@ -116,9 +116,7 @@ export function FavoritesProvider({ children }) {
         (cb) => {
             if (!service.current) return;
             return service.current.onConfig((event) => {
-                if (event.source === 'manual') {
-                    cb(event.data);
-                }
+                cb(event.data);
             });
         },
         [service],

--- a/special-pages/pages/new-tab/app/favorites/components/Tile.module.css
+++ b/special-pages/pages/new-tab/app/favorites/components/Tile.module.css
@@ -8,6 +8,7 @@
     outline: none;
     padding-left: var(--sp-3);
     padding-right: var(--sp-3);
+    height: 96px;
 
     &:focus-visible .icon {
         box-shadow: var(--focus-ring);
@@ -33,7 +34,7 @@
     justify-items: center;
     width: var(--icon-width);
     height: var(--icon-width);
-    margin-bottom: 4px;
+    margin-bottom: 6px;
     border-radius: var(--border-radius-lg);
 }
 
@@ -88,13 +89,25 @@
         height: calc(32 * var(--px-in-rem));
         width: calc(32 * var(--px-in-rem));
     }
+
+    /*&[data-state="loading favicon-src"] {*/
+    /*    outline: 1px solid blue;*/
+    /*}*/
+
+    /*&[data-state="did load favicon-src"] {*/
+    /*    outline: 1px solid green;*/
+    /*}*/
+
+    /*&[data-state="did load fallback"] {*/
+    /*    outline: 1px dotted orange;*/
+    /*}*/
 }
 
 .text {
     width: var(--icon-width);
     text-align: center;
     font-size: calc(10 * var(--px-in-rem));
-    line-height: 1.1;
+    line-height: calc(13 * var(--px-in-rem));
     font-weight: 400;
     overflow: hidden;
     text-overflow: ellipsis;


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/0/1201141132935289/1209132650948830/f

## Description

A regression was introduced that affects multiple open windows.

## Testing Steps

- open 2 separate windows, both at https://deploy-preview-1387--content-scope-scripts.netlify.app/build/pages/new-tab/
- now, toggle the favorites ’show more’ and verify it’s reflected in the other tab correctly.

## Checklist

<!--
  These questions are a friendly reminder to shipping code, if you're uncertain ask the AoR owners.
  It's also totally appropriate to not check some of these boxes, if they don't apply to your change.
-->
*Please tick all that apply:*

- [ ] I have tested this change locally
- [ ] I have tested this change locally in all supported browsers
- [ ] This change will be visible to users
- [ ] I have added automated tests that cover this change
- [ ] I have ensured the change is gated by config
- [ ] This change was covered by a ship review
- [ ] This change was covered by a tech design
- [ ] Any dependent config has been merged

