### PR TITLE
iOS Malicious Site Protection - Ship Review feedback 

### DIFF
--- a/special-pages/pages/special-error/app/components/Warning.module.css
+++ b/special-pages/pages/special-error/app/components/Warning.module.css
@@ -119,4 +119,10 @@
     & .phishing .icon, & .malware .icon {
         background-image: url(../../../../shared/assets/img/icons/Malware-Site-96.svg);
     }
+
+    /* Inserts line break before an inline element. Used for the Learn More link in the Warning text */
+    & [data-line-break]::before {
+        content: ' ';
+        display: block;
+    }
 }

--- a/special-pages/pages/special-error/app/hooks/ErrorStrings.jsx
+++ b/special-pages/pages/special-error/app/hooks/ErrorStrings.jsx
@@ -27,6 +27,7 @@ const sanitizeURL = (urlString) => {
  */
 
 const helpPageAnchorTagParams = {
+    'data-line-break': true,
     href: phishingMalwareHelpPageURL,
     target: '_blank',
 };


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/0/0/1209233393259133/f

## Description

- Introduces `data-line-break` attribute to allow inserting line breaks before inline elements
- Applies `data-line-break` to the Learn More link on the iOS Phishing and Malware warnings

## Testing Steps

- Confirm that [iOS Malware](https://deploy-preview-1433--content-scope-scripts.netlify.app/build/pages/special-error/?errorId=malware&platform=ios) and [iOS Phishing](https://deploy-preview-1433--content-scope-scripts.netlify.app/build/pages/special-error/?errorId=phishing&platform=ios) screens show a line break before Learn More
- Confirm that [macOS Malware](https://deploy-preview-1433--content-scope-scripts.netlify.app/build/pages/special-error/?errorId=malware&platform=macos) and [macOS Phishing](https://deploy-preview-1433--content-scope-scripts.netlify.app/build/pages/special-error/?errorId=phishing&platform=macos) do not
- Check for any visible regressions on the SSL error page for [macOS](https://deploy-preview-1433--content-scope-scripts.netlify.app/build/pages/special-error/?platform=macos) and [iOS](https://deploy-preview-1433--content-scope-scripts.netlify.app/build/pages/special-error/?platform=ios)

Before
<img width="491" alt="image" src="https://github.com/user-attachments/assets/17e97aec-450e-411c-94f8-c397f1f9e184" />

After
<img width="489" alt="image" src="https://github.com/user-attachments/assets/75819a1d-6260-482c-aab1-91bc93cd1ae0" />


## Checklist

<!--
  These questions are a friendly reminder to shipping code, if you're uncertain ask the AoR owners.
  It's also totally appropriate to not check some of these boxes, if they don't apply to your change.
-->
*Please tick all that apply:*

- [ ] I have tested this change locally
- [ ] I have tested this change locally in all supported browsers
- [ ] This change will be visible to users
- [ ] I have added automated tests that cover this change
- [ ] I have ensured the change is gated by config
- [ ] This change was covered by a ship review
- [ ] This change was covered by a tech design
- [ ] Any dependent config has been merged

