### PR TITLE
ntp: activity translations (RC1)

### DIFF
--- a/special-pages/pages/new-tab/app/activity/components/Activity.examples.js
+++ b/special-pages/pages/new-tab/app/activity/components/Activity.examples.js
@@ -10,28 +10,12 @@ import { normalizeData, NormalizedDataContext } from '../NormalizeDataProvider.j
 export const activityExamples = {
     'activity.empty': {
         factory: () => {
-            return (
-                <Activity
-                    expansion={'expanded'}
-                    itemCount={0}
-                    trackerCount={0}
-                    toggle={noop('toggle')}
-                    didClick={noop('did click')}
-                    batched={false}
-                />
-            );
+            return <Activity expansion={'expanded'} itemCount={0} trackerCount={0} toggle={noop('toggle')} batched={false} />;
         },
     },
     'activity.few': {
         factory: () => (
-            <Activity
-                expansion={'expanded'}
-                itemCount={10}
-                trackerCount={20}
-                toggle={noop('toggle')}
-                didClick={noop('did click')}
-                batched={false}
-            >
+            <Activity expansion={'expanded'} itemCount={10} trackerCount={20} toggle={noop('toggle')} batched={false}>
                 <Mock size={3}>
                     <ActivityBody canBurn={false} visibility={'visible'} />
                 </Mock>
@@ -40,14 +24,7 @@ export const activityExamples = {
     },
     'activity.noTrackers': {
         factory: () => (
-            <Activity
-                expansion={'expanded'}
-                itemCount={20}
-                trackerCount={0}
-                toggle={noop('toggle')}
-                didClick={noop('did click')}
-                batched={false}
-            >
+            <Activity expansion={'expanded'} itemCount={20} trackerCount={0} toggle={noop('toggle')} batched={false}>
                 <Mock size={1}>
                     <ActivityBody canBurn={false} visibility={'visible'} />
                 </Mock>

--- a/special-pages/pages/new-tab/app/activity/components/Activity.js
+++ b/special-pages/pages/new-tab/app/activity/components/Activity.js
@@ -30,7 +30,6 @@ import { ActivityInteractionsContext } from '../../burning/ActivityInteractionsC
  * Renders the Activity component with associated heading and body, managing interactivity and state.
  *
  * @param {Object} props - Object containing all properties required by the Activity component.
- * @param {(evt: MouseEvent) => void} props.didClick - Callback function triggered when the root element is clicked.
  * @param {Expansion} props.expansion - String indicating the expansion state of the activity, such as 'expanded' or 'collapsed'.
  * @param {() => void} props.toggle - Callback function to handle the expansion/collapse action.
  * @param {number} props.trackerCount - Object representing the tracker count for the activity.
@@ -38,14 +37,19 @@ import { ActivityInteractionsContext } from '../../burning/ActivityInteractionsC
  * @param {boolean} props.batched - Boolean indicating whether the activity uses batched loading.
  * @param {import("preact").ComponentChild} [props.children]
  */
-export function Activity({ didClick, expansion, toggle, trackerCount, itemCount, batched, children }) {
+export function Activity({ expansion, toggle, trackerCount, itemCount, batched, children }) {
     // see: https://www.w3.org/WAI/ARIA/apg/patterns/accordion/examples/accordion/
     const expanded = expansion === 'expanded';
     const WIDGET_ID = useId();
     const TOGGLE_ID = useId();
+    const { didClick } = useContext(ActivityInteractionsContext);
+
+    const ref = useRef(null);
+    useOnMiddleClick(ref, didClick);
+
     return (
         <Fragment>
-            <div class={styles.root} onClick={didClick}>
+            <div class={styles.root} onClick={didClick} ref={ref}>
                 <ActivityHeading
                     trackerCount={trackerCount}
                     itemCount={itemCount}
@@ -240,10 +244,6 @@ export function ActivityConfigured({ expansion, toggle, children }) {
     const batched = useBatchedActivityApi();
 
     const { activity } = useContext(NormalizedDataContext);
-    const { didClick } = useContext(ActivityInteractionsContext);
-
-    const ref = useRef(/** @type {HTMLUListElement|null} */ (null));
-    useOnMiddleClick(ref, didClick);
 
     const count = useComputed(() => {
         return activity.value.totalTrackers;
@@ -254,14 +254,7 @@ export function ActivityConfigured({ expansion, toggle, children }) {
     });
 
     return (
-        <Activity
-            batched={batched}
-            itemCount={itemCount.value}
-            trackerCount={count.value}
-            expansion={expansion}
-            toggle={toggle}
-            didClick={didClick}
-        >
+        <Activity batched={batched} itemCount={itemCount.value} trackerCount={count.value} expansion={expansion} toggle={toggle}>
             {children}
         </Activity>
     );

--- a/special-pages/pages/new-tab/app/activity/integration-tests/activity.page.js
+++ b/special-pages/pages/new-tab/app/activity/integration-tests/activity.page.js
@@ -193,6 +193,7 @@ export class ActivityPage {
         await page.getByText('example.com').click();
         await page.getByText('example.com').click({ modifiers: ['Meta'] });
         await page.getByText('example.com').click({ modifiers: ['Shift'] });
+        await page.getByText('example.com').click({ button: 'middle' });
         await this._opensMainLink();
     }
     async _opensMainLink() {
@@ -210,6 +211,11 @@ export class ActivityPage {
         });
 
         expect(calls[2].payload.params).toStrictEqual({
+            url,
+            target: 'new-window',
+        });
+
+        expect(calls[3].payload.params).toStrictEqual({
             url,
             target: 'new-window',
         });

--- a/special-pages/pages/new-tab/app/customizer/components/BrowserThemeSection.js
+++ b/special-pages/pages/new-tab/app/customizer/components/BrowserThemeSection.js
@@ -31,7 +31,7 @@ export function BrowserThemeSection(props) {
                 >
                     <span class="sr-only">{t('customizer_browser_theme_label', { type: 'light' })}</span>
                 </button>
-                {t('customizer_browser_theme_light')}
+                <span>{t('customizer_browser_theme_light')}</span>
             </li>
             <li class={styles.themeItem}>
                 <button
@@ -44,7 +44,7 @@ export function BrowserThemeSection(props) {
                 >
                     <span class="sr-only">{t('customizer_browser_theme_label', { type: 'dark' })}</span>
                 </button>
-                {t('customizer_browser_theme_dark')}
+                <span>{t('customizer_browser_theme_dark')}</span>
             </li>
             <li class={styles.themeItem}>
                 <button
@@ -57,7 +57,7 @@ export function BrowserThemeSection(props) {
                 >
                     <span class="sr-only">{t('customizer_browser_theme_label', { type: 'system' })}</span>
                 </button>
-                {t('customizer_browser_theme_system')}
+                <span>{t('customizer_browser_theme_system')}</span>
             </li>
         </ul>
     );

--- a/special-pages/pages/new-tab/app/customizer/components/BrowserThemeSection.module.css
+++ b/special-pages/pages/new-tab/app/customizer/components/BrowserThemeSection.module.css
@@ -5,9 +5,16 @@
     --chip-size-half: calc(var(--chip-size) / 2);
 }
 .themeItem {
-    display: grid;
-    justify-items: center;
-    grid-row-gap: 4px;
+    width: 42px;
+
+    span {
+        margin-top: 6px;
+        text-align: center;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        display: block;
+        width: 100%;
+    }
 }
 .themeButton {
     display: block;

--- a/special-pages/pages/new-tab/app/customizer/components/BrowserThemeSection.module.css
+++ b/special-pages/pages/new-tab/app/customizer/components/BrowserThemeSection.module.css
@@ -13,7 +13,6 @@
         overflow: hidden;
         text-overflow: ellipsis;
         display: block;
-        width: 100%;
     }
 }
 .themeButton {

--- a/special-pages/pages/new-tab/app/customizer/components/CustomizerDrawerInner.module.css
+++ b/special-pages/pages/new-tab/app/customizer/components/CustomizerDrawerInner.module.css
@@ -18,6 +18,11 @@
     display: flex;
     justify-content: space-between;
     align-items: center;
+    gap: 6px;
+
+    > * {
+        overflow: hidden;
+    }
 }
 
 .internal {
@@ -30,6 +35,7 @@
     width: 24px;
     height: 24px;
     position: relative;
+    flex-shrink: 0;
 
     color: var(--color-black-at-84);
     background-color: var(--color-black-at-9);
@@ -91,7 +97,6 @@
 .bgListItem {
     display: grid;
     grid-row-gap: 4px;
-    white-space: nowrap;
     position: relative;
 
     &:hover {

--- a/special-pages/pages/new-tab/app/favorites/integration-tests/favorites.page.js
+++ b/special-pages/pages/new-tab/app/favorites/integration-tests/favorites.page.js
@@ -26,8 +26,10 @@ export class FavoritesPage {
 
     async opensInNewWindow() {
         await this.nthFavorite(0).click({ modifiers: ['Shift'] });
-        const calls = await this.ntp.mocks.waitForCallCount({ method: 'favorites_open', count: 1 });
+        await this.nthFavorite(0).click({ button: 'middle' });
+        const calls = await this.ntp.mocks.waitForCallCount({ method: 'favorites_open', count: 2 });
         expect(calls[0].payload.params).toStrictEqual({ id: 'id-many-1', url: 'https://example.com/?id=id-many-1', target: 'new-window' });
+        expect(calls[1].payload.params).toStrictEqual({ id: 'id-many-1', url: 'https://example.com/?id=id-many-1', target: 'new-window' });
     }
 
     async opensInSameTab() {

--- a/special-pages/pages/new-tab/public/locales/es/new-tab.json
+++ b/special-pages/pages/new-tab/public/locales/es/new-tab.json
@@ -271,5 +271,53 @@
   "customizer_image_delete" : {
     "title" : "Eliminar imagen {number}",
     "note" : "Label text on a button that deletes an image. {number} will be replaced with a numeric reference of 1-8, eg: 'Delete image 1'"
+  },
+  "activity_noRecent_title" : {
+    "title" : "No hay actividad de navegación reciente",
+    "note" : "Placeholder to indicate that no browsing activity was seen in the last 7 days"
+  },
+  "activity_noRecent_subtitle" : {
+    "title" : "Los sitios visitados recientemente aparecen aquí. Sigue navegando para ver cuántos rastreadores hemos bloqueado.",
+    "note" : "Shown in the place a list of browsing history entries will be displayed."
+  },
+  "activity_no_trackers" : {
+    "title" : "No se han encontrado rastreadores",
+    "note" : "Placeholder message indicating that no trackers are detected"
+  },
+  "activity_no_trackers_blocked" : {
+    "title" : "No se han bloqueado rastreadores",
+    "note" : "Placeholder message indicating that no trackers are blocked"
+  },
+  "activity_countBlockedPlural" : {
+    "title" : "<b>{count}</b> intentos de rastreo bloqueados",
+    "note" : "The main headline indicating that more than 1 attempt has been blocked. Eg: '2 tracking attempts blocked'"
+  },
+  "activity_favoriteAdd" : {
+    "title" : "Añadir {domain} a favoritos",
+    "note" : "Button label, allows the user to add the specified domain to their favorites"
+  },
+  "activity_favoriteRemove" : {
+    "title" : "Eliminar {domain} de favoritos",
+    "note" : "Button label, allows the user to remove the specified domain from their favorites"
+  },
+  "activity_itemRemove" : {
+    "title" : "Eliminar {domain} del historial",
+    "note" : "Button label for clearing browsing history for a given domain."
+  },
+  "activity_burn" : {
+    "title" : "Borra el historial de navegación y los datos de {domain}",
+    "note" : "Button label for clearing browsing history and data exclusively for the specified domain"
+  },
+  "activity_menuTitle" : {
+    "title" : "Actividad reciente",
+    "note" : "Used as a label in a customization menu"
+  },
+  "activity_show_more_history" : {
+    "title" : "Mostrar {count} más",
+    "note" : "Button label that expands the list of browsing history with the specified count of additional items. Example: 'Show 5 more'"
+  },
+  "activity_show_less_history" : {
+    "title" : "Ocultar adicional",
+    "note" : "Button label that hides the expanded browsing history items."
   }
 }

--- a/special-pages/pages/new-tab/public/locales/fr/new-tab.json
+++ b/special-pages/pages/new-tab/public/locales/fr/new-tab.json
@@ -271,5 +271,53 @@
   "customizer_image_delete" : {
     "title" : "Supprimer l'image {number}",
     "note" : "Label text on a button that deletes an image. {number} will be replaced with a numeric reference of 1-8, eg: 'Delete image 1'"
+  },
+  "activity_noRecent_title" : {
+    "title" : "Aucune activité de navigation récente",
+    "note" : "Placeholder to indicate that no browsing activity was seen in the last 7 days"
+  },
+  "activity_noRecent_subtitle" : {
+    "title" : "Les sites récemment visités apparaîtront ici. Continuez à naviguer pour voir combien de traqueurs nous bloquons.",
+    "note" : "Shown in the place a list of browsing history entries will be displayed."
+  },
+  "activity_no_trackers" : {
+    "title" : "Aucun traqueur trouvé",
+    "note" : "Placeholder message indicating that no trackers are detected"
+  },
+  "activity_no_trackers_blocked" : {
+    "title" : "Aucun traqueur bloqué",
+    "note" : "Placeholder message indicating that no trackers are blocked"
+  },
+  "activity_countBlockedPlural" : {
+    "title" : "<b>{count}</b> tentative(s) de pistage bloquée(s)",
+    "note" : "The main headline indicating that more than 1 attempt has been blocked. Eg: '2 tracking attempts blocked'"
+  },
+  "activity_favoriteAdd" : {
+    "title" : "Ajouter {domain} aux favoris",
+    "note" : "Button label, allows the user to add the specified domain to their favorites"
+  },
+  "activity_favoriteRemove" : {
+    "title" : "Supprimer {domain} des favoris",
+    "note" : "Button label, allows the user to remove the specified domain from their favorites"
+  },
+  "activity_itemRemove" : {
+    "title" : "Supprimer {domain} de l’historique",
+    "note" : "Button label for clearing browsing history for a given domain."
+  },
+  "activity_burn" : {
+    "title" : "Effacer l'historique de navigation et les données pour {domain}",
+    "note" : "Button label for clearing browsing history and data exclusively for the specified domain"
+  },
+  "activity_menuTitle" : {
+    "title" : "Activité récente",
+    "note" : "Used as a label in a customization menu"
+  },
+  "activity_show_more_history" : {
+    "title" : "Afficher {count} de plus",
+    "note" : "Button label that expands the list of browsing history with the specified count of additional items. Example: 'Show 5 more'"
+  },
+  "activity_show_less_history" : {
+    "title" : "Masquer les éléments supplémentaires",
+    "note" : "Button label that hides the expanded browsing history items."
   }
 }

--- a/special-pages/pages/new-tab/public/locales/it/new-tab.json
+++ b/special-pages/pages/new-tab/public/locales/it/new-tab.json
@@ -9,27 +9,27 @@
     }]
   },
   "ntp_show_less" : {
-    "title" : "Show Less",
+    "title" : "Mostra meno",
     "note" : "Button that reduces the number of items or content displayed."
   },
   "ntp_show_more" : {
-    "title" : "Show More",
+    "title" : "Mostra altro",
     "note" : "Button that increases the number of items or content displayed."
   },
   "ntp_dismiss" : {
-    "title" : "Dismiss",
+    "title" : "Ignora",
     "note" : "Button that closes or hides the current popup or notification."
   },
   "ntp_customizer_button" : {
-    "title" : "Customize",
+    "title" : "Personalizza",
     "note" : "Button opens a menu. The menu allows the user to customize the page, such as showing/hiding sections."
   },
   "widgets_visibility_menu_title" : {
-    "title" : "Customize New Tab Page",
+    "title" : "Personalizza pagina Nuova scheda",
     "note" : "Heading text describing that there's a list of toggles for customizing the page layout."
   },
   "updateNotification_updated_version" : {
-    "title" : "Browser Updated to version {version}.",
+    "title" : "Browser aggiornato alla versione {version}.",
     "note" : "Text to indicate which new version was updated. `{version}` will be formatted like `1.22.0`"
   },
   "updateNotification_whats_new" : {
@@ -37,15 +37,15 @@
     "note" : "The `<a>` tag represents a clickable link, please preserve it."
   },
   "updateNotification_dismiss_btn" : {
-    "title" : "Dismiss",
+    "title" : "Ignora",
     "note" : "Button label text for an action that removes the widget from the screen."
   },
   "stats_menuTitle" : {
-    "title" : "Blocked Tracking Attempts",
+    "title" : "Tentativi di tracciamento bloccati",
     "note" : "Used as a label in a customization menu"
   },
   "stats_menuTitle_v2" : {
-    "title" : "Protection Stats",
+    "title" : "Statistiche sulla protezione",
     "note" : "Used as a label in a customization menu"
   },
   "stats_noActivity" : {
@@ -53,51 +53,51 @@
     "note" : "Placeholder for when we cannot report any blocked trackers yet"
   },
   "stats_noRecent" : {
-    "title" : "Tracking protections active",
+    "title" : "Protezioni di tracciamento attive",
     "note" : "Placeholder to indicate that no tracking activity was blocked in the last 7 days"
   },
   "stats_countBlockedSingular" : {
-    "title" : "1 tracking attempt blocked",
+    "title" : "1 tentativo di tracciamento bloccato",
     "note" : "The main headline indicating that a single tracker was blocked"
   },
   "stats_countBlockedPlural" : {
-    "title" : "{count} tracking attempts blocked",
+    "title" : "{count} tentativi di tracciamento bloccati",
     "note" : "The main headline indicating that more than 1 attempt has been blocked. Eg: '2 tracking attempts blocked'"
   },
   "stats_feedCountBlockedSingular" : {
-    "title" : "1 attempt blocked by DuckDuckGo in the last 7 days",
+    "title" : "1 tentativo bloccato da DuckDuckGo negli ultimi 7 giorni",
     "note" : "A summary description of how many tracking attempts where blocked, when only one exists."
   },
   "stats_feedCountBlockedPeriod" : {
-    "title" : "Past 7 days",
+    "title" : "Ultimi 7 giorni",
     "note" : "A summary description indicating the time period of the blocked tracking attempts, which is the past 7 days."
   },
   "stats_feedCountBlockedPlural" : {
-    "title" : "{count} tracking attempts blocked",
+    "title" : "{count} tentativi di tracciamento bloccati",
     "note" : "A summary description of how many tracking attempts were blocked by DuckDuckGo in the last 7 days when there is more than one. E.g., '1,028 tracking attempts blocked."
   },
   "stats_toggleLabel" : {
-    "title" : "Show recent activity",
+    "title" : "Mostra attività recente",
     "note" : "The aria-label text for a toggle button that shows the detailed activity feed"
   },
   "stats_hideLabel" : {
-    "title" : "Hide recent activity",
+    "title" : "Nascondi attività recente",
     "note" : "The aria-label text for a toggle button that hides the detailed activity feed"
   },
   "stats_otherCompanyName" : {
-    "title" : "Other",
+    "title" : "Altro",
     "note" : "A placeholder to represent an aggregated count of entries, not present in the rest of the list. For example, 'Other: 200', which would mean 200 entries excluding the ones already shown"
   },
   "stats_otherCount" : {
-    "title" : "{count} attempts from other networks",
+    "title" : "{count} tentativi da altre reti",
     "note" : "An aggregated count of blocked entries not present in the main list. For example, '200 attempts from other networks'"
   },
   "nextSteps_sectionTitle" : {
-    "title" : "Next Steps",
+    "title" : "Passaggi successivi",
     "note" : "Text that goes in the Next Steps bubble above the first card"
   },
   "nextSteps_bringStuff_title" : {
-    "title" : "Bring Your Stuff",
+    "title" : "Importa i tuoi file",
     "note" : "Title of the Next Steps card for importing bookmarks and favorites"
   },
   "nextSteps_bringStuff_summary" : {
@@ -105,23 +105,23 @@
     "note" : "Summary of the Next Steps card for importing bookmarks and favorites"
   },
   "nextSteps_bringStuff_actionText" : {
-    "title" : "Import Now",
+    "title" : "Importa ora",
     "note" : "Button text of the Next Steps card for importing bookmarks and favorites"
   },
   "nextSteps_defaultApp_title" : {
-    "title" : "Set as Default Browser",
+    "title" : "Imposta come Browser predefinito",
     "note" : "Title of the Next Steps card for making DDG the user's default browser"
   },
   "nextSteps_defaultApp_summary" : {
-    "title" : "We automatically block trackers as you browse. It’s privacy, simplified.",
+    "title" : "Blocchiamo automaticamente i sistemi di tracciamento mentre navighi. Tutelare la privacy, ora è semplice.",
     "note" : "Summary of the Next Steps card for making DDG the user's default browser"
   },
   "nextSteps_defaultApp_actionText" : {
-    "title" : "Make Default Browser",
+    "title" : "Rendi il browser predefinito",
     "note" : "Button text of the Next Steps card for making DDG the user's default browser"
   },
   "nextSteps_blockCookies_title" : {
-    "title" : "Block Cookie Pop-ups",
+    "title" : "Blocca i popup dei cookie",
     "note" : "Title of the Next Steps card for blocking cookie pop-ups"
   },
   "nextSteps_blockCookies_summary" : {
@@ -129,11 +129,11 @@
     "note" : "Summary of the Next Steps card for blocking cookie pop-ups"
   },
   "nextSteps_blockCookies_actionText" : {
-    "title" : "Block Cookie Pop-ups",
+    "title" : "Blocca i popup dei cookie",
     "note" : "Button text of the Next Steps card for blocking cookie pop-ups"
   },
   "nextSteps_emailProtection_title" : {
-    "title" : "Protect Your Inbox",
+    "title" : "Proteggi la tua casella di posta",
     "note" : "Title of the Next Steps card for email protection"
   },
   "nextSteps_emailProtection_summary" : {
@@ -145,15 +145,15 @@
     "note" : "Button text of the Next Steps card for email protection"
   },
   "nextSteps_duckPlayer_title" : {
-    "title" : "YouTube Without Creepy Ads",
+    "title" : "YouTube senza annunci inquietanti",
     "note" : "Title of the Next Steps card for adopting DuckPlayer"
   },
   "nextSteps_duckPlayer_summary" : {
-    "title" : "Enjoy a clean viewing experience without personalized ads.",
+    "title" : "Usufruisci di un'esperienza di visione lineare, senza annunci personalizzati.",
     "note" : "Summary of the Next Steps card for adopting DuckPlayer"
   },
   "nextSteps_duckPlayer_actionText" : {
-    "title" : "Try DuckPlayer",
+    "title" : "Prova Duck Player",
     "note" : "Button text of the Next Steps card for adopting DuckPlayer"
   },
   "nextSteps_addAppDockMac_title" : {
@@ -165,11 +165,11 @@
     "note" : "Summary of the Next Steps card for adding DDG app to OS dock"
   },
   "nextSteps_addAppDockMac_actionText" : {
-    "title" : "Add to Dock",
+    "title" : "Aggiungi al dock",
     "note" : "Initial button text of the Next Steps card for adding DDG app to OS dock"
   },
   "nextSteps_addAppDockMac_confirmationText" : {
-    "title" : "Added to Dock!",
+    "title" : "Aggiunto al dock!",
     "note" : "Button text after clicking on the Next Steps card for adding DDG app to OS dock"
   },
   "nextSteps_pinAppToTaskbarWindows_title" : {
@@ -181,7 +181,7 @@
     "note" : "Summary of the Next Steps card for adding DDG app to OS dock"
   },
   "nextSteps_pinAppToTaskbarWindows_actionText" : {
-    "title" : "Pin to Taskbar",
+    "title" : "Aggiungi alla barra delle applicazioni",
     "note" : "Initial button text of the Next Steps card for adding DDG app to OS dock"
   },
   "nextSteps_pinAppToTaskbarWindows_confirmationText" : {
@@ -189,7 +189,7 @@
     "note" : "Button text after clicking on the Next Steps card for adding DDG app to OS dock"
   },
   "favorites_show_less" : {
-    "title" : "Show less",
+    "title" : "Mostra meno",
     "note" : "Button label to display fewer items"
   },
   "favorites_show_more" : {
@@ -197,11 +197,11 @@
     "note" : "Button text to show hidden items. {count} will be replaced with the number of remaining favorite items to show, including the parentheses. Example: 'Show more (18 remaining)'"
   },
   "favorites_menu_title" : {
-    "title" : "Favorites",
+    "title" : "Preferiti",
     "note" : "Used as a label in a customization menu"
   },
   "favorites_add" : {
-    "title" : "Add Favorite",
+    "title" : "Aggiungi preferito",
     "note" : "A button that allows a user to add a new 'favorite' bookmark to their existing list"
   },
   "customizer_image_privacy" : {
@@ -209,67 +209,67 @@
     "note" : "Shown near a button that allows a user to upload an image to be used as a background."
   },
   "customizer_drawer_title" : {
-    "title" : "Customize",
+    "title" : "Personalizza",
     "note" : "Title in a slide-out drawer that contains options for customizing the browser."
   },
   "customizer_section_title_background" : {
-    "title" : "Background",
+    "title" : "Sfondo",
     "note" : "Section title displayed in the UI for customizing the background."
   },
   "customizer_section_title_theme" : {
-    "title" : "Browser Theme",
+    "title" : "Tema del browser",
     "note" : "Section title for a section where users can customize the browser theme. (for example, 'light' or 'dark')"
   },
   "customizer_section_title_sections" : {
-    "title" : "Sections",
+    "title" : "Sezioni",
     "note" : "Section title for a list of toggles for showing/hiding certain sections of the page."
   },
   "customizer_browser_theme_light" : {
-    "title" : "Light",
+    "title" : "Chiaro",
     "note" : "The label for a button that sets the browser theme to 'light' mode"
   },
   "customizer_browser_theme_dark" : {
-    "title" : "Dark",
+    "title" : "Scuro",
     "note" : "The label for a button that sets the browser theme to 'dark' mode"
   },
   "customizer_browser_theme_system" : {
-    "title" : "System",
+    "title" : "Sistema",
     "note" : "The label for a button that sets the browser theme to 'system', which matches the operating system setting"
   },
   "customizer_browser_theme_label" : {
-    "title" : "Select {type} theme",
+    "title" : "Seleziona il tema {type}",
     "note" : "The label text on a button, for assistive technologies (like screen readers). {type} will be replace with 'light', 'dark' or 'system'"
   },
   "customizer_settings_link" : {
-    "title" : "Go to Settings",
+    "title" : "Vai a Impostazioni",
     "note" : "The label text on a link that opens the Settings"
   },
   "customizer_background_selection_default" : {
-    "title" : "Default",
+    "title" : "Predefinito",
     "note" : "Label text below a button that selects a 'default' background"
   },
   "customizer_background_selection_color" : {
-    "title" : "Solid Colors",
+    "title" : "Colori a tinta unita",
     "note" : "Label text below a button that allows a color background"
   },
   "customizer_background_selection_gradient" : {
-    "title" : "Gradients",
+    "title" : "Gradienti",
     "note" : "Label text below a button that allows a gradient background"
   },
   "customizer_background_selection_image_add" : {
-    "title" : "Add Background",
+    "title" : "Aggiungi sfondo",
     "note" : "Label text shown on a button that allows an image to be uploaded"
   },
   "customizer_background_selection_image_existing" : {
-    "title" : "My Backgrounds",
+    "title" : "I miei sfondi",
     "note" : "Label text shown on a button navigates to list of existing background (that the user previously uploaded)"
   },
   "customizer_image_select" : {
-    "title" : "Select image {number}",
+    "title" : "Seleziona immagine {number}",
     "note" : "Label text on a button, for assistive technologies (like screen readers). {number} will be replaced with a numeric reference of 1-8, eg: 'Select image 1'"
   },
   "customizer_image_delete" : {
-    "title" : "Delete image {number}",
+    "title" : "Elimina immagine {number}",
     "note" : "Label text on a button that deletes an image. {number} will be replaced with a numeric reference of 1-8, eg: 'Delete image 1'"
   },
   "activity_noRecent_title" : {

--- a/special-pages/pages/new-tab/public/locales/it/new-tab.json
+++ b/special-pages/pages/new-tab/public/locales/it/new-tab.json
@@ -9,315 +9,315 @@
     }]
   },
   "ntp_show_less" : {
-    "title" : "Weniger anzeigen",
+    "title" : "Show Less",
     "note" : "Button that reduces the number of items or content displayed."
   },
   "ntp_show_more" : {
-    "title" : "Mehr anzeigen",
+    "title" : "Show More",
     "note" : "Button that increases the number of items or content displayed."
   },
   "ntp_dismiss" : {
-    "title" : "Verwerfen",
+    "title" : "Dismiss",
     "note" : "Button that closes or hides the current popup or notification."
   },
   "ntp_customizer_button" : {
-    "title" : "Anpassen",
+    "title" : "Customize",
     "note" : "Button opens a menu. The menu allows the user to customize the page, such as showing/hiding sections."
   },
   "widgets_visibility_menu_title" : {
-    "title" : "Neuen Tab anpassen",
+    "title" : "Customize New Tab Page",
     "note" : "Heading text describing that there's a list of toggles for customizing the page layout."
   },
   "updateNotification_updated_version" : {
-    "title" : "Browser auf Version {version} aktualisiert.",
+    "title" : "Browser Updated to version {version}.",
     "note" : "Text to indicate which new version was updated. `{version}` will be formatted like `1.22.0`"
   },
   "updateNotification_whats_new" : {
-    "title" : "Sieh dir an, was es in dieser Version <a>Neues</a> gibt.",
+    "title" : "See <a>what's new</a> in this release.",
     "note" : "The `<a>` tag represents a clickable link, please preserve it."
   },
   "updateNotification_dismiss_btn" : {
-    "title" : "Verwerfen",
+    "title" : "Dismiss",
     "note" : "Button label text for an action that removes the widget from the screen."
   },
   "stats_menuTitle" : {
-    "title" : "Blockierte Tracking-Versuche",
+    "title" : "Blocked Tracking Attempts",
     "note" : "Used as a label in a customization menu"
   },
   "stats_menuTitle_v2" : {
-    "title" : "Schutzstatistiken",
+    "title" : "Protection Stats",
     "note" : "Used as a label in a customization menu"
   },
   "stats_noActivity" : {
-    "title" : "DuckDuckGo blockiert Tracking-Versuche, während du browst. Besuche ein paar Seiten, um zu sehen, wie viele wir blockieren!",
+    "title" : "DuckDuckGo blocks tracking attempts as you browse. Visit a few sites to see how many we block!",
     "note" : "Placeholder for when we cannot report any blocked trackers yet"
   },
   "stats_noRecent" : {
-    "title" : "Tracking-Schutz aktiv",
+    "title" : "Tracking protections active",
     "note" : "Placeholder to indicate that no tracking activity was blocked in the last 7 days"
   },
   "stats_countBlockedSingular" : {
-    "title" : "1 Tracking-Versuch blockiert",
+    "title" : "1 tracking attempt blocked",
     "note" : "The main headline indicating that a single tracker was blocked"
   },
   "stats_countBlockedPlural" : {
-    "title" : "{count} Tracking-Versuche blockiert",
+    "title" : "{count} tracking attempts blocked",
     "note" : "The main headline indicating that more than 1 attempt has been blocked. Eg: '2 tracking attempts blocked'"
   },
   "stats_feedCountBlockedSingular" : {
-    "title" : "1 Versuch von DuckDuckGo in den letzten 7 Tagen blockiert",
+    "title" : "1 attempt blocked by DuckDuckGo in the last 7 days",
     "note" : "A summary description of how many tracking attempts where blocked, when only one exists."
   },
   "stats_feedCountBlockedPeriod" : {
-    "title" : "Vergangene 7 Tage",
+    "title" : "Past 7 days",
     "note" : "A summary description indicating the time period of the blocked tracking attempts, which is the past 7 days."
   },
   "stats_feedCountBlockedPlural" : {
-    "title" : "{count} Tracking-Versuche blockiert",
+    "title" : "{count} tracking attempts blocked",
     "note" : "A summary description of how many tracking attempts were blocked by DuckDuckGo in the last 7 days when there is more than one. E.g., '1,028 tracking attempts blocked."
   },
   "stats_toggleLabel" : {
-    "title" : "Aktuelle Aktivität anzeigen",
+    "title" : "Show recent activity",
     "note" : "The aria-label text for a toggle button that shows the detailed activity feed"
   },
   "stats_hideLabel" : {
-    "title" : "Letzte Aktivitäten ausblenden",
+    "title" : "Hide recent activity",
     "note" : "The aria-label text for a toggle button that hides the detailed activity feed"
   },
   "stats_otherCompanyName" : {
-    "title" : "Anderes",
+    "title" : "Other",
     "note" : "A placeholder to represent an aggregated count of entries, not present in the rest of the list. For example, 'Other: 200', which would mean 200 entries excluding the ones already shown"
   },
   "stats_otherCount" : {
-    "title" : "{count} Versuche von anderen Netzwerken",
+    "title" : "{count} attempts from other networks",
     "note" : "An aggregated count of blocked entries not present in the main list. For example, '200 attempts from other networks'"
   },
   "nextSteps_sectionTitle" : {
-    "title" : "Nächste Schritte",
+    "title" : "Next Steps",
     "note" : "Text that goes in the Next Steps bubble above the first card"
   },
   "nextSteps_bringStuff_title" : {
-    "title" : "Bring deine Sachen",
+    "title" : "Bring Your Stuff",
     "note" : "Title of the Next Steps card for importing bookmarks and favorites"
   },
   "nextSteps_bringStuff_summary" : {
-    "title" : "Importiere Lesezeichen, Favoriten und Passwörter für einen reibungslosen Übergang von deinem alten Browser.",
+    "title" : "Import bookmarks, favorites, and passwords for a smooth transition from your old browser.",
     "note" : "Summary of the Next Steps card for importing bookmarks and favorites"
   },
   "nextSteps_bringStuff_actionText" : {
-    "title" : "Jetzt importieren",
+    "title" : "Import Now",
     "note" : "Button text of the Next Steps card for importing bookmarks and favorites"
   },
   "nextSteps_defaultApp_title" : {
-    "title" : "Als Standard-Browser festlegen",
+    "title" : "Set as Default Browser",
     "note" : "Title of the Next Steps card for making DDG the user's default browser"
   },
   "nextSteps_defaultApp_summary" : {
-    "title" : "Wir blockieren automatisch Tracker, während du browst. Das ist Datenschutz, vereinfacht.",
+    "title" : "We automatically block trackers as you browse. It’s privacy, simplified.",
     "note" : "Summary of the Next Steps card for making DDG the user's default browser"
   },
   "nextSteps_defaultApp_actionText" : {
-    "title" : "Standardbrowser erstellen",
+    "title" : "Make Default Browser",
     "note" : "Button text of the Next Steps card for making DDG the user's default browser"
   },
   "nextSteps_blockCookies_title" : {
-    "title" : "Cookie-Pop-ups blockieren",
+    "title" : "Block Cookie Pop-ups",
     "note" : "Title of the Next Steps card for blocking cookie pop-ups"
   },
   "nextSteps_blockCookies_summary" : {
-    "title" : "Wir brauchen deine Erlaubnis, um in deinem Namen Cookies abzulehnen. Leichte Entscheidung.",
+    "title" : "We need your permission to say no to cookies on your behalf. Easy choice.",
     "note" : "Summary of the Next Steps card for blocking cookie pop-ups"
   },
   "nextSteps_blockCookies_actionText" : {
-    "title" : "Cookie-Pop-ups blockieren",
+    "title" : "Block Cookie Pop-ups",
     "note" : "Button text of the Next Steps card for blocking cookie pop-ups"
   },
   "nextSteps_emailProtection_title" : {
-    "title" : "Schütze deinen Posteingang",
+    "title" : "Protect Your Inbox",
     "note" : "Title of the Next Steps card for email protection"
   },
   "nextSteps_emailProtection_summary" : {
-    "title" : "Erstelle @duck.com-Adressen, die Tracker aus E-Mails entfernen und an deinen Posteingang weiterleiten.",
+    "title" : "Generate @duck.com addresses that remove trackers from email and forwards to your inbox.",
     "note" : "Summary of the Next Steps card for email protection"
   },
   "nextSteps_emailProtection_actionText" : {
-    "title" : "Email-Schutz erhalten",
+    "title" : "Get Email Protection",
     "note" : "Button text of the Next Steps card for email protection"
   },
   "nextSteps_duckPlayer_title" : {
-    "title" : "YouTube ohne aufdringliche Werbung",
+    "title" : "YouTube Without Creepy Ads",
     "note" : "Title of the Next Steps card for adopting DuckPlayer"
   },
   "nextSteps_duckPlayer_summary" : {
-    "title" : "Genieße ein sauberes Seherlebnis ohne personalisierte Werbung.",
+    "title" : "Enjoy a clean viewing experience without personalized ads.",
     "note" : "Summary of the Next Steps card for adopting DuckPlayer"
   },
   "nextSteps_duckPlayer_actionText" : {
-    "title" : "Duck Player testen",
+    "title" : "Try DuckPlayer",
     "note" : "Button text of the Next Steps card for adopting DuckPlayer"
   },
   "nextSteps_addAppDockMac_title" : {
-    "title" : "App zum Dock hinzufügen",
+    "title" : "Add App to the Dock",
     "note" : "Title of the Next Steps card for adding DDG app to OS dock"
   },
   "nextSteps_addAppDockMac_summary" : {
-    "title" : "Greife schneller auf DuckDuckGo zu, indem du es zum Dock hinzufügst.",
+    "title" : "Access DuckDuckGo faster by adding it to the Dock.",
     "note" : "Summary of the Next Steps card for adding DDG app to OS dock"
   },
   "nextSteps_addAppDockMac_actionText" : {
-    "title" : "Zum Dock hinzufügen",
+    "title" : "Add to Dock",
     "note" : "Initial button text of the Next Steps card for adding DDG app to OS dock"
   },
   "nextSteps_addAppDockMac_confirmationText" : {
-    "title" : "Zum Dock hinzugefügt!",
+    "title" : "Added to Dock!",
     "note" : "Button text after clicking on the Next Steps card for adding DDG app to OS dock"
   },
   "nextSteps_pinAppToTaskbarWindows_title" : {
-    "title" : "App an die Taskleiste anheften",
+    "title" : "Pin App to the Taskbar",
     "note" : "Title of the Next Steps card for adding DDG app to OS dock"
   },
   "nextSteps_pinAppToTaskbarWindows_summary" : {
-    "title" : "Greife schneller auf DuckDuckGo zu, indem du es an die Taskleiste heftest.",
+    "title" : "Access DuckDuckGo faster by pinning it to the Taskbar.",
     "note" : "Summary of the Next Steps card for adding DDG app to OS dock"
   },
   "nextSteps_pinAppToTaskbarWindows_actionText" : {
-    "title" : "An Taskleiste pinnen",
+    "title" : "Pin to Taskbar",
     "note" : "Initial button text of the Next Steps card for adding DDG app to OS dock"
   },
   "nextSteps_pinAppToTaskbarWindows_confirmationText" : {
-    "title" : "An die Taskleiste angeheftet!",
+    "title" : "Pinned to Taskbar!",
     "note" : "Button text after clicking on the Next Steps card for adding DDG app to OS dock"
   },
   "favorites_show_less" : {
-    "title" : "Weniger anzeigen",
+    "title" : "Show less",
     "note" : "Button label to display fewer items"
   },
   "favorites_show_more" : {
-    "title" : "Mehr anzeigen ({count} verbleibend)",
+    "title" : "Show more ({count} remaining)",
     "note" : "Button text to show hidden items. {count} will be replaced with the number of remaining favorite items to show, including the parentheses. Example: 'Show more (18 remaining)'"
   },
   "favorites_menu_title" : {
-    "title" : "Favoriten",
+    "title" : "Favorites",
     "note" : "Used as a label in a customization menu"
   },
   "favorites_add" : {
-    "title" : "Favorit hinzufügen",
+    "title" : "Add Favorite",
     "note" : "A button that allows a user to add a new 'favorite' bookmark to their existing list"
   },
   "customizer_image_privacy" : {
-    "title" : "Die Bilder werden auf deinem Gerät gespeichert, sodass DuckDuckGo sie nicht sehen oder darauf zugreifen kann.",
+    "title" : "Images are stored on your device so DuckDuckGo can’t see or access them.",
     "note" : "Shown near a button that allows a user to upload an image to be used as a background."
   },
   "customizer_drawer_title" : {
-    "title" : "Anpassen",
+    "title" : "Customize",
     "note" : "Title in a slide-out drawer that contains options for customizing the browser."
   },
   "customizer_section_title_background" : {
-    "title" : "Hintergrund",
+    "title" : "Background",
     "note" : "Section title displayed in the UI for customizing the background."
   },
   "customizer_section_title_theme" : {
-    "title" : "Browser-Thema",
+    "title" : "Browser Theme",
     "note" : "Section title for a section where users can customize the browser theme. (for example, 'light' or 'dark')"
   },
   "customizer_section_title_sections" : {
-    "title" : "Abschnitte",
+    "title" : "Sections",
     "note" : "Section title for a list of toggles for showing/hiding certain sections of the page."
   },
   "customizer_browser_theme_light" : {
-    "title" : "Hell",
+    "title" : "Light",
     "note" : "The label for a button that sets the browser theme to 'light' mode"
   },
   "customizer_browser_theme_dark" : {
-    "title" : "Dunkel",
+    "title" : "Dark",
     "note" : "The label for a button that sets the browser theme to 'dark' mode"
   },
   "customizer_browser_theme_system" : {
-    "title" : "Standard",
+    "title" : "System",
     "note" : "The label for a button that sets the browser theme to 'system', which matches the operating system setting"
   },
   "customizer_browser_theme_label" : {
-    "title" : "Design {type} auswählen",
+    "title" : "Select {type} theme",
     "note" : "The label text on a button, for assistive technologies (like screen readers). {type} will be replace with 'light', 'dark' or 'system'"
   },
   "customizer_settings_link" : {
-    "title" : "Gehe zu Einstellungen",
+    "title" : "Go to Settings",
     "note" : "The label text on a link that opens the Settings"
   },
   "customizer_background_selection_default" : {
-    "title" : "Standard",
+    "title" : "Default",
     "note" : "Label text below a button that selects a 'default' background"
   },
   "customizer_background_selection_color" : {
-    "title" : "Solide Farben",
+    "title" : "Solid Colors",
     "note" : "Label text below a button that allows a color background"
   },
   "customizer_background_selection_gradient" : {
-    "title" : "Farbverläufe",
+    "title" : "Gradients",
     "note" : "Label text below a button that allows a gradient background"
   },
   "customizer_background_selection_image_add" : {
-    "title" : "Hintergrund hinzufügen",
+    "title" : "Add Background",
     "note" : "Label text shown on a button that allows an image to be uploaded"
   },
   "customizer_background_selection_image_existing" : {
-    "title" : "Meine Hintergründe",
+    "title" : "My Backgrounds",
     "note" : "Label text shown on a button navigates to list of existing background (that the user previously uploaded)"
   },
   "customizer_image_select" : {
-    "title" : "Bild {number} auswählen",
+    "title" : "Select image {number}",
     "note" : "Label text on a button, for assistive technologies (like screen readers). {number} will be replaced with a numeric reference of 1-8, eg: 'Select image 1'"
   },
   "customizer_image_delete" : {
-    "title" : "Bild {number} löschen",
+    "title" : "Delete image {number}",
     "note" : "Label text on a button that deletes an image. {number} will be replaced with a numeric reference of 1-8, eg: 'Delete image 1'"
   },
   "activity_noRecent_title" : {
-    "title" : "Keine kürzliche Browsing-Aktivität",
+    "title" : "Nessuna attività di navigazione recente",
     "note" : "Placeholder to indicate that no browsing activity was seen in the last 7 days"
   },
   "activity_noRecent_subtitle" : {
-    "title" : "Zuletzt besuchte Seiten werden hier angezeigt. Browse weiter, um zu sehen, wie viele Tracker wir blockieren.",
+    "title" : "I siti visitati di recente appariranno qui. Continua la navigazione per vedere quanti sistemi di tracciamento vengono bloccati.",
     "note" : "Shown in the place a list of browsing history entries will be displayed."
   },
   "activity_no_trackers" : {
-    "title" : "Keine Tracker gefunden",
+    "title" : "Nessun sistema di tracciamento trovato",
     "note" : "Placeholder message indicating that no trackers are detected"
   },
   "activity_no_trackers_blocked" : {
-    "title" : "Keine Tracker blockiert",
+    "title" : "Nessun sistema di tracciamento bloccato",
     "note" : "Placeholder message indicating that no trackers are blocked"
   },
   "activity_countBlockedPlural" : {
-    "title" : "<b>{count}</b> Tracking-Versuche blockiert",
+    "title" : "<b>{count}</b> tentativi di tracciamento bloccati",
     "note" : "The main headline indicating that more than 1 attempt has been blocked. Eg: '2 tracking attempts blocked'"
   },
   "activity_favoriteAdd" : {
-    "title" : "{domain} zu Favoriten hinzufügen",
+    "title" : "Aggiungi {domain} ai Preferiti",
     "note" : "Button label, allows the user to add the specified domain to their favorites"
   },
   "activity_favoriteRemove" : {
-    "title" : "{domain} aus Favoriten entfernen",
+    "title" : "Rimuovi {domain} dai preferiti",
     "note" : "Button label, allows the user to remove the specified domain from their favorites"
   },
   "activity_itemRemove" : {
-    "title" : "{domain} aus dem Verlauf entfernen",
+    "title" : "Rimuovi {domain} dalla cronologia",
     "note" : "Button label for clearing browsing history for a given domain."
   },
   "activity_burn" : {
-    "title" : "Browserverlauf und Daten für {domain} löschen",
+    "title" : "Cancella la cronologia di navigazione e i dati per {domain}",
     "note" : "Button label for clearing browsing history and data exclusively for the specified domain"
   },
   "activity_menuTitle" : {
-    "title" : "Aktuelle Aktivitäten",
+    "title" : "Attività recente",
     "note" : "Used as a label in a customization menu"
   },
   "activity_show_more_history" : {
-    "title" : "{count} weitere anzeigen",
+    "title" : "Mostra altri {count}",
     "note" : "Button label that expands the list of browsing history with the specified count of additional items. Example: 'Show 5 more'"
   },
   "activity_show_less_history" : {
-    "title" : "Zusätzliches ausblenden",
+    "title" : "Nascondi altro",
     "note" : "Button label that hides the expanded browsing history items."
   }
 }

--- a/special-pages/pages/new-tab/public/locales/nl/new-tab.json
+++ b/special-pages/pages/new-tab/public/locales/nl/new-tab.json
@@ -271,5 +271,53 @@
   "customizer_image_delete" : {
     "title" : "Afbeelding {number} verwijderen",
     "note" : "Label text on a button that deletes an image. {number} will be replaced with a numeric reference of 1-8, eg: 'Delete image 1'"
+  },
+  "activity_noRecent_title" : {
+    "title" : "Geen recente browse-activiteit",
+    "note" : "Placeholder to indicate that no browsing activity was seen in the last 7 days"
+  },
+  "activity_noRecent_subtitle" : {
+    "title" : "Onlangs bezochte websites verschijnen hier. Blijf browsen om te zien hoeveel trackers we blokkeren.",
+    "note" : "Shown in the place a list of browsing history entries will be displayed."
+  },
+  "activity_no_trackers" : {
+    "title" : "Geen trackers gevonden",
+    "note" : "Placeholder message indicating that no trackers are detected"
+  },
+  "activity_no_trackers_blocked" : {
+    "title" : "Geen trackers geblokkeerd",
+    "note" : "Placeholder message indicating that no trackers are blocked"
+  },
+  "activity_countBlockedPlural" : {
+    "title" : "<b>{count}</b> trackingpogingen geblokkeerd",
+    "note" : "The main headline indicating that more than 1 attempt has been blocked. Eg: '2 tracking attempts blocked'"
+  },
+  "activity_favoriteAdd" : {
+    "title" : "{domain} toevoegen aan favorieten",
+    "note" : "Button label, allows the user to add the specified domain to their favorites"
+  },
+  "activity_favoriteRemove" : {
+    "title" : "{domain} verwijderen uit favorieten",
+    "note" : "Button label, allows the user to remove the specified domain from their favorites"
+  },
+  "activity_itemRemove" : {
+    "title" : "{domain} verwijderen uit geschiedenis",
+    "note" : "Button label for clearing browsing history for a given domain."
+  },
+  "activity_burn" : {
+    "title" : "Browsegeschiedenis en -data voor {domain}wissen",
+    "note" : "Button label for clearing browsing history and data exclusively for the specified domain"
+  },
+  "activity_menuTitle" : {
+    "title" : "Recente activiteit",
+    "note" : "Used as a label in a customization menu"
+  },
+  "activity_show_more_history" : {
+    "title" : "Nog {count} weergeven",
+    "note" : "Button label that expands the list of browsing history with the specified count of additional items. Example: 'Show 5 more'"
+  },
+  "activity_show_less_history" : {
+    "title" : "Aanvullende gegevens verbergen",
+    "note" : "Button label that hides the expanded browsing history items."
   }
 }

--- a/special-pages/pages/new-tab/public/locales/pl/new-tab.json
+++ b/special-pages/pages/new-tab/public/locales/pl/new-tab.json
@@ -271,5 +271,53 @@
   "customizer_image_delete" : {
     "title" : "Usuń obraz {number}",
     "note" : "Label text on a button that deletes an image. {number} will be replaced with a numeric reference of 1-8, eg: 'Delete image 1'"
+  },
+  "activity_noRecent_title" : {
+    "title" : "Brak ostatniej aktywności przeglądania",
+    "note" : "Placeholder to indicate that no browsing activity was seen in the last 7 days"
+  },
+  "activity_noRecent_subtitle" : {
+    "title" : "Tutaj będą widoczne ostatnio odwiedzone witryny. Przeglądaj dalej, aby zobaczyć liczbę zablokowanych mechanizmów śledzących",
+    "note" : "Shown in the place a list of browsing history entries will be displayed."
+  },
+  "activity_no_trackers" : {
+    "title" : "Nie znaleziono żadnych mechanizmów śledzących",
+    "note" : "Placeholder message indicating that no trackers are detected"
+  },
+  "activity_no_trackers_blocked" : {
+    "title" : "Nie zablokowano żadnych mechanizmów śledzących",
+    "note" : "Placeholder message indicating that no trackers are blocked"
+  },
+  "activity_countBlockedPlural" : {
+    "title" : "Zablokowanych prób śledzenia: <b>{count}</b>",
+    "note" : "The main headline indicating that more than 1 attempt has been blocked. Eg: '2 tracking attempts blocked'"
+  },
+  "activity_favoriteAdd" : {
+    "title" : "Dodaj {domain} do ulubionych",
+    "note" : "Button label, allows the user to add the specified domain to their favorites"
+  },
+  "activity_favoriteRemove" : {
+    "title" : "Usuń {domain} z ulubionych",
+    "note" : "Button label, allows the user to remove the specified domain from their favorites"
+  },
+  "activity_itemRemove" : {
+    "title" : "Usuń {domain} z historii",
+    "note" : "Button label for clearing browsing history for a given domain."
+  },
+  "activity_burn" : {
+    "title" : "Wyczyść historię przeglądania i dane domeny {domain}",
+    "note" : "Button label for clearing browsing history and data exclusively for the specified domain"
+  },
+  "activity_menuTitle" : {
+    "title" : "Ostatnia aktywność",
+    "note" : "Used as a label in a customization menu"
+  },
+  "activity_show_more_history" : {
+    "title" : "Pokaż jeszcze {count}",
+    "note" : "Button label that expands the list of browsing history with the specified count of additional items. Example: 'Show 5 more'"
+  },
+  "activity_show_less_history" : {
+    "title" : "Ukryj dodatkowe",
+    "note" : "Button label that hides the expanded browsing history items."
   }
 }

--- a/special-pages/pages/new-tab/public/locales/pt/new-tab.json
+++ b/special-pages/pages/new-tab/public/locales/pt/new-tab.json
@@ -271,5 +271,53 @@
   "customizer_image_delete" : {
     "title" : "Eliminar imagem {number}",
     "note" : "Label text on a button that deletes an image. {number} will be replaced with a numeric reference of 1-8, eg: 'Delete image 1'"
+  },
+  "activity_noRecent_title" : {
+    "title" : "Nenhuma atividade de navegação recente",
+    "note" : "Placeholder to indicate that no browsing activity was seen in the last 7 days"
+  },
+  "activity_noRecent_subtitle" : {
+    "title" : "Os sites visitados recentemente aparecem aqui. Continua a navegar para veres quantos rastreadores bloqueamos.",
+    "note" : "Shown in the place a list of browsing history entries will be displayed."
+  },
+  "activity_no_trackers" : {
+    "title" : "Nenhum rastreador encontrado",
+    "note" : "Placeholder message indicating that no trackers are detected"
+  },
+  "activity_no_trackers_blocked" : {
+    "title" : "Nenhum rastreador bloqueado",
+    "note" : "Placeholder message indicating that no trackers are blocked"
+  },
+  "activity_countBlockedPlural" : {
+    "title" : "<b>{count}</b> tentativas de rastreamento bloqueadas",
+    "note" : "The main headline indicating that more than 1 attempt has been blocked. Eg: '2 tracking attempts blocked'"
+  },
+  "activity_favoriteAdd" : {
+    "title" : "Adicionar {domain} aos favoritos",
+    "note" : "Button label, allows the user to add the specified domain to their favorites"
+  },
+  "activity_favoriteRemove" : {
+    "title" : "Remover {domain} dos favoritos",
+    "note" : "Button label, allows the user to remove the specified domain from their favorites"
+  },
+  "activity_itemRemove" : {
+    "title" : "Remove {domain} do histórico",
+    "note" : "Button label for clearing browsing history for a given domain."
+  },
+  "activity_burn" : {
+    "title" : "Limpar histórico de navegação e dados de {domain}",
+    "note" : "Button label for clearing browsing history and data exclusively for the specified domain"
+  },
+  "activity_menuTitle" : {
+    "title" : "Atividade recente",
+    "note" : "Used as a label in a customization menu"
+  },
+  "activity_show_more_history" : {
+    "title" : "Mostrar mais {count}",
+    "note" : "Button label that expands the list of browsing history with the specified count of additional items. Example: 'Show 5 more'"
+  },
+  "activity_show_less_history" : {
+    "title" : "Ocultar itens adicionais",
+    "note" : "Button label that hides the expanded browsing history items."
   }
 }

--- a/special-pages/pages/new-tab/public/locales/pt/new-tab.json
+++ b/special-pages/pages/new-tab/public/locales/pt/new-tab.json
@@ -301,7 +301,7 @@
     "note" : "Button label, allows the user to remove the specified domain from their favorites"
   },
   "activity_itemRemove" : {
-    "title" : "Remove {domain} do histórico",
+    "title" : "Remover {domain} do histórico",
     "note" : "Button label for clearing browsing history for a given domain."
   },
   "activity_burn" : {

--- a/special-pages/pages/new-tab/public/locales/ru/new-tab.json
+++ b/special-pages/pages/new-tab/public/locales/ru/new-tab.json
@@ -271,5 +271,53 @@
   "customizer_image_delete" : {
     "title" : "Удалить изображение {number}",
     "note" : "Label text on a button that deletes an image. {number} will be replaced with a numeric reference of 1-8, eg: 'Delete image 1'"
+  },
+  "activity_noRecent_title" : {
+    "title" : "Нет недавней истории просмотра сайтов",
+    "note" : "Placeholder to indicate that no browsing activity was seen in the last 7 days"
+  },
+  "activity_noRecent_subtitle" : {
+    "title" : "Недавно посещенные сайты появятся здесь. Продолжайте бродить по интернету и узнайте, сколько трекеров поймал DuckDuckGo!",
+    "note" : "Shown in the place a list of browsing history entries will be displayed."
+  },
+  "activity_no_trackers" : {
+    "title" : "Ни одного трекера не найдено",
+    "note" : "Placeholder message indicating that no trackers are detected"
+  },
+  "activity_no_trackers_blocked" : {
+    "title" : "Заблокированных трекеров пока нет",
+    "note" : "Placeholder message indicating that no trackers are blocked"
+  },
+  "activity_countBlockedPlural" : {
+    "title" : "Пресечено попыток отслеживания: <b>{count}</b>",
+    "note" : "The main headline indicating that more than 1 attempt has been blocked. Eg: '2 tracking attempts blocked'"
+  },
+  "activity_favoriteAdd" : {
+    "title" : "Добавить {domain} в избранное",
+    "note" : "Button label, allows the user to add the specified domain to their favorites"
+  },
+  "activity_favoriteRemove" : {
+    "title" : "Удалить {domain} из избранного",
+    "note" : "Button label, allows the user to remove the specified domain from their favorites"
+  },
+  "activity_itemRemove" : {
+    "title" : "Удалить {domain} из истории",
+    "note" : "Button label for clearing browsing history for a given domain."
+  },
+  "activity_burn" : {
+    "title" : "Стереть историю просмотров и данные сайта {domain}",
+    "note" : "Button label for clearing browsing history and data exclusively for the specified domain"
+  },
+  "activity_menuTitle" : {
+    "title" : "Недавняя активность",
+    "note" : "Used as a label in a customization menu"
+  },
+  "activity_show_more_history" : {
+    "title" : "Показать еще {count}",
+    "note" : "Button label that expands the list of browsing history with the specified count of additional items. Example: 'Show 5 more'"
+  },
+  "activity_show_less_history" : {
+    "title" : "Свернуть",
+    "note" : "Button label that hides the expanded browsing history items."
   }
 }


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/0/1201141132935289/1209262697199928

## Description

- [x] small layout fixes and other languages

## Testing Steps
- Open the customizer drawer with text length = 1.5 https://deploy-preview-1459--content-scope-scripts.netlify.app/build/pages/new-tab/? customizerDrawer=enabled&favorites=100&locale=pt&feed=activity&textLength=1.5
- it should layout correctly, even though the text length t is artificially long
- Compare with https://content-scope-scripts.netlify.app/build/pages/new-tab/?customizerDrawer=enabled&favorites=100&locale=pt&feed=activity&textLength=1.5

## Checklist

<!--
  These questions are a friendly reminder to shipping code, if you're uncertain ask the AoR owners.
  It's also totally appropriate to not check some of these boxes, if they don't apply to your change.
-->
*Please tick all that apply:*

- [ ] I have tested this change locally
- [ ] I have tested this change locally in all supported browsers
- [ ] This change will be visible to users
- [ ] I have added automated tests that cover this change
- [ ] I have ensured the change is gated by config
- [ ] This change was covered by a ship review
- [ ] This change was covered by a tech design
- [ ] Any dependent config has been merged

