### PR TITLE
history: use double-click for opening links

### DIFF
--- a/special-pages/pages/history/app/components/Item.module.css
+++ b/special-pages/pages/history/app/components/Item.module.css
@@ -106,6 +106,7 @@
     text-decoration: none;
     color: inherit;
     line-height: var(--row-height);
+    pointer-events: none;
 }
 
 .domain {

--- a/special-pages/pages/history/app/global/hooks/useAuxClickHandler.js
+++ b/special-pages/pages/history/app/global/hooks/useAuxClickHandler.js
@@ -11,7 +11,8 @@ export function useAuxClickHandler() {
     const dispatch = useHistoryServiceDispatch();
     useEffect(() => {
         const handleAuxClick = (event) => {
-            const anchor = /** @type {HTMLButtonElement|null} */ (event.target.closest('a[href][data-url]'));
+            const row = /** @type {HTMLDivElement|null} */ (event.target.closest('[aria-selected]'));
+            const anchor = /** @type {HTMLAnchorElement|null} */ (row?.querySelector('a[href][data-url]'));
             const url = anchor?.dataset.url;
             if (anchor && url && event.button === 1) {
                 event.preventDefault();
@@ -24,5 +25,5 @@ export function useAuxClickHandler() {
         return () => {
             document.removeEventListener('auxclick', handleAuxClick);
         };
-    }, []);
+    }, [platformName, dispatch]);
 }

--- a/special-pages/pages/history/integration-tests/history.page.js
+++ b/special-pages/pages/history/integration-tests/history.page.js
@@ -174,12 +174,12 @@ export class HistoryTestPage {
     }
 
     async opensLinks() {
-        const { page } = this;
-        const link = page.locator('a[href][data-url]').nth(0);
-        await link.click();
-        await link.click({ modifiers: ['Meta'] });
-        await link.click({ modifiers: ['Shift'] });
-        await link.click({ button: 'middle' });
+        const row = this.main().locator('[aria-selected]').nth(0);
+        await row.dblclick();
+        await row.dblclick({ modifiers: ['Meta'] });
+        await row.dblclick({ modifiers: ['Shift'] });
+
+        await row.locator('a').click({ button: 'middle', force: true });
         await this._opensMainLink();
     }
     async _opensMainLink() {
@@ -302,19 +302,9 @@ export class HistoryTestPage {
      * @param {import('../types/history.ts').DeleteRangeResponse} resp
      */
     async menuForHistoryEntry(nth, resp) {
-        const { page } = this;
-
-        const cleanup = this._withDialogHandling(resp);
-        // console.log(data[0].title);
         const data = generateSampleData({ count: this.entries, offset: 0 });
         const nthItem = data[nth];
-        const row = page.getByText(nthItem.title);
-        await row.hover();
-        await page.locator(`[data-action="entries_menu"][value=${nthItem.id}]`).click();
-
-        const calls = await this.mocks.waitForCallCount({ method: 'entries_menu', count: 1 });
-        expect(calls[0].payload.params).toStrictEqual({ ids: [nthItem.id] });
-        cleanup();
+        await this.menuForMultipleHistoryEntries(nth, [nthItem.id], resp);
     }
 
     /**
@@ -329,7 +319,7 @@ export class HistoryTestPage {
         // console.log(data[0].title);
         const data = generateSampleData({ count: this.entries, offset: 0 });
         const nthItem = data[nth];
-        const row = page.getByText(nthItem.title);
+        const row = this.main().locator(`[data-history-entry=${nthItem.id}]`);
         await row.hover();
         await page.locator(`[data-action="entries_menu"][value=${nthItem.id}]`).click();
 

--- a/special-pages/shared/handlers.js
+++ b/special-pages/shared/handlers.js
@@ -1,5 +1,5 @@
 /**
- * @param {MouseEvent} event
+ * @param {MouseEvent|KeyboardEvent} event
  * @param {ImportMeta['platform']} platformName
  * @return {'new-tab' | 'new-window' | 'same-tab'}
  */
@@ -7,7 +7,7 @@ export function eventToTarget(event, platformName) {
     const isControlClick = platformName === 'macos' ? event.metaKey : event.ctrlKey;
     if (isControlClick) {
         return 'new-tab';
-    } else if (event.shiftKey || event.button === 1 /* middle click */) {
+    } else if (event.shiftKey || ('button' in event && event.button === 1) /* middle click */) {
         return 'new-window';
     }
     return 'same-tab';


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/0/0/1209547462194588/f

## Description

- [x] change the behaviour of a row - now you have to double-click (or right-click) to open as a link

## Testing Steps

- For these, check the console. 
  - double-click a row
  - double-click a row with shift
  - double-click a row CMD/CTRL
  
## Checklist

<!--
  These questions are a friendly reminder to shipping code, if you're uncertain ask the AoR owners.
  It's also totally appropriate to not check some of these boxes, if they don't apply to your change.
-->
*Please tick all that apply:*

- [ ] I have tested this change locally
- [ ] I have tested this change locally in all supported browsers
- [ ] This change will be visible to users
- [ ] I have added automated tests that cover this change
- [ ] I have ensured the change is gated by config
- [ ] This change was covered by a ship review
- [ ] This change was covered by a tech design
- [ ] Any dependent config has been merged

