### PR TITLE
onboarding: prevent scroll overflow whilst hiker is animating in

### DIFF
--- a/special-pages/pages/onboarding/app/components/App2.js
+++ b/special-pages/pages/onboarding/app/components/App2.js
@@ -23,6 +23,7 @@ export function App2({ children }) {
     const dispatch = useContext(GlobalDispatch);
 
     const { activeStep, activeStepVisible, exiting, step } = globalState;
+    const entering = step.id === 'welcome' || step.id === 'getStarted';
 
     const advance = () => dispatch({ kind: 'advance' });
 
@@ -51,7 +52,7 @@ export function App2({ children }) {
     };
 
     return (
-        <main className={styles.main} data-platform-name={platformName || 'macos'} data-app-version="2">
+        <main className={styles.main} data-platform-name={platformName || 'macos'} data-app-version="2" data-fixed-height={entering}>
             <Background />
             {debugState && <Debug state={globalState} />}
             <div
@@ -68,7 +69,7 @@ export function App2({ children }) {
                     </BeforeAfterProvider>
                 </ErrorBoundary>
             </div>
-            {(step.id === 'welcome' || step.id === 'getStarted') && <Hiker />}
+            {entering && <Hiker />}
             {children}
         </main>
     );

--- a/special-pages/pages/onboarding/app/components/App2.module.css
+++ b/special-pages/pages/onboarding/app/components/App2.module.css
@@ -3,6 +3,11 @@
     height: 100%;
 }
 
+/* This doesn't need guarding behind app version, because it will be absent elsewhere */
+body:has(main[data-fixed-height="true"]) {
+    overflow-y: hidden;
+}
+
 [data-app-version="2"] {
     .main {
         font-family: system, -apple-system, system-ui, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1209698262999393/task/1210122049551002?focus=true

## Description

Don't allow overflow-y until we're past the first 2 steps. This prevents a small glitch where the scroll height of the 'body' is accommodating the hiker.

## Testing Steps

- check production first https://content-scope-scripts.netlify.app/build/pages/onboarding/ - set animation speed to 10% in dev tools to see the issue (see my screenshot)
- next, compare the same here https://deploy-preview-1660--content-scope-scripts.netlify.app/build/pages/onboarding/

## Checklist

<!--
  These questions are a friendly reminder to shipping code, if you're uncertain ask the AoR owners.
  It's also totally appropriate to not check some of these boxes, if they don't apply to your change.
-->
*Please tick all that apply:*

- [ ] I have tested this change locally
- [ ] I have tested this change locally in all supported browsers
- [ ] This change will be visible to users
- [ ] I have added automated tests that cover this change
- [ ] I have ensured the change is gated by config
- [ ] This change was covered by a ship review
- [ ] This change was covered by a tech design
- [ ] Any dependent config has been merged

