### PR TITLE
Duck Player - YouTube error detection fix

### DIFF
--- a/special-pages/pages/duckplayer/app/features/error-detection.js
+++ b/special-pages/pages/duckplayer/app/features/error-detection.js
@@ -136,7 +136,7 @@ export class ErrorDetection {
         if (node?.nodeType === Node.ELEMENT_NODE) {
             const element = /** @type {HTMLElement} */ (node);
             // Check if element has the error class or contains any children with that class
-            return element.classList.contains('ytp-error') || !!element.querySelector('ytp-error');
+            return element.classList.contains('ytp-error') || !!element.querySelector('.ytp-error');
         }
 
         return false;


### PR DESCRIPTION
## Description

Fixes a selector that prevented a YouTube error from being detected before the mutation observer is in place.

## Testing Steps

This one is hard to test. Might be better to demo in person.

## Checklist

<!--
  These questions are a friendly reminder to shipping code, if you're uncertain ask the AoR owners.
  It's also totally appropriate to not check some of these boxes, if they don't apply to your change.
-->
*Please tick all that apply:*

- [ ] I have tested this change locally
- [ ] I have tested this change locally in all supported browsers
- [ ] This change will be visible to users
- [ ] I have added automated tests that cover this change
- [ ] I have ensured the change is gated by config
- [ ] This change was covered by a ship review
- [ ] This change was covered by a tech design
- [ ] Any dependent config has been merged

