### PR TITLE
Duck Player: Pause video playback on “Watch on YouTube"

### DIFF
--- a/special-pages/pages/duckplayer/app/components/InfoBar.jsx
+++ b/special-pages/pages/duckplayer/app/components/InfoBar.jsx
@@ -11,6 +11,7 @@ import { SwitchContext, SwitchProvider } from '../providers/SwitchProvider.jsx';
 import { Tooltip } from './Tooltip.jsx';
 import { useSetFocusMode } from './FocusMode.jsx';
 import { useTypedTranslation } from '../types.js';
+import { usePlaybackControl } from './PlaybackControl';
 
 /**
  * @param {object} props
@@ -99,6 +100,7 @@ export function InfoIcon({ debugStyles = false }) {
  */
 function ControlBarDesktop({ embed }) {
     const settingsUrl = useSettingsUrl();
+    const { pauseVideo } = usePlaybackControl();
     const openOnYoutube = useOpenOnYoutubeHandler();
     const { t } = useTypedTranslation();
     const { state } = useContext(SwitchContext);
@@ -120,7 +122,10 @@ function ControlBarDesktop({ embed }) {
                 formfactor={'desktop'}
                 buttonProps={{
                     onClick: () => {
-                        if (embed) openOnYoutube(embed);
+                        if (embed) {
+                            pauseVideo();
+                            openOnYoutube(embed);
+                        }
                     },
                 }}
             >

--- a/special-pages/pages/duckplayer/app/components/MobileButtons.jsx
+++ b/special-pages/pages/duckplayer/app/components/MobileButtons.jsx
@@ -1,5 +1,6 @@
 import { h } from 'preact';
 import { useOpenInfoHandler, useOpenOnYoutubeHandler, useOpenSettingsHandler } from '../providers/SettingsProvider.jsx';
+import { usePlaybackControl } from './PlaybackControl.jsx';
 import { useTypedTranslation } from '../types.js';
 import { Button, Icon } from './Button.jsx';
 
@@ -15,6 +16,7 @@ export function MobileButtons({ embed }) {
     const openSettings = useOpenSettingsHandler();
     const openInfo = useOpenInfoHandler();
     const openOnYoutube = useOpenOnYoutubeHandler();
+    const { pauseVideo } = usePlaybackControl();
     const { t } = useTypedTranslation();
     return (
         <div class={styles.buttons}>
@@ -40,7 +42,10 @@ export function MobileButtons({ embed }) {
                 fill={true}
                 buttonProps={{
                     onClick: () => {
-                        if (embed) openOnYoutube(embed);
+                        if (embed) {
+                            pauseVideo();
+                            openOnYoutube(embed);
+                        }
                     },
                 }}
             >

--- a/special-pages/pages/duckplayer/app/components/MobileButtons.jsx
+++ b/special-pages/pages/duckplayer/app/components/MobileButtons.jsx
@@ -43,7 +43,6 @@ export function MobileButtons({ embed }) {
                 buttonProps={{
                     onClick: () => {
                         if (embed) {
-                            pauseVideo();
                             openOnYoutube(embed);
                         }
                     },

--- a/special-pages/pages/duckplayer/app/components/MobileButtons.jsx
+++ b/special-pages/pages/duckplayer/app/components/MobileButtons.jsx
@@ -1,6 +1,5 @@
 import { h } from 'preact';
 import { useOpenInfoHandler, useOpenOnYoutubeHandler, useOpenSettingsHandler } from '../providers/SettingsProvider.jsx';
-import { usePlaybackControl } from './PlaybackControl.jsx';
 import { useTypedTranslation } from '../types.js';
 import { Button, Icon } from './Button.jsx';
 
@@ -16,7 +15,6 @@ export function MobileButtons({ embed }) {
     const openSettings = useOpenSettingsHandler();
     const openInfo = useOpenInfoHandler();
     const openOnYoutube = useOpenOnYoutubeHandler();
-    const { pauseVideo } = usePlaybackControl();
     const { t } = useTypedTranslation();
     return (
         <div class={styles.buttons}>
@@ -42,9 +40,7 @@ export function MobileButtons({ embed }) {
                 fill={true}
                 buttonProps={{
                     onClick: () => {
-                        if (embed) {
-                            openOnYoutube(embed);
-                        }
+                        if (embed) openOnYoutube(embed);
                     },
                 }}
             >

--- a/special-pages/pages/duckplayer/app/components/PlaybackControl.jsx
+++ b/special-pages/pages/duckplayer/app/components/PlaybackControl.jsx
@@ -1,0 +1,13 @@
+export const EVENT_PLAY = 'ddg-duckplayer-play';
+export const EVENT_PAUSE = 'ddg-duckplayer-pause';
+
+export function usePlaybackControl() {
+    return {
+        playVideo: () => {
+            window.dispatchEvent(new Event(EVENT_PLAY));
+        },
+        pauseVideo: () => {
+            window.dispatchEvent(new Event(EVENT_PAUSE));
+        },
+    };
+}

--- a/special-pages/pages/duckplayer/app/components/PlaybackControl.jsx
+++ b/special-pages/pages/duckplayer/app/components/PlaybackControl.jsx
@@ -5,9 +5,11 @@ export function usePlaybackControl() {
     return {
         playVideo: () => {
             window.dispatchEvent(new Event(EVENT_PLAY));
+            console.log(EVENT_PLAY);
         },
         pauseVideo: () => {
             window.dispatchEvent(new Event(EVENT_PAUSE));
+            console.log(EVENT_PAUSE);
         },
     };
 }

--- a/special-pages/pages/duckplayer/app/components/Player.jsx
+++ b/special-pages/pages/duckplayer/app/components/Player.jsx
@@ -102,6 +102,7 @@ function useIframeEffects(src) {
             features.clickCapture(),
             features.titleCapture(),
             features.mouseCapture(),
+            features.playbackEvents(),
         ];
 
         /**

--- a/special-pages/pages/duckplayer/app/features/iframe.js
+++ b/special-pages/pages/duckplayer/app/features/iframe.js
@@ -79,7 +79,10 @@ export function createIframeFeatures(settings) {
          * @return {IframeFeature}
          */
         playbackEvents: () => {
-            return new PlaybackEvents();
+            if (settings.playbackEvents) {
+                return new PlaybackEvents();
+            }
+            return IframeFeature.noop();
         },
     };
 }

--- a/special-pages/pages/duckplayer/app/features/iframe.js
+++ b/special-pages/pages/duckplayer/app/features/iframe.js
@@ -3,6 +3,7 @@ import { AutoFocus } from './autofocus.js';
 import { ClickCapture } from './click-capture.js';
 import { TitleCapture } from './title-capture.js';
 import { MouseCapture } from './mouse-capture.js';
+import { PlaybackEvents } from './playback-events.js';
 
 /**
  * Represents an individual piece of functionality in the iframe.
@@ -73,6 +74,12 @@ export function createIframeFeatures(settings) {
          */
         mouseCapture: () => {
             return new MouseCapture();
+        },
+        /**
+         * @return {IframeFeature}
+         */
+        playbackEvents: () => {
+            return new PlaybackEvents();
         },
     };
 }

--- a/special-pages/pages/duckplayer/app/features/playback-events.js
+++ b/special-pages/pages/duckplayer/app/features/playback-events.js
@@ -10,76 +10,21 @@ import { EVENT_PLAY, EVENT_PAUSE } from '../components/PlaybackControl.jsx';
  * @implements IframeFeature
  */
 export class PlaybackEvents {
-    /** @type {MutationObserver} */
-    observer;
-
-    /** @type {[EVENT_PLAY|EVENT_PAUSE, (() => void)][]} */
-    handlers = [];
-
-    destroy() {
-        if (this.observer) this.observer.disconnect();
-
-        this.handlers.forEach(([event, handler]) => {
-            window.removeEventListener(event, handler);
-        });
-    }
-
     /**
      * @param {HTMLIFrameElement} iframe
      */
     iframeDidLoad(iframe) {
-        const documentBody = iframe.contentWindow?.document?.body;
+        const document = iframe.contentWindow?.document;
 
-        if (documentBody) {
-            const videoElement = documentBody.querySelector('video');
+        const playHandler = () => document?.querySelector('video')?.play();
+        window.addEventListener(EVENT_PLAY, playHandler);
 
-            // Check if iframe already contains video
-            if (videoElement) {
-                this.addHandlersToVideo(videoElement);
-            } else {
-                // No video found. Observe iframe's document for changes
-                this.observer = new MutationObserver(this.handleMutation.bind(this));
-
-                this.observer.observe(documentBody, {
-                    childList: true,
-                    subtree: true, // Observe all descendants of the body
-                });
-            }
-        }
+        const pauseHandler = () => document?.querySelector('video')?.pause();
+        window.addEventListener(EVENT_PAUSE, pauseHandler);
 
         return () => {
-            this.destroy();
+            window.removeEventListener(EVENT_PLAY, playHandler);
+            window.removeEventListener(EVENT_PAUSE, pauseHandler);
         };
-    }
-
-    /**
-     *
-     * @param {HTMLVideoElement} videoElement
-     */
-    addHandlersToVideo(videoElement) {
-        const playHandler = () => videoElement.play();
-        window.addEventListener(EVENT_PLAY, playHandler);
-        this.handlers.push([EVENT_PLAY, playHandler]);
-
-        const pauseHandler = () => videoElement.pause();
-        window.addEventListener(EVENT_PAUSE, pauseHandler);
-        this.handlers.push([EVENT_PAUSE, pauseHandler]);
-    }
-
-    /**
-     * Mutation handler that checks for a new video element
-     *
-     * @type {MutationCallback}
-     */
-    handleMutation(mutationsList) {
-        for (const mutation of mutationsList) {
-            if (mutation.type === 'childList') {
-                mutation.addedNodes.forEach((node) => {
-                    if (node.nodeType === Node.ELEMENT_NODE && /** @type {HTMLElement} */ (node).tagName === 'VIDEO') {
-                        this.addHandlersToVideo(/** @type {HTMLVideoElement} */ (node));
-                    }
-                });
-            }
-        }
     }
 }

--- a/special-pages/pages/duckplayer/app/features/playback-events.js
+++ b/special-pages/pages/duckplayer/app/features/playback-events.js
@@ -1,0 +1,85 @@
+import { EVENT_PLAY, EVENT_PAUSE } from '../components/PlaybackControl.jsx';
+
+/**
+ * @typedef {import("./iframe").IframeFeature} IframeFeature
+ */
+
+/**
+ * Exposes video element in iframe.
+ *
+ * @implements IframeFeature
+ */
+export class PlaybackEvents {
+    /** @type {MutationObserver} */
+    observer;
+
+    /** @type {[EVENT_PLAY|EVENT_PAUSE, (() => void)][]} */
+    handlers = [];
+
+    destroy() {
+        if (this.observer) this.observer.disconnect();
+
+        this.handlers.forEach(([event, handler]) => {
+            window.removeEventListener(event, handler);
+        });
+    }
+
+    /**
+     * @param {HTMLIFrameElement} iframe
+     */
+    iframeDidLoad(iframe) {
+        const documentBody = iframe.contentWindow?.document?.body;
+
+        if (documentBody) {
+            const videoElement = documentBody.querySelector('video');
+
+            // Check if iframe already contains video
+            if (videoElement) {
+                this.addHandlersToVideo(videoElement);
+            } else {
+                // No video found. Observe iframe's document for changes
+                this.observer = new MutationObserver(this.handleMutation.bind(this));
+
+                this.observer.observe(documentBody, {
+                    childList: true,
+                    subtree: true, // Observe all descendants of the body
+                });
+            }
+        }
+
+        return () => {
+            this.destroy();
+        };
+    }
+
+    /**
+     *
+     * @param {HTMLVideoElement} videoElement
+     */
+    addHandlersToVideo(videoElement) {
+        const playHandler = () => videoElement.play();
+        window.addEventListener(EVENT_PLAY, playHandler);
+        this.handlers.push([EVENT_PLAY, playHandler]);
+
+        const pauseHandler = () => videoElement.pause();
+        window.addEventListener(EVENT_PAUSE, pauseHandler);
+        this.handlers.push([EVENT_PAUSE, pauseHandler]);
+    }
+
+    /**
+     * Mutation handler that checks for a new video element
+     *
+     * @type {MutationCallback}
+     */
+    handleMutation(mutationsList) {
+        for (const mutation of mutationsList) {
+            if (mutation.type === 'childList') {
+                mutation.addedNodes.forEach((node) => {
+                    if (node.nodeType === Node.ELEMENT_NODE && /** @type {HTMLElement} */ (node).tagName === 'VIDEO') {
+                        this.addHandlersToVideo(/** @type {HTMLVideoElement} */ (node));
+                    }
+                });
+            }
+        }
+    }
+}

--- a/special-pages/pages/duckplayer/app/settings.js
+++ b/special-pages/pages/duckplayer/app/settings.js
@@ -103,4 +103,13 @@ export class Settings {
                 return 'desktop';
         }
     }
+
+    /**
+     * Enables sending events to video embed
+     *
+     * @returns {boolean}
+     */
+    get playbackEvents() {
+        return this.layout === 'desktop';
+    }
 }

--- a/special-pages/pages/duckplayer/integration-tests/duck-player.js
+++ b/special-pages/pages/duckplayer/integration-tests/duck-player.js
@@ -402,11 +402,11 @@ export class DuckPlayerPage {
          * @type {Promise<boolean>}
          */
         const evaluatePromise = this.page.evaluate((event) => {
-           return new Promise((resolve) => {
+            return new Promise((resolve) => {
                 window.addEventListener(event, () => {
                     resolve(true);
                 });
-           });
+            });
         }, expectedEvent);
 
         await this.page.getByRole('button', { name: 'Watch on YouTube' }).click();

--- a/special-pages/pages/duckplayer/integration-tests/duck-player.js
+++ b/special-pages/pages/duckplayer/integration-tests/duck-player.js
@@ -397,20 +397,21 @@ export class DuckPlayerPage {
     }
 
     async firesPauseEventWhenOpeningInYoutube() {
+        const expectedEvent = 'ddg-duckplayer-pause';
         /**
-         * @type {Promise<void>}
+         * @type {Promise<boolean>}
          */
-        const consolePromise = new Promise((resolve) => {
-            this.page.on('console', (msg) => {
-                if (msg.type() === 'log' && msg.text() === 'ddg-duckplayer-pause') {
-                    resolve();
-                }
-            });
-        });
+        const evaluatePromise = this.page.evaluate((event) => {
+           return new Promise((resolve) => {
+                window.addEventListener(event, () => {
+                    resolve(true);
+                });
+           });
+        }, expectedEvent);
 
         await this.page.getByRole('button', { name: 'Watch on YouTube' }).click();
 
-        await consolePromise;
+        await evaluatePromise;
     }
 
     /**

--- a/special-pages/pages/duckplayer/integration-tests/duck-player.js
+++ b/special-pages/pages/duckplayer/integration-tests/duck-player.js
@@ -396,6 +396,23 @@ export class DuckPlayerPage {
         });
     }
 
+    async firesPauseEventWhenOpeningInYoutube() {
+        /**
+         * @type {Promise<void>}
+         */
+        const consolePromise = new Promise((resolve) => {
+            this.page.on('console', (msg) => {
+                if (msg.type() === 'log' && msg.text() === 'ddg-duckplayer-pause') {
+                    resolve();
+                }
+            });
+        });
+
+        await this.page.getByRole('button', { name: 'Watch on YouTube' }).click();
+
+        await consolePromise;
+    }
+
     /**
      * @return {Promise<void>}
      */

--- a/special-pages/pages/duckplayer/integration-tests/duckplayer.spec.js
+++ b/special-pages/pages/duckplayer/integration-tests/duckplayer.spec.js
@@ -94,6 +94,13 @@ test.describe('duckplayer iframe', () => {
         await duckplayer.hasLoadedIframe();
         await duckplayer.focusModeIsAbsent();
     });
+    test('fires pause when clicking on Watch on YouTube', async ({ page }, workerInfo) => {
+        const duckplayer = DuckPlayerPage.create(page, workerInfo);
+        // load as normal
+        await duckplayer.openWithVideoID();
+        await duckplayer.hasLoadedIframe();
+        await duckplayer.firesPauseEventWhenOpeningInYoutube();
+    });
 });
 
 test.describe('duckplayer toolbar', () => {

--- a/special-pages/pages/duckplayer/integration-tests/duckplayer.spec.js
+++ b/special-pages/pages/duckplayer/integration-tests/duckplayer.spec.js
@@ -95,6 +95,7 @@ test.describe('duckplayer iframe', () => {
         await duckplayer.focusModeIsAbsent();
     });
     test('fires pause when clicking on Watch on YouTube', async ({ page }, workerInfo) => {
+        test.skip(isMobile(workerInfo));
         const duckplayer = DuckPlayerPage.create(page, workerInfo);
         // load as normal
         await duckplayer.openWithVideoID();


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/0/1207252092703676/1207942134403719/f

## Description

Pauses video playback when clicking on Watch on YouTube.

Notes:

1. Only tested on macOS local build (branch `daniel/duckplayer.open.in.youtube`)

## Testing Steps

1. Run native app with C-S-S branch
2. Play a video on Duck Player
4. Click on Watch on YouTube
5. Confirm that Duck Player video pauses and new tab opens on YouTube

## Checklist

<!—
  These questions are a friendly reminder to shipping code, if you're uncertain ask the AoR owners.
  It's also totally appropriate to not check some of these boxes, if they don't apply to your change.
—>
*Please tick all that apply:*

- [ ] I have tested this change locally
- [ ] I have tested this change locally in all supported browsers
- [ ] This change will be visible to users
- [ ] I have added automated tests that cover this change
- [ ] I have ensured the change is gated by config
- [ ] This change was covered by a ship review
- [ ] This change was covered by a tech design
- [ ] Any dependent config has been merged

