### PR TITLE
Support elements that only contain textContent, remove commas from the end of addresses

### DIFF
--- a/injected/src/features/broker-protection/actions/extract.js
+++ b/injected/src/features/broker-protection/actions/extract.js
@@ -160,15 +160,20 @@ export function createProfile(elementFactory, extractData) {
 }
 
 /**
- * @param {{innerText: string}[]} elements
+ * @param {(HTMLElement | { innerText: string })[]} elements
  * @param {string} key
  * @param {ExtractProfileProperty} extractField
  * @return {string[]}
  */
 function stringValuesFromElements(elements, key, extractField) {
     return elements.map((element) => {
-        // todo: should we use textContent here?
-        let elementValue = rules[key]?.(element) ?? element?.innerText ?? null;
+        let elementValue;
+
+        if ('nodeType' in element && element.nodeType === Node.TEXT_NODE) {
+            elementValue = element.textContent;
+        } else {
+            elementValue = rules[key]?.(element) ?? element?.innerText ?? null;
+        }
 
         if (extractField?.afterText) {
             elementValue = elementValue?.split(extractField.afterText)[1]?.trim() || elementValue;

--- a/injected/src/features/broker-protection/actions/extract.js
+++ b/injected/src/features/broker-protection/actions/extract.js
@@ -160,21 +160,25 @@ export function createProfile(elementFactory, extractData) {
 }
 
 /**
- * @param {(HTMLElement | { innerText: string })[]} elements
+ * @param {({ textContent: string } | { innerText: string })[]} elements
  * @param {string} key
  * @param {ExtractProfileProperty} extractField
  * @return {string[]}
  */
-function stringValuesFromElements(elements, key, extractField) {
+export function stringValuesFromElements(elements, key, extractField) {
     return elements.map((element) => {
         let elementValue;
 
-        if (element?.innerText) {
+        if ('innerText' in element) {
             elementValue = rules[key]?.(element) ?? element?.innerText ?? null;
-        
-        // In instances where we use the text() node test, innerText will be undefined, and we fall back to textContent
-        } else if ('nodeType' in element && element.nodeType === Node.TEXT_NODE) {
+
+            // In instances where we use the text() node test, innerText will be undefined, and we fall back to textContent
+        } else if ('textContent' in element) {
             elementValue = rules[key]?.(element) ?? element?.textContent ?? null;
+        }
+
+        if (!elementValue) {
+            return elementValue;
         }
 
         if (extractField?.afterText) {

--- a/injected/src/features/broker-protection/actions/extract.js
+++ b/injected/src/features/broker-protection/actions/extract.js
@@ -169,10 +169,12 @@ function stringValuesFromElements(elements, key, extractField) {
     return elements.map((element) => {
         let elementValue;
 
-        if ('nodeType' in element && element.nodeType === Node.TEXT_NODE) {
-            elementValue = element.textContent;
-        } else {
+        if (element?.innerText) {
             elementValue = rules[key]?.(element) ?? element?.innerText ?? null;
+        
+        // In instances where we use the text() node test, innerText will be undefined, and we fall back to textContent
+        } else if ('nodeType' in element && element.nodeType === Node.TEXT_NODE) {
+            elementValue = rules[key]?.(element) ?? element?.textContent ?? null;
         }
 
         if (extractField?.afterText) {

--- a/injected/src/features/broker-protection/extractors/address.js
+++ b/injected/src/features/broker-protection/extractors/address.js
@@ -53,6 +53,9 @@ function getCityStateCombos(inputList) {
         // Strip out the zip code since we're only interested in city/state here.
         item = item.replace(/,?\s*\d{5}(-\d{4})?/, '');
 
+        // Replace any commas at the end of the string that could confuse the city/state split.
+        item = item.replace(/,$/, '');
+
         if (item.includes(',')) {
             words = item.split(',').map((item) => item.trim());
         } else {

--- a/injected/unit-test/broker-protection-extract.js
+++ b/injected/unit-test/broker-protection-extract.js
@@ -1,4 +1,4 @@
-import { aggregateFields, createProfile } from '../src/features/broker-protection/actions/extract.js';
+import { aggregateFields, createProfile, stringValuesFromElements } from '../src/features/broker-protection/actions/extract.js';
 import { cleanArray } from '../src/features/broker-protection/utils.js';
 
 describe('create profiles from extracted data', () => {
@@ -359,5 +359,20 @@ describe('create profiles from extracted data', () => {
         const actual = aggregateFields(scraped);
 
         expect(actual.alternativeNames).toEqual(['Fred Firth', 'Jerry Doug', 'Marvin Smith', 'Roger Star']);
+    });
+
+    it('should extract innerText by default', () => {
+        const element = {
+            innerText: 'John Smith, 39',
+            textContent: 'Ignore me',
+        };
+        expect(stringValuesFromElements([element], 'testKey', { selector: 'example' })).toEqual(['John Smith, 39']);
+    });
+
+    it('should extract textElement if innerText is not present', () => {
+        const element = {
+            textContent: 'John Smith, 39',
+        };
+        expect(stringValuesFromElements([element], 'testKey', { selector: 'example' })).toEqual(['John Smith, 39']);
     });
 });


### PR DESCRIPTION
**Asana Task/Github Issue:** <!-- Link to Asana Task/Github Issue -->

## Description
When using XPath’s text() node test (e.g. `//strong[contains(text(), 'Locations:')]/following-sibling::text()`), a node is returned that only contains textContent, not innerText.

This change updates the extractor to check for innerText, and fallback to textContent. Also included, a small change to strip out commas at the end of addresses.

<!--
  Provide a terse summary of what the change is, detailed descriptions should belong in ship reviews or tech designs
-->

## Testing Steps

- Run integration / unit tests
- Drag this version of C-S-S into XCode and run PIR.

## Checklist

<!--
  These questions are a friendly reminder to shipping code, if you're uncertain ask the AoR owners.
  It's also totally appropriate to not check some of these boxes, if they don't apply to your change.
-->
*Please tick all that apply:*

- [x] I have tested this change locally
- [x] I have tested this change locally in all supported browsers
- [ ] This change will be visible to users
- [x] I have added automated tests that cover this change
- [ ] I have ensured the change is gated by config
- [ ] This change was covered by a ship review
- [ ] This change was covered by a tech design
- [ ] Any dependent config has been merged

