### PR TITLE
Fixes privacy-config hash on CI

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,7 @@
       },
       "devDependencies": {
         "@canvas/image-data": "^1.0.0",
-        "@duckduckgo/privacy-configuration": "github:duckduckgo/privacy-configuration#e159899e1301fb36c76fd60126f9840a70dd2c3a",
+        "@duckduckgo/privacy-configuration": "github:duckduckgo/privacy-configuration#main",
         "@fingerprintjs/fingerprintjs": "^4.5.1",
         "@types/chrome": "^0.0.308",
         "@types/jasmine": "^5.1.7",
@@ -250,8 +250,7 @@
     },
     "node_modules/@duckduckgo/privacy-configuration": {
       "version": "1.0.0",
-      "resolved": "git+ssh://git@github.com/duckduckgo/privacy-configuration.git#e159899e1301fb36c76fd60126f9840a70dd2c3a",
-      "integrity": "sha512-qfShbMTeteTOW3SR4XSNJk8+rVEIymzLnNvfKR59V3cLRPUi/Leki8zeSG54rsEV/4clSie0Nzf+QWvIdxYy8A==",
+      "resolved": "git+ssh://git@github.com/duckduckgo/privacy-configuration.git#062f6778b99c2f82dcff0e41dd9181cb997fc7e2",
       "dev": true,
       "license": "Apache 2.0",
       "dependencies": {


### PR DESCRIPTION
## Description

I upgraded privacy-configuration for the injected doc generation but didn't update package-lock.json with it, which is causing Netlify build errors on PRs. This fixes it.

## Testing Steps

- The Netlify build below should not fail

## Checklist

<!--
  These questions are a friendly reminder to shipping code, if you're uncertain ask the AoR owners.
  It's also totally appropriate to not check some of these boxes, if they don't apply to your change.
-->
*Please tick all that apply:*

- [ ] I have tested this change locally
- [ ] I have tested this change locally in all supported browsers
- [ ] This change will be visible to users
- [ ] I have added automated tests that cover this change
- [ ] I have ensured the change is gated by config
- [ ] This change was covered by a ship review
- [ ] This change was covered by a tech design
- [ ] Any dependent config has been merged

