### PR TITLE
ntp: customizer translations

### DIFF
--- a/bslive.yaml
+++ b/bslive.yaml
@@ -1,0 +1,9 @@
+servers:
+  - bind_address: 0.0.0.0:3000
+    routes:
+      - path: /
+        dir: Sources/ContentScopeScripts/dist/pages/new-tab
+        cors: true
+      - path: /windows
+        dir: build/windows/pages/new-tab
+        cors: true

--- a/bslive.yaml
+++ b/bslive.yaml
@@ -1,9 +1,0 @@
-servers:
-  - bind_address: 0.0.0.0:3000
-    routes:
-      - path: /
-        dir: Sources/ContentScopeScripts/dist/pages/new-tab
-        cors: true
-      - path: /windows
-        dir: build/windows/pages/new-tab
-        cors: true

--- a/special-pages/pages/new-tab/app/customizer/strings.json
+++ b/special-pages/pages/new-tab/app/customizer/strings.json
@@ -9,15 +9,15 @@
   },
   "customizer_section_title_background": {
     "title": "Background",
-    "note": ""
+    "note": "Section title displayed in the UI for customizing the background."
   },
   "customizer_section_title_theme": {
     "title": "Browser Theme",
-    "note": ""
+    "note": "Section title for a section where users can customize the browser theme. (for example, 'light' or 'dark')"
   },
   "customizer_section_title_sections": {
     "title": "Sections",
-    "note": ""
+    "note": "Section title for a list of toggles for showing/hiding certain sections of the page."
   },
   "customizer_browser_theme_light": {
     "title": "Light",
@@ -33,7 +33,7 @@
   },
   "customizer_browser_theme_label": {
     "title": "Select {type} theme",
-    "note": "The label text on a button, for assistive technologies. {type} will be replace with 'light', 'dark' or 'system'"
+    "note": "The label text on a button, for assistive technologies (like screen readers). {type} will be replace with 'light', 'dark' or 'system'"
   },
   "customizer_settings_link": {
     "title": "Go to Settings",
@@ -61,7 +61,7 @@
   },
   "customizer_image_select": {
     "title": "Select image {number}",
-    "note": "Label text on a button, for assistive technologies. {number} will be replaced with a numeric reference of 1-8, eg: 'Select image 1'"
+    "note": "Label text on a button, for assistive technologies (like screen readers). {number} will be replaced with a numeric reference of 1-8, eg: 'Select image 1'"
   },
   "customizer_image_delete": {
     "title": "Delete image {number}",

--- a/special-pages/pages/new-tab/app/favorites/components/Favorites.js
+++ b/special-pages/pages/new-tab/app/favorites/components/Favorites.js
@@ -46,8 +46,6 @@ export const FavoritesThemeContext = createContext({
  */
 export function Favorites({ gridRef, favorites, expansion, toggle, openContextMenu, openFavorite, add, canAnimateItems }) {
     const { t } = useTypedTranslationWith(/** @type {import('../strings.json')} */ ({}));
-    const platformName = usePlatformName();
-
     // see: https://www.w3.org/WAI/ARIA/apg/patterns/accordion/examples/accordion/
     const WIDGET_ID = useId();
     const TOGGLE_ID = useId();
@@ -60,12 +58,10 @@ export function Favorites({ gridRef, favorites, expansion, toggle, openContextMe
     const kind = useComputed(() => data.value.background.kind);
 
     // A flag to determine if animations are available. This is needed
-    // because in webkit applying 'view-transition' css properties causes an odd experience
+    // because 'view-transition' CSS properties causes an odd experience
     // with filters.
     const animateItems = useComputed(() => {
-        if (platformName === 'windows' && canAnimateItems) return true;
-        if (platformName === 'macos' && canAnimateItems && kind.value !== 'userImage') return true;
-        return false;
+        return canAnimateItems && kind.value !== 'userImage';
     });
 
     return (

--- a/special-pages/pages/new-tab/app/favorites/components/FavoritesCustomized.js
+++ b/special-pages/pages/new-tab/app/favorites/components/FavoritesCustomized.js
@@ -10,7 +10,6 @@ import { PragmaticDND } from './PragmaticDND.js';
 import { FavoritesMemo } from './Favorites.js';
 import { viewTransition } from '../../utils.js';
 import { CustomizerContext } from '../../customizer/CustomizerProvider.js';
-import { usePlatformName } from '../../settings.provider.js';
 
 /**
  * @typedef {import('../../../types/new-tab.ts').Favorite} Favorite

--- a/special-pages/pages/new-tab/app/favorites/components/FavoritesCustomized.js
+++ b/special-pages/pages/new-tab/app/favorites/components/FavoritesCustomized.js
@@ -19,7 +19,6 @@ import { usePlatformName } from '../../settings.provider.js';
 export function FavoritesConsumer() {
     const { state, toggle, favoritesDidReOrder, openContextMenu, openFavorite, add } = useContext(FavoritesContext);
     const telemetry = useTelemetry();
-    const platformName = usePlatformName();
     const { data: backgroundData } = useContext(CustomizerContext);
 
     /**
@@ -29,12 +28,7 @@ export function FavoritesConsumer() {
      */
     function didReorder(data) {
         const background = backgroundData.value.background;
-        let supportsViewTransitions = false;
-
-        if (state.config?.animation?.kind === 'view-transitions') {
-            if (platformName === 'windows') supportsViewTransitions = true;
-            if (platformName === 'macos' && background.kind !== 'userImage') supportsViewTransitions = true;
-        }
+        const supportsViewTransitions = state.config?.animation?.kind === 'view-transitions' && background.kind !== 'userImage';
 
         if (supportsViewTransitions) {
             viewTransition(() => {

--- a/special-pages/pages/new-tab/public/locales/de/new-tab.json
+++ b/special-pages/pages/new-tab/public/locales/de/new-tab.json
@@ -44,12 +44,16 @@
     "title" : "Blockierte Tracking-Versuche",
     "note" : "Used as a label in a customization menu"
   },
+  "stats_menuTitle_v2" : {
+    "title" : "Schutzstatistiken",
+    "note" : "Used as a label in a customization menu"
+  },
   "stats_noActivity" : {
-    "title" : "Blockierte Tracking-Versuche werden hier angezeigt. Browse weiter, um zu sehen, wie viele wir blockieren.",
+    "title" : "DuckDuckGo blockiert Tracking-Versuche, während du browst. Besuche ein paar Seiten, um zu sehen, wie viele wir blockieren!",
     "note" : "Placeholder for when we cannot report any blocked trackers yet"
   },
   "stats_noRecent" : {
-    "title" : "Keine aktuellen Tracking-Aktivitäten",
+    "title" : "Tracking-Schutz aktiv",
     "note" : "Placeholder to indicate that no tracking activity was blocked in the last 7 days"
   },
   "stats_countBlockedSingular" : {
@@ -199,5 +203,73 @@
   "favorites_add" : {
     "title" : "Favorit hinzufügen",
     "note" : "A button that allows a user to add a new 'favorite' bookmark to their existing list"
+  },
+  "customizer_image_privacy" : {
+    "title" : "Die Bilder werden auf deinem Gerät gespeichert, sodass DuckDuckGo sie nicht sehen oder darauf zugreifen kann.",
+    "note" : "Shown near a button that allows a user to upload an image to be used as a background."
+  },
+  "customizer_drawer_title" : {
+    "title" : "Anpassen",
+    "note" : "Title in a slide-out drawer that contains options for customizing the browser."
+  },
+  "customizer_section_title_background" : {
+    "title" : "Hintergrund",
+    "note" : "Section title displayed in the UI for customizing the background."
+  },
+  "customizer_section_title_theme" : {
+    "title" : "Browser-Thema",
+    "note" : "Section title for a section where users can customize the browser theme. (for example, 'light' or 'dark')"
+  },
+  "customizer_section_title_sections" : {
+    "title" : "Abschnitte",
+    "note" : "Section title for a list of toggles for showing/hiding certain sections of the page."
+  },
+  "customizer_browser_theme_light" : {
+    "title" : "Hell",
+    "note" : "The label for a button that sets the browser theme to 'light' mode"
+  },
+  "customizer_browser_theme_dark" : {
+    "title" : "Dunkel",
+    "note" : "The label for a button that sets the browser theme to 'dark' mode"
+  },
+  "customizer_browser_theme_system" : {
+    "title" : "Standard",
+    "note" : "The label for a button that sets the browser theme to 'system', which matches the operating system setting"
+  },
+  "customizer_browser_theme_label" : {
+    "title" : "Design {type} auswählen",
+    "note" : "The label text on a button, for assistive technologies (like screen readers). {type} will be replace with 'light', 'dark' or 'system'"
+  },
+  "customizer_settings_link" : {
+    "title" : "Gehe zu Einstellungen",
+    "note" : "The label text on a link that opens the Settings"
+  },
+  "customizer_background_selection_default" : {
+    "title" : "Standard",
+    "note" : "Label text below a button that selects a 'default' background"
+  },
+  "customizer_background_selection_color" : {
+    "title" : "Solide Farben",
+    "note" : "Label text below a button that allows a color background"
+  },
+  "customizer_background_selection_gradient" : {
+    "title" : "Farbverläufe",
+    "note" : "Label text below a button that allows a gradient background"
+  },
+  "customizer_background_selection_image_add" : {
+    "title" : "Hintergrund hinzufügen",
+    "note" : "Label text shown on a button that allows an image to be uploaded"
+  },
+  "customizer_background_selection_image_existing" : {
+    "title" : "Meine Hintergründe",
+    "note" : "Label text shown on a button navigates to list of existing background (that the user previously uploaded)"
+  },
+  "customizer_image_select" : {
+    "title" : "Bild {number} auswählen",
+    "note" : "Label text on a button, for assistive technologies (like screen readers). {number} will be replaced with a numeric reference of 1-8, eg: 'Select image 1'"
+  },
+  "customizer_image_delete" : {
+    "title" : "Bild {number} löschen",
+    "note" : "Label text on a button that deletes an image. {number} will be replaced with a numeric reference of 1-8, eg: 'Delete image 1'"
   }
 }

--- a/special-pages/pages/new-tab/public/locales/en/new-tab.json
+++ b/special-pages/pages/new-tab/public/locales/en/new-tab.json
@@ -215,15 +215,15 @@
   },
   "customizer_section_title_background": {
     "title": "Background",
-    "note": ""
+    "note": "Section title displayed in the UI for customizing the background."
   },
   "customizer_section_title_theme": {
     "title": "Browser Theme",
-    "note": ""
+    "note": "Section title for a section where users can customize the browser theme. (for example, 'light' or 'dark')"
   },
   "customizer_section_title_sections": {
     "title": "Sections",
-    "note": ""
+    "note": "Section title for a list of toggles for showing/hiding certain sections of the page."
   },
   "customizer_browser_theme_light": {
     "title": "Light",
@@ -239,7 +239,7 @@
   },
   "customizer_browser_theme_label": {
     "title": "Select {type} theme",
-    "note": "The label text on a button, for assistive technologies. {type} will be replace with 'light', 'dark' or 'system'"
+    "note": "The label text on a button, for assistive technologies (like screen readers). {type} will be replace with 'light', 'dark' or 'system'"
   },
   "customizer_settings_link": {
     "title": "Go to Settings",
@@ -267,7 +267,7 @@
   },
   "customizer_image_select": {
     "title": "Select image {number}",
-    "note": "Label text on a button, for assistive technologies. {number} will be replaced with a numeric reference of 1-8, eg: 'Select image 1'"
+    "note": "Label text on a button, for assistive technologies (like screen readers). {number} will be replaced with a numeric reference of 1-8, eg: 'Select image 1'"
   },
   "customizer_image_delete": {
     "title": "Delete image {number}",

--- a/special-pages/pages/new-tab/public/locales/es/new-tab.json
+++ b/special-pages/pages/new-tab/public/locales/es/new-tab.json
@@ -44,12 +44,16 @@
     "title" : "Intentos de rastreo bloqueados",
     "note" : "Used as a label in a customization menu"
   },
+  "stats_menuTitle_v2" : {
+    "title" : "Estadísticas de protección",
+    "note" : "Used as a label in a customization menu"
+  },
   "stats_noActivity" : {
-    "title" : "Los intentos de rastreo bloqueados aparecerán aquí. Sigue navegando para ver cuántos bloqueamos.",
+    "title" : "DuckDuckGo bloquea los intentos de rastreo mientras navegas. ¡Visita algunos sitios para ver cuántos bloqueamos!",
     "note" : "Placeholder for when we cannot report any blocked trackers yet"
   },
   "stats_noRecent" : {
-    "title" : "No hay actividad de rastreo reciente",
+    "title" : "Protecciones de rastreo activas",
     "note" : "Placeholder to indicate that no tracking activity was blocked in the last 7 days"
   },
   "stats_countBlockedSingular" : {
@@ -199,5 +203,73 @@
   "favorites_add" : {
     "title" : "Añadir favorito",
     "note" : "A button that allows a user to add a new 'favorite' bookmark to their existing list"
+  },
+  "customizer_image_privacy" : {
+    "title" : "Las imágenes se almacenan en tu dispositivo, por lo que DuckDuckGo no puede verlas ni acceder a ellas.",
+    "note" : "Shown near a button that allows a user to upload an image to be used as a background."
+  },
+  "customizer_drawer_title" : {
+    "title" : "Personalizar",
+    "note" : "Title in a slide-out drawer that contains options for customizing the browser."
+  },
+  "customizer_section_title_background" : {
+    "title" : "Fondo",
+    "note" : "Section title displayed in the UI for customizing the background."
+  },
+  "customizer_section_title_theme" : {
+    "title" : "Tema del navegador",
+    "note" : "Section title for a section where users can customize the browser theme. (for example, 'light' or 'dark')"
+  },
+  "customizer_section_title_sections" : {
+    "title" : "Secciones",
+    "note" : "Section title for a list of toggles for showing/hiding certain sections of the page."
+  },
+  "customizer_browser_theme_light" : {
+    "title" : "Claro",
+    "note" : "The label for a button that sets the browser theme to 'light' mode"
+  },
+  "customizer_browser_theme_dark" : {
+    "title" : "Oscuro",
+    "note" : "The label for a button that sets the browser theme to 'dark' mode"
+  },
+  "customizer_browser_theme_system" : {
+    "title" : "Sistema",
+    "note" : "The label for a button that sets the browser theme to 'system', which matches the operating system setting"
+  },
+  "customizer_browser_theme_label" : {
+    "title" : "Seleccionar tema {type}",
+    "note" : "The label text on a button, for assistive technologies (like screen readers). {type} will be replace with 'light', 'dark' or 'system'"
+  },
+  "customizer_settings_link" : {
+    "title" : "Ir a Ajustes",
+    "note" : "The label text on a link that opens the Settings"
+  },
+  "customizer_background_selection_default" : {
+    "title" : "Predeterminado",
+    "note" : "Label text below a button that selects a 'default' background"
+  },
+  "customizer_background_selection_color" : {
+    "title" : "Colores sólidos",
+    "note" : "Label text below a button that allows a color background"
+  },
+  "customizer_background_selection_gradient" : {
+    "title" : "Gradientes",
+    "note" : "Label text below a button that allows a gradient background"
+  },
+  "customizer_background_selection_image_add" : {
+    "title" : "Añadir fondo",
+    "note" : "Label text shown on a button that allows an image to be uploaded"
+  },
+  "customizer_background_selection_image_existing" : {
+    "title" : "Mis fondos",
+    "note" : "Label text shown on a button navigates to list of existing background (that the user previously uploaded)"
+  },
+  "customizer_image_select" : {
+    "title" : "Seleccionar imagen {number}",
+    "note" : "Label text on a button, for assistive technologies (like screen readers). {number} will be replaced with a numeric reference of 1-8, eg: 'Select image 1'"
+  },
+  "customizer_image_delete" : {
+    "title" : "Eliminar imagen {number}",
+    "note" : "Label text on a button that deletes an image. {number} will be replaced with a numeric reference of 1-8, eg: 'Delete image 1'"
   }
 }

--- a/special-pages/pages/new-tab/public/locales/fr/new-tab.json
+++ b/special-pages/pages/new-tab/public/locales/fr/new-tab.json
@@ -44,12 +44,16 @@
     "title" : "Tentatives de pistage bloquées",
     "note" : "Used as a label in a customization menu"
   },
+  "stats_menuTitle_v2" : {
+    "title" : "Statistiques de protection",
+    "note" : "Used as a label in a customization menu"
+  },
   "stats_noActivity" : {
-    "title" : "Les tentatives de pistage bloquées apparaîtront ici. Continuez à naviguer pour voir combien nous en bloquons.",
+    "title" : "DuckDuckGo bloque les tentatives de pistage pendant que vous naviguez. Visitez quelques sites pour voir combien nous en bloquons !",
     "note" : "Placeholder for when we cannot report any blocked trackers yet"
   },
   "stats_noRecent" : {
-    "title" : "Aucune activité de pistage récente",
+    "title" : "Protections actives contre le pistage",
     "note" : "Placeholder to indicate that no tracking activity was blocked in the last 7 days"
   },
   "stats_countBlockedSingular" : {
@@ -199,5 +203,73 @@
   "favorites_add" : {
     "title" : "Ajouter un favori",
     "note" : "A button that allows a user to add a new 'favorite' bookmark to their existing list"
+  },
+  "customizer_image_privacy" : {
+    "title" : "Les images sont stockées sur votre appareil afin que DuckDuckGo ne puisse pas les voir ni y accéder.",
+    "note" : "Shown near a button that allows a user to upload an image to be used as a background."
+  },
+  "customizer_drawer_title" : {
+    "title" : "Personnaliser",
+    "note" : "Title in a slide-out drawer that contains options for customizing the browser."
+  },
+  "customizer_section_title_background" : {
+    "title" : "Arrière-plan :",
+    "note" : "Section title displayed in the UI for customizing the background."
+  },
+  "customizer_section_title_theme" : {
+    "title" : "Thème du navigateur",
+    "note" : "Section title for a section where users can customize the browser theme. (for example, 'light' or 'dark')"
+  },
+  "customizer_section_title_sections" : {
+    "title" : "Sections",
+    "note" : "Section title for a list of toggles for showing/hiding certain sections of the page."
+  },
+  "customizer_browser_theme_light" : {
+    "title" : "Clair",
+    "note" : "The label for a button that sets the browser theme to 'light' mode"
+  },
+  "customizer_browser_theme_dark" : {
+    "title" : "Sombre",
+    "note" : "The label for a button that sets the browser theme to 'dark' mode"
+  },
+  "customizer_browser_theme_system" : {
+    "title" : "Système",
+    "note" : "The label for a button that sets the browser theme to 'system', which matches the operating system setting"
+  },
+  "customizer_browser_theme_label" : {
+    "title" : "Choisir le thème {type}",
+    "note" : "The label text on a button, for assistive technologies (like screen readers). {type} will be replace with 'light', 'dark' or 'system'"
+  },
+  "customizer_settings_link" : {
+    "title" : "Accéder à Paramètres",
+    "note" : "The label text on a link that opens the Settings"
+  },
+  "customizer_background_selection_default" : {
+    "title" : "Défaut",
+    "note" : "Label text below a button that selects a 'default' background"
+  },
+  "customizer_background_selection_color" : {
+    "title" : "Couleurs unies",
+    "note" : "Label text below a button that allows a color background"
+  },
+  "customizer_background_selection_gradient" : {
+    "title" : "Gradients",
+    "note" : "Label text below a button that allows a gradient background"
+  },
+  "customizer_background_selection_image_add" : {
+    "title" : "Ajouter un arrière-plan",
+    "note" : "Label text shown on a button that allows an image to be uploaded"
+  },
+  "customizer_background_selection_image_existing" : {
+    "title" : "Mes arrière-plans",
+    "note" : "Label text shown on a button navigates to list of existing background (that the user previously uploaded)"
+  },
+  "customizer_image_select" : {
+    "title" : "Sélectionner l'image {number}",
+    "note" : "Label text on a button, for assistive technologies (like screen readers). {number} will be replaced with a numeric reference of 1-8, eg: 'Select image 1'"
+  },
+  "customizer_image_delete" : {
+    "title" : "Supprimer l'image {number}",
+    "note" : "Label text on a button that deletes an image. {number} will be replaced with a numeric reference of 1-8, eg: 'Delete image 1'"
   }
 }

--- a/special-pages/pages/new-tab/public/locales/nl/new-tab.json
+++ b/special-pages/pages/new-tab/public/locales/nl/new-tab.json
@@ -44,12 +44,16 @@
     "title" : "Geblokkeerde trackingpogingen",
     "note" : "Used as a label in a customization menu"
   },
+  "stats_menuTitle_v2" : {
+    "title" : "Beschermingsstatistieken",
+    "note" : "Used as a label in a customization menu"
+  },
   "stats_noActivity" : {
-    "title" : "Geblokkeerde trackingpogingen worden hier weergegeven. Blijf browsen om te zien hoeveel we er blokkeren.",
+    "title" : "DuckDuckGo blokkeert trackingpogingen terwijl je surft. Bezoek een paar sites om te zien hoeveel pogingen we blokkeren!",
     "note" : "Placeholder for when we cannot report any blocked trackers yet"
   },
   "stats_noRecent" : {
-    "title" : "Geen recente trackingactiviteit",
+    "title" : "Trackingbescherming actief",
     "note" : "Placeholder to indicate that no tracking activity was blocked in the last 7 days"
   },
   "stats_countBlockedSingular" : {
@@ -199,5 +203,73 @@
   "favorites_add" : {
     "title" : "Favoriet toevoegen",
     "note" : "A button that allows a user to add a new 'favorite' bookmark to their existing list"
+  },
+  "customizer_image_privacy" : {
+    "title" : "Afbeeldingen worden opgeslagen op je apparaat zodat DuckDuckGo ze niet kan zien of openen.",
+    "note" : "Shown near a button that allows a user to upload an image to be used as a background."
+  },
+  "customizer_drawer_title" : {
+    "title" : "Aanpassen",
+    "note" : "Title in a slide-out drawer that contains options for customizing the browser."
+  },
+  "customizer_section_title_background" : {
+    "title" : "Achtergrond",
+    "note" : "Section title displayed in the UI for customizing the background."
+  },
+  "customizer_section_title_theme" : {
+    "title" : "Browserthema",
+    "note" : "Section title for a section where users can customize the browser theme. (for example, 'light' or 'dark')"
+  },
+  "customizer_section_title_sections" : {
+    "title" : "Secties",
+    "note" : "Section title for a list of toggles for showing/hiding certain sections of the page."
+  },
+  "customizer_browser_theme_light" : {
+    "title" : "Licht",
+    "note" : "The label for a button that sets the browser theme to 'light' mode"
+  },
+  "customizer_browser_theme_dark" : {
+    "title" : "Donker",
+    "note" : "The label for a button that sets the browser theme to 'dark' mode"
+  },
+  "customizer_browser_theme_system" : {
+    "title" : "Systeem",
+    "note" : "The label for a button that sets the browser theme to 'system', which matches the operating system setting"
+  },
+  "customizer_browser_theme_label" : {
+    "title" : "Thema {type} selecteren",
+    "note" : "The label text on a button, for assistive technologies (like screen readers). {type} will be replace with 'light', 'dark' or 'system'"
+  },
+  "customizer_settings_link" : {
+    "title" : "Ga naar Instellingen",
+    "note" : "The label text on a link that opens the Settings"
+  },
+  "customizer_background_selection_default" : {
+    "title" : "Standaard",
+    "note" : "Label text below a button that selects a 'default' background"
+  },
+  "customizer_background_selection_color" : {
+    "title" : "Effen kleuren",
+    "note" : "Label text below a button that allows a color background"
+  },
+  "customizer_background_selection_gradient" : {
+    "title" : "Kleurverlopen",
+    "note" : "Label text below a button that allows a gradient background"
+  },
+  "customizer_background_selection_image_add" : {
+    "title" : "Achtergrond toevoegen",
+    "note" : "Label text shown on a button that allows an image to be uploaded"
+  },
+  "customizer_background_selection_image_existing" : {
+    "title" : "Mijn achtergronden",
+    "note" : "Label text shown on a button navigates to list of existing background (that the user previously uploaded)"
+  },
+  "customizer_image_select" : {
+    "title" : "Afbeelding {number} selecteren",
+    "note" : "Label text on a button, for assistive technologies (like screen readers). {number} will be replaced with a numeric reference of 1-8, eg: 'Select image 1'"
+  },
+  "customizer_image_delete" : {
+    "title" : "Afbeelding {number} verwijderen",
+    "note" : "Label text on a button that deletes an image. {number} will be replaced with a numeric reference of 1-8, eg: 'Delete image 1'"
   }
 }

--- a/special-pages/pages/new-tab/public/locales/pl/new-tab.json
+++ b/special-pages/pages/new-tab/public/locales/pl/new-tab.json
@@ -44,12 +44,16 @@
     "title" : "Zablokowane próby śledzenia",
     "note" : "Used as a label in a customization menu"
   },
+  "stats_menuTitle_v2" : {
+    "title" : "Statystyki ochrony",
+    "note" : "Used as a label in a customization menu"
+  },
   "stats_noActivity" : {
-    "title" : "Tutaj pojawią się zablokowane próby śledzenia. Przeglądaj dalej, aby zobaczyć, ile zablokujemy.",
+    "title" : "DuckDuckGo blokuje próby śledzenia, gdy korzystasz z przeglądarki. Odwiedź kilka stron, aby przekonać się, ile mechanizmów śledzących zablokujemy!",
     "note" : "Placeholder for when we cannot report any blocked trackers yet"
   },
   "stats_noRecent" : {
-    "title" : "Brak ostatniej aktywności w zakresie śledzenia",
+    "title" : "Ochrona przed śledzeniem aktywna",
     "note" : "Placeholder to indicate that no tracking activity was blocked in the last 7 days"
   },
   "stats_countBlockedSingular" : {
@@ -199,5 +203,73 @@
   "favorites_add" : {
     "title" : "Dodaj do Ulubionych",
     "note" : "A button that allows a user to add a new 'favorite' bookmark to their existing list"
+  },
+  "customizer_image_privacy" : {
+    "title" : "Obrazy są przechowywane na Twoim urządzeniu, więc DuckDuckGo nie może ich zobaczyć ani uzyskać do nich dostępu.",
+    "note" : "Shown near a button that allows a user to upload an image to be used as a background."
+  },
+  "customizer_drawer_title" : {
+    "title" : "Spersonalizuj",
+    "note" : "Title in a slide-out drawer that contains options for customizing the browser."
+  },
+  "customizer_section_title_background" : {
+    "title" : "Tło",
+    "note" : "Section title displayed in the UI for customizing the background."
+  },
+  "customizer_section_title_theme" : {
+    "title" : "Motyw przeglądarki",
+    "note" : "Section title for a section where users can customize the browser theme. (for example, 'light' or 'dark')"
+  },
+  "customizer_section_title_sections" : {
+    "title" : "Sekcje",
+    "note" : "Section title for a list of toggles for showing/hiding certain sections of the page."
+  },
+  "customizer_browser_theme_light" : {
+    "title" : "Jasny",
+    "note" : "The label for a button that sets the browser theme to 'light' mode"
+  },
+  "customizer_browser_theme_dark" : {
+    "title" : "Ciemny",
+    "note" : "The label for a button that sets the browser theme to 'dark' mode"
+  },
+  "customizer_browser_theme_system" : {
+    "title" : "Systemowy",
+    "note" : "The label for a button that sets the browser theme to 'system', which matches the operating system setting"
+  },
+  "customizer_browser_theme_label" : {
+    "title" : "Wybierz {type} motyw",
+    "note" : "The label text on a button, for assistive technologies (like screen readers). {type} will be replace with 'light', 'dark' or 'system'"
+  },
+  "customizer_settings_link" : {
+    "title" : "Przejdź do ustawień",
+    "note" : "The label text on a link that opens the Settings"
+  },
+  "customizer_background_selection_default" : {
+    "title" : "Domyślne",
+    "note" : "Label text below a button that selects a 'default' background"
+  },
+  "customizer_background_selection_color" : {
+    "title" : "Jednolite kolory",
+    "note" : "Label text below a button that allows a color background"
+  },
+  "customizer_background_selection_gradient" : {
+    "title" : "Gradienty",
+    "note" : "Label text below a button that allows a gradient background"
+  },
+  "customizer_background_selection_image_add" : {
+    "title" : "Dodaj tło",
+    "note" : "Label text shown on a button that allows an image to be uploaded"
+  },
+  "customizer_background_selection_image_existing" : {
+    "title" : "Moje tła",
+    "note" : "Label text shown on a button navigates to list of existing background (that the user previously uploaded)"
+  },
+  "customizer_image_select" : {
+    "title" : "Wybierz zdjęcie {number}",
+    "note" : "Label text on a button, for assistive technologies (like screen readers). {number} will be replaced with a numeric reference of 1-8, eg: 'Select image 1'"
+  },
+  "customizer_image_delete" : {
+    "title" : "Usuń obraz {number}",
+    "note" : "Label text on a button that deletes an image. {number} will be replaced with a numeric reference of 1-8, eg: 'Delete image 1'"
   }
 }

--- a/special-pages/pages/new-tab/public/locales/pt/new-tab.json
+++ b/special-pages/pages/new-tab/public/locales/pt/new-tab.json
@@ -44,12 +44,16 @@
     "title" : "Tentativas de rastreamento bloqueadas",
     "note" : "Used as a label in a customization menu"
   },
+  "stats_menuTitle_v2" : {
+    "title" : "Estatísticas de proteção",
+    "note" : "Used as a label in a customization menu"
+  },
   "stats_noActivity" : {
-    "title" : "As tentativas de rastreamento bloqueadas aparecem aqui. Continua a navegar para veres quantas bloqueamos.",
+    "title" : "O DuckDuckGo bloqueia tentativas de rastreamento enquanto navegas. Visita alguns sites para veres quantas tentativas bloqueamos!",
     "note" : "Placeholder for when we cannot report any blocked trackers yet"
   },
   "stats_noRecent" : {
-    "title" : "Nenhuma atividade de rastreamento recente",
+    "title" : "Proteções contra rastreamento ativas",
     "note" : "Placeholder to indicate that no tracking activity was blocked in the last 7 days"
   },
   "stats_countBlockedSingular" : {
@@ -199,5 +203,73 @@
   "favorites_add" : {
     "title" : "Adicionar favorito",
     "note" : "A button that allows a user to add a new 'favorite' bookmark to their existing list"
+  },
+  "customizer_image_privacy" : {
+    "title" : "As imagens são armazenadas no teu dispositivo, pelo que o DuckDuckGo não consegue aceder às imagens nem vê-las.",
+    "note" : "Shown near a button that allows a user to upload an image to be used as a background."
+  },
+  "customizer_drawer_title" : {
+    "title" : "Personalizar",
+    "note" : "Title in a slide-out drawer that contains options for customizing the browser."
+  },
+  "customizer_section_title_background" : {
+    "title" : "Fundo",
+    "note" : "Section title displayed in the UI for customizing the background."
+  },
+  "customizer_section_title_theme" : {
+    "title" : "Tema do navegador",
+    "note" : "Section title for a section where users can customize the browser theme. (for example, 'light' or 'dark')"
+  },
+  "customizer_section_title_sections" : {
+    "title" : "Secções",
+    "note" : "Section title for a list of toggles for showing/hiding certain sections of the page."
+  },
+  "customizer_browser_theme_light" : {
+    "title" : "Claro",
+    "note" : "The label for a button that sets the browser theme to 'light' mode"
+  },
+  "customizer_browser_theme_dark" : {
+    "title" : "Escuro",
+    "note" : "The label for a button that sets the browser theme to 'dark' mode"
+  },
+  "customizer_browser_theme_system" : {
+    "title" : "Sistema",
+    "note" : "The label for a button that sets the browser theme to 'system', which matches the operating system setting"
+  },
+  "customizer_browser_theme_label" : {
+    "title" : "Selecionar tema {type}",
+    "note" : "The label text on a button, for assistive technologies (like screen readers). {type} will be replace with 'light', 'dark' or 'system'"
+  },
+  "customizer_settings_link" : {
+    "title" : "Aceder às Definições",
+    "note" : "The label text on a link that opens the Settings"
+  },
+  "customizer_background_selection_default" : {
+    "title" : "Pré-definido",
+    "note" : "Label text below a button that selects a 'default' background"
+  },
+  "customizer_background_selection_color" : {
+    "title" : "Cores sólidas",
+    "note" : "Label text below a button that allows a color background"
+  },
+  "customizer_background_selection_gradient" : {
+    "title" : "Gradientes",
+    "note" : "Label text below a button that allows a gradient background"
+  },
+  "customizer_background_selection_image_add" : {
+    "title" : "Adicionar fundo",
+    "note" : "Label text shown on a button that allows an image to be uploaded"
+  },
+  "customizer_background_selection_image_existing" : {
+    "title" : "Os meus fundos",
+    "note" : "Label text shown on a button navigates to list of existing background (that the user previously uploaded)"
+  },
+  "customizer_image_select" : {
+    "title" : "Selecionar imagem {number}",
+    "note" : "Label text on a button, for assistive technologies (like screen readers). {number} will be replaced with a numeric reference of 1-8, eg: 'Select image 1'"
+  },
+  "customizer_image_delete" : {
+    "title" : "Eliminar imagem {number}",
+    "note" : "Label text on a button that deletes an image. {number} will be replaced with a numeric reference of 1-8, eg: 'Delete image 1'"
   }
 }

--- a/special-pages/pages/new-tab/public/locales/ru/new-tab.json
+++ b/special-pages/pages/new-tab/public/locales/ru/new-tab.json
@@ -44,12 +44,16 @@
     "title" : "Заблокированные попытки отслеживания",
     "note" : "Used as a label in a customization menu"
   },
+  "stats_menuTitle_v2" : {
+    "title" : "Статистика защиты",
+    "note" : "Used as a label in a customization menu"
+  },
   "stats_noActivity" : {
-    "title" : "Заблокированные попытки отслеживания будут отображаться здесь. Продолжайте бродить по интернету и узнайте, сколько трекеров поймал DuckDuckGo!",
+    "title" : "Пока вы бороздите Интернет, DuckDuckGo блокирует попытки отследить ваши действия. Посетите несколько сайтов и наглядно оцените нашу работу!",
     "note" : "Placeholder for when we cannot report any blocked trackers yet"
   },
   "stats_noRecent" : {
-    "title" : "Нет недавних отслеживаний",
+    "title" : "Защита от отслеживания включена",
     "note" : "Placeholder to indicate that no tracking activity was blocked in the last 7 days"
   },
   "stats_countBlockedSingular" : {
@@ -199,5 +203,73 @@
   "favorites_add" : {
     "title" : "Добавить в избранное",
     "note" : "A button that allows a user to add a new 'favorite' bookmark to their existing list"
+  },
+  "customizer_image_privacy" : {
+    "title" : "Изображения хранятся на вашем устройстве, поэтому у DuckDuckGo нет к ним доступа (даже для просмотра).",
+    "note" : "Shown near a button that allows a user to upload an image to be used as a background."
+  },
+  "customizer_drawer_title" : {
+    "title" : "Собственная настройка",
+    "note" : "Title in a slide-out drawer that contains options for customizing the browser."
+  },
+  "customizer_section_title_background" : {
+    "title" : "Фон",
+    "note" : "Section title displayed in the UI for customizing the background."
+  },
+  "customizer_section_title_theme" : {
+    "title" : "Тема браузера",
+    "note" : "Section title for a section where users can customize the browser theme. (for example, 'light' or 'dark')"
+  },
+  "customizer_section_title_sections" : {
+    "title" : "Разделы",
+    "note" : "Section title for a list of toggles for showing/hiding certain sections of the page."
+  },
+  "customizer_browser_theme_light" : {
+    "title" : "Светлая",
+    "note" : "The label for a button that sets the browser theme to 'light' mode"
+  },
+  "customizer_browser_theme_dark" : {
+    "title" : "Тёмная",
+    "note" : "The label for a button that sets the browser theme to 'dark' mode"
+  },
+  "customizer_browser_theme_system" : {
+    "title" : "Тема системы",
+    "note" : "The label for a button that sets the browser theme to 'system', which matches the operating system setting"
+  },
+  "customizer_browser_theme_label" : {
+    "title" : "Выбрать тему: «{type}»",
+    "note" : "The label text on a button, for assistive technologies (like screen readers). {type} will be replace with 'light', 'dark' or 'system'"
+  },
+  "customizer_settings_link" : {
+    "title" : "Открыть «Настройки»",
+    "note" : "The label text on a link that opens the Settings"
+  },
+  "customizer_background_selection_default" : {
+    "title" : "По умолчанию",
+    "note" : "Label text below a button that selects a 'default' background"
+  },
+  "customizer_background_selection_color" : {
+    "title" : "Сплошные цвета",
+    "note" : "Label text below a button that allows a color background"
+  },
+  "customizer_background_selection_gradient" : {
+    "title" : "Градиенты",
+    "note" : "Label text below a button that allows a gradient background"
+  },
+  "customizer_background_selection_image_add" : {
+    "title" : "Добавить фон",
+    "note" : "Label text shown on a button that allows an image to be uploaded"
+  },
+  "customizer_background_selection_image_existing" : {
+    "title" : "Мои фоны",
+    "note" : "Label text shown on a button navigates to list of existing background (that the user previously uploaded)"
+  },
+  "customizer_image_select" : {
+    "title" : "Выбрать изображение {number}",
+    "note" : "Label text on a button, for assistive technologies (like screen readers). {number} will be replaced with a numeric reference of 1-8, eg: 'Select image 1'"
+  },
+  "customizer_image_delete" : {
+    "title" : "Удалить изображение {number}",
+    "note" : "Label text on a button that deletes an image. {number} will be replaced with a numeric reference of 1-8, eg: 'Delete image 1'"
   }
 }


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/0/1201141132935289/1209262697199928/f

## Description

- [x] added translations for the customizer panel

## Testing Steps

- check the drawer here https://deploy-preview-1439--content-scope-scripts.netlify.app/build/pages/new-tab/?customizerDrawer=enabled&locale=pl

NOTE: There are some known styling issues, to be addressed in the next PR - merging this will help keep the sizes down (and will not be seen yet)

## Checklist

<!--
  These questions are a friendly reminder to shipping code, if you're uncertain ask the AoR owners.
  It's also totally appropriate to not check some of these boxes, if they don't apply to your change.
-->
*Please tick all that apply:*

- [ ] I have tested this change locally
- [ ] I have tested this change locally in all supported browsers
- [ ] This change will be visible to users
- [ ] I have added automated tests that cover this change
- [ ] I have ensured the change is gated by config
- [ ] This change was covered by a ship review
- [ ] This change was covered by a tech design
- [ ] Any dependent config has been merged

