### PR TITLE
feat(pir): add error object control flow

### DIFF
--- a/injected/src/features/broker-protection/captcha-services/factory.js
+++ b/injected/src/features/broker-protection/captcha-services/factory.js
@@ -32,6 +32,11 @@ export class CaptchaFactory {
         return this._getAllProviders().find((provider) => provider.isSupportedForElement(element)) || null;
     }
 
+    /**
+     * Detect the captcha provider based on the root document
+     * @param {Document} root - The root document
+     * @returns {import('./providers/provider.interface').CaptchaProvider|null}
+     */
     detectSolveProvider(root) {
         return this._getAllProviders().find((provider) => provider.canSolve(root)) || null;
     }

--- a/injected/src/features/broker-protection/captcha-services/get-captcha-provider.js
+++ b/injected/src/features/broker-protection/captcha-services/get-captcha-provider.js
@@ -1,3 +1,4 @@
+import { PirError } from '../types';
 import { captchaFactory } from './providers/registry';
 
 /**
@@ -5,13 +6,11 @@ import { captchaFactory } from './providers/registry';
  *
  * @param {HTMLElement} captchaDiv
  * @param {string} captchaType
- * @return {import('./providers/provider.interface.js').CaptchaProvider}
- * @throws {Error}
  */
 export function getCaptchaProvider(captchaDiv, captchaType) {
     const captchaProvider = captchaFactory.getProviderByType(captchaType);
     if (!captchaProvider) {
-        throw new Error(`[getCaptchaProvider] could not find captchaProvider with type ${captchaType}`);
+        return PirError.create(`[getCaptchaProvider] could not find captchaProvider with type ${captchaType}`);
     }
 
     if (captchaProvider.isSupportedForElement(captchaDiv)) {
@@ -25,7 +24,9 @@ export function getCaptchaProvider(captchaDiv, captchaType) {
     );
     const detectedProvider = captchaFactory.detectProvider(captchaDiv);
     if (!detectedProvider) {
-        throw new Error(`[getCaptchaProvider] could not detect captcha provider for ${captchaType} captcha and element ${captchaDiv}`);
+        return PirError.create(
+            `[getCaptchaProvider] could not detect captcha provider for ${captchaType} captcha and element ${captchaDiv}`,
+        );
     }
 
     return detectedProvider;
@@ -35,13 +36,11 @@ export function getCaptchaProvider(captchaDiv, captchaType) {
  * Gets the captcha provider for the solveCaptcha action
  * @param {Document} root
  * @param {string} captchaType
- * @return {import('./providers/provider.interface.js').CaptchaProvider}
- * @throws {Error}
  */
 export function getCaptchaSolveProvider(root, captchaType) {
     const captchaProvider = captchaFactory.getProviderByType(captchaType);
     if (!captchaProvider) {
-        throw new Error(`[getCaptchaSolveProvider] could not find captchaProvider with type ${captchaType}`);
+        return PirError.create(`[getCaptchaSolveProvider] could not find captchaProvider with type ${captchaType}`);
     }
 
     if (captchaProvider.canSolve(root)) {
@@ -55,7 +54,9 @@ export function getCaptchaSolveProvider(root, captchaType) {
     );
     const detectedProvider = captchaFactory.detectSolveProvider(root);
     if (!detectedProvider) {
-        throw new Error(`[getCaptchaSolveProvider] could not detect captcha provider for ${captchaType} captcha and element ${root}`);
+        return PirError.create(
+            `[getCaptchaSolveProvider] could not detect captcha provider for ${captchaType} captcha and element ${root}`,
+        );
     }
 
     return detectedProvider;

--- a/injected/src/features/broker-protection/captcha-services/providers/cloudflare-turnstile.js
+++ b/injected/src/features/broker-protection/captcha-services/providers/cloudflare-turnstile.js
@@ -1,3 +1,5 @@
+import { PirError } from '../../types';
+
 /**
  * @import { CaptchaProvider } from './provider.interface';
  * @implements {CaptchaProvider}
@@ -42,7 +44,7 @@ export class CloudFlareTurnstileProvider {
      */
     injectToken(root, token) {
         // TODO: Implement
-        return false;
+        return PirError.create('Not implemented');
     }
 
     /**

--- a/injected/src/features/broker-protection/captcha-services/providers/hcaptcha.js
+++ b/injected/src/features/broker-protection/captcha-services/providers/hcaptcha.js
@@ -1,3 +1,4 @@
+import { PirError } from '../../types';
 import { getUrlHashParameter, getUrlParameter } from '../../utils/url';
 import { getElementByName, getElementWithSrcStart } from '../../utils/utils';
 import { stringifyFunction } from '../utils/stringify-function';
@@ -24,18 +25,16 @@ export class HCaptchaProvider {
 
     /**
      * @param {HTMLElement} captchaContainerElement - The element to check
-     * @returns {string|null} - The site key or null if not found
-     * @throws {Error}
      */
     getCaptchaIdentifier(captchaContainerElement) {
         const captchaElement = this._getCaptchaElement(captchaContainerElement);
         if (!captchaElement) {
-            throw new Error('[getCaptchaIdentifier] could not find captcha');
+            return PirError.create('[getCaptchaIdentifier] could not find captcha');
         }
 
         const siteKey = this._getSiteKeyFromElement(captchaElement) || this._getSiteKeyFromUrl(captchaElement);
         if (!siteKey) {
-            throw new Error('[HCaptchaProvider.getCaptchaIdentifier] could not extract site key');
+            return PirError.create('[HCaptchaProvider.getCaptchaIdentifier] could not extract site key');
         }
 
         return siteKey;
@@ -68,7 +67,6 @@ export class HCaptchaProvider {
      * Injects the token to solve the captcha
      * @param {Document} root - The document root
      * @param {string} token - The solved captcha token
-     * @returns {boolean} - Whether the injection was successful
      */
     injectToken(root, token) {
         return injectTokenIntoElement({ root, elementName: this.#CAPTCHA_RESPONSE_ELEMENT_NAME, token });
@@ -95,7 +93,6 @@ export class HCaptchaProvider {
     /**
      * @private
      * @param {HTMLElement} captchaElement
-     * @returns {string|null} The site key or null if not found
      */
     _getSiteKeyFromUrl(captchaElement) {
         if (!('src' in captchaElement)) {

--- a/injected/src/features/broker-protection/captcha-services/providers/provider.interface.js
+++ b/injected/src/features/broker-protection/captcha-services/providers/provider.interface.js
@@ -1,5 +1,6 @@
 /**
  * Base interface for captcha providers
+ * @import {PirError, PirResponse} from '../../types';
  * @interface
  * @abstract
  */
@@ -27,7 +28,7 @@ export class CaptchaProvider {
      * Extracts the site key from the captcha container element
      * @abstract
      * @param {HTMLElement} captchaContainerElement - The element containing the captcha
-     * @returns {string|null} The site key or null if not found
+     * @returns {PirError | string | null} The site key or null if not found
      */
     getCaptchaIdentifier(captchaContainerElement) {
         throw new Error('getCaptchaIdentifier() missing implementation');
@@ -56,7 +57,7 @@ export class CaptchaProvider {
      * @abstract
      * @param {Document} root - The document root containing the captcha
      * @param {string} token - The solved captcha token
-     * @returns {boolean} True if the token was successfully injected
+     * @returns {PirResponse<{ injected: boolean }>} - Whether the token was injected
      */
     injectToken(root, token) {
         throw new Error('injectToken() missing implementation');
@@ -66,7 +67,7 @@ export class CaptchaProvider {
      * Creates a callback function to execute when the captcha is solved
      * @abstract
      * @param {string} token - The solved captcha token
-     * @returns {string|null} Callback function to execute when the captcha is solved
+     * @returns {PirError|string|null} Callback function to execute when the captcha is solved
      */
     getSolveCallback(token) {
         throw new Error('getSolveCallback() missing implementation');

--- a/injected/src/features/broker-protection/captcha-services/providers/recaptcha.js
+++ b/injected/src/features/broker-protection/captcha-services/providers/recaptcha.js
@@ -4,6 +4,7 @@ import { stringifyFunction } from '../utils/stringify-function';
 import { injectTokenIntoElement } from '../utils/token';
 // TODO move on the same folder level once we deprecate the existing captcha scripts
 import { captchaCallback } from '../../actions/captcha-callback';
+import { safeCallWithError } from '../../utils/safe-call';
 
 // define the config below to reuse it in the class
 /**
@@ -43,10 +44,12 @@ export class ReCaptchaProvider {
 
     /**
      * @param {HTMLElement} captchaContainerElement
-     * @throws {Error}
      */
     getCaptchaIdentifier(captchaContainerElement) {
-        return getSiteKeyFromSearchParam({ captchaElement: this._getCaptchaElement(captchaContainerElement), siteKeyAttrName: 'k' });
+        return safeCallWithError(
+            () => getSiteKeyFromSearchParam({ captchaElement: this._getCaptchaElement(captchaContainerElement), siteKeyAttrName: 'k' }),
+            { errorMessage: '[ReCaptchaProvider.getCaptchaIdentifier] could not extract site key' },
+        );
     }
 
     getSupportingCodeToInject() {

--- a/injected/src/features/broker-protection/captcha-services/utils/token.js
+++ b/injected/src/features/broker-protection/captcha-services/utils/token.js
@@ -1,27 +1,27 @@
-import { safeCall } from '../../utils/safe-call';
+import { PirError, PirSuccess } from '../../types';
+import { safeCallWithError } from '../../utils/safe-call';
 import { getElementByName } from '../../utils/utils';
 
 /**
  * Inject a token into a named element
+ * @import { PirResponse } from '../../types';
  * @param {object} params
  * @param {Document} params.root - The document root
  * @param {string} params.elementName - Name attribute of the element to inject into
  * @param {string} params.token - The token to inject
- * @returns {boolean} - Whether the injection was successful
+ * @returns {PirResponse<{ injected: boolean }>} - Whether the token was injected
  */
 export function injectTokenIntoElement({ root, elementName, token }) {
     const element = getElementByName(root, elementName);
     if (!element) {
-        return false;
+        return PirError.create(`[injectTokenIntoElement] could not find element with name ${elementName}`);
     }
 
-    return (
-        safeCall(
-            () => {
-                element.innerHTML = token;
-                return true;
-            },
-            { errorMessage: `[injectTokenIntoElement] error injecting token into element ${elementName}` },
-        ) ?? false
+    return safeCallWithError(
+        () => {
+            element.innerHTML = token;
+            return PirSuccess.create({ injected: true });
+        },
+        { errorMessage: `[injectTokenIntoElement] error injecting token into element ${elementName}` },
     );
 }

--- a/injected/src/features/broker-protection/types.js
+++ b/injected/src/features/broker-protection/types.js
@@ -2,16 +2,96 @@
  * @typedef {SuccessResponse | ErrorResponse} ActionResponse
  * @typedef {{ result: true } | { result: false; error: string }} BooleanResult
  * @typedef {{type: "element" | "text" | "url"; selector: string; parent?: string; expect?: string; failSilently?: boolean}} Expectation
- *
- * @typedef {{
- *   id: string;
- *   actionType: "extract" | "fillForm" | "click" | "expectation" | "getCaptchaInfo" | "solveCaptcha" | "navigate";
- *   selector: string;
- *   captchaType?: string;
- *   injectCaptchaHandler?: string
- *   dataSource?: string;
- * }} PirAction
  */
+
+/**
+ * @typedef {object} PirAction
+ * @property {string} id
+ * @property {"extract" | "fillForm" | "click" | "expectation" | "getCaptchaInfo" | "solveCaptcha" | "navigate"} actionType
+ * @property {string} selector
+ * @property {string} [captchaType]
+ * @property {string} [injectCaptchaHandler]
+ * @property {string} [dataSource]
+ */
+
+/**
+ * @template T
+ * @typedef {PirError | PirSuccess<T>} PirResponse
+ */
+
+export class PirError {
+    /**
+     * @param {object} params
+     * @param {boolean} params.success
+     * @param {object} params.error
+     * @param {string} params.error.message
+     */
+    constructor(params) {
+        this.success = params.success;
+        this.error = params.error;
+    }
+
+    /**
+     * @param {string} message
+     * @return {PirError}
+     * @static
+     * @memberof PirError
+     */
+    static create(message) {
+        return new PirError({ success: false, error: { message } });
+    }
+
+    /**
+     * @param {object} error
+     * @return {error is PirError}
+     * @static
+     * @memberof PirError
+     */
+    static isError(error) {
+        return error instanceof PirError && error.success === false;
+    }
+}
+
+/**
+ * Represents a successful response
+ * @template T
+ */
+export class PirSuccess {
+    /**
+     * @param {object} params
+     * @param {boolean} params.success
+     * @param {T} params.response
+     */
+    constructor(params) {
+        this.success = params.success;
+        this.response = params.response;
+    }
+
+    /**
+     * @template T
+     * @param {T} response
+     * @return {PirSuccess<T>}
+     * @static
+     * @memberof PirSuccess
+     */
+    static create(response) {
+        return new PirSuccess({ success: true, response });
+    }
+
+    static createEmpty() {
+        return new PirSuccess({ success: true, response: null });
+    }
+
+    /**
+     * @param {object} params
+     * @return {params is PirSuccess}
+     * @static
+     * @memberof PirSuccess
+     */
+    static isSuccess(params) {
+        return params instanceof PirSuccess && params.success === true;
+    }
+}
 
 /**
  * Represents an error
@@ -25,22 +105,58 @@ export class ErrorResponse {
     constructor(params) {
         this.error = params;
     }
+
+    /**
+     * @param {ActionResponse} response
+     * @return {response is ErrorResponse}
+     * @static
+     * @memberof ErrorResponse
+     */
+    static isErrorResponse(response) {
+        return response instanceof ErrorResponse;
+    }
+
+    /**
+     * @param {object} params
+     * @param {PirAction['id']} params.actionID
+     * @param {string} [params.context]
+     * @return {(message: string) => ErrorResponse}
+     * @static
+     * @memberof ErrorResponse
+     */
+    static generateErrorResponseFunction({ actionID, context = '' }) {
+        return (message) => new ErrorResponse({ actionID, message: [context, message].filter(Boolean).join(': ') });
+    }
 }
+
+/**
+ * @typedef {object} SuccessResponseInterface
+ * @property {PirAction['id']} actionID
+ * @property {PirAction['actionType']} actionType
+ * @property {any} response
+ * @property {import("./actions/extract").Action[]} [next]
+ * @property {Record<string, any>} [meta] - optional meta data
+ */
 
 /**
  * Represents success, `response` can contain other complex types
  */
 export class SuccessResponse {
     /**
-     * @param {object} params
-     * @param {string} params.actionID
-     * @param {string} params.actionType
-     * @param {any} params.response
-     * @param {import("./actions/extract").Action[]} [params.next]
-     * @param {Record<string, any>} [params.meta] - optional meta data
+     * @param {SuccessResponseInterface} params
      */
     constructor(params) {
         this.success = params;
+    }
+
+    /**
+     * @param {SuccessResponseInterface} params
+     * @return {SuccessResponse}
+     * @static
+     * @memberof SuccessResponse
+     */
+    static create(params) {
+        return new SuccessResponse(params);
     }
 }
 

--- a/injected/src/features/broker-protection/utils/safe-call.js
+++ b/injected/src/features/broker-protection/utils/safe-call.js
@@ -1,3 +1,5 @@
+import { PirError } from '../types';
+
 /**
  * @template T
  * @param {function(): T} fn - The function to call safely
@@ -13,4 +15,16 @@ export function safeCall(fn, { errorMessage } = {}) {
         // TODO fire pixel
         return null;
     }
+}
+
+/**
+ * @template T
+ * @param {function(): T} fn - The function to call safely
+ * @param {object} [options]
+ * @param {string} [options.errorMessage] - The error message to log
+ * @returns {T|PirError} - The result of the function call, or an error response if an error occurred
+ */
+export function safeCallWithError(fn, { errorMessage } = {}) {
+    const message = errorMessage ?? '[safeCallWithError] Error';
+    return safeCall(fn, { errorMessage: message }) ?? PirError.create(message);
 }


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/0/0/1209555302496203

- tech design: https://app.asana.com/0/0/1209498481524623

## Description

This PR addresses the following PR feedback: https://github.com/duckduckgo/content-scope-scripts/pull/1550#discussion_r1986787482, introducing error control flow based on objects (as opposed to throw/try/catch)

## Testing Steps

n/a

## Checklist

<!--
  These questions are a friendly reminder to shipping code, if you're uncertain ask the AoR owners.
  It's also totally appropriate to not check some of these boxes, if they don't apply to your change.
-->
*Please tick all that apply:*

- [x] I have tested this change locally
- [ ] I have tested this change locally in all supported browsers
- [ ] This change will be visible to users
- [ ] I have added automated tests that cover this change
- [ ] I have ensured the change is gated by config
- [ ] This change was covered by a ship review
- [x] This change was covered by a tech design
- [ ] Any dependent config has been merged

