### PR TITLE
Enables Duck Player custom error on all platforms

### DIFF
--- a/special-pages/pages/duckplayer/app/features/error-detection.js
+++ b/special-pages/pages/duckplayer/app/features/error-detection.js
@@ -3,7 +3,7 @@ import { YOUTUBE_ERROR_EVENT, YOUTUBE_ERRORS } from '../providers/YouTubeErrorPr
 /**
  * @typedef {import("./iframe").IframeFeature} IframeFeature
  * @typedef {import('../../types/duckplayer').YouTubeError} YouTubeError
- * @typedef {import('../../types/duckplayer').DuckPlayerPageSettings['customError']} CustomErrorOptions
+ * @typedef {import('../../types/duckplayer').CustomErrorSettings} CustomErrorSettings
  */
 
 /**
@@ -15,11 +15,11 @@ export class ErrorDetection {
     /** @type {HTMLIFrameElement} */
     iframe;
 
-    /** @type {CustomErrorOptions} */
+    /** @type {CustomErrorSettings} */
     options;
 
     /**
-     * @param {CustomErrorOptions} options
+     * @param {CustomErrorSettings} options
      */
     constructor(options) {
         this.options = options;
@@ -115,7 +115,8 @@ export class ErrorDetection {
 
             // 2. Check for sign-in support link
             try {
-                if (this.options?.signInRequiredSelector && !!iframeWindow.document.querySelector(this.options.signInRequiredSelector)) {
+                const { settings } = this.options;
+                if (settings?.signInRequiredSelector && !!iframeWindow.document.querySelector(settings.signInRequiredSelector)) {
                     return YOUTUBE_ERRORS.signInRequired;
                 }
             } catch (e) {

--- a/special-pages/pages/duckplayer/app/features/error-detection.js
+++ b/special-pages/pages/duckplayer/app/features/error-detection.js
@@ -31,8 +31,8 @@ export class ErrorDetection {
     iframeDidLoad(iframe) {
         this.iframe = iframe;
 
-        if (!this.options || !this.options.signInRequiredSelector) {
-            console.log('Missing Custom Error options');
+        if (this.options?.state !== 'enabled') {
+            console.log('Error detection disabled');
             return null;
         }
 

--- a/special-pages/pages/duckplayer/app/providers/YouTubeErrorProvider.jsx
+++ b/special-pages/pages/duckplayer/app/providers/YouTubeErrorProvider.jsx
@@ -41,7 +41,6 @@ export function YouTubeErrorProvider({ initial = null, children }) {
     const [error, setError] = useState(initialError);
 
     const messaging = useMessaging();
-    const platformName = usePlatformName();
     const setFocusMode = useSetFocusMode();
 
     // listen for updates
@@ -52,9 +51,7 @@ export function YouTubeErrorProvider({ initial = null, children }) {
             if (YOUTUBE_ERROR_IDS.includes(eventError) || eventError === null) {
                 if (eventError && eventError !== error) {
                     setFocusMode('paused');
-                    if (platformName === 'macos' || platformName === 'ios') {
-                        messaging.reportYouTubeError({ error: eventError });
-                    }
+                    messaging.reportYouTubeError({ error: eventError });
                 } else {
                     setFocusMode('enabled');
                 }

--- a/special-pages/pages/duckplayer/app/settings.js
+++ b/special-pages/pages/duckplayer/app/settings.js
@@ -5,7 +5,7 @@ const DEFAULT_SIGN_IN_REQURED_HREF = '[href*="//support.google.com/youtube/answe
  * @property {'enabled'|'disabled'} state
  * @property {object} [settings]
  * @property {string} [settings.signInRequiredSelector]
-*/
+ */
 
 export class Settings {
     /**
@@ -47,12 +47,12 @@ export class Settings {
      *   }
      * }
      *
-     * @param {import("../types/duckplayer.js").InitialSetupResponse['settings']['customError']} customErrorSettings
+     * @param {import("../types/duckplayer.js").DuckPlayerPageSettings['customError']} customErrorSettings
      * @return {CustomErrorSettings}
      */
     parseLegacyCustomError(customErrorSettings) {
-        if (!customErrorSettings || customErrorSettings.state !== 'enabled') {
-            return { state: 'disabled'};
+        if (customErrorSettings?.state !== 'enabled') {
+            return { state: 'disabled' };
         }
 
         const { settings, signInRequiredSelector } = customErrorSettings;
@@ -61,8 +61,8 @@ export class Settings {
             state: 'enabled',
             settings: {
                 ...settings,
-                ...(signInRequiredSelector && { signInRequiredSelector })
-            }
+                ...(signInRequiredSelector && { signInRequiredSelector }),
+            },
         };
     }
 

--- a/special-pages/pages/duckplayer/app/settings.js
+++ b/special-pages/pages/duckplayer/app/settings.js
@@ -1,12 +1,5 @@
 const DEFAULT_SIGN_IN_REQURED_HREF = '[href*="//support.google.com/youtube/answer/3037019"]';
 
-/**
- * @typedef {object} CustomErrorSettings
- * @property {'enabled'|'disabled'} state
- * @property {object} [settings]
- * @property {string} [settings.signInRequiredSelector]
- */
-
 export class Settings {
     /**
      * @param {object} params
@@ -47,15 +40,15 @@ export class Settings {
      *   }
      * }
      *
-     * @param {import("../types/duckplayer.js").DuckPlayerPageSettings['customError']} customErrorSettings
-     * @return {CustomErrorSettings}
+     * @param {import("../types/duckplayer.js").DuckPlayerPageSettings['customError']} initialSettings
+     * @return {import("../types/duckplayer.js").CustomErrorSettings}
      */
-    parseLegacyCustomError(customErrorSettings) {
-        if (customErrorSettings?.state !== 'enabled') {
+    parseLegacyCustomError(initialSettings) {
+        if (initialSettings?.state !== 'enabled') {
             return { state: 'disabled' };
         }
 
-        const { settings, signInRequiredSelector } = customErrorSettings;
+        const { settings, signInRequiredSelector } = initialSettings;
 
         return {
             state: 'enabled',

--- a/special-pages/pages/duckplayer/messages/customErrorSettings.shared.json
+++ b/special-pages/pages/duckplayer/messages/customErrorSettings.shared.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "CustomErrorSettings",
+  "type": "object",
+  "description": "Configures a custom error message for YouTube errors",
+  "required": ["state"],
+  "properties": {
+    "state": {
+      "type": "string",
+      "enum": ["enabled", "disabled"]
+    },
+    "settings": {
+      "type": "object",
+      "description": "Custom error settings",
+      "properties": {
+        "signInRequiredSelector": {
+          "description": "A selector that, when not empty, indicates a sign-in required error",
+          "type": "string"
+        }
+      }
+    }
+  }
+}

--- a/special-pages/pages/duckplayer/messages/initialSetup.response.json
+++ b/special-pages/pages/duckplayer/messages/initialSetup.response.json
@@ -42,15 +42,24 @@
         "customError": {
           "type": "object",
           "description": "Configures a custom error message for YouTube errors",
-          "required": ["state", "signInRequiredSelector"],
+          "required": ["state"],
           "properties": {
             "state": {
               "type": "string",
               "enum": ["enabled", "disabled"]
             },
+            "settings": {
+              "type": "object",
+              "description": "Custom error settings",
+              "properties": {
+                "signInRequiredSelector": {
+                  "$ref": "#/definitions/signInRequiredSelector"
+                }
+              }
+            },
             "signInRequiredSelector": {
-              "description": "A selector that, when not empty, indicates a sign-in required error",
-              "type": "string"
+              "$ref": "#/definitions/signInRequiredSelector",
+              "$comment": "This setting is duplicated at the top level until Apple and Windows are migrated to the settings object above"
             }
           }
         }
@@ -76,6 +85,12 @@
     "localeStrings": {
       "type": "string",
       "description": "Optional locale-specific strings"
+    }
+  },
+  "definitions": {
+    "signInRequiredSelector": {
+      "description": "A selector that, when not empty, indicates a sign-in required error",
+      "type": "string"
     }
   }
 }

--- a/special-pages/pages/duckplayer/messages/initialSetup.response.json
+++ b/special-pages/pages/duckplayer/messages/initialSetup.response.json
@@ -40,28 +40,18 @@
           }
         },
         "customError": {
-          "type": "object",
-          "description": "Configures a custom error message for YouTube errors",
-          "required": ["state"],
-          "properties": {
-            "state": {
-              "type": "string",
-              "enum": ["enabled", "disabled"]
-            },
-            "settings": {
-              "type": "object",
-              "description": "Custom error settings",
+          "allOf": [
+            { "$ref": "customErrorSettings.shared.json" },
+            {
               "properties": {
                 "signInRequiredSelector": {
-                  "$ref": "#/definitions/signInRequiredSelector"
+                  "type": "string",
+                  "description": "A selector that, when not empty, indicates a sign-in required error",
+                  "$comment": "This setting is duplicated at the top level until Apple and Windows are migrated to the settings object above"
                 }
               }
-            },
-            "signInRequiredSelector": {
-              "$ref": "#/definitions/signInRequiredSelector",
-              "$comment": "This setting is duplicated at the top level until Apple and Windows are migrated to the settings object above"
             }
-          }
+          ]
         }
       }
     },
@@ -85,12 +75,6 @@
     "localeStrings": {
       "type": "string",
       "description": "Optional locale-specific strings"
-    }
-  },
-  "definitions": {
-    "signInRequiredSelector": {
-      "description": "A selector that, when not empty, indicates a sign-in required error",
-      "type": "string"
     }
   }
 }

--- a/special-pages/pages/duckplayer/types/duckplayer.ts
+++ b/special-pages/pages/duckplayer/types/duckplayer.ts
@@ -135,9 +135,18 @@ export interface DuckPlayerPageSettings {
   customError?: {
     state: "enabled" | "disabled";
     /**
+     * Custom error settings
+     */
+    settings?: {
+      /**
+       * A selector that, when not empty, indicates a sign-in required error
+       */
+      signInRequiredSelector?: string;
+    };
+    /**
      * A selector that, when not empty, indicates a sign-in required error
      */
-    signInRequiredSelector: string;
+    signInRequiredSelector?: string;
   };
 }
 /**

--- a/special-pages/pages/duckplayer/types/duckplayer.ts
+++ b/special-pages/pages/duckplayer/types/duckplayer.ts
@@ -129,20 +129,22 @@ export interface DuckPlayerPageSettings {
   focusMode?: {
     state: "enabled" | "disabled";
   };
-  /**
-   * Configures a custom error message for YouTube errors
-   */
-  customError?: {
-    state: "enabled" | "disabled";
+  customError?: CustomErrorSettings & {
     /**
-     * Custom error settings
+     * A selector that, when not empty, indicates a sign-in required error
      */
-    settings?: {
-      /**
-       * A selector that, when not empty, indicates a sign-in required error
-       */
-      signInRequiredSelector?: string;
-    };
+    signInRequiredSelector?: string;
+  };
+}
+/**
+ * Configures a custom error message for YouTube errors
+ */
+export interface CustomErrorSettings {
+  state: "enabled" | "disabled";
+  /**
+   * Custom error settings
+   */
+  settings?: {
     /**
      * A selector that, when not empty, indicates a sign-in required error
      */

--- a/special-pages/pages/duckplayer/unit-tests/settings.mjs
+++ b/special-pages/pages/duckplayer/unit-tests/settings.mjs
@@ -6,11 +6,11 @@ describe('parses settings', () => {
     it('handles disabled custom error schema', () => {
         const settings = new Settings({
             customError: {
-                state: 'disabled'
-            }
+                state: 'disabled',
+            },
         });
         const expected = {
-            state: 'disabled'
+            state: 'disabled',
         };
 
         deepEqual(settings.customError, expected);
@@ -19,14 +19,14 @@ describe('parses settings', () => {
         const settings = new Settings({
             customError: {
                 state: 'enabled',
-                signInRequiredSelector: 'div'
-            }
+                signInRequiredSelector: 'div',
+            },
         });
         const expected = {
             state: 'enabled',
             settings: {
-                signInRequiredSelector: 'div'
-            }
+                signInRequiredSelector: 'div',
+            },
         };
 
         deepEqual(settings.customError, expected);
@@ -36,15 +36,15 @@ describe('parses settings', () => {
             customError: {
                 state: 'enabled',
                 settings: {
-                    signInRequiredSelector: 'div'
-                }
-            }
+                    signInRequiredSelector: 'div',
+                },
+            },
         });
         const expected = {
             state: 'enabled',
             settings: {
-                signInRequiredSelector: 'div'
-            }
+                signInRequiredSelector: 'div',
+            },
         };
 
         deepEqual(settings.customError, expected);
@@ -52,12 +52,12 @@ describe('parses settings', () => {
     it('handles custom error enabled without settings', () => {
         const settings = new Settings({
             customError: {
-                state: 'enabled'
-            }
+                state: 'enabled',
+            },
         });
         const expected = {
             state: 'enabled',
-            settings: {}
+            settings: {},
         };
 
         deepEqual(settings.customError, expected);
@@ -66,11 +66,11 @@ describe('parses settings', () => {
         const settings = new Settings({
             customError: {
                 // @ts-expect-error - Malformed object on purpose
-                status: 'enabled'
-            }
+                status: 'enabled',
+            },
         });
         const expected = {
-            state: 'disabled'
+            state: 'disabled',
         };
 
         deepEqual(settings.customError, expected);

--- a/special-pages/pages/duckplayer/unit-tests/settings.mjs
+++ b/special-pages/pages/duckplayer/unit-tests/settings.mjs
@@ -1,0 +1,78 @@
+import { describe, it } from 'node:test';
+import { deepEqual } from 'node:assert/strict';
+import { Settings } from '../app/settings.js';
+
+describe('parses settings', () => {
+    it('handles disabled custom error schema', () => {
+        const settings = new Settings({
+            customError: {
+                state: 'disabled'
+            }
+        });
+        const expected = {
+            state: 'disabled'
+        };
+
+        deepEqual(settings.customError, expected);
+    });
+    it('handles old custom error schema', () => {
+        const settings = new Settings({
+            customError: {
+                state: 'enabled',
+                signInRequiredSelector: 'div'
+            }
+        });
+        const expected = {
+            state: 'enabled',
+            settings: {
+                signInRequiredSelector: 'div'
+            }
+        };
+
+        deepEqual(settings.customError, expected);
+    });
+    it('handles new custom error schema', () => {
+        const settings = new Settings({
+            customError: {
+                state: 'enabled',
+                settings: {
+                    signInRequiredSelector: 'div'
+                }
+            }
+        });
+        const expected = {
+            state: 'enabled',
+            settings: {
+                signInRequiredSelector: 'div'
+            }
+        };
+
+        deepEqual(settings.customError, expected);
+    });
+    it('handles custom error enabled without settings', () => {
+        const settings = new Settings({
+            customError: {
+                state: 'enabled'
+            }
+        });
+        const expected = {
+            state: 'enabled',
+            settings: {}
+        };
+
+        deepEqual(settings.customError, expected);
+    });
+    it('handles malformed custom error schema', () => {
+        const settings = new Settings({
+            customError: {
+                // @ts-expect-error - Malformed object on purpose
+                status: 'enabled'
+            }
+        });
+        const expected = {
+            state: 'disabled'
+        };
+
+        deepEqual(settings.customError, expected);
+    });
+});


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/0/0/1209459625347015
https://app.asana.com/0/0/1209459625347014

## Description

- Implements the custom error screen for Duck Player on Android and Windows
- Adds legacy support for Apple/Windows custom error settings schema and new Android-compatible schema

## Testing Steps

[Test builds](https://app.asana.com/0/1142021229838617/1209392401656236)

#### Android

1. Override privacy config to https://www.jsonblob.com/api/jsonBlob/1344674224849215488
2. Follow the steps here: https://app.asana.com/0/1142021229838617/1209392401656236

#### Windows

1. Override privacy config to https://www.jsonblob.com/api/jsonBlob/1345007201051402240
2. Follow the steps here: https://app.asana.com/0/1142021229838617/1209392401656236


## Checklist

<!--
  These questions are a friendly reminder to shipping code, if you're uncertain ask the AoR owners.
  It's also totally appropriate to not check some of these boxes, if they don't apply to your change.
-->
*Please tick all that apply:*

- [ ] I have tested this change locally
- [ ] I have tested this change locally in all supported browsers
- [ ] This change will be visible to users
- [ ] I have added automated tests that cover this change
- [ ] I have ensured the change is gated by config
- [ ] This change was covered by a ship review
- [ ] This change was covered by a tech design
- [ ] Any dependent config has been merged

