### PR TITLE
ntp: remove legacy menu

### DIFF
--- a/special-pages/pages/new-tab/app/components/App.js
+++ b/special-pages/pages/new-tab/app/components/App.js
@@ -1,15 +1,10 @@
 import { Fragment, h } from 'preact';
 import cn from 'classnames';
 import styles from './App.module.css';
-import { useCustomizerDrawerSettings, useCustomizerKind, usePlatformName } from '../settings.provider.js';
+import { useCustomizerDrawerSettings, usePlatformName } from '../settings.provider.js';
 import { WidgetList } from '../widget-list/WidgetList.js';
 import { useGlobalDropzone } from '../dropzone.js';
-import {
-    CustomizerMenu,
-    CustomizerButton,
-    CustomizerMenuPositionedFixed,
-    useContextMenu,
-} from '../customizer/components/CustomizerMenu.js';
+import { CustomizerButton, CustomizerMenuPositionedFixed, useContextMenu } from '../customizer/components/CustomizerMenu.js';
 import { useDrawer, useDrawerControls } from './Drawer.js';
 import { CustomizerDrawer } from '../customizer/components/CustomizerDrawer.js';
 import { BackgroundConsumer } from './BackgroundProvider.js';
@@ -27,8 +22,6 @@ import { InlineErrorBoundary } from '../InlineErrorBoundary.js';
 export function App() {
     const platformName = usePlatformName();
     const customizerDrawer = useCustomizerDrawerSettings();
-
-    const customizerKind = useCustomizerKind();
 
     useGlobalDropzone();
     useContextMenu();
@@ -63,42 +56,37 @@ export function App() {
                 </main>
                 <div class={styles.themeContext} data-theme={main}>
                     <CustomizerMenuPositionedFixed>
-                        {customizerKind === 'menu' && <CustomizerMenu />}
-                        {customizerKind === 'drawer' && (
-                            <CustomizerButton
-                                buttonId={buttonId}
-                                menuId={drawerId}
-                                toggleMenu={toggle}
-                                buttonRef={buttonRef}
-                                isOpen={isOpen}
-                                kind={'drawer'}
-                            />
-                        )}
+                        <CustomizerButton
+                            buttonId={buttonId}
+                            menuId={drawerId}
+                            toggleMenu={toggle}
+                            buttonRef={buttonRef}
+                            isOpen={isOpen}
+                            kind={'drawer'}
+                        />
                     </CustomizerMenuPositionedFixed>
                 </div>
-                {customizerKind === 'drawer' && (
-                    <aside
-                        class={cn(styles.aside, styles.asideLayout, styles.asideScroller)}
-                        tabindex={tabIndex}
-                        aria-hidden={hidden}
-                        data-theme={browser}
-                        data-browser-panel
-                        ref={asideRef}
-                    >
-                        <div class={styles.asideContent}>
-                            <InlineErrorBoundary
-                                context={'Customizer Drawer'}
-                                fallback={(message) => (
-                                    <div class={styles.paddedError}>
-                                        <p>{message}</p>
-                                    </div>
-                                )}
-                            >
-                                <CustomizerDrawer displayChildren={displayChildren} />
-                            </InlineErrorBoundary>
-                        </div>
-                    </aside>
-                )}
+                <aside
+                    class={cn(styles.aside, styles.asideLayout, styles.asideScroller)}
+                    tabindex={tabIndex}
+                    aria-hidden={hidden}
+                    data-theme={browser}
+                    data-browser-panel
+                    ref={asideRef}
+                >
+                    <div class={styles.asideContent}>
+                        <InlineErrorBoundary
+                            context={'Customizer Drawer'}
+                            fallback={(message) => (
+                                <div class={styles.paddedError}>
+                                    <p>{message}</p>
+                                </div>
+                            )}
+                        >
+                            <CustomizerDrawer displayChildren={displayChildren} />
+                        </InlineErrorBoundary>
+                    </div>
+                </aside>
             </div>
         </Fragment>
     );

--- a/special-pages/pages/new-tab/app/customizer/components/Customizer.examples.js
+++ b/special-pages/pages/new-tab/app/customizer/components/Customizer.examples.js
@@ -1,7 +1,7 @@
 import { h } from 'preact';
 import { noop } from '../../utils.js';
 import { CustomizerButton } from './CustomizerMenu.js';
-import { EmbeddedVisibilityMenu, VisibilityMenu } from './VisibilityMenu.js';
+import { EmbeddedVisibilityMenu } from './VisibilityMenu.js';
 import { BackgroundSection } from './BackgroundSection.js';
 import { ColorSelection } from './ColorSelection.js';
 import { GradientSelection } from './GradientSelection.js';
@@ -67,27 +67,6 @@ export const customizerExamples = {
         factory: () => (
             <MaxContent>
                 <CustomizerButton isOpen={true} kind="menu" />
-                <br />
-                <VisibilityMenu
-                    rows={[
-                        {
-                            id: 'favorites',
-                            title: 'Favorites',
-                            icon: 'star',
-                            toggle: noop('toggle favorites'),
-                            visibility: 'hidden',
-                            index: 0,
-                        },
-                        {
-                            id: 'privacyStats',
-                            title: 'Privacy Stats',
-                            icon: 'shield',
-                            toggle: noop('toggle favorites'),
-                            visibility: 'visible',
-                            index: 1,
-                        },
-                    ]}
-                />
                 <br />
                 <div style="width: 206px; border: 1px dotted black">
                     <EmbeddedVisibilityMenu

--- a/special-pages/pages/new-tab/app/customizer/components/Customizer.module.css
+++ b/special-pages/pages/new-tab/app/customizer/components/Customizer.module.css
@@ -1,22 +1,7 @@
-.root {
-    position: relative
-}
-
 .lowerRightFixed {
     position: absolute;
     bottom: 1rem;
     right: 1rem;
-}
-
-.dropdownMenu {
-    display: none;
-    position: absolute;
-    right: 0;
-    bottom: calc(100% + 10px);
-}
-
-.show {
-    display: block;
 }
 
 /** todo: is this a re-usable button, yet? */

--- a/special-pages/pages/new-tab/app/customizer/components/VisibilityMenu.js
+++ b/special-pages/pages/new-tab/app/customizer/components/VisibilityMenu.js
@@ -1,6 +1,6 @@
 import { h } from 'preact';
 import cn from 'classnames';
-import { useId, useContext } from 'preact/hooks';
+import { useContext } from 'preact/hooks';
 
 import { DuckFoot, Shield } from '../../components/Icons.js';
 import styles from './VisibilityMenu.module.css';
@@ -12,55 +12,6 @@ import { CustomizerThemesContext } from '../CustomizerProvider.js';
  * @import { Widgets, WidgetConfigItem } from '../../../types/new-tab.js'
  * @import { VisibilityRowData } from './CustomizerMenu.js'
  */
-
-/**
- * When the button is pressed, we dispatch an event to allow widgets to provide
- * meta data like translated titles
- *
- * @param {object} props
- * @param {VisibilityRowData[]} props.rows
- */
-export function VisibilityMenu({ rows }) {
-    const MENU_ID = useId();
-
-    return (
-        <ul className={cn(styles.list)}>
-            {rows.map((row) => {
-                return (
-                    <li key={row.id}>
-                        <label className={styles.menuItemLabel} htmlFor={MENU_ID + row.id}>
-                            <input
-                                type="checkbox"
-                                checked={row.visibility === 'visible'}
-                                onChange={() => row.toggle?.(row.id)}
-                                id={MENU_ID + row.id}
-                                class={styles.checkbox}
-                            />
-                            <span aria-hidden={true} className={styles.checkboxIcon}>
-                                {row.visibility === 'visible' && (
-                                    <svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
-                                        <path
-                                            d="M3.5 9L6 11.5L12.5 5"
-                                            stroke="white"
-                                            stroke-width="1.5"
-                                            stroke-linecap="round"
-                                            stroke-linejoin="round"
-                                        />
-                                    </svg>
-                                )}
-                            </span>
-                            <span className={styles.svg}>
-                                {row.icon === 'shield' && <DuckFoot />}
-                                {row.icon === 'star' && <Shield />}
-                            </span>
-                            <span>{row.title ?? row.id}</span>
-                        </label>
-                    </li>
-                );
-            })}
-        </ul>
-    );
-}
 
 /**
  * @param {object} props
@@ -96,8 +47,4 @@ export function EmbeddedVisibilityMenu({ rows }) {
             })}
         </ul>
     );
-}
-
-export function VisibilityMenuPopover({ children }) {
-    return <div className={styles.dropdownInner}>{children}</div>;
 }

--- a/special-pages/pages/new-tab/app/customizer/components/VisibilityMenu.module.css
+++ b/special-pages/pages/new-tab/app/customizer/components/VisibilityMenu.module.css
@@ -1,18 +1,3 @@
-.dropdownInner {
-    background: var(--ntp-surface-background-color);
-    padding: var(--sp-1);
-    border-radius: var(--border-radius-md);
-    backdrop-filter: blur(48px);
-    padding-inline: calc(10 * var(--px-in-rem));
-    border: 1px solid var(--color-black-at-9);
-    box-shadow: 0px 0px 0px 1px rgba(0, 0, 0, 0.12), 0px 8px 16px 0px rgba(0, 0, 0, 0.20), 0px 2px 4px 0px rgba(0, 0, 0, 0.15);
-
-    [data-theme=dark] & {
-        border-color: var(--color-white-at-9);
-        box-shadow: 0px 0px 0px 1px rgba(255, 255, 255, 0.09) inset, 0px 0px 0px 1px rgba(0, 0, 0, 0.50), 0px 2px 4px 0px rgba(0, 0, 0, 0.15), 0px 8px 16px 0px rgba(0, 0, 0, 0.40);
-    }
-}
-
 .list {
     list-style: none;
     margin: 0;
@@ -52,98 +37,9 @@
     }
 }
 
-
 .svg {
     flex-shrink: 0;
     width: 1rem;
     height: 1rem;
     display: flex;
-}
-
-.checkbox {
-    position: absolute;
-    clip: rect(1px, 1px, 1px, 1px);
-    padding: 0;
-    border: 0;
-    height: 1px;
-    width: 1px;
-    overflow: hidden;
-}
-
-.checkboxIcon {
-    font-size: 0;
-    width: 1rem;
-    height: 1rem;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    flex-shrink: 0;
-    border-radius: var(--border-radius-xs);
-    border: 1px solid var(--color-black-at-48);
-
-    [data-theme=dark] & {
-        border-color: rgba(255, 255, 255, 0.42);
-        background: rgba(255, 255, 255, 0.12);
-    }
-
-    &:hover {
-        background: linear-gradient(0deg, var(--color-black-at-6) 0%, var(--color-black-at-6) 100%);
-        [data-theme=dark] & {
-            background: linear-gradient(0deg, var(--color-white-at-18) 0%, var(--color-white-at-18) 100%), var(--color-white-at-12);
-        }
-    }
-
-    &:active {
-        background: linear-gradient(0deg, var(--color-black-at-12) 0%, var(--color-black-at-12) 100%), var(--color-white-at-60);
-        [data-theme=dark] & {
-            background: linear-gradient(0deg, var(--color-white-at-24) 0%, var(--color-white-at-24) 100%), var(--color-white-at-12);
-        }
-    }
-}
-
-.menuItemLabel input:checked + .checkboxIcon  {
-    background: var(--color-blue-50);
-    border-color: var(--color-blue-50);
-
-    [data-theme=dark] & {
-        background: var(--color-blue-20);
-        border-color: var(--color-blue-20);
-    }
-
-    &:hover {
-        background: var(--color-blue-60);
-        border-color: var(--color-blue-60);
-        [data-theme=dark] & {
-            background: var(--color-blue-30);
-            border-color: var(--color-blue-30);
-        }
-    }
-
-    &:active {
-        background: var(--color-blue-70);
-        border-color: var(--color-blue-70);
-
-        [data-theme=dark] & {
-            background: var(--color-blue-40);
-            border-color: var(--color-blue-40);
-        }
-    }
-
-}
-
-.menuItemLabel .checkboxIcon svg path {
-    opacity: 0;
-}
-
-.menuItemLabel input:checked + .checkboxIcon svg path {
-    stroke: white;
-    opacity: 1;
-    [data-theme=dark] & {
-        stroke: black;
-    }
-}
-
-.menuItemLabel input:focus-visible + .checkboxIcon {
-    outline: dotted 1px var(--ntp-focus-outline-color);
-    outline-offset: 2px
 }

--- a/special-pages/pages/new-tab/app/customizer/components/VisibilityMenuSection.js
+++ b/special-pages/pages/new-tab/app/customizer/components/VisibilityMenuSection.js
@@ -1,5 +1,5 @@
 import { useLayoutEffect, useState } from 'preact/hooks';
-import { CustomizerMenu, getItems } from './CustomizerMenu.js';
+import { getItems, UPDATE_EVENT } from './CustomizerMenu.js';
 import { EmbeddedVisibilityMenu } from './VisibilityMenu.js';
 import { h } from 'preact';
 
@@ -13,9 +13,9 @@ export function VisibilityMenuSection() {
             setRowData(getItems());
         }
 
-        window.addEventListener(CustomizerMenu.UPDATE_EVENT, handler);
+        window.addEventListener(UPDATE_EVENT, handler);
         return () => {
-            window.removeEventListener(CustomizerMenu.UPDATE_EVENT, handler);
+            window.removeEventListener(UPDATE_EVENT, handler);
         };
     }, []);
 

--- a/special-pages/pages/new-tab/app/customizer/integration-tests/customizer.spec.js
+++ b/special-pages/pages/new-tab/app/customizer/integration-tests/customizer.spec.js
@@ -7,7 +7,7 @@ test.describe('newtab customizer', () => {
         const ntp = NewtabPage.create(page, workerInfo);
         const cp = new CustomizerPage(ntp);
         await ntp.reducedMotion();
-        await ntp.openPage({ additional: { customizerDrawer: 'disabled' } });
+        await ntp.openPage({});
         await cp.hasDefaultBackground();
     });
     test('loads with the default dark background when disabled', async ({ page }, workerInfo) => {
@@ -15,21 +15,21 @@ test.describe('newtab customizer', () => {
         const cp = new CustomizerPage(ntp);
         await ntp.reducedMotion();
         await ntp.darkMode();
-        await ntp.openPage({ additional: { customizerDrawer: 'disabled' } });
+        await ntp.openPage();
         await cp.hasDefaultDarkBackground();
     });
     test('Opens automatically from initialSetup settings', async ({ page }, workerInfo) => {
         const ntp = NewtabPage.create(page, workerInfo);
         const cp = new CustomizerPage(ntp);
         await ntp.reducedMotion();
-        await ntp.openPage({ additional: { customizerDrawer: 'enabled', autoOpen: 'true' } });
+        await ntp.openPage({ additional: { autoOpen: 'true' } });
         await cp.closesCustomizer();
     });
     test('Opens automatically from subscription message', async ({ page }, workerInfo) => {
         const ntp = NewtabPage.create(page, workerInfo);
         const cp = new CustomizerPage(ntp);
         await ntp.reducedMotion();
-        await ntp.openPage({ additional: { customizerDrawer: 'enabled' } });
+        await ntp.openPage();
 
         // control
         await cp.opensCustomizer();
@@ -42,7 +42,7 @@ test.describe('newtab customizer', () => {
         const ntp = NewtabPage.create(page, workerInfo);
         const cp = new CustomizerPage(ntp);
         await ntp.reducedMotion();
-        await ntp.openPage({ additional: { customizerDrawer: 'enabled' } });
+        await ntp.openPage();
 
         await cp.opensCustomizer();
         await cp.hasDefaultBackgroundSelected();
@@ -52,7 +52,7 @@ test.describe('newtab customizer', () => {
         const cp = new CustomizerPage(ntp);
         await ntp.reducedMotion();
 
-        await ntp.openPage({ additional: { customizerDrawer: 'enabled', theme: 'system' } });
+        await ntp.openPage({ additional: { theme: 'system' } });
         await cp.opensCustomizer();
 
         // check the main page + drawer both are light theme
@@ -70,7 +70,7 @@ test.describe('newtab customizer', () => {
         const ntp = NewtabPage.create(page, workerInfo);
         const cp = new CustomizerPage(ntp);
         await ntp.reducedMotion();
-        await ntp.openPage({ additional: { customizerDrawer: 'enabled' } });
+        await ntp.openPage();
 
         await cp.hasDefaultBackground();
         await cp.opensCustomizer();
@@ -86,7 +86,7 @@ test.describe('newtab customizer', () => {
         const ntp = NewtabPage.create(page, workerInfo);
         const cp = new CustomizerPage(ntp);
         await ntp.reducedMotion();
-        await ntp.openPage({ additional: { customizerDrawer: 'enabled' } });
+        await ntp.openPage();
 
         await cp.opensCustomizer();
         await cp.hasDefaultBackgroundSelected();
@@ -102,7 +102,7 @@ test.describe('newtab customizer', () => {
         const ntp = NewtabPage.create(page, workerInfo);
         const cp = new CustomizerPage(ntp);
         await ntp.reducedMotion();
-        await ntp.openPage({ additional: { customizerDrawer: 'enabled', background: 'color01', theme: 'dark' } });
+        await ntp.openPage({ additional: { background: 'color01', theme: 'dark' } });
         await cp.opensCustomizer();
         await cp.hasColorSelected();
         await cp.acceptsThemeUpdate('light');
@@ -111,7 +111,7 @@ test.describe('newtab customizer', () => {
         const ntp = NewtabPage.create(page, workerInfo);
         const cp = new CustomizerPage(ntp);
         await ntp.reducedMotion();
-        await ntp.openPage({ additional: { customizerDrawer: 'enabled', background: 'color01' } });
+        await ntp.openPage({ additional: { background: 'color01' } });
         await cp.opensCustomizer();
         await cp.hasColorSelected();
         await cp.selectsDefault();
@@ -120,7 +120,7 @@ test.describe('newtab customizer', () => {
         const ntp = NewtabPage.create(page, workerInfo);
         const cp = new CustomizerPage(ntp);
         await ntp.reducedMotion();
-        await ntp.openPage({ additional: { customizerDrawer: 'enabled' } });
+        await ntp.openPage();
         await cp.opensCustomizer();
         await cp.hasDefaultBackgroundSelected();
         const back = await cp.selectsColor();
@@ -131,7 +131,7 @@ test.describe('newtab customizer', () => {
         const ntp = NewtabPage.create(page, workerInfo);
         const cp = new CustomizerPage(ntp);
         await ntp.reducedMotion();
-        await ntp.openPage({ additional: { customizerDrawer: 'enabled', background: 'default' } });
+        await ntp.openPage({ additional: { background: 'default' } });
         await cp.opensCustomizer();
         await cp.hasDefaultBackgroundSelected();
         await cp.showsColorSelectionPanel();
@@ -143,7 +143,7 @@ test.describe('newtab customizer', () => {
         const ntp = NewtabPage.create(page, workerInfo);
         const cp = new CustomizerPage(ntp);
         await ntp.reducedMotion();
-        await ntp.openPage({ additional: { customizerDrawer: 'enabled', background: 'default' } });
+        await ntp.openPage({ additional: { background: 'default' } });
         await cp.opensCustomizer();
         await cp.hasDefaultBackgroundSelected();
         await cp.showsColorSelectionPanel();
@@ -161,7 +161,7 @@ test.describe('newtab customizer', () => {
         const ntp = NewtabPage.create(page, workerInfo);
         const cp = new CustomizerPage(ntp);
         await ntp.reducedMotion();
-        await ntp.openPage({ additional: { customizerDrawer: 'enabled', background: 'color01', userColor: 'cacaca' } });
+        await ntp.openPage({ additional: { background: 'color01', userColor: 'cacaca' } });
         await cp.opensCustomizer();
         await cp.hasColorSelected();
         await cp.selectsPreviousCustomColor('#cacaca');
@@ -171,7 +171,7 @@ test.describe('newtab customizer', () => {
         const ntp = NewtabPage.create(page, workerInfo);
         const cp = new CustomizerPage(ntp);
         await ntp.reducedMotion();
-        await ntp.openPage({ additional: { customizerDrawer: 'enabled' } });
+        await ntp.openPage();
         await cp.opensCustomizer();
         await cp.hasDefaultBackgroundSelected();
         const back = await cp.selectsGradient();
@@ -182,7 +182,7 @@ test.describe('newtab customizer', () => {
         const ntp = NewtabPage.create(page, workerInfo);
         const cp = new CustomizerPage(ntp);
         await ntp.reducedMotion();
-        await ntp.openPage({ additional: { customizerDrawer: 'enabled', background: 'gradient02' } });
+        await ntp.openPage({ additional: { background: 'gradient02' } });
         await cp.opensCustomizer();
         await cp.hasGradientSelected();
     });
@@ -190,7 +190,7 @@ test.describe('newtab customizer', () => {
         const ntp = NewtabPage.create(page, workerInfo);
         const cp = new CustomizerPage(ntp);
         await ntp.reducedMotion();
-        await ntp.openPage({ additional: { customizerDrawer: 'enabled', background: 'userImage:01', userImages: 'true' } });
+        await ntp.openPage({ additional: { background: 'userImage:01', userImages: 'true' } });
         await cp.opensCustomizer();
         await cp.hasImagesSelected();
     });
@@ -198,7 +198,7 @@ test.describe('newtab customizer', () => {
         const ntp = NewtabPage.create(page, workerInfo);
         const cp = new CustomizerPage(ntp);
         await ntp.reducedMotion();
-        await ntp.openPage({ additional: { customizerDrawer: 'enabled' } });
+        await ntp.openPage();
         await cp.opensCustomizer();
         await cp.hasEmptyImagesPanel();
         await cp.acceptsImagesUpdate();
@@ -207,7 +207,7 @@ test.describe('newtab customizer', () => {
         const ntp = NewtabPage.create(page, workerInfo);
         const cp = new CustomizerPage(ntp);
         await ntp.reducedMotion();
-        await ntp.openPage({ additional: { customizerDrawer: 'enabled' } });
+        await ntp.openPage();
         await cp.opensCustomizer();
         await cp.hasEmptyImagesPanel();
         await cp.acceptsBadImagesUpdate();
@@ -217,7 +217,7 @@ test.describe('newtab customizer', () => {
         const ntp = NewtabPage.create(page, workerInfo);
         const cp = new CustomizerPage(ntp);
         await ntp.reducedMotion();
-        await ntp.openPage({ additional: { customizerDrawer: 'enabled', userImages: 'true', willThrowPageException: 'userImages' } });
+        await ntp.openPage({ additional: { userImages: 'true', willThrowPageException: 'userImages' } });
         await cp.opensCustomizer();
         await cp.opensImages();
         await cp.handlesNestedException();
@@ -226,7 +226,7 @@ test.describe('newtab customizer', () => {
         const ntp = NewtabPage.create(page, workerInfo);
         const cp = new CustomizerPage(ntp);
         await ntp.reducedMotion();
-        await ntp.openPage({ additional: { customizerDrawer: 'enabled' } });
+        await ntp.openPage();
         await cp.opensCustomizer();
         await cp.uploadsFirstImage();
     });
@@ -234,7 +234,7 @@ test.describe('newtab customizer', () => {
         const ntp = NewtabPage.create(page, workerInfo);
         const cp = new CustomizerPage(ntp);
         await ntp.reducedMotion();
-        await ntp.openPage({ additional: { customizerDrawer: 'enabled', userImages: 'true' } });
+        await ntp.openPage({ additional: { userImages: 'true' } });
         await cp.opensCustomizer();
         await cp.opensImages();
         await cp.uploadsAdditional({ existing: 3 });
@@ -243,7 +243,7 @@ test.describe('newtab customizer', () => {
         const ntp = NewtabPage.create(page, workerInfo);
         const cp = new CustomizerPage(ntp);
         await ntp.reducedMotion();
-        await ntp.openPage({ additional: { customizerDrawer: 'enabled', theme: 'light' } });
+        await ntp.openPage({ additional: { theme: 'light' } });
         await cp.opensCustomizer();
         await cp.lightThemeIsSelected();
         await cp.setsDarkTheme();
@@ -253,7 +253,7 @@ test.describe('newtab customizer', () => {
         const ntp = NewtabPage.create(page, workerInfo);
         const cp = new CustomizerPage(ntp);
         await ntp.reducedMotion();
-        await ntp.openPage({ additional: { customizerDrawer: 'enabled', theme: 'light' } });
+        await ntp.openPage({ additional: { theme: 'light' } });
         await cp.opensCustomizer();
         await cp.hidesSection('Protection Stats');
     });
@@ -261,7 +261,7 @@ test.describe('newtab customizer', () => {
         const ntp = NewtabPage.create(page, workerInfo);
         const cp = new CustomizerPage(ntp);
         await ntp.reducedMotion();
-        await ntp.openPage({ additional: { customizerDrawer: 'enabled', theme: 'light' } });
+        await ntp.openPage({ additional: { theme: 'light' } });
         await cp.opensCustomizer();
         await cp.opensSettings();
     });
@@ -269,7 +269,7 @@ test.describe('newtab customizer', () => {
         const ntp = NewtabPage.create(page, workerInfo);
         await ntp.reducedMotion();
         const cp = new CustomizerPage(ntp);
-        await ntp.openPage({ additional: { customizerDrawer: 'enabled', userImages: 'true' } });
+        await ntp.openPage({ additional: { userImages: 'true' } });
         await cp.opensCustomizer();
         await cp.opensImages();
         await cp.rightClicksFirstImage();

--- a/special-pages/pages/new-tab/app/mock-transport.js
+++ b/special-pages/pages/new-tab/app/mock-transport.js
@@ -515,16 +515,15 @@ export function mockTransport() {
                         widgetConfigFromStorage.push({ id: 'activity', visibility: 'visible' });
                     }
 
+                    initial.customizer = customizerData();
+
                     /** @type {import('../types/new-tab').NewTabPageSettings} */
-                    const settings = {};
+                    const settings = {
+                        customizerDrawer: { state: 'enabled' },
+                    };
 
-                    if (url.searchParams.get('customizerDrawer') === 'enabled') {
-                        settings.customizerDrawer = { state: 'enabled' };
-                        if (url.searchParams.get('autoOpen') === 'true') {
-                            settings.customizerDrawer.autoOpen = true;
-                        }
-
-                        initial.customizer = customizerData();
+                    if (url.searchParams.get('autoOpen') === 'true' && settings.customizerDrawer) {
+                        settings.customizerDrawer.autoOpen = true;
                     }
 
                     if (url.searchParams.get('adBlocking') === 'enabled') {

--- a/special-pages/pages/new-tab/app/privacy-stats/components/PrivacyStatsCustomized.js
+++ b/special-pages/pages/new-tab/app/privacy-stats/components/PrivacyStatsCustomized.js
@@ -1,5 +1,4 @@
 import { useTypedTranslationWith } from '../../types.js';
-import { useAdBlocking, useCustomizerDrawerSettings } from '../../settings.provider.js';
 import { useVisibility } from '../../widget-list/widget-config.provider.js';
 import { useCustomizer } from '../../customizer/components/CustomizerMenu.js';
 import { PrivacyStatsProvider } from './PrivacyStatsProvider.js';
@@ -21,16 +20,11 @@ import { BodyExpanderProvider } from './BodyExpansionProvider.js';
  */
 export function PrivacyStatsCustomized() {
     const { t } = useTypedTranslationWith(/** @type {Strings} */ ({}));
-    const drawer = useCustomizerDrawerSettings();
-    const adBlocking = useAdBlocking();
 
     /**
      * The menu title for the stats widget is changes when the menu is in the sidebar.
      */
-    // prettier-ignore
-    const sectionTitle = drawer.state === 'enabled' || adBlocking
-            ? t('stats_menuTitle_v2')
-            : t('stats_menuTitle');
+    const sectionTitle = t('stats_menuTitle_v2');
 
     const { visibility, id, toggle, index } = useVisibility();
 

--- a/special-pages/pages/new-tab/app/settings.js
+++ b/special-pages/pages/new-tab/app/settings.js
@@ -7,7 +7,7 @@ export class Settings {
      */
     constructor({
         platform = { name: 'macos' },
-        customizerDrawer = { state: 'disabled', autoOpen: false },
+        customizerDrawer = { state: 'enabled', autoOpen: false },
         adBlocking = { state: 'disabled' },
     }) {
         this.platform = platform;

--- a/special-pages/pages/new-tab/app/settings.provider.js
+++ b/special-pages/pages/new-tab/app/settings.provider.js
@@ -21,14 +21,6 @@ export function useCustomizerDrawerSettings() {
 }
 
 /**
- * @returns {"menu" | "drawer"}
- */
-export function useCustomizerKind() {
-    const settings = useContext(SettingsContext).settings;
-    return settings.customizerDrawer.state === 'enabled' ? 'drawer' : 'menu';
-}
-
-/**
  * @returns {boolean}
  */
 export function useBatchedActivityApi() {

--- a/special-pages/pages/new-tab/integration-tests/new-tab.screenshots.spec.js
+++ b/special-pages/pages/new-tab/integration-tests/new-tab.screenshots.spec.js
@@ -66,7 +66,7 @@ test.describe('NTP screenshots', { tag: ['@screenshots'] }, () => {
             const ap = new ActivityPage(page, ntp);
             const customizer = new CustomizerPage(ntp);
             await ntp.reducedMotion();
-            await ntp.openPage({ additional: { feed: 'activity', customizerDrawer: 'enabled' } });
+            await ntp.openPage({ additional: { feed: 'activity' } });
             await ap.didRender();
             await customizer.opensCustomizer();
             await expect(page).toHaveScreenshot('wide-default-drawer.png', { maxDiffPixels });

--- a/special-pages/pages/new-tab/integration-tests/new-tab.spec.js
+++ b/special-pages/pages/new-tab/integration-tests/new-tab.spec.js
@@ -4,18 +4,19 @@ import { CustomizerPage } from '../app/customizer/integration-tests/customizer.p
 
 test.describe('newtab widgets', () => {
     test('widget config single click', async ({ page }, workerInfo) => {
+        await page.clock.install();
+
         const ntp = NewtabPage.create(page, workerInfo);
+        const cp = new CustomizerPage(ntp);
         await ntp.reducedMotion();
         await ntp.openPage();
-
-        // menu
-        await page.getByRole('button', { name: 'Customize' }).click();
+        await cp.opensCustomizer();
 
         // hide
-        await page.locator('label').filter({ hasText: 'Blocked Tracking Attempts' }).click();
+        await page.getByRole('switch', { name: 'Toggle Protection Stats' }).uncheck();
 
         // debounced
-        await page.waitForTimeout(500);
+        await page.clock.fastForward(501);
 
         // verify the single sync call, where one is hidden
         const outgoing = await ntp.mocks.outgoing({ names: ['widgets_setConfig'] });
@@ -90,7 +91,7 @@ test.describe('newtab widgets', () => {
                     },
                     {
                         id: 'privacyStats',
-                        title: 'Blocked Tracking Attempts',
+                        title: 'Protection Stats',
                     },
                 ],
             },

--- a/special-pages/pages/new-tab/integration-tests/new-tab.spec.js
+++ b/special-pages/pages/new-tab/integration-tests/new-tab.spec.js
@@ -115,7 +115,7 @@ test.describe('newtab widgets', () => {
         test('with overrides from initial setup (light)', async ({ page }, workerInfo) => {
             const ntp = NewtabPage.create(page, workerInfo);
             await ntp.reducedMotion();
-            await ntp.openPage({ additional: { defaultStyles: 'visual-refresh', customizerDrawer: 'enabled' } });
+            await ntp.openPage({ additional: { defaultStyles: 'visual-refresh' } });
             await ntp.waitForCustomizer();
             await page.pause();
             await ntp.hasBackgroundColor({ hex: '#E9EBEC' });
@@ -124,7 +124,7 @@ test.describe('newtab widgets', () => {
             const ntp = NewtabPage.create(page, workerInfo);
             await ntp.reducedMotion();
             await ntp.darkMode();
-            await ntp.openPage({ additional: { defaultStyles: 'visual-refresh', customizerDrawer: 'enabled' } });
+            await ntp.openPage({ additional: { defaultStyles: 'visual-refresh' } });
             await ntp.waitForCustomizer();
             await ntp.hasBackgroundColor({ hex: '#27282A' });
         });

--- a/special-pages/pages/new-tab/messages/types/settings.json
+++ b/special-pages/pages/new-tab/messages/types/settings.json
@@ -9,7 +9,7 @@
       "properties": {
         "state": {
           "type": "string",
-          "enum": ["enabled", "disabled"]
+          "enum": ["enabled"]
         },
         "autoOpen": {
           "description": "Should the customizer drawer be opened on page load?",

--- a/special-pages/pages/new-tab/readme.md
+++ b/special-pages/pages/new-tab/readme.md
@@ -22,7 +22,6 @@ URL parameters can be used to override the default values of the New Tab Page's 
 - `favorites` - Specifies which Favorites mock dataset to use. Expects a key from `favorites.data.js` (e.g., `many`, `none`) or a number to generate that many mock favorites.
 - `favorites.config.expansion` - If set to `expanded`, sets the initial state of the Favorites widget to be expanded.
 - `feed` - Controls which primary feed widget(s) are included in the initial setup. Can be `stats`, `activity`, or `both`. Defaults to `stats`.
-- `customizerDrawer` - If set to `enabled`, enables the Customizer feature flag in the initial setup.
-- `autoOpen` - If `customizerDrawer` is `enabled` and this parameter is `true`, sets the `autoOpen` flag for the customizer drawer in the initial setup.
+- `autoOpen` - Sets the `autoOpen` flag for the customizer drawer in the initial setup.
 - `defaultStyles` - If set to `visual-refresh`, applies specific background color variables (`--default-light-background-color`, `--default-dark-background-color`) to the body.
 - `adBlocking` - If set to `enabled`, configures the Activity and Privacy Stats widgets to indicate that both ads and trackers are blocked.

--- a/special-pages/pages/new-tab/types/new-tab.ts
+++ b/special-pages/pages/new-tab/types/new-tab.ts
@@ -742,7 +742,7 @@ export interface WidgetListItem {
 }
 export interface NewTabPageSettings {
   customizerDrawer?: {
-    state: "enabled" | "disabled";
+    state: "enabled";
     /**
      * Should the customizer drawer be opened on page load?
      */


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1209698262999393/task/1210001582798249?focus=true

## Description

- [x] during the initial roll out, we supported 2 kinds of customization: basic on/off for sections and then the full slide out panel. Now only the panel is supported, so this PR removes unused code paths :)

## Testing Steps

- All tests were updated to expect the drawer is enabled by default
- A quick check here, https://deploy-preview-1638--content-scope-scripts.netlify.app/build/pages/new-tab/ - the panel should open when you press 'customize'

## Checklist

<!--
  These questions are a friendly reminder to shipping code, if you're uncertain ask the AoR owners.
  It's also totally appropriate to not check some of these boxes, if they don't apply to your change.
-->
*Please tick all that apply:*

- [ ] I have tested this change locally
- [ ] I have tested this change locally in all supported browsers
- [ ] This change will be visible to users
- [ ] I have added automated tests that cover this change
- [ ] I have ensured the change is gated by config
- [ ] This change was covered by a ship review
- [ ] This change was covered by a tech design
- [ ] Any dependent config has been merged

