### PR TITLE
Enable batchedActivityApi on all platforms

### DIFF
--- a/special-pages/pages/new-tab/app/settings.js
+++ b/special-pages/pages/new-tab/app/settings.js
@@ -51,7 +51,6 @@ export class Settings {
     }
 
     get batchedActivityApi() {
-        if (this.platform.name === 'windows') return { state: 'enabled' };
-        return { state: 'disabled' };
+        return { state: 'enabled' };
     }
 }


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1201048563534612/task/1210444641565740?focus=true

## Description
This change enables infinite scrolling for NTP’s Recent Activity widget on all platforms (previously disabled on macOS).

## Testing Steps

## Checklist

- [ ] I have tested this change locally
- [ ] I have tested this change locally in all supported browsers
- [ ] This change will be visible to users
- [ ] I have added automated tests that cover this change
- [ ] I have ensured the change is gated by config
- [ ] This change was covered by a ship review
- [ ] This change was covered by a tech design
- [ ] Any dependent config has been merged

