### PR TITLE
history: reset when clicking outside the main container

### DIFF
--- a/special-pages/pages/history/app/components/App.jsx
+++ b/special-pages/pages/history/app/components/App.jsx
@@ -19,6 +19,7 @@ import { useSearchCommit } from '../global/hooks/useSearchCommit.js';
 import { useRangesData } from '../global/Providers/HistoryServiceProvider.js';
 import { usePlatformName } from '../types.js';
 import { useLayoutMode } from '../global/hooks/useLayoutMode.js';
+import { useClickAnywhereElse } from '../global/hooks/useClickAnywhereElse.jsx';
 
 export function App() {
     const platformName = usePlatformName();
@@ -39,6 +40,7 @@ export function App() {
     useURLReflection();
     useSearchCommit();
     useSearchCommitForRange();
+    const clickAnywhere = useClickAnywhereElse();
 
     /**
      * onClick can be passed directly to the main container,
@@ -62,7 +64,13 @@ export function App() {
     }, [onKeyDown, query]);
 
     return (
-        <div class={styles.layout} data-theme={isDarkMode ? 'dark' : 'light'} data-platform={platformName} data-layout-mode={mode}>
+        <div
+            class={styles.layout}
+            data-theme={isDarkMode ? 'dark' : 'light'}
+            data-platform={platformName}
+            data-layout-mode={mode}
+            onClick={clickAnywhere}
+        >
             <aside class={styles.aside}>
                 <Sidebar ranges={ranges} />
             </aside>

--- a/special-pages/pages/history/app/global/Providers/SelectionProvider.js
+++ b/special-pages/pages/history/app/global/Providers/SelectionProvider.js
@@ -99,11 +99,7 @@ export function useRowInteractions(mainRef) {
             if (handled) {
                 event.preventDefault();
                 event.stopImmediatePropagation();
-            } else {
-                console.log('did not handle selection');
             }
-        } else {
-            dispatch({ kind: 'reset', reason: 'click occurred outside of rows' });
         }
     }
 

--- a/special-pages/pages/history/app/global/hooks/useClickAnywhereElse.jsx
+++ b/special-pages/pages/history/app/global/hooks/useClickAnywhereElse.jsx
@@ -1,0 +1,18 @@
+import { useSelectionDispatch } from '../Providers/SelectionProvider.js';
+import { useCallback } from 'preact/hooks';
+
+/**
+ * Custom hook that creates a callback function to handle click events occurring outside of specified elements.
+ * The callback dispatches a reset action when the click event target is not a button or an anchor element.
+ */
+export function useClickAnywhereElse() {
+    const dispatch = useSelectionDispatch();
+    return useCallback(
+        (e) => {
+            if (e.target?.closest?.('button,a') === null) {
+                dispatch({ kind: 'reset', reason: 'click occurred outside of rows' });
+            }
+        },
+        [dispatch],
+    );
+}


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/0/0/1209532669589622/f

## Description

- Before, only the main container would capture additional clicks (to deselect)
- After: now any click outside of buttons and links will cause the selections to reset

## Testing Steps

- `npm run watch -- --page history -v`
- select a row, then click something like the header, or below the sidebar links, everything should de-select

## Checklist

<!--
  These questions are a friendly reminder to shipping code, if you're uncertain ask the AoR owners.
  It's also totally appropriate to not check some of these boxes, if they don't apply to your change.
-->
*Please tick all that apply:*

- [ ] I have tested this change locally
- [ ] I have tested this change locally in all supported browsers
- [ ] This change will be visible to users
- [ ] I have added automated tests that cover this change
- [ ] I have ensured the change is gated by config
- [ ] This change was covered by a ship review
- [ ] This change was covered by a tech design
- [ ] Any dependent config has been merged

