### PR TITLE
Onboarding: Skip Duck Player step when ad blocking is enabled

### DIFF
--- a/special-pages/pages/onboarding/app/components/v3/data.js
+++ b/special-pages/pages/onboarding/app/components/v3/data.js
@@ -83,10 +83,7 @@ export const stepsConfig = {
             content: <SettingsStep data={settingsRowItems} />,
         };
     },
-    duckPlayerSingle: ({ t, globalState, advance, beforeAfter }) => {
-        const isYouTubeAdBlockingEnabled = globalState.values['youtube-ad-blocking']?.enabled ?? false;
-        const title = isYouTubeAdBlockingEnabled ? t('duckPlayer_alt_title') : t('duckPlayer_title');
-        const subtitle = isYouTubeAdBlockingEnabled ? t('duckPlayer_alt_subtitle') : t('duckPlayer_subtitle');
+    duckPlayerSingle: ({ t, advance, beforeAfter }) => {
         const beforeAfterState = beforeAfter.get();
         const longestText = [t('beforeAfter_duckPlayer_show'), t('beforeAfter_duckPlayer_hide')].reduce((acc, cur) => {
             return cur.length > acc.length ? cur : acc;
@@ -95,8 +92,8 @@ export const stepsConfig = {
         return {
             variant: 'box',
             heading: {
-                title,
-                subtitle,
+                title: t('duckPlayer_title'),
+                subtitle: t('duckPlayer_subtitle'),
                 speechBubble: true,
             },
             dismissButton: {

--- a/special-pages/pages/onboarding/app/global.js
+++ b/special-pages/pages/onboarding/app/global.js
@@ -76,6 +76,14 @@ export function reducer(state, action) {
                         /** @type {import('./types').SystemValueId} */
                         const systemValueId = action.id;
 
+                        // skip Duck Player onboarding step when ad blocking is enabled
+                        // note: there's no UI for disabling this setting, so we never need to re-insert duckPlayerSingle into order
+                        const isAdBlockingSetting = systemValueId === 'ad-blocking' || systemValueId === 'youtube-ad-blocking';
+                        const nextOrder =
+                            isAdBlockingSetting && action.payload.enabled
+                                ? state.order.filter((step) => step !== 'duckPlayerSingle')
+                                : state.order;
+
                         /** @type {import('./types').UIValue} */
                         const nextUIState = isCurrent && action.payload.enabled ? 'accepted' : 'skipped';
 
@@ -86,6 +94,7 @@ export function reducer(state, action) {
                                 // bump the step (show the next row)
                                 ...state.step,
                             },
+                            order: nextOrder,
                             activeRow: isCurrent ? state.activeRow + 1 : state.activeRow,
                             values: {
                                 ...state.values,

--- a/special-pages/pages/onboarding/integration-tests/onboarding.js
+++ b/special-pages/pages/onboarding/integration-tests/onboarding.js
@@ -699,7 +699,10 @@ export class OnboardingPage {
         await this.startBrowsing();
     }
 
-    async completesOrderV3WithAdBlocking() {
+    /**
+     * @param {'ad-blocking'|'youtube-ad-blocking'} adBlockingId
+     */
+    async completesOrderV3WithAdBlockingEnabled(adBlockingId) {
         const { page } = this;
 
         /* Welcome */
@@ -715,22 +718,23 @@ export class OnboardingPage {
         await page.getByText('Excellent!').nth(1).waitFor({ timeout: 1000 });
         await page.getByRole('button', { name: 'Next' }).click();
 
-        /* System settings (with ad-blocking) */
+        /* System settings */
         await page.getByText('Let’s get you set up!').nth(1).waitFor({ timeout: 1000 });
         const dockButton = this.build.switch({
             windows: () => page.getByRole('button', { name: 'Pin to Taskbar' }),
             apple: () => page.getByRole('button', { name: 'Keep in Dock' }),
         });
         await dockButton.click();
-        await page.getByRole('button', { name: 'Turn on Enhanced Ad Blocking', exact: true }).click();
+        await page
+            .getByRole('button', {
+                name: adBlockingId === 'youtube-ad-blocking' ? 'Block Ads' : 'Turn on Enhanced Ad Blocking',
+                exact: true,
+            })
+            .click();
         await page.getByRole('button', { name: 'Import Now', exact: true }).click();
         await page.getByRole('button', { name: 'Next' }).click();
 
-        /* Duckplayer */
-        await page.getByText('Drowning in ads').nth(1).waitFor({ timeout: 1000 });
-        await page.getByLabel('See Without Duck Player').click();
-        await page.getByLabel('See With Duck Player').click();
-        await page.getByRole('button', { name: 'Next' }).click();
+        /* No Duck Player step as ad blocking was enabled */
 
         /* Customize */
         await page.getByText('Let’s customize a few things').nth(1).waitFor({ timeout: 1000 });
@@ -740,8 +744,9 @@ export class OnboardingPage {
         await this.startBrowsing();
     }
 
-    async completesOrderV3WithYouTubeAdBlocking() {
+    async completesOrderV3WithAdBlockingDisabled() {
         const { page } = this;
+
         /* Welcome */
         await page.getByText('Welcome to DuckDuckGo').nth(1).waitFor({ timeout: 1000 });
 
@@ -755,20 +760,19 @@ export class OnboardingPage {
         await page.getByText('Excellent!').nth(1).waitFor({ timeout: 1000 });
         await page.getByRole('button', { name: 'Next' }).click();
 
-        /* System settings (with youtube ad-blocking) */
+        /* System settings */
         await page.getByText('Let’s get you set up!').nth(1).waitFor({ timeout: 1000 });
         const dockButton = this.build.switch({
             windows: () => page.getByRole('button', { name: 'Pin to Taskbar' }),
             apple: () => page.getByRole('button', { name: 'Keep in Dock' }),
         });
         await dockButton.click();
-        await page.getByRole('button', { name: 'Block Ads', exact: true }).click();
+        await page.getByRole('button', { name: 'Skip', exact: true }).click();
         await page.getByRole('button', { name: 'Import Now', exact: true }).click();
         await page.getByRole('button', { name: 'Next' }).click();
 
-        /* Duckplayer - alternate title/subtitle */
-        await page.getByText('Watch YouTube privately with Duck Player').nth(1).waitFor({ timeout: 1000 });
-        await expect(page.locator('h2')).toContainText("Watching videos in Duck Player won't influence your YouTube recommendations.");
+        /* Duck Player */
+        await page.getByText('Drowning in ads').nth(1).waitFor({ timeout: 1000 });
         await page.getByLabel('See Without Duck Player').click();
         await page.getByLabel('See With Duck Player').click();
         await page.getByRole('button', { name: 'Next' }).click();

--- a/special-pages/pages/onboarding/integration-tests/onboarding.spec.js
+++ b/special-pages/pages/onboarding/integration-tests/onboarding.spec.js
@@ -246,7 +246,22 @@ test.describe('onboarding', () => {
             await onboarding.reducedMotion();
             await onboarding.darkMode();
             await onboarding.openPage();
-            await onboarding.completesOrderV3WithAdBlocking();
+            await onboarding.completesOrderV3WithAdBlockingEnabled('ad-blocking');
+        });
+        test('shows v3 flow with ad blocking disabled', async ({ page }, workerInfo) => {
+            const onboarding = OnboardingPage.create(page, workerInfo);
+            onboarding.withInitData({
+                stepDefinitions: {
+                    systemSettings: {
+                        rows: ['dock', 'ad-blocking', 'import'],
+                    },
+                },
+                order: 'v3',
+            });
+            await onboarding.reducedMotion();
+            await onboarding.darkMode();
+            await onboarding.openPage();
+            await onboarding.completesOrderV3WithAdBlockingDisabled();
         });
         test('shows v3 flow with YouTube ad blocking', async ({ page }, workerInfo) => {
             const onboarding = OnboardingPage.create(page, workerInfo);
@@ -261,7 +276,22 @@ test.describe('onboarding', () => {
             await onboarding.reducedMotion();
             await onboarding.darkMode();
             await onboarding.openPage();
-            await onboarding.completesOrderV3WithYouTubeAdBlocking();
+            await onboarding.completesOrderV3WithAdBlockingEnabled('youtube-ad-blocking');
+        });
+        test('shows v3 flow with YouTube ad blocking disabled', async ({ page }, workerInfo) => {
+            const onboarding = OnboardingPage.create(page, workerInfo);
+            onboarding.withInitData({
+                stepDefinitions: {
+                    systemSettings: {
+                        rows: ['dock', 'youtube-ad-blocking', 'import'],
+                    },
+                },
+                order: 'v3',
+            });
+            await onboarding.reducedMotion();
+            await onboarding.darkMode();
+            await onboarding.openPage();
+            await onboarding.completesOrderV3WithAdBlockingDisabled();
         });
         test.describe('Given I am on the settings step', () => {
             test('When I have choosen to add to dock/taskbar', async ({ page }, workerInfo) => {

--- a/special-pages/pages/onboarding/public/locales/en/onboarding.json
+++ b/special-pages/pages/onboarding/public/locales/en/onboarding.json
@@ -285,14 +285,6 @@
     "title": "No targeted ads. No targeted recommendations. Just your video.",
     "note": "Subtitle for a page that shows the benefits of using the Duck Player feature to watch YouTube videos more privately."
   },
-  "duckPlayer_alt_title": {
-    "title": "Watch YouTube privately with Duck Player",
-    "note": "Alternative title for Duck Player step when YouTube ad blocking is also offered."
-  },
-  "duckPlayer_alt_subtitle": {
-    "title": "Watching videos in Duck Player won't influence your YouTube recommendations.",
-    "note": "Alternative subtitle for Duck Player step when YouTube ad blocking is also offered."
-  },
   "customize_title_v3": {
     "title": "Let’s customize a few things…",
     "note": "Title for a page that allows the user to customize specific settings in the DuckDuckGo browser."


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1209121419454298/task/1210051898870594?focus=true

## Description

Skip the Duck Player step in the onboarding flow when the user enables ad blocking. 

## Testing Steps

1. Navigate to https://deploy-preview-1673--content-scope-scripts.netlify.app/build/pages/onboarding/?adBlocking=enabled&platform=windows.
2. Select “Turn on Enhanced Ad Blocking” when prompted.
3. Note that Duck Player step does not appear after clicking _Next_.
4. Repeat, but this time select “Skip” when prompted to enable ad blocking.
5. Note that Duck Player step appears after clicking _Next_.

Repeat steps with https://deploy-preview-1673--content-scope-scripts.netlify.app/build/pages/onboarding/?adBlocking=youtube&platform=windows

## Checklist

*Please tick all that apply:*

- [x] I have tested this change locally
- [ ] I have tested this change locally in all supported browsers
- [ ] This change will be visible to users
- [x] I have added automated tests that cover this change
- [x] I have ensured the change is gated by config
- [ ] This change was covered by a ship review
- [ ] This change was covered by a tech design
- [x] Any dependent config has been merged

