### PR TITLE
pass message value to  so it applies for priviledged domains

### DIFF
--- a/injected/entry-points/android.js
+++ b/injected/entry-points/android.js
@@ -38,6 +38,7 @@ function initCode() {
         site: processedConfig.site,
         bundledConfig: processedConfig.bundledConfig,
         messagingConfig: processedConfig.messagingConfig,
+        messageSecret: processedConfig.messageSecret,
     });
 
     init(processedConfig);

--- a/injected/entry-points/apple.js
+++ b/injected/entry-points/apple.js
@@ -49,6 +49,7 @@ function initCode() {
         site: processedConfig.site,
         bundledConfig: processedConfig.bundledConfig,
         messagingConfig: processedConfig.messagingConfig,
+        messageSecret: processedConfig.messageSecret,
     });
 
     init(processedConfig);

--- a/injected/src/content-scope-features.js
+++ b/injected/src/content-scope-features.js
@@ -27,6 +27,7 @@ const isHTMLDocument =
  * @property {string} [injectName]
  * @property {object} trackerLookup - provided currently only by the extension
  * @property {import('@duckduckgo/messaging').MessagingConfig} [messagingConfig]
+ * @property {string} [messageSecret] - optional, used in the messageBridge creation
  */
 
 /**


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/0/414235014887631/1209235566031320/f

## Description

This bug was only visible in production because the navigatorInterface is injected via a different path when it’s a privileged domain. (which has a different payload).

This means all local testing (using domains like ngrok) did not hightlight this problem

## Testing Steps

- Tests on the production SERP with latest iOS

## Checklist

<!--
  These questions are a friendly reminder to shipping code, if you're uncertain ask the AoR owners.
  It's also totally appropriate to not check some of these boxes, if they don't apply to your change.
-->
*Please tick all that apply:*

- [x] I have tested this change locally
- [x] I have tested this change locally in all supported browsers
- [ ] This change will be visible to users
- [ ] I have added automated tests that cover this change
- [ ] I have ensured the change is gated by config
- [ ] This change was covered by a ship review
- [ ] This change was covered by a tech design
- [ ] Any dependent config has been merged

