### PR TITLE
history: error boundary

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -4,7 +4,7 @@
     "ignoreFiles": ["build/**/*.css", "Sources/**/*.css", "docs/**/*.css", "special-pages/pages/**/*/dist/*.css"],
     "rules": {
         "csstree/validator": {
-            "ignoreProperties": ["text-wrap"]
+            "ignoreProperties": ["text-wrap", "view-transition-name"]
         },
         "alpha-value-notation": null,
         "at-rule-empty-line-before": null,

--- a/special-pages/pages/history/app/components/App.jsx
+++ b/special-pages/pages/history/app/components/App.jsx
@@ -84,7 +84,6 @@ export function AppLevelErrorBoundaryFallback({ children }) {
                 You can try to{' '}
                 <button
                     onClick={() => {
-                        9;
                         const current = new URL(window.location.href);
                         current.search = '';
                         current.pathname = '';

--- a/special-pages/pages/history/app/components/App.jsx
+++ b/special-pages/pages/history/app/components/App.jsx
@@ -75,3 +75,25 @@ export function App() {
         </div>
     );
 }
+
+export function AppLevelErrorBoundaryFallback({ children }) {
+    return (
+        <div class={styles.paddedError}>
+            <p>{children}</p>
+            <div class={styles.paddedErrorRecovery}>
+                You can try to{' '}
+                <button
+                    onClick={() => {
+                        9;
+                        const current = new URL(window.location.href);
+                        current.search = '';
+                        current.pathname = '';
+                        location.href = current.toString();
+                    }}
+                >
+                    Reload this page
+                </button>
+            </div>
+        </div>
+    );
+}

--- a/special-pages/pages/history/app/components/App.module.css
+++ b/special-pages/pages/history/app/components/App.module.css
@@ -40,6 +40,9 @@ body {
     grid-area: header;
     padding-left: var(--main-padding-left);
     padding-right: var(--main-padding-right);
+    view-transition-name: header;
+    z-index: 1;
+    background-color: var(--history-background-color);
 }
 .search {
     justify-self: flex-end;

--- a/special-pages/pages/history/app/components/App.module.css
+++ b/special-pages/pages/history/app/components/App.module.css
@@ -106,3 +106,11 @@ body {
         }
     }
 }
+
+.paddedError {
+    padding: 1rem;
+}
+
+.paddedErrorRecovery {
+    margin-top: 1rem;
+}

--- a/special-pages/pages/history/app/components/Empty.js
+++ b/special-pages/pages/history/app/components/Empty.js
@@ -2,20 +2,38 @@ import { h } from 'preact';
 import { useTypedTranslation } from '../types.js';
 import cn from 'classnames';
 import styles from './VirtualizedList.module.css';
+import { useQueryContext } from '../global/Providers/QueryProvider.js';
 
 /**
  * Empty state component displayed when no results are available
+ * @param {object} props
+ * @param {object} props.title
+ * @param {object} props.text
  */
-export function Empty() {
-    const { t } = useTypedTranslation();
+export function Empty({ title, text }) {
     return (
         <div class={cn(styles.emptyState, styles.emptyStateOffset)}>
             <div class={styles.icons}>
                 <img src="icons/backdrop.svg" width={128} height={96} alt="" />
                 <img src="icons/clock.svg" width={60} height={60} alt="" class={styles.forground} />
             </div>
-            <h2 class={styles.emptyTitle}>{t('empty_title')}</h2>
-            <p class={styles.emptyText}>{t('empty_text')}</p>
+            <h2 class={styles.emptyTitle}>{title}</h2>
+            <p class={styles.emptyText}>{text}</p>
         </div>
     );
+}
+
+/**
+ * Use the application state to figure out which title+text to use.
+ */
+export function EmptyState() {
+    const { t } = useTypedTranslation();
+    const query = useQueryContext();
+    const hasSearch = query.value.term !== null && query.value.term.trim().length > 0;
+
+    if (hasSearch) {
+        return <Empty title={t('no_results_title', { term: `"${query.value.term}"` })} text={t('no_results_text')} />;
+    }
+
+    return <Empty title={t('empty_title')} text={t('empty_text')} />;
 }

--- a/special-pages/pages/history/app/components/Results.js
+++ b/special-pages/pages/history/app/components/Results.js
@@ -3,7 +3,7 @@ import { DDG_DEFAULT_ICON_SIZE, OVERSCAN_AMOUNT } from '../constants.js';
 import { Item } from './Item.js';
 import styles from './VirtualizedList.module.css';
 import { VisibleItems } from './VirtualizedList.js';
-import { Empty } from './Empty.js';
+import { EmptyState } from './Empty.js';
 import { useSelected, useSelectionState } from '../global/Providers/SelectionProvider.js';
 import { useHistoryServiceDispatch, useResultsData } from '../global/Providers/HistoryServiceProvider.js';
 import { useCallback, useEffect } from 'preact/hooks';
@@ -45,7 +45,7 @@ export function ResultsContainer() {
  */
 export function Results({ results, selected, onChange }) {
     if (results.value.items.length === 0) {
-        return <Empty />;
+        return <EmptyState />;
     }
 
     /**

--- a/special-pages/pages/history/app/history.md
+++ b/special-pages/pages/history/app/history.md
@@ -73,7 +73,8 @@ params for a query: (note: can be an empty string!)
     "term": "example.com"
   },
   "offset": 0,
-  "limit": 50
+  "limit": 50,
+  "source": "initial"
 }
 ```
 
@@ -85,7 +86,8 @@ params for a range, note: the values here will match what you returned from `get
     "range": "today"
   },
   "offset": 0,
-  "limit": 50
+  "limit": 50,
+  "source": "initial"
 }
 ```
 

--- a/special-pages/pages/history/app/index.js
+++ b/special-pages/pages/history/app/index.js
@@ -1,7 +1,7 @@
 import { h, render } from 'preact';
 import { EnvironmentProvider, UpdateEnvironment } from '../../../shared/components/EnvironmentProvider.js';
 
-import { App } from './components/App.jsx';
+import { App, AppLevelErrorBoundaryFallback } from './components/App.jsx';
 import { Components } from './components/Components.jsx';
 
 import enStrings from '../public/locales/en/history.json';
@@ -14,6 +14,7 @@ import { HistoryServiceProvider } from './global/Providers/HistoryServiceProvide
 import { Settings } from './Settings.js';
 import { SelectionProvider } from './global/Providers/SelectionProvider.js';
 import { QueryProvider } from './global/Providers/QueryProvider.js';
+import { InlineErrorBoundary } from '../../../shared/components/InlineErrorBoundary.js';
 
 /**
  * @param {Element} root
@@ -45,47 +46,54 @@ export async function init(root, messaging, baseEnvironment) {
         .withDebounce(baseEnvironment.urlParams.get('debounce'))
         .withUrlDebounce(baseEnvironment.urlParams.get('urlDebounce'));
 
-    console.log('initialSetup', init);
-    console.log('environment', environment);
-    console.log('settings', settings);
+    if (!window.__playwright_01) {
+        console.log('initialSetup', init);
+        console.log('environment', environment);
+        console.log('settings', settings);
+    }
 
-    const strings =
-        environment.locale === 'en'
-            ? enStrings
-            : await fetch(`./locales/${environment.locale}/history.json`)
-                  .then((resp) => {
-                      if (!resp.ok) {
-                          throw new Error('did not give a result');
-                      }
-                      return resp.json();
-                  })
-                  .catch((e) => {
-                      console.error('Could not load locale', environment.locale, e);
-                      return enStrings;
-                  });
+    /**
+     * @param {string} message
+     */
+    const didCatchInit = (message) => {
+        messaging.reportInitException({ message });
+    };
 
+    const strings = await getStrings(environment);
     const service = new HistoryService(messaging);
     const query = paramsToQuery(environment.urlParams, 'initial');
-    const initial = await service.getInitial(query);
+    const initial = await fetchInitial(query, service, didCatchInit);
 
     if (environment.display === 'app') {
         render(
-            <EnvironmentProvider debugState={environment.debugState} injectName={environment.injectName} willThrow={environment.willThrow}>
-                <UpdateEnvironment search={window.location.search} />
-                <TranslationProvider translationObject={strings} fallback={enStrings} textLength={environment.textLength}>
-                    <MessagingContext.Provider value={messaging}>
-                        <SettingsContext.Provider value={settings}>
-                            <QueryProvider query={query.query}>
-                                <HistoryServiceProvider service={service} initial={initial}>
-                                    <SelectionProvider>
-                                        <App />
-                                    </SelectionProvider>
-                                </HistoryServiceProvider>
-                            </QueryProvider>
-                        </SettingsContext.Provider>
-                    </MessagingContext.Provider>
-                </TranslationProvider>
-            </EnvironmentProvider>,
+            <InlineErrorBoundary
+                messaging={messaging}
+                context={'History view application'}
+                fallback={(message) => {
+                    return <AppLevelErrorBoundaryFallback>{message}</AppLevelErrorBoundaryFallback>;
+                }}
+            >
+                <EnvironmentProvider
+                    debugState={environment.debugState}
+                    injectName={environment.injectName}
+                    willThrow={environment.willThrow}
+                >
+                    <UpdateEnvironment search={window.location.search} />
+                    <TranslationProvider translationObject={strings} fallback={enStrings} textLength={environment.textLength}>
+                        <MessagingContext.Provider value={messaging}>
+                            <SettingsContext.Provider value={settings}>
+                                <QueryProvider query={query.query}>
+                                    <HistoryServiceProvider service={service} initial={initial}>
+                                        <SelectionProvider>
+                                            <App />
+                                        </SelectionProvider>
+                                    </HistoryServiceProvider>
+                                </QueryProvider>
+                            </SettingsContext.Provider>
+                        </MessagingContext.Provider>
+                    </TranslationProvider>
+                </EnvironmentProvider>
+            </InlineErrorBoundary>,
             root,
         );
     } else if (environment.display === 'components') {
@@ -98,4 +106,43 @@ export async function init(root, messaging, baseEnvironment) {
             root,
         );
     }
+}
+
+/**
+ * @param {import('../types/history.js').HistoryQuery} query
+ * @param {HistoryService} service
+ * @param {(message: string) => void} didCatch
+ * @returns {Promise<import('./history.service.js').InitialServiceData>}
+ */
+async function fetchInitial(query, service, didCatch) {
+    try {
+        return await service.getInitial(query);
+    } catch (e) {
+        console.error(e);
+        didCatch(e.message || String(e));
+        return {
+            ranges: {
+                ranges: [{ id: 'all', count: 0 }],
+            },
+            query: {
+                info: { query: { term: '' }, finished: true },
+                results: [],
+                lastQueryParams: null,
+            },
+        };
+    }
+}
+
+/**
+ * @param {import("../../../shared/environment").Environment} environment
+ */
+async function getStrings(environment) {
+    return environment.locale === 'en'
+        ? enStrings
+        : await fetch(`./locales/${environment.locale}/new-tab.json`)
+              .then((x) => x.json())
+              .catch((e) => {
+                  console.error('Could not load locale', environment.locale, e);
+                  return enStrings;
+              });
 }

--- a/special-pages/pages/history/app/mocks/mock-transport.js
+++ b/special-pages/pages/history/app/mocks/mock-transport.js
@@ -218,6 +218,9 @@ function queryResponseFrom(memory, msg) {
     if ('term' in msg.params.query) {
         const { term } = msg.params.query;
         if (term !== '') {
+            if (term === 'empty' || term.includes('"') || term.includes('<')) {
+                return asResponse([], msg.params.offset, msg.params.limit);
+            }
             if (term === 'empty') {
                 return asResponse([], msg.params.offset, msg.params.limit);
             }

--- a/special-pages/pages/history/app/strings.json
+++ b/special-pages/pages/history/app/strings.json
@@ -4,8 +4,16 @@
     "note": "Text shown where there are no remaining history entries"
   },
   "empty_text": {
-    "title": "Page visits will appear once you start browsing.",
+    "title": "No browsing history yet.",
     "note": "Placeholder text when there's no results to show"
+  },
+  "no_results_title": {
+    "title": "No results found for {term}",
+    "note": "The placeholder {term} will be dynamically replaced with the search term entered by the user. For example, if the user searches for 'cats', the title will become 'No results found for cats'."
+  },
+  "no_results_text": {
+    "title": "Try searching for a different URL or keywords",
+    "note": "Placeholder text when a search gave no results."
   },
   "delete_all": {
     "title": "Delete All",

--- a/special-pages/pages/history/integration-tests/history.page.js
+++ b/special-pages/pages/history/integration-tests/history.page.js
@@ -277,7 +277,19 @@ export class HistoryTestPage {
         await page.getByRole('button', { name: 'Delete All', exact: true }).click();
         const calls = await this.mocks.waitForCallCount({ method: 'deleteRange', count: 1 });
         expect(calls[0].payload.params).toStrictEqual({ range: 'all' });
+        await this.hasEmptyState();
+    }
+
+    async hasEmptyState() {
+        const { page } = this;
         await expect(page.getByRole('heading', { level: 2, name: 'Nothing to see here!' })).toBeVisible();
+        await expect(page.getByText('No browsing history yet.')).toBeVisible();
+    }
+
+    async hasNoResultsState() {
+        const { page } = this;
+        await expect(page.getByRole('heading', { level: 2, name: 'No results found for "empty"' })).toBeVisible();
+        await expect(page.getByText('Try searching for a different URL or keywords')).toBeVisible();
     }
 
     /**

--- a/special-pages/pages/history/integration-tests/history.spec.js
+++ b/special-pages/pages/history/integration-tests/history.spec.js
@@ -2,6 +2,20 @@ import { test } from '@playwright/test';
 import { HistoryTestPage } from './history.page.js';
 
 test.describe('history', () => {
+    test('has empty state', async ({ page }, workerInfo) => {
+        const hp = HistoryTestPage.create(page, workerInfo).withEntries(0);
+        await hp.openPage();
+        await hp.didMakeInitialQueries({ term: '' });
+        await hp.hasEmptyState();
+    });
+    test('has no-results state', async ({ page }, workerInfo) => {
+        const hp = HistoryTestPage.create(page, workerInfo).withEntries(0);
+        await hp.openPage();
+        await hp.didMakeInitialQueries({ term: '' });
+        await hp.hasEmptyState();
+        await hp.types('empty');
+        await hp.hasNoResultsState();
+    });
     test('makes an initial empty query', async ({ page }, workerInfo) => {
         const hp = HistoryTestPage.create(page, workerInfo).withEntries(100);
         await hp.openPage();

--- a/special-pages/pages/history/public/locales/en/history.json
+++ b/special-pages/pages/history/public/locales/en/history.json
@@ -14,8 +14,16 @@
     "note": "Text shown where there are no remaining history entries"
   },
   "empty_text": {
-    "title": "Page visits will appear once you start browsing.",
+    "title": "No browsing history yet.",
     "note": "Placeholder text when there's no results to show"
+  },
+  "no_results_title": {
+    "title": "No results found for {term}",
+    "note": "The placeholder {term} will be dynamically replaced with the search term entered by the user. For example, if the user searches for 'cats', the title will become 'No results found for cats'."
+  },
+  "no_results_text": {
+    "title": "Try searching for a different URL or keywords",
+    "note": "Placeholder text when a search gave no results."
   },
   "delete_all": {
     "title": "Delete All",

--- a/special-pages/shared/components/InlineErrorBoundary.js
+++ b/special-pages/shared/components/InlineErrorBoundary.js
@@ -1,0 +1,29 @@
+import { h } from 'preact';
+import { ErrorBoundary } from './ErrorBoundary.js';
+
+export const INLINE_ERROR = 'A problem occurred with this feature. DuckDuckGo was notified';
+
+/**
+ * @param {object} props
+ * @param {import("preact").ComponentChild} props.children
+ * @param {(message: string) => string} [props.format] - This gives you access to the error message, so you can append relevant context
+ * @param {string} [props.context] - Passed to `ErrorBoundary`, if you provide this, it will be prepended to messages. Favor this before
+ * using `format`
+ * @param {(message: string) => import("preact").ComponentChild} [props.fallback]
+ * @param {{reportPageException: (arg: {message:string}) => void}} props.messaging
+ */
+export function InlineErrorBoundary({ children, format, context, fallback, messaging }) {
+    /**
+     * @param {string} message
+     */
+    const didCatch = (message) => {
+        const formatted = format?.(message) || message;
+        messaging.reportPageException({ message: formatted });
+    };
+    const fallbackElement = fallback?.(INLINE_ERROR) || <p>{INLINE_ERROR}</p>;
+    return (
+        <ErrorBoundary context={context} didCatch={({ message }) => didCatch(message)} fallback={fallbackElement}>
+            {children}
+        </ErrorBoundary>
+    );
+}


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/0/492600419927320/1209580861623842

## Description

- [x] global error handler that allows a page reload

## Testing Steps

- Run locally with `npm run watch -- --page history -v` (run inside `special-pages`)
- Place a `throw new Error('oops!')`  in any component, such as `special-pages/pages/history/app/components/App.jsx`
- verify you see the recovery UI
- NOTE: this is more of a debugging tool, it's not expected to be shown to users. If it were, there'd be a much bigger issue.

## Checklist

<!--
  These questions are a friendly reminder to shipping code, if you're uncertain ask the AoR owners.
  It's also totally appropriate to not check some of these boxes, if they don't apply to your change.
-->
*Please tick all that apply:*

- [ ] I have tested this change locally
- [ ] I have tested this change locally in all supported browsers
- [ ] This change will be visible to users
- [ ] I have added automated tests that cover this change
- [ ] I have ensured the change is gated by config
- [ ] This change was covered by a ship review
- [ ] This change was covered by a tech design
- [ ] Any dependent config has been merged

