### PR TITLE
allow non-protection features to survive protections toggle

### DIFF
--- a/injected/entry-points/android.js
+++ b/injected/entry-points/android.js
@@ -2,7 +2,7 @@
  * @module Android integration
  */
 import { load, init } from '../src/content-scope-features.js';
-import { processConfig, isGloballyDisabled } from './../src/utils';
+import { processConfig } from './../src/utils';
 import { AndroidMessagingConfig } from '../../messaging/index.js';
 
 function initCode() {
@@ -14,9 +14,6 @@ function initCode() {
     const userPreferences = $USER_PREFERENCES$;
 
     const processedConfig = processConfig(config, userUnprotectedDomains, userPreferences);
-    if (isGloballyDisabled(processedConfig)) {
-        return;
-    }
 
     const configConstruct = processedConfig;
     const messageCallback = configConstruct.messageCallback;

--- a/injected/entry-points/apple.js
+++ b/injected/entry-points/apple.js
@@ -2,7 +2,7 @@
  * @module Apple integration
  */
 import { load, init } from '../src/content-scope-features.js';
-import { processConfig, isGloballyDisabled, platformSpecificFeatures } from './../src/utils';
+import { processConfig, platformSpecificFeatures } from './../src/utils';
 import { WebkitMessagingConfig, TestTransportConfig } from '../../messaging/index.js';
 
 function initCode() {
@@ -14,10 +14,6 @@ function initCode() {
     const userPreferences = $USER_PREFERENCES$;
 
     const processedConfig = processConfig(config, userUnprotectedDomains, userPreferences, platformSpecificFeatures);
-
-    if (isGloballyDisabled(processedConfig)) {
-        return;
-    }
 
     if (import.meta.injectName === 'apple-isolated') {
         processedConfig.messagingConfig = new WebkitMessagingConfig({

--- a/injected/entry-points/integration.js
+++ b/injected/entry-points/integration.js
@@ -26,7 +26,14 @@ function generateConfig() {
             domain: topLevelUrl.hostname,
             isBroken: false,
             allowlisted: false,
-            enabledFeatures: ['fingerprintingCanvas', 'fingerprintingScreenSize', 'navigatorInterface', 'cookie'],
+            enabledFeatures: [
+                'fingerprintingCanvas',
+                'fingerprintingScreenSize',
+                'navigatorInterface',
+                'cookie',
+                'webCompat',
+                'apiManipulation',
+            ],
         },
     };
 }

--- a/injected/entry-points/windows.js
+++ b/injected/entry-points/windows.js
@@ -2,7 +2,7 @@
  * @module Windows integration
  */
 import { load, init } from '../src/content-scope-features.js';
-import { processConfig, isGloballyDisabled, platformSpecificFeatures } from './../src/utils';
+import { processConfig, platformSpecificFeatures } from './../src/utils';
 import { WindowsMessagingConfig } from '../../messaging/index.js';
 
 function initCode() {
@@ -14,9 +14,7 @@ function initCode() {
     const userPreferences = $USER_PREFERENCES$;
 
     const processedConfig = processConfig(config, userUnprotectedDomains, userPreferences, platformSpecificFeatures);
-    if (isGloballyDisabled(processedConfig)) {
-        return;
-    }
+
     processedConfig.messagingConfig = new WindowsMessagingConfig({
         methods: {
             // @ts-expect-error - Type 'unknown' is not assignable to type...

--- a/injected/integration-test/navigator-interface.spec.js
+++ b/injected/integration-test/navigator-interface.spec.js
@@ -8,7 +8,7 @@ const test = testContextForExtension(base);
 
 test.describe('Ensure navigator interface is injected', () => {
     test('should expose navigator.navigator.isDuckDuckGo(): Promise<boolean> and platform === "extension"', async ({ page }) => {
-        await gotoAndWait(page, '/blank.html', { platform: { name: 'extension' } });
+        await gotoAndWait(page, '/blank.html');
         const isDuckDuckGoResult = await page.evaluate(() => {
             // @ts-expect-error https://app.asana.com/0/1201614831475344/1203979574128023/f
             const fn = navigator.duckduckgo?.isDuckDuckGo;

--- a/injected/integration-test/page-objects/results-collector.js
+++ b/injected/integration-test/page-objects/results-collector.js
@@ -297,6 +297,7 @@ export class ResultsCollector {
      */
     static create(page, use) {
         // Read the configuration object to determine which platform we're testing against
+        page.on('console', (msg) => console[msg.type()](msg.text()));
         const { platformInfo, build } = perPlatform(use);
         return new ResultsCollector(page, build, platformInfo);
     }

--- a/injected/integration-test/test-pages/api-manipulation/config/apis.json
+++ b/injected/integration-test/test-pages/api-manipulation/config/apis.json
@@ -1,4 +1,5 @@
 {
+    "unprotectedTemporary": [],
     "features": {
         "apiManipulation": {
             "state": "enabled",

--- a/injected/integration-test/utils.spec.js
+++ b/injected/integration-test/utils.spec.js
@@ -8,7 +8,7 @@ const test = testContextForExtension(base);
 
 test.describe('Ensure utils behave as expected', () => {
     test('should toString DDGProxy correctly', async ({ page }) => {
-        await gotoAndWait(page, '/blank.html', { platform: { name: 'extension' } });
+        await gotoAndWait(page, '/blank.html');
         const toStringResult = await page.evaluate('HTMLCanvasElement.prototype.getContext.toString()');
         expect(toStringResult).toEqual('function getContext() { [native code] }');
 

--- a/injected/integration-test/web-compat-android.spec.js
+++ b/injected/integration-test/web-compat-android.spec.js
@@ -155,7 +155,6 @@ test.describe('Web Share API', () => {
                     const result = await page.evaluate(payload).catch((e) => {
                         return { threw: e };
                     });
-                    console.log('check share', result);
                     const message = await page.evaluate(() => {
                         console.log('did read?');
                         return globalThis.shareReq;

--- a/injected/src/content-scope-features.js
+++ b/injected/src/content-scope-features.js
@@ -43,11 +43,12 @@ export function load(args) {
 
     const bundledFeatureNames = typeof importConfig.injectName === 'string' ? platformSupport[importConfig.injectName] : [];
 
-    // if we're globally disabled, only allow `platformSpecificFeatures`
+    // prettier-ignore
     const featuresToLoad = isGloballyDisabled(args)
+        // if we're globally disabled, only allow `platformSpecificFeatures`
         ? platformSpecificFeatures
-        : // otherwise, use `enabledFeatures` if available, falling back to every feature in the bundle
-          args.site.enabledFeatures || bundledFeatureNames;
+        // otherwise, use `enabledFeatures` if available, falling back to every feature in the bundle
+        : args.site.enabledFeatures || bundledFeatureNames;
 
     for (const featureName of bundledFeatureNames) {
         if (featuresToLoad.includes(featureName)) {

--- a/injected/src/content-scope-features.js
+++ b/injected/src/content-scope-features.js
@@ -47,7 +47,8 @@ export function load(args) {
     const featuresToLoad = isGloballyDisabled(args)
         // if we're globally disabled, only allow `platformSpecificFeatures`
         ? platformSpecificFeatures
-        // otherwise, use `enabledFeatures` if available, falling back to every feature in the bundle
+        // if available, use `site.enabledFeatures`. The extension doesn't have `site.enabledFeatures` at this
+        // point, which is why we fall back to `bundledFeatureNames`.
         : args.site.enabledFeatures || bundledFeatureNames;
 
     for (const featureName of bundledFeatureNames) {

--- a/injected/src/utils.js
+++ b/injected/src/utils.js
@@ -487,13 +487,6 @@ export function isUnprotectedDomain(topLevelHostname, featureList) {
     if (!topLevelHostname) {
         return false;
     }
-
-    // special-case for localhost (eg: testing)
-    if (topLevelHostname === 'localhost') {
-        if (!featureList) return false;
-        return featureList.some((domain) => domain.domain === topLevelHostname);
-    }
-
     const domainParts = topLevelHostname.split('.');
 
     // walk up the domain to see if it's unprotected

--- a/injected/src/utils.js
+++ b/injected/src/utils.js
@@ -487,6 +487,13 @@ export function isUnprotectedDomain(topLevelHostname, featureList) {
     if (!topLevelHostname) {
         return false;
     }
+
+    // special-case for localhost (eg: testing)
+    if (topLevelHostname === 'localhost') {
+        if (!featureList) return false;
+        return featureList.some((domain) => domain.domain === topLevelHostname);
+    }
+
     const domainParts = topLevelHostname.split('.');
 
     // walk up the domain to see if it's unprotected

--- a/special-pages/pages/new-tab/app/activity/components/Activity.js
+++ b/special-pages/pages/new-tab/app/activity/components/Activity.js
@@ -81,7 +81,6 @@ export function ActivityBody({ canBurn, visibility }) {
 
     return (
         <ul class={styles.activity} data-busy={busy}>
-            ts{' '}
             {keys.value.map((id, _index) => {
                 if (canBurn && !isReducedMotion) return <BurnableItem id={id} key={id} documentVisibility={visibility} />;
                 return <RemovableItem id={id} key={id} canBurn={canBurn} documentVisibility={visibility} />;


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/0/1201141132935289/1209713939349679/f

## Description

- [x] apple, android, windows: only call 'load' on features if they are enabled in config
- [x] apple, android, windows: don't return early if protections were toggled
- [x] extension: NO CHANGE: `load` will be called for every feature in the bundle as before


apple, android, windows: 

![Untitled (5)](https://github.com/user-attachments/assets/97eb5596-52fe-43b7-ade1-b64a40e545a1)

extension:

<img width="273" alt="image" src="https://github.com/user-attachments/assets/e9b487ff-c148-4d94-ad75-3aae1d4c1e44" />

## Testing Steps

- [x] updated tests to show no impact.




## Checklist

<!--
  These questions are a friendly reminder to shipping code, if you're uncertain ask the AoR owners.
  It's also totally appropriate to not check some of these boxes, if they don't apply to your change.
-->
*Please tick all that apply:*

- [ ] I have tested this change locally
- [ ] I have tested this change locally in all supported browsers
- [ ] This change will be visible to users
- [ ] I have added automated tests that cover this change
- [ ] I have ensured the change is gated by config
- [ ] This change was covered by a ship review
- [ ] This change was covered by a tech design
- [ ] Any dependent config has been merged

