### PR TITLE
fix: Next Steps bubble spacing in Windows + visibility bug

### DIFF
--- a/special-pages/pages/new-tab/app/mock-transport.js
+++ b/special-pages/pages/new-tab/app/mock-transport.js
@@ -109,6 +109,7 @@ export function mockTransport() {
         const message = { content: newContent };
         for (const listener of listeners) {
             listener(message);
+            write('nextSteps_data', message);
         }
     }
 
@@ -256,6 +257,12 @@ export function mockTransport() {
                     const next = [...prev];
                     next.push(cb);
                     nextStepsSubscriptions.set('nextSteps_onDataUpdate', next);
+                    const params = url.searchParams.get('next-steps');
+                    if (params && params in nextSteps) {
+                        const data = read('nextSteps_data');
+                        cb(data);
+                    }
+
                     return () => {};
                 }
                 case 'rmf_onDataUpdate': {

--- a/special-pages/pages/new-tab/app/mock-transport.js
+++ b/special-pages/pages/new-tab/app/mock-transport.js
@@ -106,7 +106,7 @@ export function mockTransport() {
     function clearNextStepsCard(cardId, data) {
         const listeners = nextStepsSubscriptions.get('nextSteps_onDataUpdate') || [];
         const newContent = data.content.filter((card) => card.id !== cardId);
-        const message = { content: { newContent } };
+        const message = { content: newContent };
         for (const listener of listeners) {
             listener(message);
         }

--- a/special-pages/pages/new-tab/app/next-steps/components/NextSteps.module.css
+++ b/special-pages/pages/new-tab/app/next-steps/components/NextSteps.module.css
@@ -186,6 +186,8 @@
         display: flex;
         align-items: center;
         justify-content: center;
+        padding: 0 1px;
+        margin: 0 -1px;
 
         h2 {
             color: var(--ntp-text-on-primary);

--- a/special-pages/pages/new-tab/app/next-steps/components/NextStepsGroup.js
+++ b/special-pages/pages/new-tab/app/next-steps/components/NextStepsGroup.js
@@ -31,7 +31,7 @@ export function NextStepsCardGroup({ types, expansion, toggle, action, dismiss }
 
     return (
         <div class={styles.cardGroup} id={WIDGET_ID}>
-            <NextStepsBubbleHeader />
+            {types.length > 0 && <NextStepsBubbleHeader />}
             <div class={styles.cardGrid}>
                 {alwaysShown.map((type) => (
                     <NextStepsCard key={type} type={type} dismiss={dismiss} action={action} />


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1207414201589134/task/1210449263730669?focus=true

## Description
Fixing the odd spacing behavior of the header bubble for the Next Steps cards in Windows, and fixing a bug around visibility of the header when there are no cards left. 

<!--
  Provide a terse summary of what the change is, detailed descriptions should belong in ship reviews or tech designs
-->

## Testing Steps

- [demo](http://127.0.0.1:8000/?next-steps=defaultApp&rmf=small&next-steps=blockCookies&next-steps=emailProtection&next-steps=duckplayer&platform=windows)
- I’ve tested this in BrowserStack and have been unable to replicate the original issue with this approach
(original issue)
![image](https://github.com/user-attachments/assets/86467145-cd7c-4093-b2bf-f56c29459640)

- Added ability to dismiss next steps cards and rmf to the mock-transport

## Checklist

<!--
  These questions are a friendly reminder to shipping code, if you're uncertain ask the AoR owners.
  It's also totally appropriate to not check some of these boxes, if they don't apply to your change.
-->
*Please tick all that apply:*

- [ ] I have tested this change locally
- [ ] I have tested this change locally in all supported browsers
- [ ] This change will be visible to users
- [ ] I have added automated tests that cover this change
- [ ] I have ensured the change is gated by config
- [ ] This change was covered by a ship review
- [ ] This change was covered by a tech design
- [ ] Any dependent config has been merged

