### PR TITLE
Allow CAPTCHA actions to fail silently

### DIFF
--- a/injected/integration-test/broker-protection-tests/broker-protection-captcha.spec.js
+++ b/injected/integration-test/broker-protection-tests/broker-protection-captcha.spec.js
@@ -49,6 +49,14 @@ test.describe('Broker Protection Captcha', () => {
 
                 await dbp.isCaptchaError();
             });
+
+            test('returns a success response for an action data with an invalid "captchaType" field but "failSilently" set to true', async ({ createConfiguredDbp }) => {
+                const dbp = await createConfiguredDbp(BROKER_PROTECTION_CONFIGS.default);
+                await dbp.navigatesTo(recaptchaTargetPage);
+                await dbp.receivesInlineAction(createGetRecaptchaInfoAction({ captchaType: 'invalid', failSilently: true }));
+
+                await dbp.isCaptchaSuccess();
+            });
         });
 
         test.describe('solveCaptchaInfo', () => {
@@ -87,6 +95,14 @@ test.describe('Broker Protection Captcha', () => {
                 await dbp.receivesInlineAction(createSolveRecaptchaAction({ captchaType: 'invalid' }));
 
                 await dbp.isCaptchaError();
+            });
+
+            test('returns a success response for an action data with an invalid "captchaType" field but "failSilently" set to true', async ({ createConfiguredDbp }) => {
+                const dbp = await createConfiguredDbp(BROKER_PROTECTION_CONFIGS.default);
+                await dbp.navigatesTo(recaptchaTargetPage);
+                await dbp.receivesInlineAction(createSolveRecaptchaAction({ captchaType: 'invalid', failSilently: true }));
+
+                await dbp.getSuccessResponse();
             });
         });
 

--- a/injected/integration-test/broker-protection-tests/broker-protection-captcha.spec.js
+++ b/injected/integration-test/broker-protection-tests/broker-protection-captcha.spec.js
@@ -50,7 +50,9 @@ test.describe('Broker Protection Captcha', () => {
                 await dbp.isCaptchaError();
             });
 
-            test('returns a success response for an action data with an invalid "captchaType" field but "failSilently" set to true', async ({ createConfiguredDbp }) => {
+            test('returns a success response for an action data with an invalid "captchaType" field but "failSilently" set to true', async ({
+                createConfiguredDbp,
+            }) => {
                 const dbp = await createConfiguredDbp(BROKER_PROTECTION_CONFIGS.default);
                 await dbp.navigatesTo(recaptchaTargetPage);
                 await dbp.receivesInlineAction(createGetRecaptchaInfoAction({ captchaType: 'invalid', failSilently: true }));
@@ -97,7 +99,9 @@ test.describe('Broker Protection Captcha', () => {
                 await dbp.isCaptchaError();
             });
 
-            test('returns a success response for an action data with an invalid "captchaType" field but "failSilently" set to true', async ({ createConfiguredDbp }) => {
+            test('returns a success response for an action data with an invalid "captchaType" field but "failSilently" set to true', async ({
+                createConfiguredDbp,
+            }) => {
                 const dbp = await createConfiguredDbp(BROKER_PROTECTION_CONFIGS.default);
                 await dbp.navigatesTo(recaptchaTargetPage);
                 await dbp.receivesInlineAction(createSolveRecaptchaAction({ captchaType: 'invalid', failSilently: true }));

--- a/injected/integration-test/page-objects/broker-protection.js
+++ b/injected/integration-test/page-objects/broker-protection.js
@@ -102,6 +102,10 @@ export class BrokerProtectionPage {
         expect(response).toStrictEqual(expectedResponse);
     }
 
+    async isCaptchaSuccess() {
+        expect(await this.getSuccessResponse()).not.toBeFalsy();
+    }
+
     async isCaptchaError() {
         expect(await this.getErrorMessage()).not.toBeFalsy();
     }

--- a/injected/src/features/broker-protection/captcha-services/captcha.service.js
+++ b/injected/src/features/broker-protection/captcha-services/captcha.service.js
@@ -69,7 +69,7 @@ export function getCaptchaInfo(action, root = document) {
 
     const captchaProvider = getCaptchaProvider(captchaContainer, captchaType);
     if (PirError.isError(captchaProvider)) {
-        return failSilently ? emptySuccessResponse(actionID, actionType) : createError(captchaContainer.error.message);
+        return failSilently ? emptySuccessResponse(actionID, actionType) : createError(captchaProvider.error.message);
     }
 
     const captchaIdentifier = captchaProvider.getCaptchaIdentifier(captchaContainer);

--- a/injected/src/features/broker-protection/captcha-services/captcha.service.js
+++ b/injected/src/features/broker-protection/captcha-services/captcha.service.js
@@ -31,7 +31,7 @@ const getCaptchaContainer = (root, selector) => {
  * @return {import('../types.js').ActionResponse}
  */
 export function getSupportingCodeToInject(action) {
-    const { id: actionID, actionType, injectCaptchaHandler: captchaType, failSilently } = action;
+    const { id: actionID, actionType, injectCaptchaHandler: captchaType } = action;
     const createError = ErrorResponse.generateErrorResponseFunction({ actionID, context: 'getSupportingCodeToInject' });
     if (!captchaType) {
         // ensures backward compatibility with old actions

--- a/injected/src/features/broker-protection/captcha-services/captcha.service.js
+++ b/injected/src/features/broker-protection/captcha-services/captcha.service.js
@@ -31,7 +31,7 @@ const getCaptchaContainer = (root, selector) => {
  * @return {import('../types.js').ActionResponse}
  */
 export function getSupportingCodeToInject(action) {
-    const { id: actionID, actionType, injectCaptchaHandler: captchaType } = action;
+    const { id: actionID, actionType, injectCaptchaHandler: captchaType, failSilently } = action;
     const createError = ErrorResponse.generateErrorResponseFunction({ actionID, context: 'getSupportingCodeToInject' });
     if (!captchaType) {
         // ensures backward compatibility with old actions
@@ -40,7 +40,7 @@ export function getSupportingCodeToInject(action) {
 
     const captchaProvider = captchaFactory.getProviderByType(captchaType);
     if (!captchaProvider) {
-        return createError(`could not find captchaProvider with type ${captchaType}`);
+        return createError(`could not find captcha provider for type ${captchaType}`);
     }
 
     return SuccessResponse.create({ actionID, actionType, response: { code: captchaProvider.getSupportingCodeToInject() } });
@@ -54,7 +54,7 @@ export function getSupportingCodeToInject(action) {
  * @return {import('../types.js').ActionResponse}
  */
 export function getCaptchaInfo(action, root = document) {
-    const { id: actionID, actionType, captchaType, selector } = action;
+    const { id: actionID, actionType, captchaType, selector, failSilently } = action;
     if (!captchaType) {
         // ensures backward compatibility with old actions
         return getCaptchaInfoDeprecated(action, root);
@@ -64,17 +64,19 @@ export function getCaptchaInfo(action, root = document) {
 
     const captchaContainer = getCaptchaContainer(root, selector);
     if (PirError.isError(captchaContainer)) {
-        return createError(captchaContainer.error.message);
+        return failSilently ? emptySuccessResponse(actionID, actionType) : createError(captchaContainer.error.message);
     }
 
     const captchaProvider = getCaptchaProvider(captchaContainer, captchaType);
     if (PirError.isError(captchaProvider)) {
-        return createError(captchaProvider.error.message);
+        return failSilently ? emptySuccessResponse(actionID, actionType) : createError(captchaContainer.error.message);
     }
 
     const captchaIdentifier = captchaProvider.getCaptchaIdentifier(captchaContainer);
     if (!captchaIdentifier) {
-        return createError(`could not extract captcha identifier from the container with selector ${selector}`);
+        return failSilently
+            ? emptySuccessResponse(actionID, actionType)
+            : createError(`could not extract captcha identifier from the container with selector ${selector}`);
     }
 
     const response = {
@@ -95,7 +97,7 @@ export function getCaptchaInfo(action, root = document) {
  * @return {import('../types.js').ActionResponse}
  */
 export function solveCaptcha(action, token, root = document) {
-    const { id: actionID, actionType, captchaType, selector } = action;
+    const { id: actionID, actionType, captchaType, selector, failSilently } = action;
     if (!captchaType) {
         // ensures backward compatibility with old actions
         return solveCaptchaDeprecated(action, token, root);
@@ -105,25 +107,25 @@ export function solveCaptcha(action, token, root = document) {
 
     const captchaContainer = getCaptchaContainer(root, selector);
     if (PirError.isError(captchaContainer)) {
-        return createError(captchaContainer.error.message);
+        return failSilently ? emptySuccessResponse(actionID, actionType) : createError(captchaContainer.error.message);
     }
 
     const captchaSolveProvider = getCaptchaSolveProvider(captchaContainer, captchaType);
     if (PirError.isError(captchaSolveProvider)) {
-        return createError(captchaSolveProvider.error.message);
+        return failSilently ? emptySuccessResponse(actionID, actionType) : createError(captchaSolveProvider.error.message);
     }
 
     if (!captchaSolveProvider.canSolve(captchaContainer)) {
-        return createError('cannot solve captcha');
+        return failSilently ? emptySuccessResponse(actionID, actionType) : createError('cannot solve captcha');
     }
 
     const tokenResponse = captchaSolveProvider.injectToken(captchaContainer, token);
     if (PirError.isError(tokenResponse)) {
-        return createError(tokenResponse.error.message);
+        return failSilently ? emptySuccessResponse(actionID, actionType) : createError(tokenResponse.error.message);
     }
 
     if (!tokenResponse.response.injected) {
-        return createError('could not inject token');
+        return failSilently ? emptySuccessResponse(actionID, actionType) : createError('could not inject token');
     }
 
     return SuccessResponse.create({
@@ -131,4 +133,13 @@ export function solveCaptcha(action, token, root = document) {
         actionType,
         response: { callback: { eval: captchaSolveProvider.getSolveCallback(captchaContainer, token) } },
     });
+}
+
+/**
+ * @param {string} actionID
+ * @param {import('../types.js').PirAction['actionType']} actionType
+ * @return {import('../types.js').ActionResponse}
+ */
+function emptySuccessResponse(actionID, actionType) {
+    return SuccessResponse.create({ actionID, actionType, response: {} });
 }

--- a/injected/src/features/broker-protection/types.js
+++ b/injected/src/features/broker-protection/types.js
@@ -12,6 +12,7 @@
  * @property {string} [captchaType]
  * @property {string} [injectCaptchaHandler]
  * @property {string} [dataSource]
+ * @property {boolean} [failSilently]
  */
 
 /**

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "test-int-snapshots": "npm run test-int-snapshots --workspaces --if-present",
     "test-int-snapshots-update": "npm run test-int-snapshots-update --workspaces --if-present",
     "test-clean-tree": "npm run build && sh scripts/check-for-changes.sh",
-    "docs": "npm cache clean --force && npm ci && typedoc",
+    "docs": "typedoc",
     "docs-watch": "typedoc --watch",
     "tsc": "tsc",
     "tsc-watch": "tsc --watch",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "test-int-snapshots": "npm run test-int-snapshots --workspaces --if-present",
     "test-int-snapshots-update": "npm run test-int-snapshots-update --workspaces --if-present",
     "test-clean-tree": "npm run build && sh scripts/check-for-changes.sh",
-    "docs": "typedoc",
+    "docs": "npm cache clean --force && npm ci && typedoc",
     "docs-watch": "typedoc --watch",
     "tsc": "tsc",
     "tsc-watch": "tsc --watch",


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/0/1199230911884351/1209924515943923/f

## Description
Allows captcha actions to fail silently without stopping the opt out flow for more flexbility

<!--
  Provide a terse summary of what the change is, detailed descriptions should belong in ship reviews or tech designs
-->

## Testing Steps
See Asana

## Checklist

<!--
  These questions are a friendly reminder to shipping code, if you're uncertain ask the AoR owners.
  It's also totally appropriate to not check some of these boxes, if they don't apply to your change.
-->
*Please tick all that apply:*

- [x] I have tested this change locally
- [x] I have tested this change locally in all supported browsers
- [ ] This change will be visible to users
- [x] I have added automated tests that cover this change
- [ ] I have ensured the change is gated by config
- [ ] This change was covered by a ship review
- [ ] This change was covered by a tech design
- [ ] Any dependent config has been merged

