### PR TITLE
history: support single row context menu

### DIFF
--- a/special-pages/pages/history/app/HistoryProvider.js
+++ b/special-pages/pages/history/app/HistoryProvider.js
@@ -72,7 +72,9 @@ export function HistoryServiceProvider({ service, initial, children }) {
                 if (btn?.dataset.rowMenu) {
                     event.stopImmediatePropagation();
                     event.preventDefault();
-                    return confirm(`todo: row menu for ${btn.dataset.rowMenu}`);
+                    // eslint-disable-next-line promise/prefer-await-to-then
+                    service.entriesMenu([btn.value], [Number(btn.dataset.index)]).catch(console.error);
+                    return;
                 }
                 if (btn?.dataset.deleteRange) {
                     event.stopImmediatePropagation();
@@ -120,6 +122,7 @@ export function HistoryServiceProvider({ service, initial, children }) {
 
             const actions = {
                 '[data-section-title]': (elem) => elem.querySelector('button')?.value,
+                '[data-history-entry]': (elem) => elem.querySelector('button')?.value,
             };
 
             for (const [selector, valueFn] of Object.entries(actions)) {
@@ -129,8 +132,13 @@ export function HistoryServiceProvider({ service, initial, children }) {
                     if (value) {
                         event.preventDefault();
                         event.stopImmediatePropagation();
-                        // eslint-disable-next-line promise/prefer-await-to-then
-                        service.menuTitle(value).catch(console.error);
+                        if (match.dataset.sectionTitle) {
+                            // eslint-disable-next-line promise/prefer-await-to-then
+                            service.menuTitle(value).catch(console.error);
+                        } else if (match.dataset.historyEntry) {
+                            // eslint-disable-next-line promise/prefer-await-to-then
+                            service.entriesMenu([value], [Number(match.dataset.index)]).catch(console.error);
+                        }
                     }
                     break;
                 }

--- a/special-pages/pages/history/app/components/Item.js
+++ b/special-pages/pages/history/app/components/Item.js
@@ -18,8 +18,9 @@ export const Item = memo(
      * @param {number} props.kind - The kind or type of the item that determines its visual style.
      * @param {string} props.dateRelativeDay - The relative day information to display (shown when kind is equal to TITLE_KIND).
      * @param {string} props.dateTimeOfDay - the time of day, like 11.00am.
+     * @param {number} props.index - original index
      */
-    function Item({ id, url, domain, title, kind, dateRelativeDay, dateTimeOfDay }) {
+    function Item({ id, url, domain, title, kind, dateRelativeDay, dateTimeOfDay, index }) {
         const { t } = useTypedTranslation();
         return (
             <Fragment>
@@ -36,13 +37,13 @@ export const Item = memo(
                         </button>
                     </div>
                 )}
-                <div class={cn(styles.row, kind === END_KIND && styles.last)} tabindex={0}>
+                <div class={cn(styles.row, kind === END_KIND && styles.last)} tabindex={0} data-history-entry={id}>
                     <a href={url} data-url={url} class={styles.entryLink}>
                         {title}
                     </a>
                     <span class={styles.domain}>{domain}</span>
                     <span class={styles.time}>{dateTimeOfDay}</span>
-                    <button class={styles.dots} data-row-menu={id}>
+                    <button class={styles.dots} data-row-menu data-index={index} value={id}>
                         <Dots />
                     </button>
                 </div>

--- a/special-pages/pages/history/app/components/Results.js
+++ b/special-pages/pages/history/app/components/Results.js
@@ -33,6 +33,7 @@ export function Results({ results }) {
                                 title={item.title}
                                 dateRelativeDay={item.dateRelativeDay}
                                 dateTimeOfDay={item.dateTimeOfDay}
+                                index={index}
                             />
                         </li>
                     );

--- a/special-pages/pages/history/app/history.md
+++ b/special-pages/pages/history/app/history.md
@@ -148,6 +148,36 @@ Sent when a right-click is issued on a section title (or when the three-dots but
 }
 ```
 
+### `entries_menu`
+{@link "History Messages".EntriesMenuRequest}
+
+Sent when a right-click is issued on a section title (or when the three-dots button is clicked)  
+
+**Types:**
+- Parameters: {@link "History Messages".EntriesMenuParams}
+- Response: {@link "History Messages".EntriesMenuResponse}
+
+**params**
+```json
+{
+  "ids": ["abc", "def"]
+}
+```
+
+**response, if deleted**
+```json
+{
+  "action": "delete" 
+}
+```
+
+**response, otherwise**
+```json
+{
+  "action": "none" 
+}
+```
+
 ## Notifications
 
 ### `open`

--- a/special-pages/pages/history/app/mocks/mock-transport.js
+++ b/special-pages/pages/history/app/mocks/mock-transport.js
@@ -58,6 +58,18 @@ export function mockTransport() {
             const msg = /** @type {any} */ (_msg);
 
             switch (msg.method) {
+                case 'entries_menu': {
+                    console.log('📤 [entries_menu]: ', JSON.stringify(msg.params));
+                    // prettier-ignore
+                    const lines = [
+                        `entries_menu: ${JSON.stringify(msg.params)}`,
+                        `To simulate deleting these items, press confirm`
+                    ].join('\n');
+                    if (confirm(lines)) {
+                        return Promise.resolve({ action: 'delete' });
+                    }
+                    return Promise.resolve({ action: 'none' });
+                }
                 case 'title_menu': {
                     console.log('📤 [deleteRange]: ', JSON.stringify(msg.params));
                     // prettier-ignore

--- a/special-pages/pages/history/integration-tests/history.spec.js
+++ b/special-pages/pages/history/integration-tests/history.spec.js
@@ -118,4 +118,9 @@ test.describe('history', () => {
         await hp.openPage({});
         await hp.rightClicksSectionTitle();
     });
+    test('3 dots menu on history entry', async ({ page }, workerInfo) => {
+        const hp = HistoryTestPage.create(page, workerInfo).withEntries(2000);
+        await hp.openPage({});
+        await hp.deletesFromHistoryEntry({ action: 'delete' });
+    });
 });

--- a/special-pages/pages/history/messages/entries_menu.request.json
+++ b/special-pages/pages/history/messages/entries_menu.request.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "title": "Entries Menu Params",
+  "required": [
+    "ids"
+  ],
+  "properties": {
+    "ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    }
+  }
+}
+

--- a/special-pages/pages/history/messages/entries_menu.response.json
+++ b/special-pages/pages/history/messages/entries_menu.response.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "required": ["action"],
+  "properties": {
+    "action": {
+      "$ref": "types/action-response.json"
+    }
+  }
+}
+

--- a/special-pages/pages/history/types/history.ts
+++ b/special-pages/pages/history/types/history.ts
@@ -39,7 +39,12 @@ export type RelativeDay = string;
  */
 export interface HistoryMessages {
   notifications: OpenNotification | ReportInitExceptionNotification | ReportPageExceptionNotification;
-  requests: DeleteRangeRequest | GetRangesRequest | InitialSetupRequest | QueryRequest | TitleMenuRequest;
+  requests:
+    | DeleteRangeRequest
+    | EntriesMenuRequest
+    | GetRangesRequest
+    | InitialSetupRequest
+    | QueryRequest | TitleMenuRequest;
 }
 /**
  * Generated from @see "../messages/open.notify.json"
@@ -87,6 +92,20 @@ export interface DeleteRangeParams {
   range: Range;
 }
 export interface DeleteRangeResponse {
+  action: ActionResponse;
+}
+/**
+ * Generated from @see "../messages/entries_menu.request.json"
+ */
+export interface EntriesMenuRequest {
+  method: "entries_menu";
+  params: EntriesMenuParams;
+  result: EntriesMenuResponse;
+}
+export interface EntriesMenuParams {
+  ids: string[];
+}
+export interface EntriesMenuResponse {
   action: ActionResponse;
 }
 /**

--- a/special-pages/pages/history/types/history.ts
+++ b/special-pages/pages/history/types/history.ts
@@ -44,7 +44,8 @@ export interface HistoryMessages {
     | EntriesMenuRequest
     | GetRangesRequest
     | InitialSetupRequest
-    | QueryRequest | TitleMenuRequest;
+    | QueryRequest
+    | TitleMenuRequest;
 }
 /**
  * Generated from @see "../messages/open.notify.json"


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/0/1201141132935289/1209375474836154

## Description

- [x] added context menu + 3 buttons click on individual rows

## Testing Steps

- `cd special-pages && npm run watch -- --page=history`
- visit http://localhost:8000?history=4000
- on a row-level, click the 3 dots, or right click the row
- confirm the deletion, the item should be removed

<img width="1247" alt="image" src="https://github.com/user-attachments/assets/cc19d4c5-6bf3-46ab-894a-6997340e6f5c" />


## Checklist

<!--
  These questions are a friendly reminder to shipping code, if you're uncertain ask the AoR owners.
  It's also totally appropriate to not check some of these boxes, if they don't apply to your change.
-->
*Please tick all that apply:*

- [ ] I have tested this change locally
- [ ] I have tested this change locally in all supported browsers
- [ ] This change will be visible to users
- [ ] I have added automated tests that cover this change
- [ ] I have ensured the change is gated by config
- [ ] This change was covered by a ship review
- [ ] This change was covered by a tech design
- [ ] Any dependent config has been merged

