### PR TITLE
fixed flakey test with comparing titles

### DIFF
--- a/special-pages/pages/special-error/integration-tests/special-error.js
+++ b/special-pages/pages/special-error/integration-tests/special-error.js
@@ -154,7 +154,7 @@ export class SpecialErrorPage {
     async showsExpiredPage() {
         const { page } = this;
 
-        this.showsPageTitle('Warning: This site may be insecure');
+        await this.showsPageTitle('Warning: This site may be insecure');
 
         await expect(page.getByText('Warning: This site may be insecure', { exact: true })).toBeVisible();
         await expect(
@@ -190,7 +190,7 @@ export class SpecialErrorPage {
     async showsInvalidPage() {
         const { page } = this;
 
-        this.showsPageTitle('Warning: This site may be insecure');
+        await this.showsPageTitle('Warning: This site may be insecure');
 
         await expect(page.getByText('Warning: This site may be insecure', { exact: true })).toBeVisible();
         await expect(
@@ -212,7 +212,7 @@ export class SpecialErrorPage {
     async showsSelfSignedPage() {
         const { page } = this;
 
-        this.showsPageTitle('Warning: This site may be insecure');
+        await this.showsPageTitle('Warning: This site may be insecure');
 
         await expect(page.getByText('Warning: This site may be insecure', { exact: true })).toBeVisible();
         await expect(
@@ -234,7 +234,7 @@ export class SpecialErrorPage {
     async showsWrongHostPage() {
         const { page } = this;
 
-        this.showsPageTitle('Warning: This site may be insecure');
+        await this.showsPageTitle('Warning: This site may be insecure');
 
         await expect(page.getByText('Warning: This site may be insecure', { exact: true })).toBeVisible();
         await expect(

--- a/special-pages/pages/special-error/integration-tests/special-error.js
+++ b/special-pages/pages/special-error/integration-tests/special-error.js
@@ -175,14 +175,11 @@ export class SpecialErrorPage {
     }
 
     /**
-     *
      * @param {string} pageTitle
      */
     async showsPageTitle(pageTitle) {
         const { page } = this;
-
-        const title = await page.locator('title').textContent();
-        expect(title).toBe(pageTitle);
+        await page.waitForFunction((title) => document.title === title, pageTitle, { timeout: 2000 });
     }
 
     async showsExpiredPageInPolish() {
@@ -259,8 +256,7 @@ export class SpecialErrorPage {
     async showsPhishingPage() {
         const { page } = this;
 
-        const title = await page.locator('title').textContent();
-        expect(title).toBe('Warning: Security Risk');
+        await this.showsPageTitle('Warning: Security Risk');
 
         await expect(page.getByText('Warning: This site may be a security risk', { exact: true })).toBeVisible();
         await expect(
@@ -281,8 +277,7 @@ export class SpecialErrorPage {
     async showsMalwarePage() {
         const { page } = this;
 
-        const title = await page.locator('title').textContent();
-        expect(title).toBe('Warning: Security Risk');
+        await this.showsPageTitle('Warning: Security Risk');
 
         await expect(page.getByText('Warning: This site may be a security risk', { exact: true })).toBeVisible();
         await expect(


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/0/1201141132935289/1209485338280155

## Description

- whilst working on the History page, I noticed that some tests immediately compare the title, when they should wait instead.

## Testing Steps

- Just tests, nothing to verify

## Checklist

<!--
  These questions are a friendly reminder to shipping code, if you're uncertain ask the AoR owners.
  It's also totally appropriate to not check some of these boxes, if they don't apply to your change.
-->
*Please tick all that apply:*

- [ ] I have tested this change locally
- [ ] I have tested this change locally in all supported browsers
- [ ] This change will be visible to users
- [ ] I have added automated tests that cover this change
- [ ] I have ensured the change is gated by config
- [ ] This change was covered by a ship review
- [ ] This change was covered by a tech design
- [ ] Any dependent config has been merged

