### PR TITLE
ntp: fix regression with theme context/text color

### DIFF
--- a/special-pages/pages/new-tab/app/components/App.js
+++ b/special-pages/pages/new-tab/app/components/App.js
@@ -61,7 +61,7 @@ export function App() {
                         </div>
                     </div>
                 </main>
-                <div data-theme={main}>
+                <div class={styles.themeContext} data-theme={main}>
                     <CustomizerMenuPositionedFixed>
                         {customizerKind === 'menu' && <CustomizerMenu />}
                         {customizerKind === 'drawer' && (

--- a/special-pages/pages/new-tab/app/components/App.module.css
+++ b/special-pages/pages/new-tab/app/components/App.module.css
@@ -52,7 +52,9 @@ body[data-animate-background="true"] {
     color: var(--ntp-text-normal);
 }
 
-
+.themeContext {
+    color: var(--ntp-text-normal);
+}
 
 .mainLayout {
     will-change: transform;


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/0/1201141132935289/1209184777639415/f

## Description

The customizer button now sits outside of any theme context (this change was to fix a different bug 😢 ) - which meant it lost the context of which theme it should fall under.

This PR just adds an additional wrapper to put the context back in place. There may be a better way, but for now this solves the problem.

## Testing Steps

- go here (in dark mode) https://deploy-preview-1409--content-scope-scripts.netlify.app/build/pages/new-tab/
- open the customizer menu - the text should be the correct color for dark mode (compare with https://content-scope-scripts.netlify.app/build/pages/new-tab/)

## Checklist

<!--
  These questions are a friendly reminder to shipping code, if you're uncertain ask the AoR owners.
  It's also totally appropriate to not check some of these boxes, if they don't apply to your change.
-->
*Please tick all that apply:*

- [ ] I have tested this change locally
- [ ] I have tested this change locally in all supported browsers
- [ ] This change will be visible to users
- [ ] I have added automated tests that cover this change
- [ ] I have ensured the change is gated by config
- [ ] This change was covered by a ship review
- [ ] This change was covered by a tech design
- [ ] Any dependent config has been merged

