### PR TITLE
ntp: implement burning of history items

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1030,9 +1030,10 @@
       }
     },
     "node_modules/@preact/signals": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@preact/signals/-/signals-1.3.1.tgz",
-      "integrity": "sha512-nNvSF2O7RDzxp1Rm7SkA5QhN1a2kN8pGE8J5o6UjgDof0F0Vlg6d6HUUVxxqZ1uJrN9xnH2DpL6rpII3Es0SsQ==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@preact/signals/-/signals-2.0.1.tgz",
+      "integrity": "sha512-f9p/utMgttPb9bJ+UgRBkTDZ9uQiZfX1/gV3pXGWz+yGNQj8MrnG55Xo8MAG4IHcb5UXQO6tvt9ZlsM4A2j+Rw==",
+      "license": "MIT",
       "dependencies": {
         "@preact/signals-core": "^1.7.0"
       },
@@ -4779,6 +4780,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/lottie-web": {
+      "version": "5.12.2",
+      "resolved": "https://registry.npmjs.org/lottie-web/-/lottie-web-5.12.2.tgz",
+      "integrity": "sha512-uvhvYPC8kGPjXT3MyKMrL3JitEAmDMp30lVkuq/590Mw9ok6pWcFCwXJveo0t5uqYw1UREQHofD+jVpdjBv8wg==",
+      "license": "MIT"
+    },
     "node_modules/lru-cache": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
@@ -5554,9 +5561,9 @@
       "license": "MIT"
     },
     "node_modules/preact": {
-      "version": "10.24.3",
-      "resolved": "https://registry.npmjs.org/preact/-/preact-10.24.3.tgz",
-      "integrity": "sha512-Z2dPnBnMUfyQfSQ+GBdsGa16hz35YmLmtTLhM169uW944hYL6xzTYkJjC07j+Wosz733pMWx0fgON3JNw1jJQA==",
+      "version": "10.25.4",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.25.4.tgz",
+      "integrity": "sha512-jLdZDb+Q+odkHJ+MpW/9U5cODzqnB+fy2EiHSZES7ldV5LK7yjlVzTp7R8Xy6W6y75kfK8iWYtFVH7lvjwrCMA==",
       "license": "MIT",
       "funding": {
         "type": "opencollective",
@@ -7362,10 +7369,11 @@
         "@atlaskit/pragmatic-drag-and-drop": "^1.3.1",
         "@atlaskit/pragmatic-drag-and-drop-hitbox": "^1.0.3",
         "@formkit/auto-animate": "^0.8.2",
-        "@preact/signals": "^1.3.1",
+        "@preact/signals": "^2.0.1",
         "@rive-app/canvas-single": "^2.25.3",
         "classnames": "^2.5.1",
-        "preact": "^10.24.3"
+        "lottie-web": "^5.12.2",
+        "preact": "^10.25.4"
       },
       "devDependencies": {
         "@duckduckgo/messaging": "*",

--- a/special-pages/package.json
+++ b/special-pages/package.json
@@ -27,19 +27,20 @@
   "license": "ISC",
   "devDependencies": {
     "@duckduckgo/messaging": "*",
+    "chokidar": "^4.0.3",
     "esbuild": "^0.24.2",
-    "http-server": "^14.1.1",
-    "web-resource-inliner": "^6.0.1",
     "fast-check": "^3.23.2",
-    "chokidar": "^4.0.3"
+    "http-server": "^14.1.1",
+    "web-resource-inliner": "^6.0.1"
   },
   "dependencies": {
-    "preact": "^10.24.3",
-    "@preact/signals": "^1.3.1",
-    "classnames": "^2.5.1",
-    "@formkit/auto-animate": "^0.8.2",
-    "@rive-app/canvas-single": "^2.25.3",
     "@atlaskit/pragmatic-drag-and-drop": "^1.3.1",
-    "@atlaskit/pragmatic-drag-and-drop-hitbox": "^1.0.3"
+    "@atlaskit/pragmatic-drag-and-drop-hitbox": "^1.0.3",
+    "@formkit/auto-animate": "^0.8.2",
+    "@preact/signals": "^2.0.1",
+    "@rive-app/canvas-single": "^2.25.3",
+    "classnames": "^2.5.1",
+    "lottie-web": "^5.12.2",
+    "preact": "^10.25.4"
   }
 }

--- a/special-pages/pages/new-tab/app/burning/ActivityInteractionsContext.js
+++ b/special-pages/pages/new-tab/app/burning/ActivityInteractionsContext.js
@@ -1,0 +1,8 @@
+import { createContext } from 'preact';
+
+export const ActivityInteractionsContext = createContext({
+    /**
+     * @type {(evt: MouseEvent) => void} event
+     */
+    didClick(event) {},
+});

--- a/special-pages/pages/new-tab/app/burning/BurnAnimationLottieWeb.js
+++ b/special-pages/pages/new-tab/app/burning/BurnAnimationLottieWeb.js
@@ -1,0 +1,57 @@
+import { h } from 'preact';
+import lottie from 'lottie-web';
+import { useContext, useEffect, useRef } from 'preact/hooks';
+import { ActivityBurningSignalContext } from './BurnProvider.js';
+
+/**
+ * BurnAnimation is a React component that renders a Lottie animation and dispatches custom events when the animation stops or the component unmounts.
+ *
+ * @param {Object} props The properties object.
+ * @param {string} props.url The URL associated with the animation, used to identify or provide additional context in the dispatched events.
+ */
+export function BurnAnimation({ url }) {
+    const ref = useRef(/** @type {Lottie} */ null);
+    const json = useContext(ActivityBurningSignalContext);
+    useEffect(() => {
+        if (!ref.current) return;
+        let finished = false;
+        let timer = null;
+
+        const publish = (reason) => {
+            if (finished) return;
+            window.dispatchEvent(new CustomEvent('done-burning', { detail: { url, reason } }));
+            finished = true;
+            clearTimeout(timer);
+        };
+
+        timer = setTimeout(() => {
+            publish('timeout occurred');
+        }, 1200);
+
+        const animationHandler = () => publish('timeout occurred');
+        const hasJson = json.animation.value.state === 'ready' && json.animation.value.data;
+
+        /** @type {import('lottie-web').AnimationItem | null} */
+        let animation = lottie.loadAnimation({
+            container: ref.current,
+            renderer: 'svg',
+            loop: false,
+            autoplay: true,
+            animationData: hasJson || undefined,
+            path: hasJson === undefined ? 'burn.json' : undefined,
+        });
+
+        animation.addEventListener('complete', animationHandler);
+
+        return () => {
+            clearTimeout(timer);
+            // animation?.removeEventListener('complete', animationHandler);
+            animation = null;
+
+            if (!finished) {
+                publish('unmount occurred');
+            }
+        };
+    }, [url, json]);
+    return <div ref={ref} data-lottie-player></div>;
+}

--- a/special-pages/pages/new-tab/app/burning/BurnProvider.js
+++ b/special-pages/pages/new-tab/app/burning/BurnProvider.js
@@ -1,0 +1,240 @@
+import { h, createContext } from 'preact';
+import { useContext, useEffect } from 'preact/hooks';
+import { batch, signal, useSignal, useSignalEffect } from '@preact/signals';
+import { useEnv } from '../../../../shared/components/EnvironmentProvider.js';
+import { ActivityInteractionsContext } from './ActivityInteractionsContext.js';
+
+export const ACTION_BURN = 'burn';
+
+export const ActivityBurningSignalContext = createContext({
+    /** @type {import("@preact/signals").Signal<string[]>} */
+    burning: signal([]),
+    /** @type {import("@preact/signals").Signal<string[]>} */
+    exiting: signal([]),
+    /** @type {import("@preact/signals").Signal<{state: 'loading' | 'ready' | 'error', data: null | Record<string, any>}>} */
+    animation: signal({ state: 'loading', data: null }),
+});
+
+/**
+ * @param {object} props
+ * @param {import("preact").ComponentChild} props.children
+ * @param {{confirmBurn: (url: string) => Promise<{action: 'burn' | 'none'}>; disableBroadcast: () => void; enableBroadcast: () => void }} props.service
+ *
+ */
+export function BurnProvider({ children, service }) {
+    const burning = useSignal(/** @type {string[]} */ ([]));
+    const exiting = useSignal(/** @type {string[]} */ ([]));
+    const animation = useSignal({ state: /** @type {'loading' | 'ready' | 'error'} */ ('loading'), data: null });
+    const { didClick: originalDidClick } = useContext(ActivityInteractionsContext);
+    const { isReducedMotion } = useEnv();
+
+    async function didClick(e) {
+        const button = /** @type {HTMLButtonElement|null} */ (e.target?.closest(`button[value][data-action="${ACTION_BURN}"]`));
+        if (!button) return originalDidClick(e);
+        if (!service) throw new Error('unreachable');
+
+        e.preventDefault();
+        e.stopImmediatePropagation();
+
+        if (burning.value.length > 0 || exiting.value.length > 0) return;
+
+        const value = button.value;
+        const response = await service?.confirmBurn(value);
+        if (response && response.action === 'none') return;
+
+        // stop the service broadcasting any updates for a moment
+        service.disableBroadcast();
+
+        // mark this item as burning - this will prevent further events until we're done
+        burning.value = burning.value.concat(value);
+
+        // wait for a signal from the FE that we can continue
+        const feSignals = any(reducedMotion(isReducedMotion), animationExit(), didChangeDocumentVisibility());
+
+        // the signal from native that burning was complete
+        const nativeSignal = didCompleteNatively(service);
+
+        // at least 1 FE signal + 1 native signal is required to continue
+        const required = all(feSignals, nativeSignal);
+
+        // but don't wait any longer than 3 seconds
+        const withTimer = any(required, timer(3000));
+
+        // exec the chain
+        await toPromise(withTimer);
+
+        // when we get here, clear out all state
+        batch(() => {
+            exiting.value = [];
+            burning.value = [];
+        });
+
+        // and re-enable the data broadcasting
+        service?.enableBroadcast();
+    }
+
+    useSignalEffect(() => {
+        let cancelled = false;
+        async function fetchAnimation() {
+            const resp = await fetch('burn.json');
+            if (!resp.ok) {
+                animation.value = { state: /** @type {const} */ ('error'), data: null };
+                return;
+            }
+            const json = await resp.json();
+            if (!cancelled) animation.value = { state: 'ready', data: json };
+        }
+        fetchAnimation()
+            // eslint-disable-next-line promise/prefer-await-to-then
+            .catch((e) => {
+                animation.value = { state: /** @type {const} */ ('error'), data: null };
+            });
+        return () => {
+            cancelled = true;
+        };
+    });
+
+    useEffect(() => {
+        const handler = (e) => {
+            if (e.detail.url) {
+                batch(() => {
+                    burning.value = burning.value.filter((x) => x !== e.detail.url);
+                    exiting.value = exiting.value.concat(e.detail.url);
+                });
+            }
+        };
+        window.addEventListener('done-burning', handler);
+        return () => {
+            window.removeEventListener('done-burning', handler);
+        };
+    }, [burning, exiting]);
+
+    return (
+        <ActivityBurningSignalContext.Provider value={{ burning, exiting, animation }}>
+            <ActivityInteractionsContext.Provider value={{ didClick }}>{children}</ActivityInteractionsContext.Provider>
+        </ActivityBurningSignalContext.Provider>
+    );
+}
+
+function toPromise(fn) {
+    return new Promise((resolve) => {
+        const cleanup = fn({
+            next: (v) => {
+                resolve(v);
+                cleanup();
+            },
+        });
+    });
+}
+
+function reducedMotion(isReducedMotion) {
+    return (subject) => {
+        if (isReducedMotion) {
+            subject.next();
+        }
+    };
+}
+
+function animationExit() {
+    return (subject) => {
+        const handler = () => {
+            subject.next();
+        };
+        window.addEventListener('done-exiting', handler, { once: true });
+        return () => {
+            window.removeEventListener('done-exiting', handler);
+        };
+    };
+}
+
+function timer(ms) {
+    return (subject) => {
+        const int = setTimeout(() => {
+            return subject.next();
+        }, ms);
+        return () => {
+            clearTimeout(int);
+        };
+    };
+}
+
+function didCompleteNatively(service) {
+    return (subject) => {
+        const unsub = service?.onBurnComplete(() => {
+            subject.next();
+        });
+        return () => {
+            unsub();
+        };
+    };
+}
+
+function didChangeDocumentVisibility() {
+    return (subject) => {
+        const handler = () => {
+            return subject.next(document.visibilityState);
+        };
+        document.addEventListener('visibilitychange', handler, { once: true });
+        return () => {
+            window.removeEventListener('visibilitychange', handler);
+        };
+    };
+}
+
+function any(...fns) {
+    return (subject) => {
+        const jobs = fns.map((factory) => {
+            const subject = {
+                /** @type {any} */
+                next: undefined,
+            };
+            const promise = new Promise((resolve) => (subject.next = resolve));
+            const cleanup = factory(subject);
+            return {
+                promise,
+                cleanup,
+            };
+        });
+
+        Promise.any(jobs.map((x) => x.promise))
+            // eslint-disable-next-line promise/prefer-await-to-then
+            .then((d) => subject.next(d))
+            // eslint-disable-next-line promise/prefer-await-to-then
+            .catch(console.error);
+
+        return () => {
+            for (const job of jobs) {
+                job.cleanup?.();
+            }
+        };
+    };
+}
+
+function all(...fns) {
+    return (subject) => {
+        const jobs = fns.map((factory) => {
+            const subject = {
+                /** @type {any} */
+                next: undefined,
+            };
+            const promise = new Promise((resolve) => (subject.next = resolve));
+            const cleanup = factory(subject);
+            return {
+                promise,
+                cleanup,
+            };
+        });
+
+        Promise.all(jobs.map((x) => x.promise))
+            // eslint-disable-next-line promise/prefer-await-to-then
+            .then((d) => subject.next(d))
+            // eslint-disable-next-line promise/prefer-await-to-then
+            .catch(console.error);
+
+        return () => {
+            for (const job of jobs) {
+                job.cleanup?.();
+            }
+        };
+    };
+}


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/0/1201141132935289/1209300015210580

## Description

Separated the burning logic to make it not tied to the Activtiy widget (and for easier review)

## Testing Steps

- Try burning here (this is the next PR) https://deploy-preview-1419--content-scope-scripts.netlify.app/build/pages/new-tab/?feed=activity
- the First item should burn immediately, the second should ask you for confirmation

## Checklist

<!--
  These questions are a friendly reminder to shipping code, if you're uncertain ask the AoR owners.
  It's also totally appropriate to not check some of these boxes, if they don't apply to your change.
-->
*Please tick all that apply:*

- [ ] I have tested this change locally
- [ ] I have tested this change locally in all supported browsers
- [ ] This change will be visible to users
- [ ] I have added automated tests that cover this change
- [ ] I have ensured the change is gated by config
- [ ] This change was covered by a ship review
- [ ] This change was covered by a tech design
- [ ] Any dependent config has been merged

