### PR TITLE
Duck Player entry point: updated messaging

### DIFF
--- a/injected/integration-test/duckplayer-mobile-drawer.spec.js
+++ b/injected/integration-test/duckplayer-mobile-drawer.spec.js
@@ -94,7 +94,7 @@ test.describe('Duck Player - Drawer UI variant', () => {
             await overlays.mobile.clicksOnVideoThumbnail();
             await overlays.pixels.sendsPixels([
                 { pixelName: 'overlay', params: {} },
-                { pixelName: 'play.do_not_use.thumbnail', params: {} },
+                { pixelName: 'play.do_not_use.dismiss', params: {} },
             ]);
             await overlays.userSettingWasNotUpdated();
         });
@@ -112,7 +112,7 @@ test.describe('Duck Player - Drawer UI variant', () => {
             await overlays.mobile.clicksOnDrawerBackdrop();
             await overlays.pixels.sendsPixels([
                 { pixelName: 'overlay', params: {} },
-                { pixelName: 'play.do_not_use', params: {} },
+                { pixelName: 'play.do_not_use.dismiss', params: {} },
             ]);
             await overlays.userSettingWasNotUpdated();
         });

--- a/injected/src/features/duckplayer/overlay-messages.js
+++ b/injected/src/features/duckplayer/overlay-messages.js
@@ -157,7 +157,7 @@ export class Pixel {
      *   | {name: "play.use", remember: "0" | "1"}
      *   | {name: "play.use.thumbnail"}
      *   | {name: "play.do_not_use", remember: "0" | "1"}
-     *   | {name: "play.do_not_use.thumbnail"}} input
+     *   | {name: "play.do_not_use.dismiss"}} input
      */
     constructor(input) {
         this.input = input;
@@ -177,7 +177,7 @@ export class Pixel {
             case 'play.do_not_use': {
                 return { remember: this.input.remember };
             }
-            case 'play.do_not_use.thumbnail':
+            case 'play.do_not_use.dismiss':
                 return {};
             default:
                 throw new Error('unreachable');

--- a/injected/src/features/duckplayer/video-overlay.js
+++ b/injected/src/features/duckplayer/video-overlay.js
@@ -292,10 +292,10 @@ export class VideoOverlay {
                     return this.mobileOptOut(e.detail.remember).catch(console.error);
                 });
                 drawer.addEventListener(DDGVideoDrawerMobile.DISMISS, () => {
-                    return this.mobileOptOut(false).catch(console.error); // Dismissal should not persist user's choice. Ignore remember-me value.
+                    return this.dismissOverlay();
                 });
                 drawer.addEventListener(DDGVideoDrawerMobile.THUMBNAIL_CLICK, () => {
-                    return this.videoThumbnailClick();
+                    return this.dismissOverlay();
                 });
                 drawer.addEventListener(DDGVideoDrawerMobile.OPT_IN, (/** @type {CustomEvent<{remember: boolean}>} */ e) => {
                     return this.mobileOptIn(e.detail.remember, params).catch(console.error);
@@ -508,8 +508,8 @@ export class VideoOverlay {
         this.destroy();
     }
 
-    videoThumbnailClick() {
-        const pixel = new Pixel({ name: 'play.do_not_use.thumbnail' });
+    dismissOverlay() {
+        const pixel = new Pixel({ name: 'play.do_not_use.dismiss' });
         this.messages.sendPixel(pixel);
 
         return this.destroy();


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/0/0/1209842067000892/f

## Description

In order to fire the same "dismiss-play" pixel for thumbnail clicks and clicks outside of the overlay:
- Renamed play.do_not_use.thumbnail  message to play.do_not_use.dismiss 
- Set play.do_not_use.dismiss  to fire on clicks outside of the overlay too

## Testing Steps

- TBC (pending native PRs)

## Checklist

<!--
  These questions are a friendly reminder to shipping code, if you're uncertain ask the AoR owners.
  It's also totally appropriate to not check some of these boxes, if they don't apply to your change.
-->
*Please tick all that apply:*

- [ ] I have tested this change locally
- [ ] I have tested this change locally in all supported browsers
- [ ] This change will be visible to users
- [ ] I have added automated tests that cover this change
- [ ] I have ensured the change is gated by config
- [ ] This change was covered by a ship review
- [ ] This change was covered by a tech design
- [ ] Any dependent config has been merged

