### PR TITLE
Onboarding: Move ad blocking setting row to the last position

### DIFF
--- a/special-pages/pages/onboarding/integration-tests/onboarding.js
+++ b/special-pages/pages/onboarding/integration-tests/onboarding.js
@@ -482,14 +482,14 @@ export class OnboardingPage {
     async skipAdBlocking() {
         const { page } = this;
         await this.skippedCurrent();
-        await page.getByRole('button', { name: 'Import' }).waitFor();
+        await page.getByRole('button', { name: 'Next' }).waitFor();
         await this.didSetAdBlocking({ enabled: false }); // important that setAdBlocking() is called when skipped so that native apps can fire a pixel
     }
 
     async skipYouTubeAdBlocking() {
         const { page } = this;
         await this.skippedCurrent();
-        await page.getByRole('button', { name: 'Import' }).waitFor();
+        await page.getByRole('button', { name: 'Next' }).waitFor();
         await this.didSetAdBlocking({ enabled: false }); // important that setAdBlocking() is called when skipped so that native apps can fire a pixel
     }
 
@@ -733,13 +733,13 @@ export class OnboardingPage {
             apple: () => page.getByRole('button', { name: 'Keep in Dock' }),
         });
         await dockButton.click();
+        await page.getByRole('button', { name: 'Import Now', exact: true }).click();
         await page
             .getByRole('button', {
                 name: adBlockingId === 'youtube-ad-blocking' ? 'Block Ads' : 'Turn on Enhanced Ad Blocking',
                 exact: true,
             })
             .click();
-        await page.getByRole('button', { name: 'Import Now', exact: true }).click();
         await page.getByRole('button', { name: 'Next' }).click();
 
         /* No Duck Player step as ad blocking was enabled */
@@ -775,8 +775,8 @@ export class OnboardingPage {
             apple: () => page.getByRole('button', { name: 'Keep in Dock' }),
         });
         await dockButton.click();
-        await page.getByRole('button', { name: 'Skip', exact: true }).click();
         await page.getByRole('button', { name: 'Import Now', exact: true }).click();
+        await page.getByRole('button', { name: 'Skip', exact: true }).click();
         await page.getByRole('button', { name: 'Next' }).click();
 
         /* Duck Player */

--- a/special-pages/pages/onboarding/integration-tests/onboarding.spec.js
+++ b/special-pages/pages/onboarding/integration-tests/onboarding.spec.js
@@ -37,7 +37,7 @@ test.describe('onboarding', () => {
             onboarding.withInitData({
                 stepDefinitions: {
                     systemSettings: {
-                        rows: ['dock', 'ad-blocking', 'import'],
+                        rows: ['dock', 'import', 'ad-blocking'],
                     },
                 },
                 order: 'v3',
@@ -89,13 +89,14 @@ test.describe('onboarding', () => {
             onboarding.withInitData({
                 stepDefinitions: {
                     systemSettings: {
-                        rows: ['dock', 'ad-blocking', 'import'],
+                        rows: ['dock', 'import', 'ad-blocking'],
                     },
                 },
                 order: 'v3',
             });
             await onboarding.reducedMotion();
             await onboarding.openPage({ env: 'app', page: 'systemSettings' });
+            await onboarding.skippedCurrent();
             await onboarding.skippedCurrent();
             await onboarding.enableEnhancedAdBlocking();
         });
@@ -104,13 +105,14 @@ test.describe('onboarding', () => {
             onboarding.withInitData({
                 stepDefinitions: {
                     systemSettings: {
-                        rows: ['dock', 'ad-blocking', 'import'],
+                        rows: ['dock', 'import', 'ad-blocking'],
                     },
                 },
                 order: 'v3',
             });
             await onboarding.reducedMotion();
             await onboarding.openPage({ env: 'app', page: 'systemSettings' });
+            await onboarding.skippedCurrent();
             await onboarding.skippedCurrent();
             await onboarding.skipAdBlocking();
         });
@@ -119,13 +121,14 @@ test.describe('onboarding', () => {
             onboarding.withInitData({
                 stepDefinitions: {
                     systemSettings: {
-                        rows: ['dock', 'youtube-ad-blocking', 'import'],
+                        rows: ['dock', 'import', 'youtube-ad-blocking'],
                     },
                 },
                 order: 'v3',
             });
             await onboarding.reducedMotion();
             await onboarding.openPage({ env: 'app', page: 'systemSettings' });
+            await onboarding.skippedCurrent();
             await onboarding.skippedCurrent();
             await onboarding.enableYouTubeAdBlocking();
         });
@@ -134,13 +137,14 @@ test.describe('onboarding', () => {
             onboarding.withInitData({
                 stepDefinitions: {
                     systemSettings: {
-                        rows: ['dock', 'youtube-ad-blocking', 'import'],
+                        rows: ['dock', 'import', 'youtube-ad-blocking'],
                     },
                 },
                 order: 'v3',
             });
             await onboarding.reducedMotion();
             await onboarding.openPage({ env: 'app', page: 'systemSettings' });
+            await onboarding.skippedCurrent();
             await onboarding.skippedCurrent();
             await onboarding.skipYouTubeAdBlocking();
         });
@@ -269,7 +273,7 @@ test.describe('onboarding', () => {
             onboarding.withInitData({
                 stepDefinitions: {
                     systemSettings: {
-                        rows: ['dock', 'ad-blocking', 'import'],
+                        rows: ['dock', 'import', 'ad-blocking'],
                     },
                 },
                 order: 'v3',
@@ -284,7 +288,7 @@ test.describe('onboarding', () => {
             onboarding.withInitData({
                 stepDefinitions: {
                     systemSettings: {
-                        rows: ['dock', 'ad-blocking', 'import'],
+                        rows: ['dock', 'import', 'ad-blocking'],
                     },
                 },
                 order: 'v3',
@@ -299,7 +303,7 @@ test.describe('onboarding', () => {
             onboarding.withInitData({
                 stepDefinitions: {
                     systemSettings: {
-                        rows: ['dock', 'youtube-ad-blocking', 'import'],
+                        rows: ['dock', 'import', 'youtube-ad-blocking'],
                     },
                 },
                 order: 'v3',
@@ -314,7 +318,7 @@ test.describe('onboarding', () => {
             onboarding.withInitData({
                 stepDefinitions: {
                     systemSettings: {
-                        rows: ['dock', 'youtube-ad-blocking', 'import'],
+                        rows: ['dock', 'import', 'youtube-ad-blocking'],
                     },
                 },
                 order: 'v3',

--- a/special-pages/pages/onboarding/src/mock-transport.js
+++ b/special-pages/pages/onboarding/src/mock-transport.js
@@ -29,7 +29,7 @@ export function mockTransport() {
                         stepDefinitions.systemSettings = {
                             id: 'systemSettings',
                             kind: 'settings',
-                            rows: ['dock', adBlocking === 'youtube' ? 'youtube-ad-blocking' : 'ad-blocking', 'import'],
+                            rows: ['dock', 'import', adBlocking === 'youtube' ? 'youtube-ad-blocking' : 'ad-blocking'],
                         };
                     }
 


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/task/1209984478183529/comment/1210246117664575?focus=true

## Description

Moves the ad blocking settings row to the last position per Jack’s comment above.

<img width="824" alt="Screenshot 2025-05-14 at 11 31 20" src="https://github.com/user-attachments/assets/6cbcf8cf-c47b-47cb-a095-248dea31db5a" />

## Testing Steps

1. Browse to https://deploy-preview-1687--content-scope-scripts.netlify.app/build/pages/onboarding/?adBlocking=enabled and move through the onboarding flow.
2. Browse to https://deploy-preview-1687--content-scope-scripts.netlify.app/build/pages/onboarding/?adBlocking=youtube and move through the onboarding flow.

## Checklist

*Please tick all that apply:*

- [x] I have tested this change locally
- [ ] I have tested this change locally in all supported browsers
- [ ] This change will be visible to users
- [x] I have added automated tests that cover this change
- [x] I have ensured the change is gated by config
- [x] This change was covered by a ship review
- [ ] This change was covered by a tech design
- [ ] Any dependent config has been merged

