### PR TITLE
Add new Theme Color content feature

### DIFF
--- a/injected/docs/theme-color.md
+++ b/injected/docs/theme-color.md
@@ -1,0 +1,30 @@
+---
+title: Theme Color Monitor
+---
+
+# Theme Color Monitor
+
+Reports the presence of the theme-color meta tag on page load.
+
+The theme-color meta tag is used by browsers to customize the UI color to match the website's branding. This feature reports the theme color value when it's found on initial page load.
+
+## Notifications
+
+### `themeColorFound`
+- {@link "Theme Color Messages".ThemeColorFoundNotification}
+- Sends initial theme color value on page load
+- If no theme-color meta tag is found, the themeColor value will be null
+
+**Example**
+
+```json
+{
+  "themeColor": "#ff0000",
+  "documentUrl": "https://example.com"
+}
+```
+
+## Remote Config
+
+### Enabled (default)
+{@includeCode ../integration-test/test-pages/theme-color/config/theme-color-enabled.json}

--- a/injected/docs/theme-color.md
+++ b/injected/docs/theme-color.md
@@ -11,7 +11,7 @@ The theme-color meta tag is used by browsers to customize the UI color to match 
 ## Notifications
 
 ### `themeColorStatus`
-- {@link "Theme Color Messages".ThemeColorStatusNotification}
+- {@link "ThemeColor Messages".ThemeColorStatusNotification}
 - Sends initial theme color value on page load
 - If no theme-color meta tag is found, the themeColor value will be null
 

--- a/injected/docs/theme-color.md
+++ b/injected/docs/theme-color.md
@@ -10,8 +10,8 @@ The theme-color meta tag is used by browsers to customize the UI color to match 
 
 ## Notifications
 
-### `themeColorFound`
-- {@link "Theme Color Messages".ThemeColorFoundNotification}
+### `themeColorStatus`
+- {@link "Theme Color Messages".ThemeColorStatusNotification}
 - Sends initial theme color value on page load
 - If no theme-color meta tag is found, the themeColor value will be null
 

--- a/injected/integration-test/test-pages/favicon/config/favicon-absent.json
+++ b/injected/integration-test/test-pages/favicon/config/favicon-absent.json
@@ -1,6 +1,9 @@
 {
   "features": {
-
+    "themeColor": {
+      "state": "disabled",
+      "exceptions": []
+    }
   },
   "unprotectedTemporary": []
 }

--- a/injected/integration-test/test-pages/favicon/config/favicon-disabled.json
+++ b/injected/integration-test/test-pages/favicon/config/favicon-disabled.json
@@ -3,6 +3,10 @@
     "favicon": {
       "state": "disabled",
       "exceptions": []
+    },
+    "themeColor": {
+      "state": "disabled",
+      "exceptions": []
     }
   },
   "unprotectedTemporary": []

--- a/injected/integration-test/test-pages/favicon/config/favicon-enabled.json
+++ b/injected/integration-test/test-pages/favicon/config/favicon-enabled.json
@@ -6,6 +6,10 @@
       "settings": {
         "monitor": true
       }
+    },
+    "themeColor": {
+      "state": "disabled",
+      "exceptions": []
     }
   },
   "unprotectedTemporary": []

--- a/injected/integration-test/test-pages/favicon/config/favicon-monitor-disabled.json
+++ b/injected/integration-test/test-pages/favicon/config/favicon-monitor-disabled.json
@@ -6,6 +6,10 @@
       "settings": {
         "monitor": false
       }
+    },
+    "themeColor": {
+      "state": "disabled",
+      "exceptions": []
     }
   },
   "unprotectedTemporary": []

--- a/injected/integration-test/test-pages/message-bridge/config/message-bridge-disabled.json
+++ b/injected/integration-test/test-pages/message-bridge/config/message-bridge-disabled.json
@@ -5,6 +5,10 @@
       "state": "disabled",
       "exceptions": []
     },
+    "themeColor": {
+      "state": "disabled",
+      "exceptions": []
+    },
     "navigatorInterface": {
       "state": "enabled",
       "exceptions": []

--- a/injected/integration-test/test-pages/message-bridge/config/message-bridge-enabled.json
+++ b/injected/integration-test/test-pages/message-bridge/config/message-bridge-enabled.json
@@ -9,6 +9,10 @@
       "state": "disabled",
       "exceptions": []
     },
+    "themeColor": {
+      "state": "disabled",
+      "exceptions": []
+    },
     "messageBridge": {
       "exceptions": [],
       "state": "enabled",

--- a/injected/integration-test/test-pages/theme-color/config/theme-color-absent.json
+++ b/injected/integration-test/test-pages/theme-color/config/theme-color-absent.json
@@ -1,0 +1,6 @@
+{
+  "features": {
+
+  },
+  "unprotectedTemporary": []
+}

--- a/injected/integration-test/test-pages/theme-color/config/theme-color-disabled.json
+++ b/injected/integration-test/test-pages/theme-color/config/theme-color-disabled.json
@@ -1,0 +1,9 @@
+{
+  "features": {
+    "themeColor": {
+      "state": "disabled",
+      "exceptions": []
+    }
+  },
+  "unprotectedTemporary": []
+}

--- a/injected/integration-test/test-pages/theme-color/config/theme-color-enabled.json
+++ b/injected/integration-test/test-pages/theme-color/config/theme-color-enabled.json
@@ -1,0 +1,9 @@
+{
+  "features": {
+    "themeColor": {
+      "state": "enabled",
+      "exceptions": []
+    }
+  },
+  "unprotectedTemporary": []
+}

--- a/injected/integration-test/test-pages/theme-color/index.html
+++ b/injected/integration-test/test-pages/theme-color/index.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Theme Color Test</title>
+    <meta name="theme-color" content="#ff0000">
+</head>
+<body>
+</body>
+</html>

--- a/injected/integration-test/test-pages/theme-color/media-queries.html
+++ b/injected/integration-test/test-pages/theme-color/media-queries.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Theme Color Media Queries Test</title>
+    <meta name="theme-color" content="#ff0000">
+    <meta name="theme-color" content="#00ff00" media="(min-width: 600px)">
+    <meta name="theme-color" content="#0000ff" media="(prefers-color-scheme: dark)">
+</head>
+<body>
+</body>
+</html>

--- a/injected/integration-test/test-pages/theme-color/no-theme-color.html
+++ b/injected/integration-test/test-pages/theme-color/no-theme-color.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>No Theme Color Test</title>
+</head>
+<body>
+</body>
+</html>

--- a/injected/integration-test/theme-color.spec.js
+++ b/injected/integration-test/theme-color.spec.js
@@ -9,7 +9,7 @@ test('theme-color feature absent', async ({ page }, testInfo) => {
     const themeColor = ResultsCollector.create(page, testInfo.project.use);
     await themeColor.load(HTML, CONFIG);
 
-    const messages = await themeColor.waitForMessage('themeColorFound', 1);
+    const messages = await themeColor.waitForMessage('themeColorStatus', 1);
 
     expect(messages[0].payload.params).toStrictEqual({
         themeColor: '#ff0000',
@@ -22,7 +22,7 @@ test('theme-color (no theme color)', async ({ page }, testInfo) => {
     const themeColor = ResultsCollector.create(page, testInfo.project.use);
     await themeColor.load(HTML, CONFIG);
 
-    const messages = await themeColor.waitForMessage('themeColorFound', 1);
+    const messages = await themeColor.waitForMessage('themeColorStatus', 1);
 
     expect(messages[0].payload.params).toStrictEqual({
         themeColor: null,
@@ -38,7 +38,7 @@ test('theme-color (viewport media query)', async ({ page }, testInfo) => {
     const themeColor = ResultsCollector.create(page, testInfo.project.use);
     await themeColor.load(HTML, CONFIG);
 
-    const messages = await themeColor.waitForMessage('themeColorFound', 1);
+    const messages = await themeColor.waitForMessage('themeColorStatus', 1);
 
     expect(messages[0].payload.params).toStrictEqual({
         themeColor: '#00ff00',
@@ -54,7 +54,7 @@ test('theme-color (color scheme media query)', async ({ page }, testInfo) => {
     const themeColor = ResultsCollector.create(page, testInfo.project.use);
     await themeColor.load(HTML, CONFIG);
 
-    const messages = await themeColor.waitForMessage('themeColorFound', 1);
+    const messages = await themeColor.waitForMessage('themeColorStatus', 1);
 
     expect(messages[0].payload.params).toStrictEqual({
         themeColor: '#0000ff',

--- a/injected/integration-test/theme-color.spec.js
+++ b/injected/integration-test/theme-color.spec.js
@@ -1,0 +1,77 @@
+import { test, expect } from '@playwright/test';
+import { ResultsCollector } from './page-objects/results-collector.js';
+
+const HTML = '/theme-color/index.html';
+const CONFIG = './integration-test/test-pages/theme-color/config/theme-color-enabled.json';
+
+test('theme-color feature absent', async ({ page }, testInfo) => {
+    const CONFIG = './integration-test/test-pages/theme-color/config/theme-color-absent.json';
+    const themeColor = ResultsCollector.create(page, testInfo.project.use);
+    await themeColor.load(HTML, CONFIG);
+
+    const messages = await themeColor.waitForMessage('themeColorFound', 1);
+
+    expect(messages[0].payload.params).toStrictEqual({
+        themeColor: '#ff0000',
+        documentUrl: 'http://localhost:3220/theme-color/index.html',
+    });
+});
+
+test('theme-color (no theme color)', async ({ page }, testInfo) => {
+    const HTML = '/theme-color/no-theme-color.html';
+    const themeColor = ResultsCollector.create(page, testInfo.project.use);
+    await themeColor.load(HTML, CONFIG);
+
+    const messages = await themeColor.waitForMessage('themeColorFound', 1);
+
+    expect(messages[0].payload.params).toStrictEqual({
+        themeColor: null,
+        documentUrl: 'http://localhost:3220/theme-color/no-theme-color.html',
+    });
+});
+
+test('theme-color (viewport media query)', async ({ page }, testInfo) => {
+    // Use a desktop viewport
+    await page.setViewportSize({ width: 1280, height: 720 });
+
+    const HTML = '/theme-color/media-queries.html';
+    const themeColor = ResultsCollector.create(page, testInfo.project.use);
+    await themeColor.load(HTML, CONFIG);
+
+    const messages = await themeColor.waitForMessage('themeColorFound', 1);
+
+    expect(messages[0].payload.params).toStrictEqual({
+        themeColor: '#00ff00',
+        documentUrl: 'http://localhost:3220/theme-color/media-queries.html',
+    });
+});
+
+test('theme-color (color scheme media query)', async ({ page }, testInfo) => {
+    // Use a dark color scheme
+    await page.emulateMedia({ colorScheme: 'dark' });
+
+    const HTML = '/theme-color/media-queries.html';
+    const themeColor = ResultsCollector.create(page, testInfo.project.use);
+    await themeColor.load(HTML, CONFIG);
+
+    const messages = await themeColor.waitForMessage('themeColorFound', 1);
+
+    expect(messages[0].payload.params).toStrictEqual({
+        themeColor: '#0000ff',
+        documentUrl: 'http://localhost:3220/theme-color/media-queries.html',
+    });
+});
+
+test('theme-color feature disabled completely', async ({ page }, testInfo) => {
+    const CONFIG = './integration-test/test-pages/theme-color/config/theme-color-disabled.json';
+    const themeColor = ResultsCollector.create(page, testInfo.project.use);
+    await themeColor.load(HTML, CONFIG);
+
+    // this is here purely to guard against a false positive in this test.
+    // without this manual `wait`, it might be possible for the following assertion to
+    // pass, but just because it was too quick (eg: the first message wasn't sent yet)
+    await page.waitForTimeout(100);
+
+    const messages = await themeColor.outgoingMessages();
+    expect(messages).toHaveLength(0);
+});

--- a/injected/playwright.config.js
+++ b/injected/playwright.config.js
@@ -37,7 +37,11 @@ export default defineConfig({
         },
         {
             name: 'ios',
-            testMatch: ['integration-test/duckplayer-mobile.spec.js', 'integration-test/duckplayer-mobile-drawer.spec.js'],
+            testMatch: [
+                'integration-test/duckplayer-mobile.spec.js',
+                'integration-test/duckplayer-mobile-drawer.spec.js',
+                'integration-test/theme-color.spec.js',
+            ],
             use: { injectName: 'apple-isolated', platform: 'ios', ...devices['iPhone 13'] },
         },
         {
@@ -47,6 +51,7 @@ export default defineConfig({
                 'integration-test/duckplayer-mobile-drawer.spec.js',
                 'integration-test/web-compat-android.spec.js',
                 'integration-test/message-bridge-android.spec.js',
+                'integration-test/theme-color.spec.js',
             ],
             use: { injectName: 'android', platform: 'android', ...devices['Galaxy S5'] },
         },

--- a/injected/playwright.config.js
+++ b/injected/playwright.config.js
@@ -51,7 +51,6 @@ export default defineConfig({
                 'integration-test/duckplayer-mobile-drawer.spec.js',
                 'integration-test/web-compat-android.spec.js',
                 'integration-test/message-bridge-android.spec.js',
-                'integration-test/theme-color.spec.js',
             ],
             use: { injectName: 'android', platform: 'android', ...devices['Galaxy S5'] },
         },

--- a/injected/src/features.js
+++ b/injected/src/features.js
@@ -27,14 +27,15 @@ const otherFeatures = /** @type {const} */ ([
     'breakageReporting',
     'autofillPasswordImport',
     'favicon',
+    'themeColor',
 ]);
 
 /** @typedef {baseFeatures[number]|otherFeatures[number]} FeatureName */
 /** @type {Record<string, FeatureName[]>} */
 export const platformSupport = {
     apple: ['webCompat', ...baseFeatures],
-    'apple-isolated': ['duckPlayer', 'brokerProtection', 'performanceMetrics', 'clickToLoad', 'messageBridge', 'favicon'],
-    android: [...baseFeatures, 'webCompat', 'breakageReporting', 'duckPlayer', 'messageBridge'],
+    'apple-isolated': ['duckPlayer', 'brokerProtection', 'performanceMetrics', 'clickToLoad', 'messageBridge', 'favicon', 'themeColor'],
+    android: [...baseFeatures, 'webCompat', 'breakageReporting', 'duckPlayer', 'messageBridge', 'themeColor'],
     'android-broker-protection': ['brokerProtection'],
     'android-autofill-password-import': ['autofillPasswordImport'],
     windows: ['cookie', ...baseFeatures, 'windowsPermissionUsage', 'duckPlayer', 'brokerProtection', 'breakageReporting'],

--- a/injected/src/features.js
+++ b/injected/src/features.js
@@ -35,7 +35,7 @@ const otherFeatures = /** @type {const} */ ([
 export const platformSupport = {
     apple: ['webCompat', ...baseFeatures],
     'apple-isolated': ['duckPlayer', 'brokerProtection', 'performanceMetrics', 'clickToLoad', 'messageBridge', 'favicon', 'themeColor'],
-    android: [...baseFeatures, 'webCompat', 'breakageReporting', 'duckPlayer', 'messageBridge', 'themeColor'],
+    android: [...baseFeatures, 'webCompat', 'breakageReporting', 'duckPlayer', 'messageBridge'],
     'android-broker-protection': ['brokerProtection'],
     'android-autofill-password-import': ['autofillPasswordImport'],
     windows: ['cookie', ...baseFeatures, 'windowsPermissionUsage', 'duckPlayer', 'brokerProtection', 'breakageReporting'],

--- a/injected/src/features/theme-color.js
+++ b/injected/src/features/theme-color.js
@@ -16,7 +16,7 @@ export class ThemeColor extends ContentFeature {
 
     send() {
         const themeColor = getThemeColor();
-        this.notify('themeColorFound', { themeColor, documentUrl: document.URL });
+        this.notify('themeColorStatus', { themeColor, documentUrl: document.URL });
     }
 }
 

--- a/injected/src/features/theme-color.js
+++ b/injected/src/features/theme-color.js
@@ -1,0 +1,44 @@
+import ContentFeature from '../content-feature.js';
+import { isBeingFramed } from '../utils.js';
+
+export class ThemeColor extends ContentFeature {
+    init() {
+        /**
+         * This feature never operates in a frame
+         */
+        if (isBeingFramed()) return;
+
+        window.addEventListener('DOMContentLoaded', () => {
+            // send once, immediately
+            this.send();
+        });
+    }
+
+    send() {
+        const themeColor = getThemeColor();
+        this.notify('themeColorFound', { themeColor, documentUrl: document.URL });
+    }
+}
+
+export default ThemeColor;
+
+/**
+ * Gets current theme color considering media queries
+ * Follows browser behavior by returning the last matching meta tag in document order
+ * @returns {string|null} The theme color value or null if not found
+ */
+function getThemeColor() {
+    const metaTags = document.head.querySelectorAll('meta[name="theme-color"]');
+    if (metaTags.length === 0) {
+        return null;
+    }
+
+    let lastMatchingTag = null;
+    for (const meta of metaTags) {
+        const mediaAttr = meta.getAttribute('media');
+        if (!mediaAttr || window.matchMedia(mediaAttr).matches) {
+            lastMatchingTag = meta;
+        }
+    }
+    return lastMatchingTag ? lastMatchingTag.getAttribute('content') : null;
+}

--- a/injected/src/messages/theme-color/themeColorFound.notify.json
+++ b/injected/src/messages/theme-color/themeColorFound.notify.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "title": "ThemeColorFound",
+  "required": ["themeColor", "documentUrl"],
+  "properties": {
+    "themeColor": {
+      "type": ["string", "null"],
+      "description": "The theme color value, or null if not present"
+    },
+    "documentUrl": {
+      "type": "string",
+      "description": "The URL of the document"
+    }
+  }
+}

--- a/injected/src/messages/theme-color/themeColorStatus.notify.json
+++ b/injected/src/messages/theme-color/themeColorStatus.notify.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
-  "title": "ThemeColorFound",
+  "title": "themeColorStatus",
   "required": ["themeColor", "documentUrl"],
   "properties": {
     "themeColor": {

--- a/injected/src/types/theme-color.ts
+++ b/injected/src/types/theme-color.ts
@@ -10,16 +10,16 @@
  * Requests, Notifications and Subscriptions from the ThemeColor feature
  */
 export interface ThemeColorMessages {
-  notifications: ThemeColorFoundNotification;
+  notifications: ThemeColorStatusNotification;
 }
 /**
- * Generated from @see "../messages/theme-color/themeColorFound.notify.json"
+ * Generated from @see "../messages/theme-color/themeColorStatus.notify.json"
  */
-export interface ThemeColorFoundNotification {
-  method: "themeColorFound";
-  params: ThemeColorFound;
+export interface ThemeColorStatusNotification {
+  method: "themeColorStatus";
+  params: ThemeColorStatus;
 }
-export interface ThemeColorFound {
+export interface ThemeColorStatus {
   /**
    * The theme color value, or null if not present
    */

--- a/injected/src/types/theme-color.ts
+++ b/injected/src/types/theme-color.ts
@@ -1,0 +1,37 @@
+/**
+ * These types are auto-generated from schema files.
+ * scripts/build-types.mjs is responsible for type generation.
+ * **DO NOT** edit this file directly as your changes will be lost.
+ *
+ * @module ThemeColor Messages
+ */
+
+/**
+ * Requests, Notifications and Subscriptions from the ThemeColor feature
+ */
+export interface ThemeColorMessages {
+  notifications: ThemeColorFoundNotification;
+}
+/**
+ * Generated from @see "../messages/theme-color/themeColorFound.notify.json"
+ */
+export interface ThemeColorFoundNotification {
+  method: "themeColorFound";
+  params: ThemeColorFound;
+}
+export interface ThemeColorFound {
+  /**
+   * The theme color value, or null if not present
+   */
+  themeColor: string | null;
+  /**
+   * The URL of the document
+   */
+  documentUrl: string;
+}
+
+declare module "../features/theme-color.js" {
+  export interface ThemeColor {
+    notify: import("@duckduckgo/messaging/lib/shared-types").MessagingBase<ThemeColorMessages>['notify']
+  }
+}

--- a/injected/src/utils.js
+++ b/injected/src/utils.js
@@ -703,7 +703,7 @@ export function isGloballyDisabled(args) {
  * @import {FeatureName} from "./features";
  * @type {FeatureName[]}
  */
-export const platformSpecificFeatures = ['windowsPermissionUsage', 'messageBridge', 'favicon'];
+export const platformSpecificFeatures = ['windowsPermissionUsage', 'messageBridge', 'favicon', 'themeColor'];
 
 export function isPlatformSpecificFeature(featureName) {
     return platformSpecificFeatures.includes(featureName);


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/0/0/1209837728974673/f

## Description

Adds a new Theme Color content feature that lets the browser extract the color found in a `<meta name=“theme-color”>`.

This is based largely on https://github.com/duckduckgo/content-scope-scripts/pull/1561.

The content feature can be enabled like so:

```json
"features": {
  "themeColor": {
    "state": "enabled",
    "exceptions": []
  }
},
```

The feature then will send `themeColorFound` messages, which follow this schema:

```json
{
  "$schema": "http://json-schema.org/draft-07/schema#",
  "type": "object",
  "title": "ThemeColorFound",
  "required": ["themeColor", "documentUrl"],
  "properties": {
    "themeColor": {
      "type": ["string", "null"],
      "description": "The theme color value, or null if not present"
    },
    "documentUrl": {
      "type": "string",
      "description": "The URL of the document"
    }
  }
}
```

## Testing Steps

```bash
npm run test-int --grep theme-color
```

## Checklist

<!--
  These questions are a friendly reminder to shipping code, if you're uncertain ask the AoR owners.
  It's also totally appropriate to not check some of these boxes, if they don't apply to your change.
-->
*Please tick all that apply:*

- [ ] I have tested this change locally
- [ ] I have tested this change locally in all supported browsers
- [ ] This change will be visible to users
- [x] I have added automated tests that cover this change
- [ ] I have ensured the change is gated by config
- [ ] This change was covered by a ship review
- [ ] This change was covered by a tech design
- [ ] Any dependent config has been merged

