### PR TITLE
history: include 'count' for ranges

### DIFF
--- a/special-pages/pages/history/app/components/App.module.css
+++ b/special-pages/pages/history/app/components/App.module.css
@@ -7,6 +7,7 @@ body {
     font-weight: var(--body-font-weight);
     line-height: var(--body-line-height);
     background-color: var(--history-background-color);
+    color: var(--history-text-normal);
 }
 
 .layout {

--- a/special-pages/pages/history/app/components/Item.js
+++ b/special-pages/pages/history/app/components/Item.js
@@ -31,12 +31,17 @@ export const Item = memo(
         const hasTitle = kind === TITLE_KIND || kind === BOTH_KIND;
         return (
             <Fragment>
-                {hasTitle && <div className={cn(styles.title)}>{dateRelativeDay}</div>}
+                {hasTitle && (
+                    <div class={cn(styles.title)} style={{ viewTransitionName: `item-title-${props.id}` }}>
+                        {dateRelativeDay}
+                    </div>
+                )}
                 <div
                     class={cn(styles.row, styles.hover, hasFooterGap && styles.last)}
                     data-history-entry={props.id}
                     data-index={index}
                     aria-selected={selected}
+                    style={{ viewTransitionName: `item-${props.id}` }}
                 >
                     <div class={styles.favicon}>
                         <FaviconWithState

--- a/special-pages/pages/history/app/components/Sidebar.js
+++ b/special-pages/pages/history/app/components/Sidebar.js
@@ -6,7 +6,7 @@ import { useTypedTranslation } from '../types.js';
 import { Trash } from '../icons/Trash.js';
 import { useTypedTranslationWith } from '../../../new-tab/app/types.js';
 import { useQueryContext, useQueryDispatch } from '../global/Providers/QueryProvider.js';
-import { useHistoryServiceDispatch, useResultsData } from '../global/Providers/HistoryServiceProvider.js';
+import { useHistoryServiceDispatch } from '../global/Providers/HistoryServiceProvider.js';
 
 /**
  * @import json from "../strings.json"

--- a/special-pages/pages/history/app/components/Sidebar.js
+++ b/special-pages/pages/history/app/components/Sidebar.js
@@ -11,9 +11,10 @@ import { useHistoryServiceDispatch, useResultsData } from '../global/Providers/H
 /**
  * @import json from "../strings.json"
  * @typedef {import('../../types/history.js').Range} Range
+ * @typedef {import('../../types/history.js').RangeId} RangeId
  */
 
-/** @type {Record<Range, string>} */
+/** @type {Record<RangeId, string>} */
 const iconMap = {
     all: 'icons/all.svg',
     today: 'icons/today.svg',
@@ -28,7 +29,7 @@ const iconMap = {
     older: 'icons/older.svg',
 };
 
-/** @type {Record<Range, (t: (s: keyof json) => string) => string>} */
+/** @type {Record<RangeId, (t: (s: keyof json) => string) => string>} */
 const titleMap = {
     all: (t) => t('range_all'),
     today: (t) => t('range_today'),
@@ -53,13 +54,11 @@ export function Sidebar({ ranges }) {
     const { t } = useTypedTranslation();
     const search = useQueryContext();
     const current = useComputed(() => search.value.range);
-    const results = useResultsData();
-    const count = useComputed(() => results.value.items.length);
     const dispatch = useQueryDispatch();
     const historyServiceDispatch = useHistoryServiceDispatch();
 
     /**
-     * @param {Range} range
+     * @param {RangeId} range
      */
     function onClick(range) {
         if (range === 'all') {
@@ -69,7 +68,7 @@ export function Sidebar({ ranges }) {
         }
     }
     /**
-     * @param {Range} range
+     * @param {RangeId} range
      */
     function onDelete(range) {
         historyServiceDispatch({ kind: 'delete-range', value: range });
@@ -80,7 +79,17 @@ export function Sidebar({ ranges }) {
             <h1 class={styles.pageTitle}>{t('page_title')}</h1>
             <nav class={styles.nav}>
                 {ranges.value.map((range) => {
-                    return <Item onClick={onClick} onDelete={onDelete} current={current} range={range} ranges={ranges} count={count} />;
+                    return (
+                        <Item
+                            key={range.id}
+                            onClick={onClick}
+                            onDelete={onDelete}
+                            current={current}
+                            range={range.id}
+                            count={range.count}
+                            ranges={ranges}
+                        />
+                    );
                 })}
             </nav>
         </div>
@@ -91,12 +100,12 @@ export function Sidebar({ ranges }) {
  * A component that renders a list item with optional delete actions and a link.
  *
  * @param {Object} props
- * @param {import('@preact/signals').ReadonlySignal<Range|null>} props.current The current selection with a value property.
- * @param {Range} props.range The range represented by this item.
- * @param {(range: Range) => void} props.onClick Callback function triggered when the range is clicked.
- * @param {(range: Range) => void} props.onDelete Callback function triggered when the delete action is clicked.
+ * @param {import('@preact/signals').ReadonlySignal<RangeId|null>} props.current The current selection with a value property.
+ * @param {RangeId} props.range The range represented by this item.
+ * @param {(range: RangeId) => void} props.onClick Callback function triggered when the range is clicked.
+ * @param {(range: RangeId) => void} props.onDelete Callback function triggered when the delete action is clicked.
  * @param {import("@preact/signals").Signal<Range[]>} props.ranges
- * @param {import('@preact/signals').ReadonlySignal<number>} props.count The count value associated with the ranges.
+ * @param {number} props.count The count value associated with the ranges.
  */
 function Item({ current, range, onClick, onDelete, ranges, count }) {
     const { t } = useTypedTranslation();
@@ -124,23 +133,8 @@ function Item({ current, range, onClick, onDelete, ranges, count }) {
                 </span>
                 {titleMap[range](t)}
             </button>
-            {range === 'all' && <DeleteAllButton onClick={onDelete} ariaLabel={buttonLabel} range={range} ranges={ranges} count={count} />}
-            {range !== 'all' && <DeleteButton onClick={() => onDelete(range)} label={buttonLabel} range={range} />}
+            <DeleteAllButton onClick={onDelete} ariaLabel={buttonLabel} range={range} ranges={ranges} count={count} />
         </div>
-    );
-}
-
-/**
- * @param {Object} props
- * @param {Range} props.range The range value used for filtering and identification.
- * @param {string} props.label The title or label of the item.
- * @param {(range: MouseEvent)=>void} props.onClick
- */
-function DeleteButton({ range, onClick, label }) {
-    return (
-        <button class={styles.delete} onClick={onClick} aria-label={label} tabindex={0} value={range}>
-            <Trash />
-        </button>
     );
 }
 
@@ -149,20 +143,20 @@ function DeleteButton({ range, onClick, label }) {
  * logic that's only relevant to this row item.
  *
  * @param {Object} props - The properties passed to the component.
- * @param {Range} props.range - The range value used for filtering and identification.
+ * @param {RangeId} props.range - The range value used for filtering and identification.
  * @param {import('@preact/signals').Signal<Range[]>} props.ranges - A signal containing an array of range values used for navigation.
  * @param {string} props.ariaLabel - The accessible label for the delete button.
- * @param {(evt: Range) => void} props.onClick - The callback function triggered on button click.
- * @param {import('@preact/signals').Signal<number>} props.count - A signal representing the count of items in the range.
+ * @param {(evt: RangeId) => void} props.onClick - The callback function triggered on button click.
+ * @param {number} props.count - A signal representing the count of items in the range.
  */
 function DeleteAllButton({ range, ranges, onClick, ariaLabel, count }) {
     const { t } = useTypedTranslationWith(/** @type {json} */ ({}));
 
     const ariaDisabled = useComputed(() => {
-        return count.value === 0 && ranges.value.length === 1 ? 'true' : 'false';
+        return count === 0 ? 'true' : 'false';
     });
     const buttonTitle = useComputed(() => {
-        return count.value === 0 && ranges.value.length === 1 ? t('delete_none') : '';
+        return count === 0 ? t('delete_none') : '';
     });
 
     return (
@@ -186,7 +180,7 @@ function DeleteAllButton({ range, ranges, onClick, ariaLabel, count }) {
 }
 
 /**
- * @param {Range} range
+ * @param {RangeId} range
  * @return {{linkLabel: string, buttonLabel: string}}
  */
 function labels(range, t) {

--- a/special-pages/pages/history/app/components/Sidebar.js
+++ b/special-pages/pages/history/app/components/Sidebar.js
@@ -79,6 +79,7 @@ export function Sidebar({ ranges }) {
             <h1 class={styles.pageTitle}>{t('page_title')}</h1>
             <nav class={styles.nav}>
                 {ranges.value.map((range) => {
+                    console.log(range.id, range.count);
                     return (
                         <Item
                             key={range.id}
@@ -152,12 +153,8 @@ function Item({ current, range, onClick, onDelete, ranges, count }) {
 function DeleteAllButton({ range, ranges, onClick, ariaLabel, count }) {
     const { t } = useTypedTranslationWith(/** @type {json} */ ({}));
 
-    const ariaDisabled = useComputed(() => {
-        return count === 0 ? 'true' : 'false';
-    });
-    const buttonTitle = useComputed(() => {
-        return count === 0 ? t('delete_none') : '';
-    });
+    const ariaDisabled = count === 0 ? 'true' : 'false';
+    const buttonTitle = count === 0 ? t('delete_none') : '';
 
     return (
         <button

--- a/special-pages/pages/history/app/global/Providers/HistoryServiceProvider.js
+++ b/special-pages/pages/history/app/global/Providers/HistoryServiceProvider.js
@@ -91,8 +91,9 @@ export function HistoryServiceProvider({ service, children, initial }) {
                     service
                         .deleteRange(range)
                         .then((resp) => {
-                            if (resp.kind === 'range-deleted') {
+                            if (resp.kind === 'delete') {
                                 queryDispatch({ kind: 'reset' });
+                                service.refreshRanges();
                             }
                         })
                         .catch(console.error);
@@ -103,27 +104,43 @@ export function HistoryServiceProvider({ service, children, initial }) {
                 service
                     .deleteDomain(action.domain)
                     .then((resp) => {
-                        if (resp.kind === 'domain-deleted') {
+                        if (resp.kind === 'delete') {
                             queryDispatch({ kind: 'reset' });
+                            service.refreshRanges();
                         }
                     })
                     .catch(console.error);
                 break;
             }
             case 'delete-entries-by-index': {
-                service.entriesDelete(action.value).catch(console.error);
+                service
+                    .entriesDelete(action.value)
+                    .then((resp) => {
+                        if (resp.kind === 'delete') {
+                            service.refreshRanges();
+                        }
+                    })
+                    .catch(console.error);
                 break;
             }
             case 'delete-all': {
-                service.deleteRange('all').catch(console.error);
+                service
+                    .deleteRange('all')
+                    .then((x) => {
+                        if (x.kind === 'delete') {
+                            service.refreshRanges();
+                        }
+                    })
+                    .catch(console.error);
                 break;
             }
             case 'delete-term': {
                 service
                     .deleteTerm(action.term)
                     .then((resp) => {
-                        if (resp.kind === 'term-deleted') {
+                        if (resp.kind === 'delete') {
                             queryDispatch({ kind: 'reset' });
+                            service.refreshRanges();
                         }
                     })
                     .catch(console.error);
@@ -137,8 +154,10 @@ export function HistoryServiceProvider({ service, children, initial }) {
                 service
                     .entriesMenu(action.indexes)
                     .then((resp) => {
-                        if (resp.kind === 'domain-search') {
+                        if (resp.kind === 'domain-search' && 'value' in resp) {
                             queryDispatch({ kind: 'search-by-domain', value: resp.value });
+                        } else if (resp.kind === 'delete') {
+                            service.refreshRanges();
                         }
                     })
                     .catch(console.error);

--- a/special-pages/pages/history/app/global/Providers/QueryProvider.js
+++ b/special-pages/pages/history/app/global/Providers/QueryProvider.js
@@ -4,9 +4,10 @@ import { signal, useSignal } from '@preact/signals';
 
 /**
  * @typedef {import('../../../types/history.ts').Range} Range
+ * @typedef {import('../../../types/history.ts').RangeId} RangeId
  * @typedef {{
  *   term: string | null,
- *   range: Range | null,
+ *   range: RangeId | null,
  *   domain: string | null,
  * }} QueryState - this is the value the entire application can read/observe
  */
@@ -22,7 +23,7 @@ const QueryContext = createContext(
     /** @type {import('@preact/signals').ReadonlySignal<QueryState>} */ (
         signal({
             term: /** @type {string|null} */ (null),
-            range: /** @type {import('../../../types/history.ts').Range|null} */ (null),
+            range: /** @type {RangeId|null} */ (null),
             domain: /** @type {string|null} */ (null),
         })
     ),
@@ -65,7 +66,7 @@ export function QueryProvider({ children, query = { term: '' } }) {
                     return { term: null, domain: action.value, range: null };
                 }
                 case 'search-by-range': {
-                    return { term: null, domain: null, range: /** @type {Range} */ (action.value) };
+                    return { term: null, domain: null, range: /** @type {RangeId} */ (action.value) };
                 }
                 case 'search-by-term': {
                     return { term: action.value, domain: null, range: null };

--- a/special-pages/pages/history/app/history.md
+++ b/special-pages/pages/history/app/history.md
@@ -34,7 +34,24 @@ Retrieves available time ranges for history filtering.
 
 ```json
 {
-  "ranges": ["today", "yesterday", "monday", "recentlyOpened"]
+  "ranges": [
+    {
+      "id": "today",
+      "count": 13
+    },
+    {
+      "id": "yesterday",
+      "count": 10
+    },
+    {
+      "id": "monday",
+      "count": 2
+    },
+    {
+      "id": "older",
+      "count": 120
+    }
+  ]
 }
 ```
 

--- a/special-pages/pages/history/app/history.range.service.js
+++ b/special-pages/pages/history/app/history.range.service.js
@@ -1,5 +1,6 @@
 /**
  * @typedef {import('../types/history.js').Range} Range
+ * @typedef {import('../types/history.js').RangeId} RangeId
  * @typedef {{ranges: Range[]}} RangeData
  * @typedef {{kind: 'none'} | { kind: 'domain-search'; value: string }} MenuContinuation
  */
@@ -61,7 +62,7 @@ export class HistoryRangeService {
     }
 
     /**
-     * @param {Range} range
+     * @param {RangeId} range
      */
     async deleteRange(range) {
         console.log('📤 [deleteRange]: ', JSON.stringify({ range }));
@@ -70,14 +71,14 @@ export class HistoryRangeService {
             if (range === 'all') {
                 this.update((_old) => {
                     return {
-                        ranges: ['all'],
+                        ranges: [{ id: 'all', count: 0 }],
                     };
                 });
             } else {
                 this.update((old) => {
                     return {
                         ...old,
-                        ranges: old.ranges.filter((x) => x !== range),
+                        ranges: old.ranges.filter((x) => x.id !== range),
                     };
                 });
             }

--- a/special-pages/pages/history/app/history.range.service.js
+++ b/special-pages/pages/history/app/history.range.service.js
@@ -87,7 +87,6 @@ export class HistoryRangeService {
      */
     async deleteRange(range) {
         console.log('📤 [deleteRange]: ', JSON.stringify({ range }));
-        const resp = await this.history.messaging.request('deleteRange', { range });
-        return { kind: resp.action };
+        return await this.history.messaging.request('deleteRange', { range });
     }
 }

--- a/special-pages/pages/history/app/history.range.service.js
+++ b/special-pages/pages/history/app/history.range.service.js
@@ -83,35 +83,11 @@ export class HistoryRangeService {
     }
 
     /**
-     * @param {(d: RangeData) => RangeData} updater
-     */
-    update(updater) {
-        if (this.ranges === null) throw new Error('unreachable');
-        this.accept(updater(this.ranges));
-    }
-
-    /**
      * @param {RangeId} range
      */
     async deleteRange(range) {
         console.log('📤 [deleteRange]: ', JSON.stringify({ range }));
         const resp = await this.history.messaging.request('deleteRange', { range });
-        if (resp.action === 'delete') {
-            if (range === 'all') {
-                this.update((_old) => {
-                    return {
-                        ranges: [{ id: 'all', count: 0 }],
-                    };
-                });
-            } else {
-                this.update((old) => {
-                    return {
-                        ...old,
-                        ranges: old.ranges.filter((x) => x.id !== range),
-                    };
-                });
-            }
-        }
-        return resp;
+        return { kind: resp.action };
     }
 }

--- a/special-pages/pages/history/app/history.service.js
+++ b/special-pages/pages/history/app/history.service.js
@@ -4,6 +4,7 @@ import { HistoryRangeService } from './history.range.service.js';
 /**
  * @import {ActionResponse} from "../types/history.js"
  * @typedef {import('../types/history.js').Range} Range
+ * @typedef {import('../types/history.js').RangeId} RangeId
  * @typedef {import('../types/history.js').HistoryQuery} HistoryQuery
  * @typedef {import("../types/history.js").HistoryQueryInfo} HistoryQueryInfo
  * @typedef {import("../types/history.js").QueryKind} QueryKind
@@ -301,7 +302,7 @@ export class HistoryService {
     }
 
     /**
-     * @param {Range} range
+     * @param {RangeId} range
      * @return {Promise<{kind: 'none'} | {kind: "range-deleted"}>}
      */
     async deleteRange(range) {
@@ -392,7 +393,7 @@ export function paramsToQuery(params) {
 
 /**
  * @param {null|undefined|string} input
- * @return {import('../types/history.js').Range|null}
+ * @return {import('../types/history.js').RangeId|null}
  */
 export function toRange(input) {
     if (typeof input !== 'string') return null;
@@ -410,7 +411,7 @@ export function toRange(input) {
         'recentlyOpened',
         'older',
     ];
-    return valid.includes(input) ? /** @type {import('../types/history.js').Range} */ (input) : null;
+    return valid.includes(input) ? /** @type {import('../types/history.js').RangeId} */ (input) : null;
 }
 
 /**

--- a/special-pages/pages/history/app/history.service.js
+++ b/special-pages/pages/history/app/history.service.js
@@ -1,5 +1,6 @@
 import { OVERSCAN_AMOUNT } from './constants.js';
 import { HistoryRangeService } from './history.range.service.js';
+import { viewTransition } from '../../new-tab/app/utils.js';
 
 /**
  * @import {ActionResponse} from "../types/history.js"
@@ -261,7 +262,9 @@ export class HistoryService {
         console.log('📤 [entries_delete]: ', JSON.stringify({ ids }));
         const response = await this.history.messaging.request('entries_delete', { ids });
         if (response.action === 'delete') {
-            this._postdelete(indexes);
+            viewTransition(() => {
+                this._postdelete(indexes);
+            });
         }
         return { kind: response.action };
     }

--- a/special-pages/pages/history/app/mocks/mock-transport.js
+++ b/special-pages/pages/history/app/mocks/mock-transport.js
@@ -28,6 +28,18 @@ export function mockTransport() {
     }
 
     let memory = clone(historyMocks.few).value;
+    /** @type {import('../../types/history.ts').GetRangesResponse} */
+    const rangeMemory = {
+        ranges: [
+            { id: 'all', count: 1 },
+            { id: 'today', count: 1 },
+            { id: 'yesterday', count: 1 },
+            { id: 'tuesday', count: 1 },
+            { id: 'monday', count: 1 },
+            { id: 'friday', count: 1 },
+            { id: 'older', count: 1 },
+        ],
+    };
 
     if (url.searchParams.has('history')) {
         const key = url.searchParams.get('history');
@@ -113,19 +125,6 @@ export function mockTransport() {
                     }
                     return Promise.resolve({ action: 'none' });
                 }
-                case 'deleteRange': {
-                    // console.log('📤 [deleteRange]: ', JSON.stringify(msg.params));
-                    // prettier-ignore
-                    const lines = [
-                        `deleteRange: ${JSON.stringify(msg.params)}`,
-                        `To simulate deleting this item, press confirm`
-                    ].join('\n',);
-                    if (confirm(lines)) {
-                        if (msg.params.range === 'all') memory = [];
-                        return Promise.resolve({ action: 'delete' });
-                    }
-                    return Promise.resolve({ action: 'none' });
-                }
                 case 'deleteDomain': {
                     // console.log('📤 [deleteDomain]: ', JSON.stringify(msg.params));
                     // prettier-ignore
@@ -150,7 +149,6 @@ export function mockTransport() {
                     }
                     return Promise.resolve({ action: 'none' });
                 }
-
                 case 'initialSetup': {
                     /** @type {import('../../types/history.ts').InitialSetupResponse} */
                     const initial = {
@@ -161,25 +159,31 @@ export function mockTransport() {
 
                     return Promise.resolve(initial);
                 }
+
+                case 'deleteRange': {
+                    // console.log('📤 [deleteRange]: ', JSON.stringify(msg.params));
+                    // prettier-ignore
+                    const lines = [
+                        `deleteRange: ${JSON.stringify(msg.params)}`,
+                        `To simulate deleting this item, press confirm`
+                    ].join('\n',);
+                    if (confirm(lines)) {
+                        if (msg.params.range === 'all') memory = [];
+                        rangeMemory.ranges = rangeMemory.ranges.filter((x) => {
+                            return x.id !== msg.params.range;
+                        });
+                        console.log(rangeMemory.ranges);
+                        return Promise.resolve({ action: 'delete' });
+                    }
+                    return Promise.resolve({ action: 'none' });
+                }
                 case 'getRanges': {
-                    /** @type {import('../../types/history.ts').GetRangesResponse} */
-                    const response = {
-                        ranges: [
-                            { id: 'all', count: 1 },
-                            { id: 'today', count: 1 },
-                            { id: 'yesterday', count: 1 },
-                            { id: 'tuesday', count: 1 },
-                            { id: 'monday', count: 1 },
-                            { id: 'friday', count: 1 },
-                            { id: 'older', count: 1 },
-                        ],
-                    };
                     if (url.searchParams.get('history') === '0') {
-                        response.ranges = response.ranges.map((range) => {
+                        rangeMemory.ranges = rangeMemory.ranges.map((range) => {
                             return { ...range, count: 0 };
                         });
                     }
-                    return Promise.resolve(response);
+                    return Promise.resolve(rangeMemory);
                 }
                 default: {
                     return Promise.reject(new Error('unhandled request' + msg));

--- a/special-pages/pages/history/app/mocks/mock-transport.js
+++ b/special-pages/pages/history/app/mocks/mock-transport.js
@@ -164,10 +164,20 @@ export function mockTransport() {
                 case 'getRanges': {
                     /** @type {import('../../types/history.ts').GetRangesResponse} */
                     const response = {
-                        ranges: ['all', 'today', 'yesterday', 'tuesday', 'monday', 'friday', 'older'],
+                        ranges: [
+                            { id: 'all', count: 1 },
+                            { id: 'today', count: 1 },
+                            { id: 'yesterday', count: 1 },
+                            { id: 'tuesday', count: 1 },
+                            { id: 'monday', count: 1 },
+                            { id: 'friday', count: 1 },
+                            { id: 'older', count: 1 },
+                        ],
                     };
                     if (url.searchParams.get('history') === '0') {
-                        response.ranges = ['all'];
+                        response.ranges = response.ranges.map((range) => {
+                            return { ...range, count: 0 };
+                        });
                     }
                     return Promise.resolve(response);
                 }

--- a/special-pages/pages/history/integration-tests/history.page.js
+++ b/special-pages/pages/history/integration-tests/history.page.js
@@ -232,7 +232,7 @@ export class HistoryTestPage {
     }
 
     /**
-     * @param {import("../types/history.js").Range} range
+     * @param {import("../types/history.js").RangeId} range
      */
     async didDeleteRange(range) {
         const calls = await this.mocks.waitForCallCount({ method: 'deleteRange', count: 1 });

--- a/special-pages/pages/history/messages/deleteRange.request.json
+++ b/special-pages/pages/history/messages/deleteRange.request.json
@@ -4,7 +4,7 @@
   "title": "Delete Range Params",
   "properties": {
     "range": {
-      "$ref": "./types/range.json"
+      "$ref": "./types/range.json#/definitions/RangeId"
     }
   }
 }

--- a/special-pages/pages/history/messages/types/query.json
+++ b/special-pages/pages/history/messages/types/query.json
@@ -35,7 +35,7 @@
         ],
         "properties": {
           "range": {
-            "$ref": "./range.json"
+            "$ref": "./range.json#/definitions/RangeId"
           }
         }
       }

--- a/special-pages/pages/history/messages/types/range.json
+++ b/special-pages/pages/history/messages/types/range.json
@@ -1,18 +1,46 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "Range",
-  "type": "string",
-  "enum": [
-    "all",
-    "today",
-    "yesterday",
-    "monday",
-    "tuesday",
-    "wednesday",
-    "thursday",
-    "friday",
-    "saturday",
-    "sunday",
-    "older"
+  "type": "object",
+  "properties": {
+    "id": {
+      "$ref": "#/definitions/RangeId"
+    },
+    "count": {
+      "type": "number"
+    }
+  },
+  "required": [
+    "id",
+    "count"
+  ],
+  "definitions": {
+    "RangeId": {
+      "type": "string",
+      "title": "RangeId",
+      "enum": [
+        "all",
+        "today",
+        "yesterday",
+        "monday",
+        "tuesday",
+        "wednesday",
+        "thursday",
+        "friday",
+        "saturday",
+        "sunday",
+        "older"
+      ]
+    }
+  },
+  "examples": [
+    {
+      "id": "today",
+      "count": 10
+    },
+    {
+      "id": "monday",
+      "count": 5
+    }
   ]
 }

--- a/special-pages/pages/history/src/index.js
+++ b/special-pages/pages/history/src/index.js
@@ -11,7 +11,7 @@ import { createSpecialPageMessaging } from '../../../shared/create-special-page-
 import { init } from '../app/index.js';
 import '../../../shared/live-reload.js';
 import { mockTransport } from '../app/mocks/mock-transport.js';
-import { render } from 'preact';
+import { Fragment, h, render } from 'preact';
 
 export class HistoryPage {
     /**
@@ -85,8 +85,22 @@ if (!root) {
 }
 
 init(root, historyPage, baseEnvironment).catch((e) => {
-    // messages.
     console.error(e);
     const msg = typeof e?.message === 'string' ? e.message : 'unknown init error';
     historyPage.reportInitException({ message: msg });
+    document.documentElement.dataset.fatalError = 'true';
+    const element = (
+        <Fragment>
+            <div style="padding: 1rem;">
+                <p>
+                    <strong>A fatal error occurred:</strong>
+                </p>
+                <br />
+                <pre style={{ whiteSpace: 'prewrap', overflow: 'auto' }}>
+                    <code>{JSON.stringify({ message: e.message }, null, 2)}</code>
+                </pre>
+            </div>
+        </Fragment>
+    );
+    render(element, document.body);
 });

--- a/special-pages/pages/history/types/history.ts
+++ b/special-pages/pages/history/types/history.ts
@@ -20,7 +20,7 @@ export type NoneAction = "none";
  * The user asked to see more results from the domain
  */
 export type DomainSearchAction = "domain-search";
-export type Range =
+export type RangeId =
   | "all"
   | "today"
   | "yesterday"
@@ -110,7 +110,7 @@ export interface DeleteRangeRequest {
   result: DeleteRangeResponse;
 }
 export interface DeleteRangeParams {
-  range: Range;
+  range: RangeId;
 }
 export interface DeleteRangeResponse {
   action: ActionResponse;
@@ -167,6 +167,10 @@ export interface GetRangesRequest {
 export interface GetRangesResponse {
   ranges: Range[];
 }
+export interface Range {
+  id: RangeId;
+  count: number;
+}
 /**
  * Generated from @see "../messages/initialSetup.request.json"
  */
@@ -207,7 +211,7 @@ export interface DomainFilter {
   domain: string;
 }
 export interface RangeFilter {
-  range: Range;
+  range: RangeId;
 }
 export interface HistoryQueryResponse {
   info: HistoryQueryInfo;


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/0/1201141132935289/1209559933155092

## Description

- before, a range was just a string enum value - now it's an object with `id` + `count`
- we use the count to optionally disable the 'delete' button

## Testing Steps

- to be tested in the native apps

## Checklist

<!--
  These questions are a friendly reminder to shipping code, if you're uncertain ask the AoR owners.
  It's also totally appropriate to not check some of these boxes, if they don't apply to your change.
-->
*Please tick all that apply:*

- [ ] I have tested this change locally
- [ ] I have tested this change locally in all supported browsers
- [ ] This change will be visible to users
- [ ] I have added automated tests that cover this change
- [ ] I have ensured the change is gated by config
- [ ] This change was covered by a ship review
- [ ] This change was covered by a tech design
- [ ] Any dependent config has been merged

