### PR TITLE
Add query param color=white to 

### DIFF
--- a/special-pages/pages/duckplayer/app/embed-settings.js
+++ b/special-pages/pages/duckplayer/app/embed-settings.js
@@ -71,6 +71,7 @@ export class EmbedSettings {
 
         url.searchParams.set('rel', '0'); // shows related videos from the same channel as the video
         url.searchParams.set('modestbranding', '1'); // disables showing the YouTube logo in the video control bar
+        url.searchParams.set('color', 'white'); // Forces legacy YouTube player UI
 
         if (this.timestamp && this.timestamp.seconds > 0) {
             url.searchParams.set('start', String(this.timestamp.seconds)); // if timestamp supplied, start video at specific point

--- a/special-pages/pages/duckplayer/integration-tests/duck-player.js
+++ b/special-pages/pages/duckplayer/integration-tests/duck-player.js
@@ -5,9 +5,9 @@ import { perPlatform } from 'injected/integration-test/type-helpers.mjs';
 
 const MOCK_VIDEO_ID = 'VIDEO_ID';
 const MOCK_VIDEO_TITLE = 'Embedded Video - YouTube';
-const youtubeEmbed = (id) => 'https://www.youtube-nocookie.com/embed/' + id + '?iv_load_policy=1&autoplay=1&rel=0&modestbranding=1';
+const youtubeEmbed = (id) => 'https://www.youtube-nocookie.com/embed/' + id + '?iv_load_policy=1&autoplay=1&rel=0&modestbranding=1&color=white';
 const youtubeEmbedIOS = (id) =>
-    'https://www.youtube-nocookie.com/embed/' + id + '?iv_load_policy=1&autoplay=1&muted=1&rel=0&modestbranding=1';
+    'https://www.youtube-nocookie.com/embed/' + id + '?iv_load_policy=1&autoplay=1&muted=1&rel=0&modestbranding=1&color=white';
 const html = {
     unsupported: `<html><head><title>${MOCK_VIDEO_TITLE}</title></head>
 <body>

--- a/special-pages/pages/duckplayer/integration-tests/duck-player.js
+++ b/special-pages/pages/duckplayer/integration-tests/duck-player.js
@@ -5,7 +5,8 @@ import { perPlatform } from 'injected/integration-test/type-helpers.mjs';
 
 const MOCK_VIDEO_ID = 'VIDEO_ID';
 const MOCK_VIDEO_TITLE = 'Embedded Video - YouTube';
-const youtubeEmbed = (id) => 'https://www.youtube-nocookie.com/embed/' + id + '?iv_load_policy=1&autoplay=1&rel=0&modestbranding=1&color=white';
+const youtubeEmbed = (id) =>
+    'https://www.youtube-nocookie.com/embed/' + id + '?iv_load_policy=1&autoplay=1&rel=0&modestbranding=1&color=white';
 const youtubeEmbedIOS = (id) =>
     'https://www.youtube-nocookie.com/embed/' + id + '?iv_load_policy=1&autoplay=1&muted=1&rel=0&modestbranding=1&color=white';
 const html = {

--- a/special-pages/pages/duckplayer/unit-tests/embed-settings.mjs
+++ b/special-pages/pages/duckplayer/unit-tests/embed-settings.mjs
@@ -5,7 +5,7 @@ import { EmbedSettings } from '../app/embed-settings.js';
 describe('creates embed url', () => {
     it('handles duck scheme', () => {
         const actual = EmbedSettings.fromHref('duck://player/123')?.toEmbedUrl();
-        const expected = 'https://www.youtube-nocookie.com/embed/123?iv_load_policy=1&autoplay=1&rel=0&modestbranding=1';
+        const expected = 'https://www.youtube-nocookie.com/embed/123?iv_load_policy=1&autoplay=1&rel=0&modestbranding=1&color=white';
         deepEqual(actual, expected);
     });
     it('handles duck scheme with timestamp', () => {
@@ -15,6 +15,7 @@ describe('creates embed url', () => {
             autoplay: '1',
             rel: '0',
             modestbranding: '1',
+            color: 'white',
             start: '3723',
         };
         if (!actual) throw new Error('unreachable');
@@ -28,6 +29,7 @@ describe('creates embed url', () => {
             autoplay: '1',
             rel: '0',
             modestbranding: '1',
+            color: 'white',
             start: '3723',
         };
         if (!actual) throw new Error('unreachable');
@@ -41,6 +43,7 @@ describe('creates embed url', () => {
             autoplay: '1',
             rel: '0',
             modestbranding: '1',
+            color: 'white',
             start: '3723',
         };
         if (!actual) throw new Error('unreachable');
@@ -54,6 +57,7 @@ describe('creates embed url', () => {
             autoplay: '1',
             rel: '0',
             modestbranding: '1',
+            color: 'white',
         };
         if (!actual) throw new Error('unreachable');
         const asParams = Object.fromEntries(new URL(actual).searchParams);
@@ -67,6 +71,7 @@ describe('creates embed url', () => {
             autoplay: '1',
             rel: '0',
             modestbranding: '1',
+            color: 'white',
             muted: '1',
         };
         if (!actual) throw new Error('unreachable');
@@ -80,6 +85,7 @@ describe('creates embed url', () => {
             iv_load_policy: '1',
             rel: '0',
             modestbranding: '1',
+            color: 'white',
         };
         if (!actual) throw new Error('unreachable');
         const asParams = Object.fromEntries(new URL(actual).searchParams);
@@ -93,6 +99,7 @@ describe('creates embed url', () => {
             autoplay: '1',
             rel: '0',
             modestbranding: '1',
+            color: 'white',
         };
         if (!actual) throw new Error('unreachable');
         const asParams = Object.fromEntries(new URL(actual).searchParams);


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1207252092703676/task/1210128066798031?focus=true

## Description

YouTube's seemingly rolling out a new embedded player UI which is used in Duck Player. We discovered that adding a URL param (color=white) will force the YouTube player to use the legacy UI instead of the new player.

## Testing Steps

- Run this branch of C-S-S on an Android or iOS build
- Open Duck Player on any video
- Use Safari or Chrome to inspect the Duck Player window
- Confirm that the iframe has a src attribute that includes the query param `color=white` . You can run this on the console to confirm `document.querySelector('iframe').src.includes('color=white');`
- Confirm that the player interface looks like this

<img width="404" alt="image" src="https://github.com/user-attachments/assets/48e3fede-cf1c-4ff3-8d96-9288f74d69b2" />

and not like this

<img width="399" alt="image" src="https://github.com/user-attachments/assets/bfc94120-5c41-418d-a805-9e4d180edae5" />


## Checklist

<!--
  These questions are a friendly reminder to shipping code, if you're uncertain ask the AoR owners.
  It's also totally appropriate to not check some of these boxes, if they don't apply to your change.
-->
*Please tick all that apply:*

- [ ] I have tested this change locally
- [ ] I have tested this change locally in all supported browsers
- [ ] This change will be visible to users
- [ ] I have added automated tests that cover this change
- [ ] I have ensured the change is gated by config
- [ ] This change was covered by a ship review
- [ ] This change was covered by a tech design
- [ ] Any dependent config has been merged

