### PR TITLE
ntp: support right-click on images

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -256,8 +256,7 @@
     },
     "node_modules/@duckduckgo/privacy-configuration": {
       "version": "1.0.0",
-      "resolved": "git+ssh://git@github.com/duckduckgo/privacy-configuration.git#0479dfed196beeed125ffe57ef034ae5b76fc208",
-      "integrity": "sha512-mbva0iUpEaprFl0udO++h5cf5YBwOfsyqZdjdyPO0gO5LSxL4N3a0AofrWX6y6qm5fzHnvCbT0MxzNA0iQjnTQ==",
+      "resolved": "git+ssh://git@github.com/duckduckgo/privacy-configuration.git#c3485ccbf9a0339242e1ce1879e926d4587c60df",
       "dev": true,
       "license": "Apache 2.0",
       "dependencies": {

--- a/special-pages/pages/new-tab/app/customizer/CustomizerProvider.js
+++ b/special-pages/pages/new-tab/app/customizer/CustomizerProvider.js
@@ -1,6 +1,6 @@
 import { createContext, h } from 'preact';
 import { useCallback } from 'preact/hooks';
-import { effect, signal, useSignal } from '@preact/signals';
+import { signal, useSignal, useSignalEffect } from '@preact/signals';
 import { useThemes } from './themes.js';
 
 /**
@@ -8,6 +8,7 @@ import { useThemes } from './themes.js';
  * @typedef {import('../../types/new-tab.js').BackgroundData} BackgroundData
  * @typedef {import('../../types/new-tab.js').ThemeData} ThemeData
  * @typedef {import('../../types/new-tab.js').UserImageData} UserImageData
+ * @typedef {import('../../types/new-tab.js').UserImageContextMenu} UserImageContextMenu
  * @typedef {import('../service.hooks.js').State<CustomizerData, undefined>} State
  * @typedef {import('../service.hooks.js').Events<CustomizerData, undefined>} Events
  */
@@ -41,6 +42,10 @@ export const CustomizerContext = createContext({
      * @type {(id: string) => void}
      */
     deleteImage: (id) => {},
+    /**
+     * @param {UserImageContextMenu} params
+     */
+    customizerContextMenu: (params) => {},
 });
 
 /**
@@ -57,7 +62,7 @@ export function CustomizerProvider({ service, initialData, children }) {
     const data = useSignal(initialData);
     const { main, browser } = useThemes(data);
 
-    effect(() => {
+    useSignalEffect(() => {
         const unsub = service.onBackground((evt) => {
             data.value = { ...data.value, background: evt.data.background };
         });
@@ -105,8 +110,11 @@ export function CustomizerProvider({ service, initialData, children }) {
         [service],
     );
 
+    /** @type {(p: UserImageContextMenu) => void} */
+    const customizerContextMenu = useCallback((params) => service.contextMenu(params), [service]);
+
     return (
-        <CustomizerContext.Provider value={{ data, select, upload, setTheme, deleteImage }}>
+        <CustomizerContext.Provider value={{ data, select, upload, setTheme, deleteImage, customizerContextMenu }}>
             <CustomizerThemesContext.Provider value={{ main, browser }}>{children}</CustomizerThemesContext.Provider>
         </CustomizerContext.Provider>
     );

--- a/special-pages/pages/new-tab/app/customizer/components/Customizer.examples.js
+++ b/special-pages/pages/new-tab/app/customizer/components/Customizer.examples.js
@@ -55,6 +55,7 @@ export const customizerExamples = {
                                 back={noop('back')}
                                 onUpload={noop('onUpload')}
                                 deleteImage={noop('deleteImage')}
+                                customizerContextMenu={noop('customizerContextMenu')}
                             />
                         );
                     }}

--- a/special-pages/pages/new-tab/app/customizer/components/CustomizerDrawer.js
+++ b/special-pages/pages/new-tab/app/customizer/components/CustomizerDrawer.js
@@ -13,6 +13,15 @@ export function CustomizerDrawer({ displayChildren }) {
 }
 
 function CustomizerConsumer() {
-    const { data, select, upload, setTheme, deleteImage } = useContext(CustomizerContext);
-    return <CustomizerDrawerInner data={data} select={select} onUpload={upload} setTheme={setTheme} deleteImage={deleteImage} />;
+    const { data, select, upload, setTheme, deleteImage, customizerContextMenu } = useContext(CustomizerContext);
+    return (
+        <CustomizerDrawerInner
+            data={data}
+            select={select}
+            onUpload={upload}
+            setTheme={setTheme}
+            deleteImage={deleteImage}
+            customizerContextMenu={customizerContextMenu}
+        />
+    );
 }

--- a/special-pages/pages/new-tab/app/customizer/components/CustomizerDrawerInner.js
+++ b/special-pages/pages/new-tab/app/customizer/components/CustomizerDrawerInner.js
@@ -16,7 +16,7 @@ import { InlineErrorBoundary } from '../../InlineErrorBoundary.js';
 import { useTypedTranslationWith } from '../../types.js';
 
 /**
- * @import { Widgets, WidgetConfigItem, WidgetVisibility, VisibilityMenuItem, CustomizerData, BackgroundData } from '../../../types/new-tab.js'
+ * @import { Widgets, WidgetConfigItem, WidgetVisibility, VisibilityMenuItem, CustomizerData, BackgroundData, UserImageContextMenu } from '../../../types/new-tab.js'
  * @import enStrings from '../strings.json';
  */
 
@@ -27,8 +27,9 @@ import { useTypedTranslationWith } from '../../types.js';
  * @param {() => void} props.onUpload
  * @param {(theme: import('../../../types/new-tab').ThemeData) => void} props.setTheme
  * @param {(id: string) => void} props.deleteImage
+ * @param {(p: UserImageContextMenu) => void} props.customizerContextMenu
  */
-export function CustomizerDrawerInner({ data, select, onUpload, setTheme, deleteImage }) {
+export function CustomizerDrawerInner({ data, select, onUpload, setTheme, deleteImage, customizerContextMenu }) {
     const { close } = useDrawerControls();
     const { t } = useTypedTranslationWith(/** @type {enStrings} */ ({}));
     return (
@@ -73,7 +74,14 @@ export function CustomizerDrawerInner({ data, select, onUpload, setTheme, delete
                             {id === 'color' && <ColorSelection data={data} select={select} back={pop} />}
                             {id === 'gradient' && <GradientSelection data={data} select={select} back={pop} />}
                             {id === 'image' && (
-                                <ImageSelection data={data} select={select} back={pop} onUpload={onUpload} deleteImage={deleteImage} />
+                                <ImageSelection
+                                    data={data}
+                                    select={select}
+                                    back={pop}
+                                    onUpload={onUpload}
+                                    deleteImage={deleteImage}
+                                    customizerContextMenu={customizerContextMenu}
+                                />
                             )}
                         </Fragment>
                     )}

--- a/special-pages/pages/new-tab/app/customizer/components/ImageSelection.js
+++ b/special-pages/pages/new-tab/app/customizer/components/ImageSelection.js
@@ -12,7 +12,7 @@ import { useTypedTranslationWith } from '../../types.js';
 
 /**
  * @import enStrings from '../strings.json';
- * @import { Widgets, WidgetConfigItem, WidgetVisibility, VisibilityMenuItem, CustomizerData, BackgroundData, PredefinedGradient } from '../../../types/new-tab.js'
+ * @import { Widgets, WidgetConfigItem, WidgetVisibility, VisibilityMenuItem, CustomizerData, BackgroundData, PredefinedGradient, UserImageContextMenu } from '../../../types/new-tab.js'
  */
 
 /**
@@ -22,8 +22,9 @@ import { useTypedTranslationWith } from '../../types.js';
  * @param {() => void} props.back
  * @param {() => void} props.onUpload
  * @param {(id: string) => void} props.deleteImage
+ * @param {(p: UserImageContextMenu) => void} props.customizerContextMenu
  */
-export function ImageSelection({ data, select, back, onUpload, deleteImage }) {
+export function ImageSelection({ data, select, back, onUpload, deleteImage, customizerContextMenu }) {
     const { t } = useTypedTranslationWith(/** @type {enStrings} */ ({}));
     function onClick(event) {
         let target = /** @type {HTMLElement|null} */ (event.target);
@@ -38,8 +39,19 @@ export function ImageSelection({ data, select, back, onUpload, deleteImage }) {
         select({ background: { kind: 'userImage', value: match } });
     }
 
+    function onContextMenu(event) {
+        const target = /** @type {HTMLElement|null} */ (event.target);
+        if (!(target instanceof HTMLElement)) return;
+        const id = target.closest('button')?.dataset.id;
+        if (typeof id === 'string') {
+            event.preventDefault();
+            event.stopImmediatePropagation();
+            customizerContextMenu({ id, target: 'userImage' });
+        }
+    }
+
     return (
-        <div>
+        <div onContextMenu={onContextMenu}>
             <button type={'button'} onClick={back} class={cn(styles.backBtn, styles.sectionTitle)}>
                 <BackChevron />
                 {t('customizer_background_selection_image_existing')}

--- a/special-pages/pages/new-tab/app/customizer/customizer.md
+++ b/special-pages/pages/new-tab/app/customizer/customizer.md
@@ -161,3 +161,14 @@ title: Customizer
         "id": "abc"
       } 
       ```
+  
+- {@link "NewTab Messages".CustomizerContextMenuNotification `customizer_contextMenu`}.
+    - Sends {@link "NewTab Messages".UserImageContextMenu} 
+    - Note: only sent for right-clicks on user images in the selection screen.
+    - For example:
+    - ```json
+      {
+        "target": "userImage",
+        "id": "01"
+      } 
+      ```

--- a/special-pages/pages/new-tab/app/customizer/customizer.service.js
+++ b/special-pages/pages/new-tab/app/customizer/customizer.service.js
@@ -2,6 +2,7 @@
  * @typedef {import("../../types/new-tab.js").CustomizerData} CustomizerData
  * @typedef {import("../../types/new-tab.js").UserImageData} UserImageData
  * @typedef {import("../../types/new-tab.js").UserColorData} UserColorData
+ * @typedef {import("../../types/new-tab.js").UserImageContextMenu} UserImageContextMenu
  * @typedef {import("../../types/new-tab.js").ThemeData} ThemeData
  * @typedef {import("../../types/new-tab.js").BackgroundData} BackgroundData
  */
@@ -134,5 +135,12 @@ export class CustomizerService {
             return theme;
         });
         this.ntp.messaging.notify('customizer_setTheme', theme);
+    }
+
+    /**
+     * @param {import('../../types/new-tab.js').UserImageContextMenu} params
+     */
+    contextMenu(params) {
+        this.ntp.messaging.notify('customizer_contextMenu', params);
     }
 }

--- a/special-pages/pages/new-tab/app/customizer/integration-tests/customizer.page.js
+++ b/special-pages/pages/new-tab/app/customizer/integration-tests/customizer.page.js
@@ -441,4 +441,11 @@ export class CustomizerPage {
             { value: 'gradient07' },
         ]);
     }
+
+    async rightClicksFirstImage() {
+        const { page } = this.ntp;
+        await page.getByRole('radio', { name: 'Select image 1' }).click({
+            button: 'right',
+        });
+    }
 }

--- a/special-pages/pages/new-tab/app/customizer/integration-tests/customizer.spec.js
+++ b/special-pages/pages/new-tab/app/customizer/integration-tests/customizer.spec.js
@@ -1,4 +1,4 @@
-import { test } from '@playwright/test';
+import { test, expect } from '@playwright/test';
 import { NewtabPage } from '../../../integration-tests/new-tab.page.js';
 import { CustomizerPage } from './customizer.page.js';
 
@@ -264,5 +264,24 @@ test.describe('newtab customizer', () => {
         await ntp.openPage({ additional: { customizerDrawer: 'enabled', theme: 'light' } });
         await cp.opensCustomizer();
         await cp.opensSettings();
+    });
+    test('context menu for image selections', async ({ page }, workerInfo) => {
+        const ntp = NewtabPage.create(page, workerInfo);
+        await ntp.reducedMotion();
+        const cp = new CustomizerPage(ntp);
+        await ntp.openPage({ additional: { customizerDrawer: 'enabled', userImages: 'true' } });
+        await cp.opensCustomizer();
+        await cp.opensImages();
+        await cp.rightClicksFirstImage();
+        const calls = await ntp.mocks.waitForCallCount({ method: 'customizer_contextMenu', count: 1 });
+        expect(calls[0].payload).toStrictEqual({
+            context: 'specialPages',
+            featureName: 'newTabPage',
+            method: 'customizer_contextMenu',
+            params: {
+                target: 'userImage',
+                id: '01',
+            },
+        });
     });
 });

--- a/special-pages/pages/new-tab/messages/customizer_contextMenu.notify.json
+++ b/special-pages/pages/new-tab/messages/customizer_contextMenu.notify.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "oneOf": [
+    {
+      "type": "object",
+      "title": "UserImageContextMenu",
+      "required": ["id", "target"],
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "target": {
+          "type": "string",
+          "const": "userImage"
+        }
+      }
+    }
+  ]
+}

--- a/special-pages/pages/new-tab/types/new-tab.ts
+++ b/special-pages/pages/new-tab/types/new-tab.ts
@@ -86,6 +86,7 @@ export type RMFIcon = "Announce" | "DDGAnnounce" | "CriticalUpdate" | "AppUpdate
 export interface NewTabMessages {
   notifications:
     | ContextMenuNotification
+    | CustomizerContextMenuNotification
     | CustomizerDeleteImageNotification
     | CustomizerSetBackgroundNotification
     | CustomizerSetThemeNotification
@@ -155,6 +156,17 @@ export interface VisibilityMenuItem {
    * Translated name of the section
    */
   title: string;
+}
+/**
+ * Generated from @see "../messages/customizer_contextMenu.notify.json"
+ */
+export interface CustomizerContextMenuNotification {
+  method: "customizer_contextMenu";
+  params: UserImageContextMenu;
+}
+export interface UserImageContextMenu {
+  id: string;
+  target: "userImage";
 }
 /**
  * Generated from @see "../messages/customizer_deleteImage.notify.json"


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/0/1201141132935289/1209163918548608/f

## Description

- sends a context menu notification when a right-click on an image occurs.

## Testing Steps

Open the customizer here, and right-click an image (once you’re in the screen of userImages) - check the console and ensure the correct notification is being sent 
 
<img width="942" alt="image" src="https://github.com/user-attachments/assets/cd0f2eb0-d7ec-4802-95a6-d65eed8a14e9" />

After right-clicking an image, check this is present in the console

<img width="407" alt="image" src="https://github.com/user-attachments/assets/94eee9c9-f810-4158-b490-a7e56e499cde" />



## Checklist

<!--
  These questions are a friendly reminder to shipping code, if you're uncertain ask the AoR owners.
  It's also totally appropriate to not check some of these boxes, if they don't apply to your change.
-->
*Please tick all that apply:*

- [ ] I have tested this change locally
- [ ] I have tested this change locally in all supported browsers
- [ ] This change will be visible to users
- [ ] I have added automated tests that cover this change
- [ ] I have ensured the change is gated by config
- [ ] This change was covered by a ship review
- [ ] This change was covered by a tech design
- [ ] Any dependent config has been merged

