### PR TITLE
history: reset to default query following delete

### DIFF
--- a/special-pages/pages/history/app/global/Providers/HistoryServiceProvider.js
+++ b/special-pages/pages/history/app/global/Providers/HistoryServiceProvider.js
@@ -1,3 +1,4 @@
+/* eslint-disable promise/prefer-await-to-then */
 import { createContext, h } from 'preact';
 import { paramsToQuery, toRange } from '../../history.service.js';
 import { useCallback, useContext } from 'preact/hooks';
@@ -89,35 +90,43 @@ export function HistoryServiceProvider({ service, children, initial }) {
                 if (range) {
                     service
                         .deleteRange(range)
-                        // eslint-disable-next-line promise/prefer-await-to-then
                         .then((resp) => {
                             if (resp.kind === 'range-deleted') {
                                 queryDispatch({ kind: 'reset' });
                             }
                         })
-                        // eslint-disable-next-line promise/prefer-await-to-then
                         .catch(console.error);
                 }
                 break;
             }
             case 'delete-domain': {
-                // eslint-disable-next-line promise/prefer-await-to-then
-                service.deleteDomain(action.domain).catch(console.error);
+                service
+                    .deleteDomain(action.domain)
+                    .then((resp) => {
+                        if (resp.kind === 'domain-deleted') {
+                            queryDispatch({ kind: 'reset' });
+                        }
+                    })
+                    .catch(console.error);
                 break;
             }
             case 'delete-entries-by-index': {
-                // eslint-disable-next-line promise/prefer-await-to-then
                 service.entriesDelete(action.value).catch(console.error);
                 break;
             }
             case 'delete-all': {
-                // eslint-disable-next-line promise/prefer-await-to-then
                 service.deleteRange('all').catch(console.error);
                 break;
             }
             case 'delete-term': {
-                // eslint-disable-next-line promise/prefer-await-to-then
-                service.deleteTerm(action.term).catch(console.error);
+                service
+                    .deleteTerm(action.term)
+                    .then((resp) => {
+                        if (resp.kind === 'term-deleted') {
+                            queryDispatch({ kind: 'reset' });
+                        }
+                    })
+                    .catch(console.error);
                 break;
             }
             case 'open-url': {
@@ -127,13 +136,11 @@ export function HistoryServiceProvider({ service, children, initial }) {
             case 'show-entries-menu': {
                 service
                     .entriesMenu(action.indexes)
-                    // eslint-disable-next-line promise/prefer-await-to-then
                     .then((resp) => {
                         if (resp.kind === 'domain-search') {
                             queryDispatch({ kind: 'search-by-domain', value: resp.value });
                         }
                     })
-                    // eslint-disable-next-line promise/prefer-await-to-then
                     .catch(console.error);
                 break;
             }

--- a/special-pages/pages/history/app/history.service.js
+++ b/special-pages/pages/history/app/history.service.js
@@ -330,14 +330,16 @@ export class HistoryService {
 
     /**
      * @param {string} term
+     * @return {Promise<{kind: 'none'} | {kind: "term-deleted"}>}
      */
     async deleteTerm(term) {
         console.log('📤 [deleteTerm]: ', JSON.stringify({ term }));
         const resp = await this.history.messaging.request('deleteTerm', { term });
         if (resp.action === 'delete') {
             this.reset();
+            return { kind: 'term-deleted' };
         }
-        return resp;
+        return { kind: 'none' };
     }
 }
 

--- a/special-pages/pages/history/app/mocks/mock-transport.js
+++ b/special-pages/pages/history/app/mocks/mock-transport.js
@@ -71,7 +71,7 @@ export function mockTransport() {
                     return withLatency(queryResponseFrom(memory, msg));
                 }
                 case 'entries_delete': {
-                    console.log('📤 [entries_delete]: ', JSON.stringify(msg.params));
+                    // console.log('📤 [entries_delete]: ', JSON.stringify(msg.params));
                     if (msg.params.ids.length > 1) {
                         // prettier-ignore
                         const lines = [
@@ -139,7 +139,7 @@ export function mockTransport() {
                     return Promise.resolve({ action: 'none' });
                 }
                 case 'deleteTerm': {
-                    console.log('📤 [deleteTerm]: ', JSON.stringify(msg.params));
+                    // console.log('📤 [deleteTerm]: ', JSON.stringify(msg.params));
                     // prettier-ignore
                     const lines = [
                         `deleteTerm: ${JSON.stringify(msg.params)}`,

--- a/special-pages/pages/history/integration-tests/history-selections.spec.js
+++ b/special-pages/pages/history/integration-tests/history-selections.spec.js
@@ -155,8 +155,17 @@ test.describe('history selections', () => {
     test('`deleteAll` during search (no selections)', async ({ page }, workerInfo) => {
         const hp = HistoryTestPage.create(page, workerInfo).withEntries(2000);
         await hp.openPage({});
+        await hp.didMakeNthQuery({ nth: 0, query: { term: '' } });
+
+        // do the search
         await hp.types('example.com');
-        await hp.deletesAllForTerm('example.com');
+        await hp.didMakeNthQuery({ nth: 1, query: { term: 'example.com' } });
+
+        // delete for the given term
+        await hp.deletesAllForTerm('example.com', { action: 'delete' });
+
+        // should have reset the UI now
+        await hp.didMakeNthQuery({ nth: 2, query: { term: '' } });
     });
     test('removes all selections with ESC key', async ({ page }, workerInfo) => {
         const hp = HistoryTestPage.create(page, workerInfo).withEntries(2000);

--- a/special-pages/pages/history/integration-tests/history.page.js
+++ b/special-pages/pages/history/integration-tests/history.page.js
@@ -429,7 +429,12 @@ export class HistoryTestPage {
         await page.locator('header').getByRole('button', { name: 'Delete All', exact: true }).click();
     }
 
-    async deletesAllForTerm(term) {
+    /**
+     * @param {string} term
+     * @param {import('../types/history.ts').DeleteRangeResponse} resp
+     */
+    async deletesAllForTerm(term, resp) {
+        this._withDialogHandling(resp);
         await this.deletesAll();
         const calls = await this.mocks.waitForCallCount({ method: 'deleteTerm', count: 1 });
         expect(calls[0].payload.params).toStrictEqual({ term });

--- a/special-pages/pages/history/integration-tests/history.spec.js
+++ b/special-pages/pages/history/integration-tests/history.spec.js
@@ -188,6 +188,9 @@ test.describe('history', () => {
         await hp.didMakeNthQuery({ nth: 1, query: { domain: 'youtube.com' } });
         await hp.clicksDeleteAllInHeader({ action: 'delete' });
         await hp.didDeleteDomain('youtube.com');
+
+        // should have reset the UI now
+        await hp.didMakeNthQuery({ nth: 2, query: { term: '' } });
     });
     test('does not concatenate results if the query is not an addition', async ({ page }, workerInfo) => {
         const hp = HistoryTestPage.create(page, workerInfo).withEntries(1);


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/0/1201141132935289/1209532669589624

## Description

- [x] added 2 more cases where deleting items should reset the UI: after searching+delete and after domain-filtering + delete

## Testing Steps

- visit https://deploy-preview-1533--content-scope-scripts.netlify.app/build/pages/history/?history=100
- search for a term (the results are faked, but you'll see a shorter list)
- press 'delete all' in the header + confirm it
- ensure the UI is reset (eg: with a blank query)


## Checklist

<!--
  These questions are a friendly reminder to shipping code, if you're uncertain ask the AoR owners.
  It's also totally appropriate to not check some of these boxes, if they don't apply to your change.
-->
*Please tick all that apply:*

- [ ] I have tested this change locally
- [ ] I have tested this change locally in all supported browsers
- [ ] This change will be visible to users
- [ ] I have added automated tests that cover this change
- [ ] I have ensured the change is gated by config
- [ ] This change was covered by a ship review
- [ ] This change was covered by a tech design
- [ ] Any dependent config has been merged

