### PR TITLE
Onboarding: Fix welcome message appearing off screen

### DIFF
--- a/special-pages/pages/onboarding/app/components/App2.module.css
+++ b/special-pages/pages/onboarding/app/components/App2.module.css
@@ -24,10 +24,10 @@
         transform: translateY(0);
 
         &[data-current="welcome"] {
-            transform: translateY(calc(50vh - 288px));
+            transform: translateY(max(50vh - 288px, 0px));
         }
         &[data-current="getStarted"] {
-            transform: translateY(calc(50vh - 288px));
+            transform: translateY(max(50vh - 288px, 0px));
         }
     }
 

--- a/special-pages/pages/onboarding/app/components/App2.module.css
+++ b/special-pages/pages/onboarding/app/components/App2.module.css
@@ -23,10 +23,10 @@
         transition: transform 0.3s ease-in-out;
         transform: translateY(0);
 
-        &[data-current="welcome"] {
-            transform: translateY(max(50vh - 288px, 0px));
-        }
+        &[data-current="welcome"],
         &[data-current="getStarted"] {
+            /* max() is not supported by stylelint's CSS parser: https://github.com/csstree/csstree/issues/164 */
+            /* stylelint-disable-next-line csstree/validator */
             transform: translateY(max(50vh - 288px, 0px));
         }
     }

--- a/special-pages/pages/onboarding/app/components/v3/Hiker.module.css
+++ b/special-pages/pages/onboarding/app/components/v3/Hiker.module.css
@@ -1,6 +1,6 @@
 .hiker {
     bottom: 0;
-    position: absolute;
+    position: fixed;
     right: var(--sp-35);
 
     animation-name: hiker-appear;


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1209121419454298/task/1210093075808892?focus=true

## Description
Prevent the welcome message in Onboarding from having a negative `translateY` value and appearing off screen.

## Testing Steps
1. Browse to https://deploy-preview-1650--content-scope-scripts.netlify.app/build/pages/onboarding/.
2. Resize your browser so that the height is small.
3. “Hi there. Ready for a faster browser that keeps you protected?” bubble should not appear off screen.

## Checklist
*Please tick all that apply:*

- [x] I have tested this change locally
- [x] I have tested this change locally in all supported browsers
- [x] This change will be visible to users
- [ ] I have added automated tests that cover this change
- [ ] I have ensured the change is gated by config
- [ ] This change was covered by a ship review
- [ ] This change was covered by a tech design
- [ ] Any dependent config has been merged

