### PR TITLE
history: scrollbars

### DIFF
--- a/special-pages/pages/history/app/components/App.module.css
+++ b/special-pages/pages/history/app/components/App.module.css
@@ -13,12 +13,16 @@ body {
     --sidebar-width: 250px;
     --main-padding-left: 48px;
     --main-padding-right: 76px;
-    --windows-scrollbar: 15px;
+    --scrollbar-width: 12px;
 
     &[data-layout-mode="reduced"] {
         --sidebar-width: 230px;
         --main-padding-left: 28px;
         --main-padding-right: 56px;
+    }
+
+    [data-platform="windows"] & {
+        --scrollbar-width: 15px
     }
 
     display: grid;
@@ -51,13 +55,39 @@ body {
     padding-right: var(--main-padding-right);
     padding-top: 24px;
 }
+
 .customScroller {
     overflow-y: scroll;
-    scrollbar-gutter: stable;
+    padding-right: calc(var(--main-padding-right) - var(--scrollbar-width));
 }
 
+/**
+ * Windows has access to newer CSS features for styling the scrollbar
+ */
 [data-platform="windows"] {
     .customScroller {
-        padding-right: calc(var(--main-padding-right) - var(--windows-scrollbar));
+        scrollbar-gutter: stable;
+        scrollbar-width: var(--scrollbar-width);
+        scrollbar-color: var(--history-surface-border-color) var(--history-background-color);
+    }
+}
+
+/**
+ * macOS specific styling to handle dark mode - without this full
+ * override you cannot change the track color :(
+ */
+[data-platform="macos"] {
+    .customScroller {
+        &::-webkit-scrollbar {
+            width: var(--scrollbar-width);
+        }
+        &::-webkit-scrollbar-track {
+            border-radius: 6px;
+        }
+        &::-webkit-scrollbar-thumb {
+            background: rgb(108, 108, 108);
+            border: 4px solid var(--history-background-color);
+            border-radius: calc(var(--scrollbar-width) / 2);
+        }
     }
 }

--- a/special-pages/pages/history/app/components/App.module.css
+++ b/special-pages/pages/history/app/components/App.module.css
@@ -13,7 +13,7 @@ body {
     --sidebar-width: 250px;
     --main-padding-left: 48px;
     --main-padding-right: 76px;
-    --scrollbar-width: 12px;
+    --scrollbar-width: 18px;
 
     &[data-layout-mode="reduced"] {
         --sidebar-width: 230px;
@@ -68,7 +68,7 @@ body {
     .customScroller {
         scrollbar-gutter: stable;
         scrollbar-width: var(--scrollbar-width);
-        scrollbar-color: var(--history-surface-border-color) var(--history-background-color);
+        scrollbar-color: var(--history-scrollbar-controls-color) var(--history-background-color);
     }
 }
 
@@ -78,16 +78,30 @@ body {
  */
 [data-platform="macos"] {
     .customScroller {
+        --webkit-thumb-color: rgba(136, 136, 136, 0.8);
+
         &::-webkit-scrollbar {
             width: var(--scrollbar-width);
         }
+
         &::-webkit-scrollbar-track {
-            border-radius: 6px;
+            background-color: var(--history-background-color)
         }
+
         &::-webkit-scrollbar-thumb {
-            background: rgb(108, 108, 108);
-            border: 4px solid var(--history-background-color);
+            background-color: var(--webkit-thumb-color);
             border-radius: calc(var(--scrollbar-width) / 2);
+
+            /** faking some padding on the thumb */
+            border: 4px solid var(--history-background-color);
+        }
+
+        &::-webkit-scrollbar-button {
+            display: block;
+            background-color: var(--history-background-color);
+
+            /** a small vertical gap to prevent it touching boundaries */
+            height: 2px;
         }
     }
 }

--- a/special-pages/pages/history/styles/history-theme.css
+++ b/special-pages/pages/history/styles/history-theme.css
@@ -35,6 +35,7 @@
     --history-background-color: var(--default-light-bg);
     --history-surface-background-color: var(--color-white-at-30);
     --history-surface-border-color: var(--color-black-at-9);
+    --history-scrollbar-controls-color: var(--color-black-at-18);
     --history-text-normal: var(--color-black-at-84);
     --history-text-invert: var(--color-white-at-84);
     --history-text-muted: var(--color-black-at-60);
@@ -44,6 +45,7 @@
     --history-background-color: var(--default-dark-bg);
     --history-surface-background-color: var(--color-black-at-18);
     --history-surface-border-color: var(--color-white-at-12);
+    --history-scrollbar-controls-color: var(--color-white-at-18);
     --history-surface-color: var(--color-white-at-12);
     --history-text-normal: var(--color-white-at-84);
     --history-text-invert: var(--color-black-at-84);


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/0/0/1209565728475049/f

## Description

- [x] Leave the default windows scrollbars, but adjust for light/dark mode
- [x] re-introduce the custom scrollbar stuff for macOS to handle light/dark there too.

## Testing Steps

- https://deploy-preview-1536--content-scope-scripts.netlify.app/build/pages/history/?history=2000
  - To verify windows, you need a windows machine (or browser stack), this is why I'm providing screenshots too)

## macOS

<img width="1291" alt="Screenshot 2025-03-04 at 08 59 57" src="https://github.com/user-attachments/assets/d457f5a3-2e63-46d2-8787-47bdd3b35759" />
<img width="1291" alt="Screenshot 2025-03-04 at 08 59 51" src="https://github.com/user-attachments/assets/d73065f7-e03e-49f2-a485-038192e097e6" />

## Windows

<img width="1157" alt="Screenshot 2025-03-04 at 08 27 36" src="https://github.com/user-attachments/assets/a11ab442-0aa7-4e67-849b-2ca47f09f540" />

<img width="1152" alt="Screenshot 2025-03-04 at 08 27 47" src="https://github.com/user-attachments/assets/026a92d7-796f-4c79-bda9-b80de51c2f44" />



## Checklist

<!--
  These questions are a friendly reminder to shipping code, if you're uncertain ask the AoR owners.
  It's also totally appropriate to not check some of these boxes, if they don't apply to your change.
-->
*Please tick all that apply:*

- [ ] I have tested this change locally
- [ ] I have tested this change locally in all supported browsers
- [ ] This change will be visible to users
- [ ] I have added automated tests that cover this change
- [ ] I have ensured the change is gated by config
- [ ] This change was covered by a ship review
- [ ] This change was covered by a tech design
- [ ] Any dependent config has been merged

