### PR TITLE
ntp: fix layout of RMF widget on older macOS

### DIFF
--- a/special-pages/pages/new-tab/app/components/Components.jsx
+++ b/special-pages/pages/new-tab/app/components/Components.jsx
@@ -171,10 +171,15 @@ function TextLength() {
 function Isolate() {
     const next = new URL(url);
     next.searchParams.set('isolate', 'true');
+    const prod = new URL('/build/pages/new-tab', 'https://content-scope-scripts.netlify.app');
+    prod.search = url.search;
     return (
         <div class={styles.buttonRow}>
             <a href={next.toString()} target={'_blank'}>
                 Isolate (open in a new tab)
+            </a>
+            <a href={prod.toString()} target={'_blank'}>
+                Open in Production (new tab)
             </a>
         </div>
     );

--- a/special-pages/pages/new-tab/app/remote-messaging-framework/components/RemoteMessagingFramework.module.css
+++ b/special-pages/pages/new-tab/app/remote-messaging-framework/components/RemoteMessagingFramework.module.css
@@ -14,7 +14,6 @@
     animation: animate-fade .2s cubic-bezier(0.55, 0.055, 0.666, 0.19);
     margin-bottom: var(--ntp-gap);
 
-
     &.icon {
         padding-left: var(--sp-2);
     }
@@ -24,11 +23,10 @@
     margin-right: var(--sp-2);
     width: 3rem;
     min-width: 3rem;
+    display: block;
 }
 
-.content {
-    flex-grow: 1;
-}
+.content {}
 
 .title {
     font-size: var(--body-font-size);
@@ -45,6 +43,7 @@
 .btnBlock {
     margin-left: var(--sp-3);
     align-self: center;
+    flex-shrink: 0;
 }
 
 .btnRow {


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/0/1201141132935289/1209495940971615

## Description

- on older macos versions, the behaviour of flexbox was causing the layout issue in the screenshots. 

## Testing Steps

- Compare production https://content-scope-scripts.netlify.app/build/pages/new-tab/?rmf=big_single_action
- to this PR: https://deploy-preview-1548--content-scope-scripts.netlify.app/build/pages/new-tab/?rmf=big_single_action
- in modern macOS/windows - you should see no difference, but in Ventura or BigSur, you'll see the following: (I used BrowserStack to verify)

**Production**:
<img width="591" alt="image" src="https://github.com/user-attachments/assets/d901e1ca-1518-460a-b05b-a24249390d20" />

**This PR**:
<img width="610" alt="image" src="https://github.com/user-attachments/assets/694f3d90-d3f1-4a88-8a3d-8fb6383fefa4" />


## Checklist

<!--
  These questions are a friendly reminder to shipping code, if you're uncertain ask the AoR owners.
  It's also totally appropriate to not check some of these boxes, if they don't apply to your change.
-->
*Please tick all that apply:*

- [ ] I have tested this change locally
- [ ] I have tested this change locally in all supported browsers
- [ ] This change will be visible to users
- [ ] I have added automated tests that cover this change
- [ ] I have ensured the change is gated by config
- [ ] This change was covered by a ship review
- [ ] This change was covered by a tech design
- [ ] Any dependent config has been merged

