### PR TITLE
ntp: fixed the empty state of activity widget when trackers are present

### DIFF
--- a/special-pages/pages/new-tab/app/activity/components/Activity.examples.js
+++ b/special-pages/pages/new-tab/app/activity/components/Activity.examples.js
@@ -31,6 +31,15 @@ export const activityExamples = {
             </Activity>
         ),
     },
+    'activity.noActivity.someTrackers': {
+        factory: () => (
+            <Activity expansion={'collapsed'} itemCount={0} trackerCount={56} toggle={noop('toggle')} batched={false}>
+                <Mock size={0}>
+                    <ActivityBody canBurn={false} visibility={'visible'} />
+                </Mock>
+            </Activity>
+        ),
+    },
 };
 
 /**

--- a/special-pages/pages/new-tab/app/activity/integration-tests/activity.page.js
+++ b/special-pages/pages/new-tab/app/activity/integration-tests/activity.page.js
@@ -426,4 +426,13 @@ export class ActivityPage {
             - paragraph: Past 7 days
         `);
     }
+
+    async hasTrackingInfoWithoutButtons() {
+        const { page } = this;
+        await expect(page.getByTestId('ActivityHeading')).toMatchAriaSnapshot(`
+          - img "Privacy Shield"
+          - heading "56 tracking attempts blocked" [level=2]
+          - paragraph: Past 7 days
+      `);
+    }
 }

--- a/special-pages/pages/new-tab/app/activity/mocks/activity.mock-transport.js
+++ b/special-pages/pages/new-tab/app/activity/mocks/activity.mock-transport.js
@@ -36,6 +36,17 @@ export function activityMockTransport() {
             /** @type {import('../../../types/new-tab.ts').NewTabMessages['notifications']} */
             const msg = /** @type {any} */ (_msg);
             switch (msg.method) {
+                case 'activity_removeItem': {
+                    const oldCount = dataset.activity.reduce((acc, item) => acc + item.trackingStatus.totalCount, 0);
+                    dataset.activity = dataset.activity.filter((x) => x.url !== msg.params.url);
+                    const cb = subs.get('activity_onDataPatch');
+                    const p = toPatch(dataset.activity);
+                    p.totalTrackersBlocked = oldCount;
+                    setTimeout(() => {
+                        cb(p);
+                    }, 0);
+                    break;
+                }
                 default: {
                     console.warn('unhandled notification', msg);
                 }
@@ -52,6 +63,9 @@ export function activityMockTransport() {
             }
             if (sub === 'activity_onDataUpdate') {
                 subs.set('activity_onDataUpdate', cb);
+            }
+            if (sub === 'activity_onDataPatch') {
+                subs.set('activity_onDataPatch', cb);
             }
             if (sub === 'activity_onDataUpdate' && url.searchParams.has('flood')) {
                 let count = 0;

--- a/special-pages/pages/new-tab/app/activity/mocks/activity.mock-transport.js
+++ b/special-pages/pages/new-tab/app/activity/mocks/activity.mock-transport.js
@@ -37,13 +37,20 @@ export function activityMockTransport() {
             const msg = /** @type {any} */ (_msg);
             switch (msg.method) {
                 case 'activity_removeItem': {
+                    // grab the tracker count of the current dataset before we alter it
                     const oldCount = dataset.activity.reduce((acc, item) => acc + item.trackingStatus.totalCount, 0);
+
+                    // now filter the items
                     dataset.activity = dataset.activity.filter((x) => x.url !== msg.params.url);
-                    const cb = subs.get('activity_onDataPatch');
-                    const p = toPatch(dataset.activity);
-                    p.totalTrackersBlocked = oldCount;
+
+                    // create the patch dataset, and use the original tracker count
+                    const patchParams = toPatch(dataset.activity);
+                    patchParams.totalTrackersBlocked = oldCount;
+
+                    // simulate the native side pushing the fresh data back into the page.
                     setTimeout(() => {
-                        cb(p);
+                        const cb = subs.get('activity_onDataPatch');
+                        cb(patchParams);
                     }, 0);
                     break;
                 }

--- a/special-pages/pages/new-tab/app/activity/mocks/activity.mocks.js
+++ b/special-pages/pages/new-tab/app/activity/mocks/activity.mocks.js
@@ -40,6 +40,23 @@ export const activityMocks = {
             },
         ],
     },
+    singleWithTrackers: {
+        activity: [
+            {
+                favicon: { src: 'selco-icon.png' },
+                url: 'https://example.com',
+                title: 'example.com',
+                etldPlusOne: 'example.com',
+                favorite: false,
+                trackersFound: true,
+                trackingStatus: {
+                    trackerCompanies: [{ displayName: 'Google' }, { displayName: 'Facebook' }, { displayName: 'Amazon' }],
+                    totalCount: 56,
+                },
+                history: [],
+            },
+        ],
+    },
     few: {
         activity: [
             {

--- a/special-pages/pages/new-tab/app/privacy-stats/components/ActivityHeading.js
+++ b/special-pages/pages/new-tab/app/privacy-stats/components/ActivityHeading.js
@@ -24,8 +24,8 @@ export function ActivityHeading({ expansion, canExpand, itemCount, trackerCount,
     const [formatter] = useState(() => new Intl.NumberFormat());
     const adBlocking = useAdBlocking();
 
-    const none = itemCount === 0;
-    const someItems = itemCount > 0;
+    const none = itemCount === 0 && trackerCount === 0;
+    const some = itemCount > 0 || trackerCount > 0;
     const trackerCountFormatted = formatter.format(trackerCount);
 
     let allTimeString;
@@ -46,7 +46,7 @@ export function ActivityHeading({ expansion, canExpand, itemCount, trackerCount,
                 <img src={adBlocking ? './icons/shield-green.svg' : './icons/shield.svg'} alt="Privacy Shield" />
             </span>
             {none && <h2 className={styles.title}>{t('activity_noRecent_title')}</h2>}
-            {someItems && (
+            {some && (
                 <h2 className={styles.title}>
                     <Trans str={allTimeString} values={{ count: trackerCountFormatted }} />
                 </h2>
@@ -64,12 +64,12 @@ export function ActivityHeading({ expansion, canExpand, itemCount, trackerCount,
                     />
                 </span>
             )}
-            {itemCount === 0 && (
+            {none && (
                 <p className={cn(styles.subtitle, { [styles.indented]: !adBlocking })}>
                     {adBlocking ? t('activity_noRecentAdsAndTrackers_subtitle') : t('activity_noRecent_subtitle')}
                 </p>
             )}
-            {itemCount > 0 && (
+            {some && (
                 <p className={cn(styles.subtitle, styles.indented, { [styles.uppercase]: !adBlocking })}>
                     {t('stats_feedCountBlockedPeriod')}
                 </p>


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1207414201589134/task/1210188026604205?focus=true

## Description

- ensure the 'empty' state following the last removal still shows the tracker count

## Testing Steps

- visit https://deploy-preview-1677--content-scope-scripts.netlify.app/build/pages/new-tab/?feed=activity&activity=singleWithTrackers&platform=windows
- Click the 'x' at the side of the only activity item
- when removed, the heading "56 tracking attempts blocked" should remain

![image](https://github.com/user-attachments/assets/e3637375-f51d-42f3-a47d-e1a8abe10141)


## Checklist

<!--
  These questions are a friendly reminder to shipping code, if you're uncertain ask the AoR owners.
  It's also totally appropriate to not check some of these boxes, if they don't apply to your change.
-->
*Please tick all that apply:*

- [ ] I have tested this change locally
- [ ] I have tested this change locally in all supported browsers
- [ ] This change will be visible to users
- [ ] I have added automated tests that cover this change
- [ ] I have ensured the change is gated by config
- [ ] This change was covered by a ship review
- [ ] This change was covered by a tech design
- [ ] Any dependent config has been merged



---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1210214336847290