### PR TITLE
Onboarding: Send set*() messages to native apps when step is skipped

### DIFF
--- a/special-pages/pages/onboarding/app/global.js
+++ b/special-pages/pages/onboarding/app/global.js
@@ -218,36 +218,23 @@ export function GlobalProvider({ order, children, stepDefinitions, messaging, fi
  * @param {ImportMeta['platform']} platform
  */
 async function handleSystemSettingUpdate(action, messaging, platform) {
-    const { id, payload, current } = action;
+    const { id, payload } = action;
     switch (id) {
         case 'bookmarks': {
-            if (!current) {
-                messaging.setBookmarksBar(payload);
-            } else {
-                if (payload.enabled) {
-                    messaging.setBookmarksBar(payload);
-                }
-            }
+            messaging.setBookmarksBar(payload);
             return payload;
         }
         case 'session-restore': {
-            if (!current) {
-                messaging.setSessionRestore(payload);
-            } else {
-                if (payload.enabled) {
-                    messaging.setSessionRestore(payload);
-                }
-            }
+            messaging.setSessionRestore(payload);
             return payload;
         }
         case 'home-shortcut': {
-            if (!current) {
-                messaging.setShowHomeButton(payload);
-            } else {
-                if (payload.enabled) {
-                    messaging.setShowHomeButton(payload);
-                }
-            }
+            messaging.setShowHomeButton(payload);
+            return payload;
+        }
+        case 'ad-blocking':
+        case 'youtube-ad-blocking': {
+            messaging.setAdBlocking(payload);
             return payload;
         }
         case 'dock': {
@@ -279,17 +266,6 @@ async function handleSystemSettingUpdate(action, messaging, platform) {
                 return { enabled: true };
             }
             break;
-        }
-        case 'ad-blocking':
-        case 'youtube-ad-blocking': {
-            if (!current) {
-                messaging.setAdBlocking(payload);
-            } else {
-                if (payload.enabled) {
-                    messaging.setAdBlocking(payload);
-                }
-            }
-            return payload;
         }
     }
     if ('value' in payload) {

--- a/special-pages/pages/onboarding/integration-tests/onboarding.js
+++ b/special-pages/pages/onboarding/integration-tests/onboarding.js
@@ -230,6 +230,50 @@ export class OnboardingPage {
 
     async skippedBookmarksBar() {
         await this.skippedCurrent();
+        await this.page.getByRole('switch', { name: 'Show Bookmarks Bar' }).waitFor();
+        const calls = await this.mocks.outgoing({ names: ['setBookmarksBar'] });
+        expect(calls).toMatchObject([
+            {
+                payload: {
+                    context: 'specialPages',
+                    featureName: 'onboarding',
+                    method: 'setBookmarksBar',
+                    params: { enabled: false },
+                },
+            },
+        ]);
+    }
+
+    async skippedSessionRestore() {
+        await this.skippedCurrent();
+        await this.page.getByRole('switch', { name: 'Enable Session Restore' }).waitFor();
+        const calls = await this.mocks.outgoing({ names: ['setSessionRestore'] });
+        expect(calls).toMatchObject([
+            {
+                payload: {
+                    context: 'specialPages',
+                    featureName: 'onboarding',
+                    method: 'setSessionRestore',
+                    params: { enabled: false },
+                },
+            },
+        ]);
+    }
+
+    async skippedShowHomeButton() {
+        await this.skippedCurrent();
+        await this.page.getByRole('switch', { name: 'Show Home Button' }).waitFor();
+        const calls = await this.mocks.outgoing({ names: ['setShowHomeButton'] });
+        expect(calls).toMatchObject([
+            {
+                payload: {
+                    context: 'specialPages',
+                    featureName: 'onboarding',
+                    method: 'setShowHomeButton',
+                    params: { enabled: false },
+                },
+            },
+        ]);
     }
 
     async canToggleBookmarksBar() {
@@ -252,6 +296,16 @@ export class OnboardingPage {
         // now check the outgoing messages
         const calls = await this.mocks.outgoing({ names: ['setBookmarksBar'] });
         expect(calls).toMatchObject([
+            // initial call from skipping:
+            {
+                payload: {
+                    context: 'specialPages',
+                    featureName: 'onboarding',
+                    method: 'setBookmarksBar',
+                    params: { enabled: false },
+                },
+            },
+            // subsequent calls from toggling:
             {
                 payload: {
                     context: 'specialPages',
@@ -308,6 +362,16 @@ export class OnboardingPage {
         // now check the outgoing messages
         const calls = await this.mocks.outgoing({ names: ['setSessionRestore'] });
         expect(calls).toMatchObject([
+            // initial call from skipping:
+            {
+                payload: {
+                    context: 'specialPages',
+                    featureName: 'onboarding',
+                    method: 'setSessionRestore',
+                    params: { enabled: false },
+                },
+            },
+            // subsequent calls from toggling:
             {
                 payload: {
                     context: 'specialPages',
@@ -347,6 +411,16 @@ export class OnboardingPage {
         // now check the outgoing messages
         const calls = await this.mocks.outgoing({ names: ['setShowHomeButton'] });
         expect(calls).toMatchObject([
+            // initial call from skipping:
+            {
+                payload: {
+                    context: 'specialPages',
+                    featureName: 'onboarding',
+                    method: 'setShowHomeButton',
+                    params: { enabled: false },
+                },
+            },
+            // subsequent calls from toggling:
             {
                 payload: {
                     context: 'specialPages',
@@ -397,7 +471,21 @@ export class OnboardingPage {
         await this.didSetAdBlocking();
     }
 
-    async didSetAdBlocking() {
+    async skipAdBlocking() {
+        const { page } = this;
+        await this.skippedCurrent();
+        await page.getByRole('button', { name: 'Import' }).waitFor();
+        await this.didSetAdBlocking({ enabled: false }); // important that setAdBlocking() is called when skipped so that native apps can fire a pixel
+    }
+
+    async skipYouTubeAdBlocking() {
+        const { page } = this;
+        await this.skippedCurrent();
+        await page.getByRole('button', { name: 'Import' }).waitFor();
+        await this.didSetAdBlocking({ enabled: false }); // important that setAdBlocking() is called when skipped so that native apps can fire a pixel
+    }
+
+    async didSetAdBlocking({ enabled = true } = {}) {
         const calls = await this.mocks.outgoing({ names: ['setAdBlocking'] });
         expect(calls).toMatchObject([
             {
@@ -405,7 +493,7 @@ export class OnboardingPage {
                     context: 'specialPages',
                     featureName: 'onboarding',
                     method: 'setAdBlocking',
-                    params: { enabled: true },
+                    params: { enabled },
                 },
             },
         ]);

--- a/special-pages/pages/onboarding/integration-tests/onboarding.spec.js
+++ b/special-pages/pages/onboarding/integration-tests/onboarding.spec.js
@@ -68,6 +68,21 @@ test.describe('onboarding', () => {
             await onboarding.skippedCurrent();
             await onboarding.enableEnhancedAdBlocking();
         });
+        test('Then I can skip enhanced ad blocking', async ({ page }, workerInfo) => {
+            const onboarding = OnboardingPage.create(page, workerInfo);
+            onboarding.withInitData({
+                stepDefinitions: {
+                    systemSettings: {
+                        rows: ['dock', 'ad-blocking', 'import'],
+                    },
+                },
+                order: 'v3',
+            });
+            await onboarding.reducedMotion();
+            await onboarding.openPage({ env: 'app', page: 'systemSettings' });
+            await onboarding.skippedCurrent();
+            await onboarding.skipAdBlocking();
+        });
         test('Then I can turn on YouTube ad blocking', async ({ page }, workerInfo) => {
             const onboarding = OnboardingPage.create(page, workerInfo);
             onboarding.withInitData({
@@ -83,7 +98,22 @@ test.describe('onboarding', () => {
             await onboarding.skippedCurrent();
             await onboarding.enableYouTubeAdBlocking();
         });
-        test('The I can skip all', async ({ page }, workerInfo) => {
+        test('Then I can skip YouTube ad blocking', async ({ page }, workerInfo) => {
+            const onboarding = OnboardingPage.create(page, workerInfo);
+            onboarding.withInitData({
+                stepDefinitions: {
+                    systemSettings: {
+                        rows: ['dock', 'youtube-ad-blocking', 'import'],
+                    },
+                },
+                order: 'v3',
+            });
+            await onboarding.reducedMotion();
+            await onboarding.openPage({ env: 'app', page: 'systemSettings' });
+            await onboarding.skippedCurrent();
+            await onboarding.skipYouTubeAdBlocking();
+        });
+        test('Then I can skip all', async ({ page }, workerInfo) => {
             const onboarding = OnboardingPage.create(page, workerInfo);
             await onboarding.reducedMotion();
             await onboarding.openPage({ env: 'app', page: 'systemSettings' });
@@ -124,8 +154,8 @@ test.describe('onboarding', () => {
             await onboarding.openPage({ env: 'app', page: 'customize' });
 
             // skipped first 2
-            await onboarding.skippedCurrent();
-            await onboarding.skippedCurrent();
+            await onboarding.skippedBookmarksBar();
+            await onboarding.skippedSessionRestore();
 
             await onboarding.showHomeButton();
         });
@@ -135,9 +165,9 @@ test.describe('onboarding', () => {
             await onboarding.openPage({ env: 'app', page: 'customize' });
 
             // skipped all
-            await onboarding.skippedCurrent();
-            await onboarding.skippedCurrent();
-            await onboarding.skippedCurrent();
+            await onboarding.skippedBookmarksBar();
+            await onboarding.skippedSessionRestore();
+            await onboarding.skippedShowHomeButton();
 
             await onboarding.canToggleHomeButton();
         });
@@ -341,7 +371,7 @@ test.describe('onboarding', () => {
                 });
                 await onboarding.reducedMotion();
                 await onboarding.openPage({ env: 'app', page: 'customize' });
-                await onboarding.skippedCurrent();
+                await onboarding.skippedBookmarksBar();
 
                 // ▶️ Then I can toggle it afterward
                 await onboarding.canToggleBookmarksBar();
@@ -354,7 +384,7 @@ test.describe('onboarding', () => {
                 });
                 await onboarding.reducedMotion();
                 await onboarding.openPage({ env: 'app', page: 'customize' });
-                await onboarding.skippedCurrent();
+                await onboarding.skippedBookmarksBar();
 
                 // ▶️ Then the restore session bar shows
                 await onboarding.restoreSession();
@@ -367,8 +397,8 @@ test.describe('onboarding', () => {
                 });
                 await onboarding.reducedMotion();
                 await onboarding.openPage({ env: 'app', page: 'customize' });
-                await onboarding.skippedCurrent();
-                await onboarding.skippedCurrent();
+                await onboarding.skippedBookmarksBar();
+                await onboarding.skippedSessionRestore();
 
                 // ▶️ Then I can toggle it afterward
                 await onboarding.canToggleRestoreSession();
@@ -383,8 +413,8 @@ test.describe('onboarding', () => {
                 await onboarding.openPage({ env: 'app', page: 'customize' });
 
                 // skipped first 2
-                await onboarding.skippedCurrent();
-                await onboarding.skippedCurrent();
+                await onboarding.skippedBookmarksBar();
+                await onboarding.skippedSessionRestore();
 
                 // ▶️ Then the home button bar shows
                 await onboarding.showHomeButton();
@@ -399,9 +429,9 @@ test.describe('onboarding', () => {
                 await onboarding.openPage({ env: 'app', page: 'customize' });
 
                 // skipped all
-                await onboarding.skippedCurrent();
-                await onboarding.skippedCurrent();
-                await onboarding.skippedCurrent();
+                await onboarding.skippedBookmarksBar();
+                await onboarding.skippedSessionRestore();
+                await onboarding.skippedShowHomeButton();
 
                 // ▶️ Then I can toggle it afterward
                 await onboarding.canToggleHomeButton();
@@ -416,9 +446,9 @@ test.describe('onboarding', () => {
                 await onboarding.openPage({ env: 'app', page: 'customize' });
 
                 // skipped all
-                await onboarding.skippedCurrent();
-                await onboarding.skippedCurrent();
-                await onboarding.skippedCurrent();
+                await onboarding.skippedBookmarksBar();
+                await onboarding.skippedSessionRestore();
+                await onboarding.skippedShowHomeButton();
 
                 // ▶️ Then I can toggle it afterward
                 await onboarding.startBrowsing();


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1209121419454298/task/1209906221282239

## Description

Modifies the Onboarding special page so that the `setBookmarksBar`, `setSessionRestore`, `setShowHomeButton`, and `setAdBlocking` messages are sent with `params.enabled = false` when the user clicks _Skip_ during onboarding. This allows the native apps to fire a pixel when the user skips one of these, if desired. 

The `requestDockOptIn`, `requestImport`, and `requestSetAsDefault` messages remain as-is. These aren’t reversible actions so it doesn’t make sense to fire a message with `params.enabled = false`.

## Testing Steps

1. Navigate to https://deploy-preview-1648--content-scope-scripts.netlify.app/build/pages/onboarding/?adBlocking=enabled.
1. Open DevTools.
1. Work your way through onboarding, skipping everything.
1. Notice that you see `unhandled notification` warnings in the console with `params.enabled = false` when skipping:
    - “Browse faster with even fewer ads”
    - “Show a bookmarks bar with your favorite sites”
    - “Restore previous websites on startup”
    - “Add a shortcut to your homepage in the toolbar"

## Checklist

*Please tick all that apply:*

- [x] I have tested this change locally
- [x] I have tested this change locally in all supported browsers
- [ ] This change will be visible to users
- [x] I have added automated tests that cover this change
- [ ] I have ensured the change is gated by config
- [ ] This change was covered by a ship review
- [ ] This change was covered by a tech design
- [ ] Any dependent config has been merged

