### PR TITLE
Onboarding: Update YouTube feature description for ad blocking experiment

### DIFF
--- a/special-pages/pages/onboarding/app/components/v3/ComparisonTable.js
+++ b/special-pages/pages/onboarding/app/components/v3/ComparisonTable.js
@@ -2,6 +2,7 @@ import { h } from 'preact';
 import cn from 'classnames';
 import { comparisonTableData, tableIconPrefix } from './data-comparison-table';
 import { useTypedTranslation } from '../../types';
+import { useGlobalState } from '../../global';
 
 import styles from './ComparisonTable.module.css';
 
@@ -69,7 +70,11 @@ export function ComparisonTableRow({ icon, title, statuses }) {
 
 export function ComparisonTable() {
     const { t } = useTypedTranslation();
-    const tableData = comparisonTableData(t);
+    const state = useGlobalState();
+
+    const systemSettingsStep = /** @type {import('../../types').SystemSettingsStep|undefined} */ (state.stepDefinitions.systemSettings);
+    const adBlockingEnabled = systemSettingsStep?.rows?.some((row) => row === 'ad-blocking' || row === 'youtube-ad-blocking') ?? false;
+    const tableData = comparisonTableData(t, adBlockingEnabled);
 
     return (
         <table className={styles.table}>

--- a/special-pages/pages/onboarding/app/components/v3/data-comparison-table.js
+++ b/special-pages/pages/onboarding/app/components/v3/data-comparison-table.js
@@ -20,8 +20,8 @@ export const tableIconPrefix = 'assets/img/steps/v3/';
  *
  * Safari was removed from the latest comparison table layout. Keeping it the data just in case it comes back.
  *
- * @type {(t: ReturnType<typeof import('../../types')['useTypedTranslation']>['t']) => FeatureSupportData[]} */
-export const comparisonTableData = (t) => [
+ * @type {(t: ReturnType<typeof import('../../types')['useTypedTranslation']>['t'], adBlockingEnabled?: boolean) => FeatureSupportData[]} */
+export const comparisonTableData = (t, adBlockingEnabled = false) => [
     {
         icon: 'search.svg',
         title: t('comparison_searchPrivately'),
@@ -69,7 +69,7 @@ export const comparisonTableData = (t) => [
     },
     {
         icon: 'video-player.svg',
-        title: t('comparison_privateYoutube'),
+        title: adBlockingEnabled ? t('comparison_youtubeAdFree') : t('comparison_privateYoutube'),
         statuses: {
             chrome: SupportStatus.NOT_SUPPORTED,
             safari: SupportStatus.NOT_SUPPORTED,

--- a/special-pages/pages/onboarding/integration-tests/onboarding.js
+++ b/special-pages/pages/onboarding/integration-tests/onboarding.js
@@ -160,6 +160,14 @@ export class OnboardingPage {
         await this.page.getByRole('button', { name: 'Skip' }).click();
     }
 
+    /**
+     * @param {boolean} adBlockingEnabled
+     */
+    async checkYouTubeText(adBlockingEnabled) {
+        const expectedText = adBlockingEnabled ? 'Watch YouTube ad-free' : 'Play YouTube without targeted ads';
+        await expect(this.page.getByRole('table')).toContainText(expectedText);
+    }
+
     async makeDefault() {
         const { page } = this;
         await page.getByRole('button', { name: 'Make Default' }).click();

--- a/special-pages/pages/onboarding/integration-tests/onboarding.spec.js
+++ b/special-pages/pages/onboarding/integration-tests/onboarding.spec.js
@@ -31,6 +31,37 @@ test.describe('onboarding', () => {
         await onboarding.openPage({ env: 'app', page: 'welcome', willThrow: true });
         await onboarding.handlesFatalException();
     });
+    test.describe('Given I am on the make default step', () => {
+        test('Then "Watch YouTube ad-free" appears when ad blocking is enabled', async ({ page }, workerInfo) => {
+            const onboarding = OnboardingPage.create(page, workerInfo);
+            onboarding.withInitData({
+                stepDefinitions: {
+                    systemSettings: {
+                        rows: ['dock', 'ad-blocking', 'import'],
+                    },
+                },
+                order: 'v3',
+            });
+            await onboarding.reducedMotion();
+            await onboarding.openPage({ env: 'app', page: 'makeDefaultSingle' });
+            await onboarding.checkYouTubeText(true);
+        });
+
+        test('Then "Play YouTube without targeted ads" appears when ad blocking is not enabled', async ({ page }, workerInfo) => {
+            const onboarding = OnboardingPage.create(page, workerInfo);
+            onboarding.withInitData({
+                stepDefinitions: {
+                    systemSettings: {
+                        rows: ['dock', 'import'],
+                    },
+                },
+                order: 'v3',
+            });
+            await onboarding.reducedMotion();
+            await onboarding.openPage({ env: 'app', page: 'makeDefaultSingle' });
+            await onboarding.checkYouTubeText(false);
+        });
+    });
     test.describe('Given I am on the summary step', () => {
         test('Then I can exit to search', async ({ page }, workerInfo) => {
             const onboarding = OnboardingPage.create(page, workerInfo);

--- a/special-pages/pages/onboarding/public/locales/en/onboarding.json
+++ b/special-pages/pages/onboarding/public/locales/en/onboarding.json
@@ -393,6 +393,10 @@
     "title": "Play YouTube without targeted ads",
     "note": "The description of a browser privacy feature in the comparison table."
   },
+  "comparison_youtubeAdFree": {
+    "title": "Watch YouTube ad-free",
+    "note": "The description of a browser privacy feature in the comparison table when ad-blocking is enabled."
+  },
   "comparison_fullSupport": {
     "title": "Significant protection",
     "note": "The level of protection offered by a browser on a specific feature in the comparison table."


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1209121419454298/task/1210051898870594?focus=true

## Description

| Default | With ad blocking experiment enabled |
| - | - |
| ![127 0 0 1_8000__platform=windows page=makeDefaultSingle(iPad Air)](https://github.com/user-attachments/assets/67edf7b5-14a5-455e-9cf8-2b8fe9641224) | ![127 0 0 1_8000__platform=windows page=makeDefaultSingle adBlocking=enabled(iPad Air)](https://github.com/user-attachments/assets/78cb13ee-9a32-45bb-a072-8706bf9c4848) |

Updates the copy of the YouTube row in the “Make DuckDuckGo Your Default” feature grid shown during onboarding when the ad blocking experiment is enabled.

## Testing Steps

1. Navigate to https://deploy-preview-1674--content-scope-scripts.netlify.app/build/pages/onboarding/?adBlocking=enabled&platform=windows&page=makeDefaultSingle.
2. Note that copy in last row is “Watch YouTube ad-free”.
1. Navigate to https://deploy-preview-1674--content-scope-scripts.netlify.app/build/pages/onboarding/?adBlocking=youtube&platform=windows&page=makeDefaultSingle.
2. Note that copy in last row is “Watch YouTube ad-free”.
1. Navigate to https://deploy-preview-1674--content-scope-scripts.netlify.app/build/pages/onboarding/?platform=windows&page=makeDefaultSingle.
2. Note that copy in last row is “Play YouTube without target ads”, as it is in `main`.

## Checklist

*Please tick all that apply:*

- [x] I have tested this change locally
- [ ] I have tested this change locally in all supported browsers
- [ ] This change will be visible to users
- [x] I have added automated tests that cover this change
- [x] I have ensured the change is gated by config
- [ ] This change was covered by a ship review
- [ ] This change was covered by a tech design
- [x] Any dependent config has been merged

