### PR TITLE
Duck Player custom error translations

### DIFF
--- a/special-pages/pages/duckplayer/app/components/YouTubeError.jsx
+++ b/special-pages/pages/duckplayer/app/components/YouTubeError.jsx
@@ -7,7 +7,6 @@ import { useOpenOnYoutubeHandler } from '../providers/SettingsProvider.jsx';
 
 import styles from './YouTubeError.module.css';
 import { useLocale, useYouTubeError } from '../providers/YouTubeErrorProvider';
-import { useEnv } from '../../../../shared/components/EnvironmentProvider';
 
 /**
  * @typedef {import('../../types/duckplayer').YouTubeError} YouTubeError
@@ -17,11 +16,13 @@ import { useEnv } from '../../../../shared/components/EnvironmentProvider';
 
 /**
  * @param {YouTubeError} youtubeError
- * @param {string} locale
  * @returns {ErrorStrings}
  */
-function useErrorStrings(youtubeError, locale) {
+function useErrorStrings(youtubeError) {
     const { t } = useTypedTranslation();
+
+    // v2 is currently used everywhere. Keeping the versioning setup in place in case we need it in the future.
+    const version = 'v2'; // All locales use v2 for now
 
     /**
      * @type {Record<string, Partial<Record<YouTubeError, ErrorStrings>>  & { unknown: ErrorStrings }>}
@@ -63,8 +64,6 @@ function useErrorStrings(youtubeError, locale) {
         },
     };
 
-    const version = locale === 'en' ? 'v2' : 'v1';
-
     return versions[version]?.[youtubeError] || versions[version]?.['unknown'] || versions['v1']['unknown'];
 }
 
@@ -75,14 +74,13 @@ function useErrorStrings(youtubeError, locale) {
  */
 export function YouTubeError({ layout, embed }) {
     const youtubeError = useYouTubeError();
-    const locale = useLocale();
     if (!youtubeError) {
         return null;
     }
 
     const { t } = useTypedTranslation();
     const openOnYoutube = useOpenOnYoutubeHandler();
-    const { heading, messages, variant } = useErrorStrings(youtubeError, locale);
+    const { heading, messages, variant } = useErrorStrings(youtubeError);
     const classes = cn(styles.error, {
         [styles.desktop]: layout === 'desktop',
         [styles.mobile]: layout === 'mobile',

--- a/special-pages/pages/duckplayer/app/components/YouTubeError.jsx
+++ b/special-pages/pages/duckplayer/app/components/YouTubeError.jsx
@@ -21,8 +21,8 @@ import { useLocale, useYouTubeError } from '../providers/YouTubeErrorProvider';
 function useErrorStrings(youtubeError) {
     const { t } = useTypedTranslation();
 
-    // v2 is currently used everywhere. Keeping the versioning setup in place in case we need it in the future.
-    const version = 'v2'; // All locales use v2 for now
+    // This versioning setup exists in case we need to experiment with copy variants in the future. At the moment, v2 is used everywhere.
+    const version = 'v2';
 
     /**
      * @type {Record<string, Partial<Record<YouTubeError, ErrorStrings>>  & { unknown: ErrorStrings }>}

--- a/special-pages/pages/duckplayer/integration-tests/duck-player.js
+++ b/special-pages/pages/duckplayer/integration-tests/duck-player.js
@@ -626,8 +626,8 @@ export class DuckPlayerPage {
 
     async didShowGenericErrorInSpanish() {
         await expect(this.page.getByTestId('YouTubeErrorContent')).toMatchAriaSnapshot(`
-            - heading "YouTube no permite que Duck Player cargue este vídeo" [level=1]
-            - paragraph: YouTube no permite que este vídeo se vea fuera de YouTube.
+            - heading "Duck Player no puede cargar este vídeo" [level=1]
+            - paragraph: Este vídeo no se puede ver fuera de YouTube.
             - paragraph: Sigues pudiendo ver este vídeo en YouTube, pero sin la privacidad adicional que ofrece Duck Player.
           `);
     }
@@ -640,11 +640,27 @@ export class DuckPlayerPage {
           `);
     }
 
+    async didShowAgeRestrictedErrorInSpanish() {
+        await expect(this.page.getByTestId('YouTubeErrorContent')).toMatchAriaSnapshot(`
+            - heading "Lo sentimos, este vídeo está restringido por edad" [level=1]
+            - paragraph: Para ver vídeos con restricción de edad, necesitas iniciar sesión en YouTube para verificar tu edad.
+            - paragraph: Todavía puedes ver este vídeo, pero tendrás que iniciar sesión y verlo en YouTube sin la privacidad adicional de Duck Player.
+          `);
+    }
+
     async didShowNoEmbedError() {
         await expect(this.page.getByTestId('YouTubeErrorContent')).toMatchAriaSnapshot(`
             - heading "Sorry, this video can only be played on YouTube" [level=1]
             - paragraph: The creator of this video has chosen not to allow it to be viewed on other sites.
             - paragraph: You can still watch it on YouTube, but without the added privacy of Duck Player.
+          `);
+    }
+
+    async didShowNoEmbedErrorInSpanish() {
+        await expect(this.page.getByTestId('YouTubeErrorContent')).toMatchAriaSnapshot(`
+            - heading "Lo sentimos, este vídeo solo se puede reproducir en YouTube" [level=1]
+            - paragraph: El creador de este vídeo ha decidido no permitir que se vea en otros sitios.
+            - paragraph: Sigues pudiendo verlo en YouTube, pero sin la privacidad adicional que ofrece Duck Player.
           `);
     }
 
@@ -658,9 +674,9 @@ export class DuckPlayerPage {
 
     async didShowSignInRequiredErrorInSpanish() {
         await expect(this.page.getByTestId('YouTubeErrorContent')).toMatchAriaSnapshot(`
-            - heading "YouTube no permite que Duck Player cargue este vídeo" [level=1]
-            - paragraph: YouTube está bloqueando la carga de este vídeo. Si estás usando una VPN, intenta desactivarla y volver a cargar la página.
-            - paragraph: Si esto no funciona, sigues pudiendo ver este vídeo en YouTube, pero sin la privacidad adicional de Duck Player.
+            - heading "Lo sentimos, YouTube piensa que eres un bot" [level=1]
+            - paragraph: Esto puede ocurrir si estás usando una VPN. Intenta desactivar la VPN o cambiar la ubicación del servidor y recarga la página.
+            - paragraph: Si eso no funciona, tendrás que iniciar sesión y ver el vídeo en YouTube sin la privacidad adicional que ofrece Duck Player.
           `);
     }
 }

--- a/special-pages/pages/duckplayer/integration-tests/duckplayer.spec.js
+++ b/special-pages/pages/duckplayer/integration-tests/duckplayer.spec.js
@@ -147,6 +147,18 @@ test.describe('duckplayer custom error', () => {
         test.skip(isDesktop(workerInfo));
         const duckplayer = DuckPlayerPage.create(page, workerInfo);
         await duckplayer.openWithYouTubeError('age-restricted', 'e90eWYPNtJ8', 'es');
+        await duckplayer.didShowAgeRestrictedErrorInSpanish();
+    });
+    test('shows custom error screen, in Spanish, for videos that can’t be embedded', async ({ page }, workerInfo) => {
+        test.skip(isDesktop(workerInfo));
+        const duckplayer = DuckPlayerPage.create(page, workerInfo);
+        await duckplayer.openWithYouTubeError('no-embed', 'e90eWYPNtJ8', 'es');
+        await duckplayer.didShowNoEmbedErrorInSpanish();
+    });
+    test('shows custom error screen, in Spanish, for videos with unknown errors', async ({ page }, workerInfo) => {
+        test.skip(isDesktop(workerInfo));
+        const duckplayer = DuckPlayerPage.create(page, workerInfo);
+        await duckplayer.openWithYouTubeError('unknown', 'e90eWYPNtJ8', 'es');
         await duckplayer.didShowGenericErrorInSpanish();
     });
 });

--- a/special-pages/pages/duckplayer/public/locales/bg/duckplayer.json
+++ b/special-pages/pages/duckplayer/public/locales/bg/duckplayer.json
@@ -32,6 +32,42 @@
     "title" : "<b>ГРЕШКА:</b> невалиден идентификатор на видеоклипа",
     "note" : "Shown when the page URL doesn't match a known video ID. Note for translators: The <b> tag makes the word 'ERROR:' bold. Depending on the grammar of the target language, you might need to move it so that the correct word is emphasized."
   },
+  "unknownErrorHeading2" : {
+    "title" : "Duck Player не може да зареди това видео",
+    "note" : "Message shown when YouTube has blocked playback of a video"
+  },
+  "unknownErrorMessage2a" : {
+    "title" : "Това видео не може да бъде гледано извън YouTube.",
+    "note" : "Explanation on why the error is happening."
+  },
+  "unknownErrorMessage2b" : {
+    "title" : "Все пак можете да гледате това видео в YouTube, но без допълнителната поверителност на Duck Player.",
+    "note" : "A message explaining that the blocked video can be watched directly on YouTube."
+  },
+  "ageRestrictedErrorHeading2" : {
+    "title" : "Съжаляваме, но това видео има възрастово ограничение",
+    "note" : "Message shown when YouTube has blocked playback of a video"
+  },
+  "ageRestrictedErrorMessage2a" : {
+    "title" : "За да гледате видеа с възрастово ограничение, трябва да влезете в YouTube, за да потвърдите възрастта си.",
+    "note" : "Explanation on why the error is happening."
+  },
+  "ageRestrictedErrorMessage2b" : {
+    "title" : "Все пак можете да гледате това видео, но ще трябва да влезете и да го гледате в YouTube без допълнителната поверителност на Duck Player.",
+    "note" : "A message explaining that the blocked video can be watched directly on YouTube."
+  },
+  "noEmbedErrorHeading2" : {
+    "title" : "Съжаляваме, но това видео може да се гледа само в YouTube",
+    "note" : "Message shown when YouTube has blocked playback of a video"
+  },
+  "noEmbedErrorMessage2a" : {
+    "title" : "Създателят на това видео е избрал да не позволява то да бъде гледано на други сайтове.",
+    "note" : "Explanation on why the error is happening."
+  },
+  "noEmbedErrorMessage2b" : {
+    "title" : "Все пак можете да го гледате в YouTube, но без допълнителната поверителност на Duck Player.",
+    "note" : "A message explaining that the blocked video can be watched directly on YouTube."
+  },
   "blockedVideoErrorHeading" : {
     "title" : "YouTube няма да позволи на Duck Player да зареди това видео",
     "note" : "Message shown when YouTube has blocked playback of a video"
@@ -44,12 +80,24 @@
     "title" : "Все пак можете да гледате това видео в YouTube, но без допълнителната поверителност на Duck Player.",
     "note" : "A message explaining that the blocked video can be watched directly on YouTube."
   },
+  "signInRequiredErrorHeading2" : {
+    "title" : "Съжаляваме, но YouTube мисли, че сте бот",
+    "note" : "Message shown when YouTube has blocked playback of a video"
+  },
   "signInRequiredErrorMessage1" : {
     "title" : "YouTube блокира зареждането на това видео. Ако използвате VPN, опитайте да го изключите и презаредете тази страница.",
     "note" : "Explanation on why the error is happening and a suggestions on how to solve it."
   },
   "signInRequiredErrorMessage2" : {
     "title" : "Ако това не свърши работа, можете да гледате това видео в YouTube, но без допълнителната поверителност на Duck Player.",
+    "note" : "More troubleshooting tips for this specific error"
+  },
+  "signInRequiredErrorMessage2a" : {
+    "title" : "Това може да се случи, ако използвате VPN. Опитайте да изключите VPN или да промените местоположението на сървъра и да презаредите тази страница.",
+    "note" : "Explanation on why the error is happening and a suggestions on how to solve it."
+  },
+  "signInRequiredErrorMessage2b" : {
+    "title" : "Ако това не проработи, ще трябва да влезете и да гледате това видео в YouTube без допълнителната поверителност на Duck Player.",
     "note" : "More troubleshooting tips for this specific error"
   },
   "tooltipInfo" : {

--- a/special-pages/pages/duckplayer/public/locales/cs/duckplayer.json
+++ b/special-pages/pages/duckplayer/public/locales/cs/duckplayer.json
@@ -32,6 +32,42 @@
     "title" : "<b>CHYBA:</b> Neplatné ID videa",
     "note" : "Shown when the page URL doesn't match a known video ID. Note for translators: The <b> tag makes the word 'ERROR:' bold. Depending on the grammar of the target language, you might need to move it so that the correct word is emphasized."
   },
+  "unknownErrorHeading2" : {
+    "title" : "Duck Player nemůže načíst tohle video",
+    "note" : "Message shown when YouTube has blocked playback of a video"
+  },
+  "unknownErrorMessage2a" : {
+    "title" : "Na video se nedá dívat mimo YouTube.",
+    "note" : "Explanation on why the error is happening."
+  },
+  "unknownErrorMessage2b" : {
+    "title" : "Na tohle video se můžeš pořád podívat na YouTube, ale bez ochrany soukromí, jakou nabízí Duck Player.",
+    "note" : "A message explaining that the blocked video can be watched directly on YouTube."
+  },
+  "ageRestrictedErrorHeading2" : {
+    "title" : "Omlouváme se, ale tohle video je věkově omezené",
+    "note" : "Message shown when YouTube has blocked playback of a video"
+  },
+  "ageRestrictedErrorMessage2a" : {
+    "title" : "Pokud chceš sledovat videa s věkovým omezením, musíš se přihlásit na YouTube a ověřit svůj věk.",
+    "note" : "Explanation on why the error is happening."
+  },
+  "ageRestrictedErrorMessage2b" : {
+    "title" : "Na tohle video se i tak můžeš podívat, ale budeš se muset přihlásit a pustit si ho na YouTube bez ochrany soukromí, kterou nabízí Duck Player.",
+    "note" : "A message explaining that the blocked video can be watched directly on YouTube."
+  },
+  "noEmbedErrorHeading2" : {
+    "title" : "Omlouváme se, ale tohle video se dá přehrát jen na YouTube",
+    "note" : "Message shown when YouTube has blocked playback of a video"
+  },
+  "noEmbedErrorMessage2a" : {
+    "title" : "Autor tohoto videa se rozhodl nepovolit jeho zobrazení na jiných stránkách.",
+    "note" : "Explanation on why the error is happening."
+  },
+  "noEmbedErrorMessage2b" : {
+    "title" : "Pořád se na něj můžeš podívat na YouTube, ale bez ochrany soukromí, jakou nabízí Duck Player.",
+    "note" : "A message explaining that the blocked video can be watched directly on YouTube."
+  },
   "blockedVideoErrorHeading" : {
     "title" : "YouTube nedovoluje přehrávači Duck Player načíst tohle video",
     "note" : "Message shown when YouTube has blocked playback of a video"
@@ -44,12 +80,24 @@
     "title" : "Na tohle video se můžeš pořád podívat na YouTube, ale bez ochrany soukromí, jakou nabízí Duck Player.",
     "note" : "A message explaining that the blocked video can be watched directly on YouTube."
   },
+  "signInRequiredErrorHeading2" : {
+    "title" : "Omlouváme se, ale YouTube si myslí, že jsi robot",
+    "note" : "Message shown when YouTube has blocked playback of a video"
+  },
   "signInRequiredErrorMessage1" : {
     "title" : "YouTube blokuje načítání tohohle videa. Pokud používáš VPN, zkus ji vypnout a stránku znovu načíst.",
     "note" : "Explanation on why the error is happening and a suggestions on how to solve it."
   },
   "signInRequiredErrorMessage2" : {
     "title" : "Pokud to nefunguje, můžeš se na video podívat na YouTube, ale bez ochrany soukromí, jakou nabízí Duck Player.",
+    "note" : "More troubleshooting tips for this specific error"
+  },
+  "signInRequiredErrorMessage2a" : {
+    "title" : "To se může stát, pokud používáš VPN. Zkus VPN vypnout nebo změnit umístění serveru a načíst stránku znovu.",
+    "note" : "Explanation on why the error is happening and a suggestions on how to solve it."
+  },
+  "signInRequiredErrorMessage2b" : {
+    "title" : "Pokud to nezabere, budeš se muset přihlásit a video si na YouTube přehrát bez ochrany soukromí, kterou nabízí Duck Player.",
     "note" : "More troubleshooting tips for this specific error"
   },
   "tooltipInfo" : {

--- a/special-pages/pages/duckplayer/public/locales/da/duckplayer.json
+++ b/special-pages/pages/duckplayer/public/locales/da/duckplayer.json
@@ -32,6 +32,42 @@
     "title" : "<b>FEJL:</b> Ugyldigt video-ID",
     "note" : "Shown when the page URL doesn't match a known video ID. Note for translators: The <b> tag makes the word 'ERROR:' bold. Depending on the grammar of the target language, you might need to move it so that the correct word is emphasized."
   },
+  "unknownErrorHeading2" : {
+    "title" : "Duck Player kan ikke indlæse denne video",
+    "note" : "Message shown when YouTube has blocked playback of a video"
+  },
+  "unknownErrorMessage2a" : {
+    "title" : "Denne video kan ikke vises uden for YouTube.",
+    "note" : "Explanation on why the error is happening."
+  },
+  "unknownErrorMessage2b" : {
+    "title" : "Du kan stadig se denne video på YouTube, men uden den ekstra fortrolighed, som Duck Player giver.",
+    "note" : "A message explaining that the blocked video can be watched directly on YouTube."
+  },
+  "ageRestrictedErrorHeading2" : {
+    "title" : "Beklager, denne video har aldersbegrænsning",
+    "note" : "Message shown when YouTube has blocked playback of a video"
+  },
+  "ageRestrictedErrorMessage2a" : {
+    "title" : "For at se aldersbegrænsede videoer skal du logge ind på YouTube for at bekræfte din alder.",
+    "note" : "Explanation on why the error is happening."
+  },
+  "ageRestrictedErrorMessage2b" : {
+    "title" : "Du kan stadig se denne video, men du skal logge ind og se den på YouTube uden den ekstra fortrolighed, som Duck Player giver.",
+    "note" : "A message explaining that the blocked video can be watched directly on YouTube."
+  },
+  "noEmbedErrorHeading2" : {
+    "title" : "Beklager, denne video kan kun afspilles på YouTube",
+    "note" : "Message shown when YouTube has blocked playback of a video"
+  },
+  "noEmbedErrorMessage2a" : {
+    "title" : "Skaberen af denne video har valgt ikke at tillade, at den kan vises på andre hjemmesider.",
+    "note" : "Explanation on why the error is happening."
+  },
+  "noEmbedErrorMessage2b" : {
+    "title" : "Du kan stadig se den på YouTube, men uden den ekstra fortrolighed, som Duck Player giver.",
+    "note" : "A message explaining that the blocked video can be watched directly on YouTube."
+  },
   "blockedVideoErrorHeading" : {
     "title" : "YouTube vil ikke lade Duck Player indlæse denne video",
     "note" : "Message shown when YouTube has blocked playback of a video"
@@ -44,12 +80,24 @@
     "title" : "Du kan stadig se denne video på YouTube, men uden den ekstra fortrolighed, som Duck Player giver.",
     "note" : "A message explaining that the blocked video can be watched directly on YouTube."
   },
+  "signInRequiredErrorHeading2" : {
+    "title" : "Beklager, YouTube tror, at du er en bot",
+    "note" : "Message shown when YouTube has blocked playback of a video"
+  },
   "signInRequiredErrorMessage1" : {
     "title" : "YouTube blokerer for, at denne video kan indlæses. Hvis du bruger en VPN, så prøv at slå den fra og genindlæse denne side.",
     "note" : "Explanation on why the error is happening and a suggestions on how to solve it."
   },
   "signInRequiredErrorMessage2" : {
     "title" : "Hvis dette ikke virker, kan du stadig se denne video på YouTube, men uden den ekstra fortrolighed, som Duck Player giver.",
+    "note" : "More troubleshooting tips for this specific error"
+  },
+  "signInRequiredErrorMessage2a" : {
+    "title" : "Dette kan ske, hvis du bruger en VPN. Prøv at slå VPN fra eller skifte serverplacering og genindlæse denne side.",
+    "note" : "Explanation on why the error is happening and a suggestions on how to solve it."
+  },
+  "signInRequiredErrorMessage2b" : {
+    "title" : "Hvis det ikke virker, skal du logge ind og se denne video på YouTube uden den ekstra fortrolighed, som Duck Player giver.",
     "note" : "More troubleshooting tips for this specific error"
   },
   "tooltipInfo" : {

--- a/special-pages/pages/duckplayer/public/locales/de/duckplayer.json
+++ b/special-pages/pages/duckplayer/public/locales/de/duckplayer.json
@@ -32,6 +32,42 @@
     "title" : "<b>FEHLER:</b> Ungültige Video-ID",
     "note" : "Shown when the page URL doesn't match a known video ID. Note for translators: The <b> tag makes the word 'ERROR:' bold. Depending on the grammar of the target language, you might need to move it so that the correct word is emphasized."
   },
+  "unknownErrorHeading2" : {
+    "title" : "Duck Player kann dieses Video nicht laden",
+    "note" : "Message shown when YouTube has blocked playback of a video"
+  },
+  "unknownErrorMessage2a" : {
+    "title" : "Dieses Video kann nicht außerhalb von YouTube angesehen werden.",
+    "note" : "Explanation on why the error is happening."
+  },
+  "unknownErrorMessage2b" : {
+    "title" : "Du kannst dieses Video auf YouTube ansehen, aber ohne die zusätzliche Privatsphäre des Duck Players.",
+    "note" : "A message explaining that the blocked video can be watched directly on YouTube."
+  },
+  "ageRestrictedErrorHeading2" : {
+    "title" : "Leider hat dieses Video eine Altersbeschränkung",
+    "note" : "Message shown when YouTube has blocked playback of a video"
+  },
+  "ageRestrictedErrorMessage2a" : {
+    "title" : "Wenn du Videos mit Altersbeschränkung ansehen möchtest, musst du dich bei YouTube anmelden und dein Alter bestätigen.",
+    "note" : "Explanation on why the error is happening."
+  },
+  "ageRestrictedErrorMessage2b" : {
+    "title" : "Du kannst dir dieses Video trotzdem ansehen, aber du musst dich anmelden und es auf YouTube ohne die zusätzliche Privatsphäre des Duck Players ansehen.",
+    "note" : "A message explaining that the blocked video can be watched directly on YouTube."
+  },
+  "noEmbedErrorHeading2" : {
+    "title" : "Es tut uns leid, dieses Video kann nur auf YouTube abgespielt werden",
+    "note" : "Message shown when YouTube has blocked playback of a video"
+  },
+  "noEmbedErrorMessage2a" : {
+    "title" : "Der Ersteller dieses Videos hat festgelegt, dass es nicht auf anderen Websites angesehen werden darf.",
+    "note" : "Explanation on why the error is happening."
+  },
+  "noEmbedErrorMessage2b" : {
+    "title" : "Du kannst es auf YouTube ansehen, aber ohne die zusätzliche Privatsphäre des Duck Players.",
+    "note" : "A message explaining that the blocked video can be watched directly on YouTube."
+  },
   "blockedVideoErrorHeading" : {
     "title" : "YouTube lässt den Duck Player dieses Video nicht laden",
     "note" : "Message shown when YouTube has blocked playback of a video"
@@ -44,12 +80,24 @@
     "title" : "Du kannst dieses Video auf YouTube ansehen, aber ohne die zusätzliche Privatsphäre des Duck Players.",
     "note" : "A message explaining that the blocked video can be watched directly on YouTube."
   },
+  "signInRequiredErrorHeading2" : {
+    "title" : "Es tut uns leid, YouTube denkt, du seist ein Bot",
+    "note" : "Message shown when YouTube has blocked playback of a video"
+  },
   "signInRequiredErrorMessage1" : {
     "title" : "YouTube blockiert das Laden dieses Videos. Falls du ein VPN benutzt, deaktiviere es und lade diese Seite neu.",
     "note" : "Explanation on why the error is happening and a suggestions on how to solve it."
   },
   "signInRequiredErrorMessage2" : {
     "title" : "Falls das nicht funktioniert, kannst du das Video dennoch auf YouTube ansehen, jedoch ohne die zusätzliche Privatsphäre des Duck Players.",
+    "note" : "More troubleshooting tips for this specific error"
+  },
+  "signInRequiredErrorMessage2a" : {
+    "title" : "Dies kann passieren, wenn ein VPN verwendet wird. Schalte das VPN aus oder wechsle den Serverstandort und lade diese Seite neu.",
+    "note" : "Explanation on why the error is happening and a suggestions on how to solve it."
+  },
+  "signInRequiredErrorMessage2b" : {
+    "title" : "Falls das nicht funktioniert, musst du dich anmelden und dieses Video auf YouTube ohne die zusätzliche Privatsphäre des Duck Players ansehen.",
     "note" : "More troubleshooting tips for this specific error"
   },
   "tooltipInfo" : {

--- a/special-pages/pages/duckplayer/public/locales/el/duckplayer.json
+++ b/special-pages/pages/duckplayer/public/locales/el/duckplayer.json
@@ -32,6 +32,42 @@
     "title" : "<b>ΣΦΑΛΜΑ:</b> Μη έγκυρο αναγνωριστικό βίντεο",
     "note" : "Shown when the page URL doesn't match a known video ID. Note for translators: The <b> tag makes the word 'ERROR:' bold. Depending on the grammar of the target language, you might need to move it so that the correct word is emphasized."
   },
+  "unknownErrorHeading2" : {
+    "title" : "Το Duck Player δεν μπορεί να φορτώσει το βίντεο αυτό",
+    "note" : "Message shown when YouTube has blocked playback of a video"
+  },
+  "unknownErrorMessage2a" : {
+    "title" : "Το βίντεο αυτό δεν μπορεί να προβληθεί εκτός YouTube.",
+    "note" : "Explanation on why the error is happening."
+  },
+  "unknownErrorMessage2b" : {
+    "title" : "Μπορείτε ακόμα να παρακολουθήσετε αυτό το βίντεο στο YouTube, αλλά χωρίς την πρόσθετη ιδιωτικότητα του Duck Player.",
+    "note" : "A message explaining that the blocked video can be watched directly on YouTube."
+  },
+  "ageRestrictedErrorHeading2" : {
+    "title" : "Δυστυχώς, αυτό το βίντεο έχει περιορισμό ηλικίας",
+    "note" : "Message shown when YouTube has blocked playback of a video"
+  },
+  "ageRestrictedErrorMessage2a" : {
+    "title" : "Για να παρακολουθήσετε βίντεο με περιορισμό ηλικίας, πρέπει να συνδεθείτε στο YouTube για να επαληθεύσετε την ηλικία σας.",
+    "note" : "Explanation on why the error is happening."
+  },
+  "ageRestrictedErrorMessage2b" : {
+    "title" : "Μπορείτε ακόμα να παρακολουθήσετε αυτό το βίντεο, ωστόσο θα πρέπει να συνδεθείτε και να το παρακολουθήσετε στο YouTube χωρίς το πρόσθετο απόρρητο του Duck Player.",
+    "note" : "A message explaining that the blocked video can be watched directly on YouTube."
+  },
+  "noEmbedErrorHeading2" : {
+    "title" : "Δυστυχώς, αυτό το βίντεο μπορεί να αναπαραχθεί μόνο στο YouTube",
+    "note" : "Message shown when YouTube has blocked playback of a video"
+  },
+  "noEmbedErrorMessage2a" : {
+    "title" : "Ο δημιουργός αυτού του βίντεο έχει επιλέξει να μην επιτρέπει την προβολή του σε άλλους ιστότοπους.",
+    "note" : "Explanation on why the error is happening."
+  },
+  "noEmbedErrorMessage2b" : {
+    "title" : "Μπορείτε ακόμα να το παρακολουθήσετε στο YouTube, αλλά χωρίς την πρόσθετη ιδιωτικότητα του Duck Player.",
+    "note" : "A message explaining that the blocked video can be watched directly on YouTube."
+  },
   "blockedVideoErrorHeading" : {
     "title" : "Το YouTube δεν θα αφήσει το Duck Player να φορτώσει το βίντεο αυτό",
     "note" : "Message shown when YouTube has blocked playback of a video"
@@ -44,12 +80,24 @@
     "title" : "Μπορείτε ακόμα να παρακολουθήσετε αυτό το βίντεο στο YouTube, αλλά χωρίς την πρόσθετη ιδιωτικότητα του Duck Player.",
     "note" : "A message explaining that the blocked video can be watched directly on YouTube."
   },
+  "signInRequiredErrorHeading2" : {
+    "title" : "Δυστυχώς, το YouTube πιστεύει ότι είστε μποτ",
+    "note" : "Message shown when YouTube has blocked playback of a video"
+  },
   "signInRequiredErrorMessage1" : {
     "title" : "Το YouTube μπλοκάρει τη φόρτωση αυτού του βίντεο. Εάν χρησιμοποιείτε VPN, δοκιμάστε να το απενεργοποιήσετε και να φορτώσετε εκ νέου αυτήν τη σελίδα.",
     "note" : "Explanation on why the error is happening and a suggestions on how to solve it."
   },
   "signInRequiredErrorMessage2" : {
     "title" : "Εάν δεν λειτουργήσει αυτό, μπορείτε να παρακολουθήσετε αυτό το βίντεο στο YouTube, ωστόσο χωρίς την πρόσθετη ιδιωτικότητα του Duck Player.",
+    "note" : "More troubleshooting tips for this specific error"
+  },
+  "signInRequiredErrorMessage2a" : {
+    "title" : "Αυτό μπορεί να συμβαίνει εάν χρησιμοποιείτε VPN. Δοκιμάστε να απενεργοποιήσετε το VPN ή να αλλάξετε τοποθεσία διακομιστή και να φορτώσετε εκ νέου αυτήν τη σελίδα.",
+    "note" : "Explanation on why the error is happening and a suggestions on how to solve it."
+  },
+  "signInRequiredErrorMessage2b" : {
+    "title" : "Εάν δεν λειτουργήσει αυτό, θα πρέπει να συνδεθείτε και να παρακολουθήσετε αυτό το βίντεο στο YouTube χωρίς την πρόσθετη ιδιωτικότητα του Duck Player.",
     "note" : "More troubleshooting tips for this specific error"
   },
   "tooltipInfo" : {

--- a/special-pages/pages/duckplayer/public/locales/es/duckplayer.json
+++ b/special-pages/pages/duckplayer/public/locales/es/duckplayer.json
@@ -32,6 +32,42 @@
     "title" : "<b>ERROR:</b> ID de vídeo no válida",
     "note" : "Shown when the page URL doesn't match a known video ID. Note for translators: The <b> tag makes the word 'ERROR:' bold. Depending on the grammar of the target language, you might need to move it so that the correct word is emphasized."
   },
+  "unknownErrorHeading2" : {
+    "title" : "Duck Player no puede cargar este vídeo",
+    "note" : "Message shown when YouTube has blocked playback of a video"
+  },
+  "unknownErrorMessage2a" : {
+    "title" : "Este vídeo no se puede ver fuera de YouTube.",
+    "note" : "Explanation on why the error is happening."
+  },
+  "unknownErrorMessage2b" : {
+    "title" : "Sigues pudiendo ver este vídeo en YouTube, pero sin la privacidad adicional que ofrece Duck Player.",
+    "note" : "A message explaining that the blocked video can be watched directly on YouTube."
+  },
+  "ageRestrictedErrorHeading2" : {
+    "title" : "Lo sentimos, este vídeo está restringido por edad",
+    "note" : "Message shown when YouTube has blocked playback of a video"
+  },
+  "ageRestrictedErrorMessage2a" : {
+    "title" : "Para ver vídeos con restricción de edad, necesitas iniciar sesión en YouTube para verificar tu edad.",
+    "note" : "Explanation on why the error is happening."
+  },
+  "ageRestrictedErrorMessage2b" : {
+    "title" : "Todavía puedes ver este vídeo, pero tendrás que iniciar sesión y verlo en YouTube sin la privacidad adicional de Duck Player.",
+    "note" : "A message explaining that the blocked video can be watched directly on YouTube."
+  },
+  "noEmbedErrorHeading2" : {
+    "title" : "Lo sentimos, este vídeo solo se puede reproducir en YouTube",
+    "note" : "Message shown when YouTube has blocked playback of a video"
+  },
+  "noEmbedErrorMessage2a" : {
+    "title" : "El creador de este vídeo ha decidido no permitir que se vea en otros sitios.",
+    "note" : "Explanation on why the error is happening."
+  },
+  "noEmbedErrorMessage2b" : {
+    "title" : "Sigues pudiendo verlo en YouTube, pero sin la privacidad adicional que ofrece Duck Player.",
+    "note" : "A message explaining that the blocked video can be watched directly on YouTube."
+  },
   "blockedVideoErrorHeading" : {
     "title" : "YouTube no permite que Duck Player cargue este vídeo",
     "note" : "Message shown when YouTube has blocked playback of a video"
@@ -44,12 +80,24 @@
     "title" : "Sigues pudiendo ver este vídeo en YouTube, pero sin la privacidad adicional que ofrece Duck Player.",
     "note" : "A message explaining that the blocked video can be watched directly on YouTube."
   },
+  "signInRequiredErrorHeading2" : {
+    "title" : "Lo sentimos, YouTube piensa que eres un bot",
+    "note" : "Message shown when YouTube has blocked playback of a video"
+  },
   "signInRequiredErrorMessage1" : {
     "title" : "YouTube está bloqueando la carga de este vídeo. Si estás usando una VPN, intenta desactivarla y volver a cargar la página.",
     "note" : "Explanation on why the error is happening and a suggestions on how to solve it."
   },
   "signInRequiredErrorMessage2" : {
     "title" : "Si esto no funciona, sigues pudiendo ver este vídeo en YouTube, pero sin la privacidad adicional de Duck Player.",
+    "note" : "More troubleshooting tips for this specific error"
+  },
+  "signInRequiredErrorMessage2a" : {
+    "title" : "Esto puede ocurrir si estás usando una VPN. Intenta desactivar la VPN o cambiar la ubicación del servidor y recarga la página.",
+    "note" : "Explanation on why the error is happening and a suggestions on how to solve it."
+  },
+  "signInRequiredErrorMessage2b" : {
+    "title" : "Si eso no funciona, tendrás que iniciar sesión y ver el vídeo en YouTube sin la privacidad adicional que ofrece Duck Player.",
     "note" : "More troubleshooting tips for this specific error"
   },
   "tooltipInfo" : {

--- a/special-pages/pages/duckplayer/public/locales/et/duckplayer.json
+++ b/special-pages/pages/duckplayer/public/locales/et/duckplayer.json
@@ -32,6 +32,42 @@
     "title" : "<b>VIGA:</b> vale video ID",
     "note" : "Shown when the page URL doesn't match a known video ID. Note for translators: The <b> tag makes the word 'ERROR:' bold. Depending on the grammar of the target language, you might need to move it so that the correct word is emphasized."
   },
+  "unknownErrorHeading2" : {
+    "title" : "Duck Player ei saa seda videot laadida",
+    "note" : "Message shown when YouTube has blocked playback of a video"
+  },
+  "unknownErrorMessage2a" : {
+    "title" : "Seda videot ei saa väljaspool YouTube'i vaadata.",
+    "note" : "Explanation on why the error is happening."
+  },
+  "unknownErrorMessage2b" : {
+    "title" : "Saate seda videot endiselt YouTube'is vaadata, kuid ilma Duck Player'i lisatud privaatsuseta.",
+    "note" : "A message explaining that the blocked video can be watched directly on YouTube."
+  },
+  "ageRestrictedErrorHeading2" : {
+    "title" : "Vabandust, see video on vanusepiiranguga",
+    "note" : "Message shown when YouTube has blocked playback of a video"
+  },
+  "ageRestrictedErrorMessage2a" : {
+    "title" : "Vanusepiiranguga videote vaatamiseks pead oma vanuse kontrollimiseks YouTube'i sisse logima.",
+    "note" : "Explanation on why the error is happening."
+  },
+  "ageRestrictedErrorMessage2b" : {
+    "title" : "Saad seda videot endiselt vaadata, kuid pead sisse logima ja vaatama seda YouTube'is ilma Duck Playeri lisatud privaatsuseta.",
+    "note" : "A message explaining that the blocked video can be watched directly on YouTube."
+  },
+  "noEmbedErrorHeading2" : {
+    "title" : "Vabandust, seda videot saab esitada ainult YouTube'is",
+    "note" : "Message shown when YouTube has blocked playback of a video"
+  },
+  "noEmbedErrorMessage2a" : {
+    "title" : "Selle video looja on otsustanud, et seda ei saa teistel saitidel vaadata.",
+    "note" : "Explanation on why the error is happening."
+  },
+  "noEmbedErrorMessage2b" : {
+    "title" : "Saate seda endiselt YouTube'is vaadata, kuid ilma Duck Playeri lisatud privaatsuseta.",
+    "note" : "A message explaining that the blocked video can be watched directly on YouTube."
+  },
   "blockedVideoErrorHeading" : {
     "title" : "YouTube ei luba Duck Playeril seda videot laadida",
     "note" : "Message shown when YouTube has blocked playback of a video"
@@ -44,12 +80,24 @@
     "title" : "Saate seda videot endiselt YouTube'is vaadata, kuid ilma Duck Player'i lisatud privaatsuseta.",
     "note" : "A message explaining that the blocked video can be watched directly on YouTube."
   },
+  "signInRequiredErrorHeading2" : {
+    "title" : "Vabandust, YouTube arvab, et sa oled robot",
+    "note" : "Message shown when YouTube has blocked playback of a video"
+  },
   "signInRequiredErrorMessage1" : {
     "title" : "YouTube blokeerib selle video laadimise. Kui kasutate VPN-i, proovige see välja lülitada ning leht uuesti laadida.",
     "note" : "Explanation on why the error is happening and a suggestions on how to solve it."
   },
   "signInRequiredErrorMessage2" : {
     "title" : "Kui see ei aita, saate seda videot ikkagi YouTube'is vaadata, kuid ilma Duck Playeri lisatud privaatsuseta.",
+    "note" : "More troubleshooting tips for this specific error"
+  },
+  "signInRequiredErrorMessage2a" : {
+    "title" : "See võib juhtuda, kui kasutad VPN-i. Proovi VPN välja lülitada või serveri asukohta vahetada ja see leht uuesti laadida.",
+    "note" : "Explanation on why the error is happening and a suggestions on how to solve it."
+  },
+  "signInRequiredErrorMessage2b" : {
+    "title" : "Kui see ei aita, pead sisse logima ja seda videot YouTube'is vaatama ilma Duck Playeri lisatud privaatsuseta.",
     "note" : "More troubleshooting tips for this specific error"
   },
   "tooltipInfo" : {

--- a/special-pages/pages/duckplayer/public/locales/fi/duckplayer.json
+++ b/special-pages/pages/duckplayer/public/locales/fi/duckplayer.json
@@ -32,6 +32,42 @@
     "title" : "<b>VIRHE:</b> virheellinen videotunnus",
     "note" : "Shown when the page URL doesn't match a known video ID. Note for translators: The <b> tag makes the word 'ERROR:' bold. Depending on the grammar of the target language, you might need to move it so that the correct word is emphasized."
   },
+  "unknownErrorHeading2" : {
+    "title" : "Duck Player ei voi ladata tätä videota",
+    "note" : "Message shown when YouTube has blocked playback of a video"
+  },
+  "unknownErrorMessage2a" : {
+    "title" : "Tätä videota ei voi katsoa YouTuben ulkopuolella.",
+    "note" : "Explanation on why the error is happening."
+  },
+  "unknownErrorMessage2b" : {
+    "title" : "Voit yhä katsoa tämän videon YouTubessa, mutta ilman Duck Playerin tarjoamaa ylimääräistä tietosuojaa.",
+    "note" : "A message explaining that the blocked video can be watched directly on YouTube."
+  },
+  "ageRestrictedErrorHeading2" : {
+    "title" : "Valitettavasti tämä video on ikärajoitettu.",
+    "note" : "Message shown when YouTube has blocked playback of a video"
+  },
+  "ageRestrictedErrorMessage2a" : {
+    "title" : "Jos haluat katsella ikärajoitettuja videoita, sinun täytyy kirjautua sisään YouTubeen vahvistaaksesi ikäsi.",
+    "note" : "Explanation on why the error is happening."
+  },
+  "ageRestrictedErrorMessage2b" : {
+    "title" : "Voit silti katsoa videon, mutta sinun täytyy kirjautua sisään ja katsoa se YouTubessa ilman Duck Playerin tarjoamaa lisätietosuojaa.",
+    "note" : "A message explaining that the blocked video can be watched directly on YouTube."
+  },
+  "noEmbedErrorHeading2" : {
+    "title" : "Valitettavasti tämän videon voi katsoa vain YouTubessa.",
+    "note" : "Message shown when YouTube has blocked playback of a video"
+  },
+  "noEmbedErrorMessage2a" : {
+    "title" : "Videon tekijä on päättänyt estää sen katselun muilla sivustoilla.",
+    "note" : "Explanation on why the error is happening."
+  },
+  "noEmbedErrorMessage2b" : {
+    "title" : "Voit silti katsoa sen YouTubessa, mutta ilman Duck Playerin tarjoamaa ylimääräistä tietosuojaa.",
+    "note" : "A message explaining that the blocked video can be watched directly on YouTube."
+  },
   "blockedVideoErrorHeading" : {
     "title" : "YouTube ei salli Duck Playerin ladata tätä videota.",
     "note" : "Message shown when YouTube has blocked playback of a video"
@@ -44,12 +80,24 @@
     "title" : "Voit yhä katsoa tämän videon YouTubessa, mutta ilman Duck Playerin tarjoamaa ylimääräistä tietosuojaa.",
     "note" : "A message explaining that the blocked video can be watched directly on YouTube."
   },
+  "signInRequiredErrorHeading2" : {
+    "title" : "Valitettavasti YouTube luulee, että olet botti",
+    "note" : "Message shown when YouTube has blocked playback of a video"
+  },
   "signInRequiredErrorMessage1" : {
     "title" : "YouTube estää tämän videon latautumisen. Jos käytät VPN:ää, kytke se pois päältä ja lataa tämä sivu uudelleen.",
     "note" : "Explanation on why the error is happening and a suggestions on how to solve it."
   },
   "signInRequiredErrorMessage2" : {
     "title" : "Jos tämä ei toimi, voit silti katsoa tämän videon YouTubessa, mutta ilman Duck Playerin tarjoamaa ylimääräistä tietosuojaa.",
+    "note" : "More troubleshooting tips for this specific error"
+  },
+  "signInRequiredErrorMessage2a" : {
+    "title" : "Näin voi käydä, jos käytät VPN-yhteyttä. Kokeile kytkeä VPN pois päältä tai vaihtaa palvelimen sijaintia ja lataa sivu uudelleen.",
+    "note" : "Explanation on why the error is happening and a suggestions on how to solve it."
+  },
+  "signInRequiredErrorMessage2b" : {
+    "title" : "Jos tämä ei auta, sinun on kirjauduttava sisään ja katsottava tämä video YouTubessa ilman Duck Playerin tarjoamaa ylimääräistä tietosuojaa.",
     "note" : "More troubleshooting tips for this specific error"
   },
   "tooltipInfo" : {

--- a/special-pages/pages/duckplayer/public/locales/fr/duckplayer.json
+++ b/special-pages/pages/duckplayer/public/locales/fr/duckplayer.json
@@ -32,6 +32,42 @@
     "title" : "<b>ERREUR :</b> identifiant vidéo non valide",
     "note" : "Shown when the page URL doesn't match a known video ID. Note for translators: The <b> tag makes the word 'ERROR:' bold. Depending on the grammar of the target language, you might need to move it so that the correct word is emphasized."
   },
+  "unknownErrorHeading2" : {
+    "title" : "Duck Player ne peut pas charger cette vidéo",
+    "note" : "Message shown when YouTube has blocked playback of a video"
+  },
+  "unknownErrorMessage2a" : {
+    "title" : "Cette vidéo ne peut pas être visionnée en dehors de YouTube.",
+    "note" : "Explanation on why the error is happening."
+  },
+  "unknownErrorMessage2b" : {
+    "title" : "Vous pouvez toujours regarder cette vidéo sur YouTube, mais sans la confidentialité renforcée de Duck Player.",
+    "note" : "A message explaining that the blocked video can be watched directly on YouTube."
+  },
+  "ageRestrictedErrorHeading2" : {
+    "title" : "Désolé, cette vidéo est soumise à une limite d'âge",
+    "note" : "Message shown when YouTube has blocked playback of a video"
+  },
+  "ageRestrictedErrorMessage2a" : {
+    "title" : "Pour regarder des vidéos soumises à une limite d'âge, vous devez vous connecter à YouTube pour confirmer votre âge.",
+    "note" : "Explanation on why the error is happening."
+  },
+  "ageRestrictedErrorMessage2b" : {
+    "title" : "Vous pouvez toujours regarder cette vidéo, mais vous devrez vous connecter et la regarder sur YouTube sans la confidentialité renforcée de Duck Player.",
+    "note" : "A message explaining that the blocked video can be watched directly on YouTube."
+  },
+  "noEmbedErrorHeading2" : {
+    "title" : "Désolé, cette vidéo ne peut être lue que sur YouTube",
+    "note" : "Message shown when YouTube has blocked playback of a video"
+  },
+  "noEmbedErrorMessage2a" : {
+    "title" : "Le créateur/La créatrice de cette vidéo a choisi de ne pas autoriser son visionnage sur d'autres sites.",
+    "note" : "Explanation on why the error is happening."
+  },
+  "noEmbedErrorMessage2b" : {
+    "title" : "Vous pouvez toujours la regarder sur YouTube, mais sans la confidentialité renforcée de Duck Player.",
+    "note" : "A message explaining that the blocked video can be watched directly on YouTube."
+  },
   "blockedVideoErrorHeading" : {
     "title" : "YouTube ne permet pas à Duck Player de charger cette vidéo",
     "note" : "Message shown when YouTube has blocked playback of a video"
@@ -44,12 +80,24 @@
     "title" : "Vous pouvez toujours regarder cette vidéo sur YouTube, mais sans la confidentialité renforcée de Duck Player.",
     "note" : "A message explaining that the blocked video can be watched directly on YouTube."
   },
+  "signInRequiredErrorHeading2" : {
+    "title" : "Désolé, YouTube pense que vous êtes un bot",
+    "note" : "Message shown when YouTube has blocked playback of a video"
+  },
   "signInRequiredErrorMessage1" : {
     "title" : "YouTube bloque le chargement de cette vidéo. Si vous utilisez un VPN, essayez de le désactiver et de recharger cette page.",
     "note" : "Explanation on why the error is happening and a suggestions on how to solve it."
   },
   "signInRequiredErrorMessage2" : {
     "title" : "Si cela ne fonctionne pas, vous pouvez toujours regarder cette vidéo sur YouTube, mais sans la confidentialité renforcée de Duck Player.",
+    "note" : "More troubleshooting tips for this specific error"
+  },
+  "signInRequiredErrorMessage2a" : {
+    "title" : "Cela peut arriver si vous utilisez un VPN. Essayez de désactiver le VPN ou de changer l'emplacement du serveur et de recharger cette page.",
+    "note" : "Explanation on why the error is happening and a suggestions on how to solve it."
+  },
+  "signInRequiredErrorMessage2b" : {
+    "title" : "Si cela ne fonctionne pas, vous devrez vous connecter et regarder cette vidéo sur YouTube sans la confidentialité renforcée de Duck Player.",
     "note" : "More troubleshooting tips for this specific error"
   },
   "tooltipInfo" : {

--- a/special-pages/pages/duckplayer/public/locales/hr/duckplayer.json
+++ b/special-pages/pages/duckplayer/public/locales/hr/duckplayer.json
@@ -32,6 +32,42 @@
     "title" : "<b>POGREŠKA:</b> Nevažeći ID videozapisa",
     "note" : "Shown when the page URL doesn't match a known video ID. Note for translators: The <b> tag makes the word 'ERROR:' bold. Depending on the grammar of the target language, you might need to move it so that the correct word is emphasized."
   },
+  "unknownErrorHeading2" : {
+    "title" : "Duck Player ne može učitati ovaj videozapis.",
+    "note" : "Message shown when YouTube has blocked playback of a video"
+  },
+  "unknownErrorMessage2a" : {
+    "title" : "Ovaj se videozapis ne može gledati izvan YouTubea.",
+    "note" : "Explanation on why the error is happening."
+  },
+  "unknownErrorMessage2b" : {
+    "title" : "Još uvijek možeš gledati ovaj videozapis na YouTubeu, ali bez dodatne privatnosti Duck Playera.",
+    "note" : "A message explaining that the blocked video can be watched directly on YouTube."
+  },
+  "ageRestrictedErrorHeading2" : {
+    "title" : "Nažalost, ovaj videozapis sadrži dobno ograničenje.",
+    "note" : "Message shown when YouTube has blocked playback of a video"
+  },
+  "ageRestrictedErrorMessage2a" : {
+    "title" : "Da bi gledao videozapise s ograničenjem dobi, moraš se prijaviti na YouTube kako bi se provjerila tvoja dob.",
+    "note" : "Explanation on why the error is happening."
+  },
+  "ageRestrictedErrorMessage2b" : {
+    "title" : "Još uvijek možeš gledati ovaj videozapis, ali morat ćeš se prijaviti i gledati ga na YouTubeu bez dodatne privatnosti Duck Playera.",
+    "note" : "A message explaining that the blocked video can be watched directly on YouTube."
+  },
+  "noEmbedErrorHeading2" : {
+    "title" : "Žao nam je, ovaj video možeš gledati samo na YouTubeu.",
+    "note" : "Message shown when YouTube has blocked playback of a video"
+  },
+  "noEmbedErrorMessage2a" : {
+    "title" : "Autor ovog videozapisa odlučio je ne dopustiti njegovo gledanje na drugim web stranicama.",
+    "note" : "Explanation on why the error is happening."
+  },
+  "noEmbedErrorMessage2b" : {
+    "title" : "Još uvijek ga možeš gledati na YouTubeu, ali bez dodatne privatnosti Duck Playera.",
+    "note" : "A message explaining that the blocked video can be watched directly on YouTube."
+  },
   "blockedVideoErrorHeading" : {
     "title" : "YouTube ne dopušta Duck Playeru da učita ovaj videozapis.",
     "note" : "Message shown when YouTube has blocked playback of a video"
@@ -44,12 +80,24 @@
     "title" : "Još uvijek možeš gledati ovaj videozapis na YouTubeu, ali bez dodatne privatnosti Duck Playera.",
     "note" : "A message explaining that the blocked video can be watched directly on YouTube."
   },
+  "signInRequiredErrorHeading2" : {
+    "title" : "Žao nam je, YouTube misli da si bot.",
+    "note" : "Message shown when YouTube has blocked playback of a video"
+  },
   "signInRequiredErrorMessage1" : {
     "title" : "YouTube blokira učitavanje ovog videozapisa. Ako koristiš VPN, pokušaj ga isključiti i ponovno učitati ovu stranicu.",
     "note" : "Explanation on why the error is happening and a suggestions on how to solve it."
   },
   "signInRequiredErrorMessage2" : {
     "title" : "Ako to ne uspije, i dalje možeš gledati ovaj videozapis na YouTubeu, ali bez dodatne privatnosti Duck Playera.",
+    "note" : "More troubleshooting tips for this specific error"
+  },
+  "signInRequiredErrorMessage2a" : {
+    "title" : "To se može dogoditi ako koristiš VPN. Pokušaj isključiti VPN ili promijeniti lokacije poslužitelja i ponovno učitati ovu stranicu.",
+    "note" : "Explanation on why the error is happening and a suggestions on how to solve it."
+  },
+  "signInRequiredErrorMessage2b" : {
+    "title" : "Ako to ne uspije, morat ćeš se prijaviti i gledati ovaj videozapis na YouTubeu bez dodatne privatnosti Duck Playera.",
     "note" : "More troubleshooting tips for this specific error"
   },
   "tooltipInfo" : {

--- a/special-pages/pages/duckplayer/public/locales/hu/duckplayer.json
+++ b/special-pages/pages/duckplayer/public/locales/hu/duckplayer.json
@@ -32,6 +32,42 @@
     "title" : "<b>HIBA:</b> Érvénytelen videoazonosító",
     "note" : "Shown when the page URL doesn't match a known video ID. Note for translators: The <b> tag makes the word 'ERROR:' bold. Depending on the grammar of the target language, you might need to move it so that the correct word is emphasized."
   },
+  "unknownErrorHeading2" : {
+    "title" : "A Duck Player nem tudja betölteni ezt a videót.",
+    "note" : "Message shown when YouTube has blocked playback of a video"
+  },
+  "unknownErrorMessage2a" : {
+    "title" : "Ezt a videót nem lehet a YouTube-on kívül megtekinteni.",
+    "note" : "Explanation on why the error is happening."
+  },
+  "unknownErrorMessage2b" : {
+    "title" : "Megnézheted a videót a YouTube-on, de a Duck Player által nyújtott extra adatvédelem nélkül.",
+    "note" : "A message explaining that the blocked video can be watched directly on YouTube."
+  },
+  "ageRestrictedErrorHeading2" : {
+    "title" : "Sajnáljuk, ez a videó korhatáros.",
+    "note" : "Message shown when YouTube has blocked playback of a video"
+  },
+  "ageRestrictedErrorMessage2a" : {
+    "title" : "A korhatáros videók megtekintéséhez a YouTube-ra való bejelentkezéssel meg kell erősítened az életkorodat.",
+    "note" : "Explanation on why the error is happening."
+  },
+  "ageRestrictedErrorMessage2b" : {
+    "title" : "Megnézheted a videót, de be kell jelentkezned a YouTube-ra, és ott a Duck Player által nyújtott extra adatvédelem nélkül láthatod.",
+    "note" : "A message explaining that the blocked video can be watched directly on YouTube."
+  },
+  "noEmbedErrorHeading2" : {
+    "title" : "Sajnáljuk, ez a videó csak a YouTube-on játszható le.",
+    "note" : "Message shown when YouTube has blocked playback of a video"
+  },
+  "noEmbedErrorMessage2a" : {
+    "title" : "A videó készítője úgy döntött, hogy nem engedélyezi a más oldalakon való lejátszását.",
+    "note" : "Explanation on why the error is happening."
+  },
+  "noEmbedErrorMessage2b" : {
+    "title" : "Megnézheted a YouTube-on, de a Duck Player által nyújtott extra adatvédelem nélkül.",
+    "note" : "A message explaining that the blocked video can be watched directly on YouTube."
+  },
   "blockedVideoErrorHeading" : {
     "title" : "A YouTube nem engedi, hogy a Duck Player betöltse ezt a videót",
     "note" : "Message shown when YouTube has blocked playback of a video"
@@ -44,12 +80,24 @@
     "title" : "Megnézheted a videót a YouTube-on, de a Duck Player által nyújtott extra adatvédelem nélkül.",
     "note" : "A message explaining that the blocked video can be watched directly on YouTube."
   },
+  "signInRequiredErrorHeading2" : {
+    "title" : "Sajnáljuk, a YouTube azt hiszi, hogy bot vagy",
+    "note" : "Message shown when YouTube has blocked playback of a video"
+  },
   "signInRequiredErrorMessage1" : {
     "title" : "A YouTube blokkolja ennek a videónak a betöltését. Ha VPN-t használsz, próbáld meg, hogy kikapcsolod, majd újra betöltöd ezt az oldalt.",
     "note" : "Explanation on why the error is happening and a suggestions on how to solve it."
   },
   "signInRequiredErrorMessage2" : {
     "title" : "Ha ez nem működik, akkor is megnézheted ezt a videót a YouTube-on, de a Duck Player által nyújtott extra adatvédelem nélkül.",
+    "note" : "More troubleshooting tips for this specific error"
+  },
+  "signInRequiredErrorMessage2a" : {
+    "title" : "Ez előfordulhat, ha VPN-t használsz. Próbáld meg kikapcsolni a VPN-t, vagy válts szerverhelyszínt, és töltsd be újra az oldalt.",
+    "note" : "Explanation on why the error is happening and a suggestions on how to solve it."
+  },
+  "signInRequiredErrorMessage2b" : {
+    "title" : "Ha ez nem működik, be kell jelentkezned a YouTube-ra, és a videót ott a Duck Player által nyújtott extra adatvédelem nélkül láthatod.",
     "note" : "More troubleshooting tips for this specific error"
   },
   "tooltipInfo" : {

--- a/special-pages/pages/duckplayer/public/locales/it/duckplayer.json
+++ b/special-pages/pages/duckplayer/public/locales/it/duckplayer.json
@@ -32,6 +32,42 @@
     "title" : "<b>ERRORE:</b> ID video non valido",
     "note" : "Shown when the page URL doesn't match a known video ID. Note for translators: The <b> tag makes the word 'ERROR:' bold. Depending on the grammar of the target language, you might need to move it so that the correct word is emphasized."
   },
+  "unknownErrorHeading2" : {
+    "title" : "Duck Player non può caricare il video",
+    "note" : "Message shown when YouTube has blocked playback of a video"
+  },
+  "unknownErrorMessage2a" : {
+    "title" : "Questo video non si può visualizzare al di fuori di YouTube.",
+    "note" : "Explanation on why the error is happening."
+  },
+  "unknownErrorMessage2b" : {
+    "title" : "Puoi ancora guardare questo video su YouTube, ma senza la privacy aggiuntiva offerta da Duck Player.",
+    "note" : "A message explaining that the blocked video can be watched directly on YouTube."
+  },
+  "ageRestrictedErrorHeading2" : {
+    "title" : "Spiacenti, questo video prevede restrizioni di età",
+    "note" : "Message shown when YouTube has blocked playback of a video"
+  },
+  "ageRestrictedErrorMessage2a" : {
+    "title" : "Per guardare video con restrizioni di età, accedi a YouTube per verificare la tua età.",
+    "note" : "Explanation on why the error is happening."
+  },
+  "ageRestrictedErrorMessage2b" : {
+    "title" : "Puoi comunque guardare il video, ma dovrai accedere e guardarlo su YouTube senza la privacy aggiuntiva di Duck Player.",
+    "note" : "A message explaining that the blocked video can be watched directly on YouTube."
+  },
+  "noEmbedErrorHeading2" : {
+    "title" : "Questo video può essere riprodotto solo su YouTube",
+    "note" : "Message shown when YouTube has blocked playback of a video"
+  },
+  "noEmbedErrorMessage2a" : {
+    "title" : "Il creatore di questo video ha scelto di non permettere la visione su altri siti.",
+    "note" : "Explanation on why the error is happening."
+  },
+  "noEmbedErrorMessage2b" : {
+    "title" : "Puoi comunque guardarlo su YouTube, ma senza la privacy aggiuntiva offerta da Duck Player.",
+    "note" : "A message explaining that the blocked video can be watched directly on YouTube."
+  },
   "blockedVideoErrorHeading" : {
     "title" : "YouTube non consente a Duck Player di caricare questo video",
     "note" : "Message shown when YouTube has blocked playback of a video"
@@ -44,12 +80,24 @@
     "title" : "Puoi ancora guardare questo video su YouTube, ma senza la privacy aggiuntiva offerta da Duck Player.",
     "note" : "A message explaining that the blocked video can be watched directly on YouTube."
   },
+  "signInRequiredErrorHeading2" : {
+    "title" : "Mi dispiace, YouTube ti ritiene un bot",
+    "note" : "Message shown when YouTube has blocked playback of a video"
+  },
   "signInRequiredErrorMessage1" : {
     "title" : "YouTube sta impedendo il caricamento di questo video. Se stai utilizzando una VPN, prova a disattivarla e a ricaricare questa pagina.",
     "note" : "Explanation on why the error is happening and a suggestions on how to solve it."
   },
   "signInRequiredErrorMessage2" : {
     "title" : "Se il problema non si risolve, puoi comunque guardare questo video su YouTube, ma senza la privacy aggiuntiva offerta da Duck Player.",
+    "note" : "More troubleshooting tips for this specific error"
+  },
+  "signInRequiredErrorMessage2a" : {
+    "title" : "Questo può succedere se usi una VPN. Prova a disattivare la VPN o a cambiare la posizione del server e a ricaricare la pagina.",
+    "note" : "Explanation on why the error is happening and a suggestions on how to solve it."
+  },
+  "signInRequiredErrorMessage2b" : {
+    "title" : "Se il problema persiste, dovrai accedere e guardare il video su YouTube senza la privacy aggiuntiva offerta da Duck Player.",
     "note" : "More troubleshooting tips for this specific error"
   },
   "tooltipInfo" : {

--- a/special-pages/pages/duckplayer/public/locales/lt/duckplayer.json
+++ b/special-pages/pages/duckplayer/public/locales/lt/duckplayer.json
@@ -32,6 +32,42 @@
     "title" : "<b>KLAIDA:</b> netinkamas vaizdo įrašo ID",
     "note" : "Shown when the page URL doesn't match a known video ID. Note for translators: The <b> tag makes the word 'ERROR:' bold. Depending on the grammar of the target language, you might need to move it so that the correct word is emphasized."
   },
+  "unknownErrorHeading2" : {
+    "title" : "„Duck Player“ negali įkelti šio vaizdo įrašo",
+    "note" : "Message shown when YouTube has blocked playback of a video"
+  },
+  "unknownErrorMessage2a" : {
+    "title" : "Šį vaizdo įrašą galima žiūrėti tik „YouTube“ platformoje.",
+    "note" : "Explanation on why the error is happening."
+  },
+  "unknownErrorMessage2b" : {
+    "title" : "Šį vaizdo įrašą vis dar gali žiūrėti „YouTube“, bet be papildomo „Duck Player“ privatumo.",
+    "note" : "A message explaining that the blocked video can be watched directly on YouTube."
+  },
+  "ageRestrictedErrorHeading2" : {
+    "title" : "Atsiprašome, šiam vaizdo įrašui taikomas amžiaus apribojimas",
+    "note" : "Message shown when YouTube has blocked playback of a video"
+  },
+  "ageRestrictedErrorMessage2a" : {
+    "title" : "Norint žiūrėti vaizdo įrašus su amžiaus apribojimais, reikia prisijungti prie „YouTube“ ir patvirtinti savo amžių.",
+    "note" : "Explanation on why the error is happening."
+  },
+  "ageRestrictedErrorMessage2b" : {
+    "title" : "Vis dar gali žiūrėti šį vaizdo įrašą, bet reikės prisijungti ir žiūrėti jį per „YouTube“ be papildomos „Duck Player“ privatumo funkcijos.",
+    "note" : "A message explaining that the blocked video can be watched directly on YouTube."
+  },
+  "noEmbedErrorHeading2" : {
+    "title" : "Atsiprašome, šį vaizdo įrašą galima žiūrėti tik per „YouTube“.",
+    "note" : "Message shown when YouTube has blocked playback of a video"
+  },
+  "noEmbedErrorMessage2a" : {
+    "title" : "Šio vaizdo įrašo kūrėjas pasirinko neleisti jo žiūrėti kitose svetainėse.",
+    "note" : "Explanation on why the error is happening."
+  },
+  "noEmbedErrorMessage2b" : {
+    "title" : "Vis tiek gali žiūrėti jį „YouTube“, bet be papildomos „Duck Player“ privatumo funkcijos.",
+    "note" : "A message explaining that the blocked video can be watched directly on YouTube."
+  },
   "blockedVideoErrorHeading" : {
     "title" : "„YouTube“ neleidžia „Duck Player“ įkelti šio vaizdo įrašo",
     "note" : "Message shown when YouTube has blocked playback of a video"
@@ -44,12 +80,24 @@
     "title" : "Šį vaizdo įrašą vis dar gali žiūrėti „YouTube“, bet be papildomo „Duck Player“ privatumo.",
     "note" : "A message explaining that the blocked video can be watched directly on YouTube."
   },
+  "signInRequiredErrorHeading2" : {
+    "title" : "Atsiprašome, „YouTube“ mano, kad tu esi robotas.",
+    "note" : "Message shown when YouTube has blocked playback of a video"
+  },
   "signInRequiredErrorMessage1" : {
     "title" : "„YouTube“ blokuoja šio vaizdo įrašo įkėlimą. Jei naudoji VPN, pabandyk jį išjungti ir iš naujo įkelti šį puslapį.",
     "note" : "Explanation on why the error is happening and a suggestions on how to solve it."
   },
   "signInRequiredErrorMessage2" : {
     "title" : "Jei tai neveikia, vis tiek gali žiūrėti šį vaizdo įrašą „YouTube“, bet be papildomo „Duck Player“ privatumo.",
+    "note" : "More troubleshooting tips for this specific error"
+  },
+  "signInRequiredErrorMessage2a" : {
+    "title" : "Taip gali nutikti, jei naudoji VPN. Pabandyk išjungti VPN arba pakeisti serverio vietą ir iš naujo įkelti šį puslapį.",
+    "note" : "Explanation on why the error is happening and a suggestions on how to solve it."
+  },
+  "signInRequiredErrorMessage2b" : {
+    "title" : "Jei tai neveikia, turėsite prisijungti ir žiūrėti šį vaizdo įrašą „YouTube“ be papildomos „Duck Player“ privatumo funkcijos.",
     "note" : "More troubleshooting tips for this specific error"
   },
   "tooltipInfo" : {

--- a/special-pages/pages/duckplayer/public/locales/lv/duckplayer.json
+++ b/special-pages/pages/duckplayer/public/locales/lv/duckplayer.json
@@ -32,6 +32,42 @@
     "title" : "<b>KĻŪDA:</b> Nederīgs video ID",
     "note" : "Shown when the page URL doesn't match a known video ID. Note for translators: The <b> tag makes the word 'ERROR:' bold. Depending on the grammar of the target language, you might need to move it so that the correct word is emphasized."
   },
+  "unknownErrorHeading2" : {
+    "title" : "Duck Player nevar ielādēt šo video.",
+    "note" : "Message shown when YouTube has blocked playback of a video"
+  },
+  "unknownErrorMessage2a" : {
+    "title" : "Šo video nevar skatīties ārpus YouTube.",
+    "note" : "Explanation on why the error is happening."
+  },
+  "unknownErrorMessage2b" : {
+    "title" : "Šo videoklipu joprojām vari skatīties vietnē YouTube, taču bez papildu Duck Player konfidencialitātes.",
+    "note" : "A message explaining that the blocked video can be watched directly on YouTube."
+  },
+  "ageRestrictedErrorHeading2" : {
+    "title" : "Atvaino, šim videoklipam ir vecuma ierobežojums.",
+    "note" : "Message shown when YouTube has blocked playback of a video"
+  },
+  "ageRestrictedErrorMessage2a" : {
+    "title" : "Lai skatītos videoklipus ar vecuma ierobežojumu, tev jāpiesakās YouTube, lai pārbaudītu savu vecumu.",
+    "note" : "Explanation on why the error is happening."
+  },
+  "ageRestrictedErrorMessage2b" : {
+    "title" : "Tu joprojām vari skatīties šo videoklipu, taču tev būs jāpiesakās un jāskatās to vietnē YouTube bez papildu privātuma, ko nodrošina Duck Player.",
+    "note" : "A message explaining that the blocked video can be watched directly on YouTube."
+  },
+  "noEmbedErrorHeading2" : {
+    "title" : "Atvaino, šo video var atskaņot tikai vietnē YouTube.",
+    "note" : "Message shown when YouTube has blocked playback of a video"
+  },
+  "noEmbedErrorMessage2a" : {
+    "title" : "Šī video veidotājs ir izvēlējies neļaut to skatīties citās vietnēs.",
+    "note" : "Explanation on why the error is happening."
+  },
+  "noEmbedErrorMessage2b" : {
+    "title" : "Joprojām vari to skatīties vietnē YouTube, taču bez papildu Duck Player privātuma.",
+    "note" : "A message explaining that the blocked video can be watched directly on YouTube."
+  },
   "blockedVideoErrorHeading" : {
     "title" : "YouTube neļauj Duck Player ielādēt šo video",
     "note" : "Message shown when YouTube has blocked playback of a video"
@@ -44,12 +80,24 @@
     "title" : "Šo videoklipu joprojām vari skatīties vietnē YouTube, taču bez papildu Duck Player konfidencialitātes.",
     "note" : "A message explaining that the blocked video can be watched directly on YouTube."
   },
+  "signInRequiredErrorHeading2" : {
+    "title" : "Atvainojiet, YouTube uzskata, ka esi robots",
+    "note" : "Message shown when YouTube has blocked playback of a video"
+  },
   "signInRequiredErrorMessage1" : {
     "title" : "YouTube bloķē šī video ielādi. Ja tu izmanto VPN, mēģini to izslēgt un pārlādēt šo lapu.",
     "note" : "Explanation on why the error is happening and a suggestions on how to solve it."
   },
   "signInRequiredErrorMessage2" : {
     "title" : "Ja tas nedarbojas, joprojām vari skatīties šo video vietnē YouTube, taču bez papildu privātuma, ko nodrošina Duck Player.",
+    "note" : "More troubleshooting tips for this specific error"
+  },
+  "signInRequiredErrorMessage2a" : {
+    "title" : "Tas var notikt, ja tu izmanto VPN. Mēģini izslēgt VPN vai mainīt servera atrašanās vietu un pārlādēt šo lapu.",
+    "note" : "Explanation on why the error is happening and a suggestions on how to solve it."
+  },
+  "signInRequiredErrorMessage2b" : {
+    "title" : "Ja tas nedarbojas, tev būs jāpierakstās un jāskatās šis video vietnē YouTube bez papildu Duck Player privātuma.",
     "note" : "More troubleshooting tips for this specific error"
   },
   "tooltipInfo" : {

--- a/special-pages/pages/duckplayer/public/locales/nb/duckplayer.json
+++ b/special-pages/pages/duckplayer/public/locales/nb/duckplayer.json
@@ -32,6 +32,42 @@
     "title" : "<b>FEIL:</b> Ugyldig video-ID",
     "note" : "Shown when the page URL doesn't match a known video ID. Note for translators: The <b> tag makes the word 'ERROR:' bold. Depending on the grammar of the target language, you might need to move it so that the correct word is emphasized."
   },
+  "unknownErrorHeading2" : {
+    "title" : "Duck Player kan ikke laste denne videoen",
+    "note" : "Message shown when YouTube has blocked playback of a video"
+  },
+  "unknownErrorMessage2a" : {
+    "title" : "Denne videoen kan ikke vises utenfor YouTube.",
+    "note" : "Explanation on why the error is happening."
+  },
+  "unknownErrorMessage2b" : {
+    "title" : "Du kan fremdeles se videoen på YouTube, men uten det ekstra personvernet som Duck Player tilbyr.",
+    "note" : "A message explaining that the blocked video can be watched directly on YouTube."
+  },
+  "ageRestrictedErrorHeading2" : {
+    "title" : "Beklager, denne videoen er aldersbegrenset",
+    "note" : "Message shown when YouTube has blocked playback of a video"
+  },
+  "ageRestrictedErrorMessage2a" : {
+    "title" : "For å se aldersbegrensede videoer må du logge inn på YouTube for å bekrefte alderen din.",
+    "note" : "Explanation on why the error is happening."
+  },
+  "ageRestrictedErrorMessage2b" : {
+    "title" : "Du kan fortsatt se denne videoen, men du må logge inn og se den på YouTube uten det ekstra personvernet som Duck Player tilbyr.",
+    "note" : "A message explaining that the blocked video can be watched directly on YouTube."
+  },
+  "noEmbedErrorHeading2" : {
+    "title" : "Beklager, denne videoen kan bare spilles av på YouTube",
+    "note" : "Message shown when YouTube has blocked playback of a video"
+  },
+  "noEmbedErrorMessage2a" : {
+    "title" : "Skaperen av denne videoen har valgt å ikke tillate at den vises på andre nettsteder.",
+    "note" : "Explanation on why the error is happening."
+  },
+  "noEmbedErrorMessage2b" : {
+    "title" : "Du kan fortsatt se den på YouTube, men uten det ekstra personvernet som Duck Player tilbyr.",
+    "note" : "A message explaining that the blocked video can be watched directly on YouTube."
+  },
   "blockedVideoErrorHeading" : {
     "title" : "YouTube lar ikke Duck Player laste denne videoen",
     "note" : "Message shown when YouTube has blocked playback of a video"
@@ -44,12 +80,24 @@
     "title" : "Du kan fremdeles se videoen på YouTube, men uten det ekstra personvernet som Duck Player tilbyr.",
     "note" : "A message explaining that the blocked video can be watched directly on YouTube."
   },
+  "signInRequiredErrorHeading2" : {
+    "title" : "Beklager, YouTube tror du er en bot",
+    "note" : "Message shown when YouTube has blocked playback of a video"
+  },
   "signInRequiredErrorMessage1" : {
     "title" : "YouTube blokkerer denne videoen fra å lastes. Hvis du bruker en VPN, kan du prøve å slå den av og laste denne siden på nytt.",
     "note" : "Explanation on why the error is happening and a suggestions on how to solve it."
   },
   "signInRequiredErrorMessage2" : {
     "title" : "Hvis ikke det virker, kan du fremdeles se videoen på YouTube, bare uten det ekstra personvernet som Duck Player tilbyr.",
+    "note" : "More troubleshooting tips for this specific error"
+  },
+  "signInRequiredErrorMessage2a" : {
+    "title" : "Dette kan skje hvis du bruker en VPN. Prøv å slå av VPN eller bytte serverlokasjon, og last inn denne siden på nytt.",
+    "note" : "Explanation on why the error is happening and a suggestions on how to solve it."
+  },
+  "signInRequiredErrorMessage2b" : {
+    "title" : "Hvis ikke det fungerer, må du logge inn og se videoen på YouTube uten det ekstra personvernet som Duck Player tilbyr.",
     "note" : "More troubleshooting tips for this specific error"
   },
   "tooltipInfo" : {

--- a/special-pages/pages/duckplayer/public/locales/nl/duckplayer.json
+++ b/special-pages/pages/duckplayer/public/locales/nl/duckplayer.json
@@ -32,6 +32,42 @@
     "title" : "<b>FOUT:</b> ongeldige video-id",
     "note" : "Shown when the page URL doesn't match a known video ID. Note for translators: The <b> tag makes the word 'ERROR:' bold. Depending on the grammar of the target language, you might need to move it so that the correct word is emphasized."
   },
+  "unknownErrorHeading2" : {
+    "title" : "Duck Player kan deze video niet laden.",
+    "note" : "Message shown when YouTube has blocked playback of a video"
+  },
+  "unknownErrorMessage2a" : {
+    "title" : "Deze video kan alleen op YouTube worden bekeken.",
+    "note" : "Explanation on why the error is happening."
+  },
+  "unknownErrorMessage2b" : {
+    "title" : "Je kunt deze video nog steeds bekijken op YouTube, maar zonder de extra privacy van Duck Player.",
+    "note" : "A message explaining that the blocked video can be watched directly on YouTube."
+  },
+  "ageRestrictedErrorHeading2" : {
+    "title" : "Sorry, deze video heeft een leeftijdsbeperking",
+    "note" : "Message shown when YouTube has blocked playback of a video"
+  },
+  "ageRestrictedErrorMessage2a" : {
+    "title" : "Om video's met leeftijdsbeperkingen te bekijken, moet je je aanmelden bij YouTube om je leeftijd te verifiëren.",
+    "note" : "Explanation on why the error is happening."
+  },
+  "ageRestrictedErrorMessage2b" : {
+    "title" : "Je kunt deze video nog steeds bekijken, maar je moet je aanmelden bij YouTube en hem daar bekijken zonder de extra privacy van Duck Player.",
+    "note" : "A message explaining that the blocked video can be watched directly on YouTube."
+  },
+  "noEmbedErrorHeading2" : {
+    "title" : "Sorry, deze video kan alleen op YouTube worden afgespeeld",
+    "note" : "Message shown when YouTube has blocked playback of a video"
+  },
+  "noEmbedErrorMessage2a" : {
+    "title" : "De maker van deze video staat niet toe dat deze video op andere sites wordt bekeken.",
+    "note" : "Explanation on why the error is happening."
+  },
+  "noEmbedErrorMessage2b" : {
+    "title" : "Je kunt deze video nog steeds op YouTube bekijken, maar zonder de extra privacy van Duck Player.",
+    "note" : "A message explaining that the blocked video can be watched directly on YouTube."
+  },
   "blockedVideoErrorHeading" : {
     "title" : "YouTube staat Duck Player niet toe om deze video te laden.",
     "note" : "Message shown when YouTube has blocked playback of a video"
@@ -44,12 +80,24 @@
     "title" : "Je kunt deze video nog steeds bekijken op YouTube, maar zonder de extra privacy van Duck Player.",
     "note" : "A message explaining that the blocked video can be watched directly on YouTube."
   },
+  "signInRequiredErrorHeading2" : {
+    "title" : "Sorry, YouTube denkt dat je een bot bent",
+    "note" : "Message shown when YouTube has blocked playback of a video"
+  },
   "signInRequiredErrorMessage1" : {
     "title" : "YouTube blokkeert het laden van deze video. Als je een VPN gebruikt, probeer deze dan uit te schakelen en deze pagina opnieuw te laden.",
     "note" : "Explanation on why the error is happening and a suggestions on how to solve it."
   },
   "signInRequiredErrorMessage2" : {
     "title" : "Als dit niet werkt, kun je deze video nog steeds op YouTube bekijken, maar dan zonder de extra privacy van Duck Player.",
+    "note" : "More troubleshooting tips for this specific error"
+  },
+  "signInRequiredErrorMessage2a" : {
+    "title" : "Dit kan gebeuren als je een VPN gebruikt. Schakel de VPN uit of wijzig de serverlocatie en laad deze pagina opnieuw.",
+    "note" : "Explanation on why the error is happening and a suggestions on how to solve it."
+  },
+  "signInRequiredErrorMessage2b" : {
+    "title" : "Als dat niet werkt, moet je je aanmelden bij YouTube en deze video daar bekijken zonder de extra privacy van Duck Player.",
     "note" : "More troubleshooting tips for this specific error"
   },
   "tooltipInfo" : {

--- a/special-pages/pages/duckplayer/public/locales/pl/duckplayer.json
+++ b/special-pages/pages/duckplayer/public/locales/pl/duckplayer.json
@@ -32,6 +32,42 @@
     "title" : "<b>BŁĄD:</b> nieprawidłowy identyfikator filmu",
     "note" : "Shown when the page URL doesn't match a known video ID. Note for translators: The <b> tag makes the word 'ERROR:' bold. Depending on the grammar of the target language, you might need to move it so that the correct word is emphasized."
   },
+  "unknownErrorHeading2" : {
+    "title" : "Duck Player nie może załadować tego filmu",
+    "note" : "Message shown when YouTube has blocked playback of a video"
+  },
+  "unknownErrorMessage2a" : {
+    "title" : "Nie można oglądać tego filmu poza YouTube.",
+    "note" : "Explanation on why the error is happening."
+  },
+  "unknownErrorMessage2b" : {
+    "title" : "Nadal możesz oglądać ten film na YouTube, ale bez dodatkowej prywatności, jaką zapewnia Duck Player.",
+    "note" : "A message explaining that the blocked video can be watched directly on YouTube."
+  },
+  "ageRestrictedErrorHeading2" : {
+    "title" : "Przepraszamy, ten film jest ograniczony wiekowo",
+    "note" : "Message shown when YouTube has blocked playback of a video"
+  },
+  "ageRestrictedErrorMessage2a" : {
+    "title" : "Aby oglądać filmy z ograniczeniami wiekowymi, musisz zalogować się na YouTube, aby potwierdzić swój wiek.",
+    "note" : "Explanation on why the error is happening."
+  },
+  "ageRestrictedErrorMessage2b" : {
+    "title" : "Nadal możesz obejrzeć ten film, ale musisz się zalogować i obejrzeć go na YouTube bez dodatkowej prywatności, jaką zapewnia Duck Player.",
+    "note" : "A message explaining that the blocked video can be watched directly on YouTube."
+  },
+  "noEmbedErrorHeading2" : {
+    "title" : "Przepraszamy, ten film można odtwarzać tylko na YouTube",
+    "note" : "Message shown when YouTube has blocked playback of a video"
+  },
+  "noEmbedErrorMessage2a" : {
+    "title" : "Twórca tego filmu nie wyraził zgody na oglądanie go na innych stronach.",
+    "note" : "Explanation on why the error is happening."
+  },
+  "noEmbedErrorMessage2b" : {
+    "title" : "Nadal możesz oglądać go na YouTube, ale bez dodatkowej prywatności, jaką zapewnia Duck Player.",
+    "note" : "A message explaining that the blocked video can be watched directly on YouTube."
+  },
   "blockedVideoErrorHeading" : {
     "title" : "YouTube nie zezwala na załadowanie tego filmu przez Duck Player",
     "note" : "Message shown when YouTube has blocked playback of a video"
@@ -44,12 +80,24 @@
     "title" : "Nadal możesz oglądać ten film na YouTube, ale bez dodatkowej prywatności, jaką zapewnia Duck Player.",
     "note" : "A message explaining that the blocked video can be watched directly on YouTube."
   },
+  "signInRequiredErrorHeading2" : {
+    "title" : "Niestety serwis YouTube uważa, że jesteś botem",
+    "note" : "Message shown when YouTube has blocked playback of a video"
+  },
   "signInRequiredErrorMessage1" : {
     "title" : "YouTube blokuje ładowanie tego filmu. Jeśli korzystasz z sieci VPN, spróbuj ją wyłączyć i ponownie załadować tę stronę.",
     "note" : "Explanation on why the error is happening and a suggestions on how to solve it."
   },
   "signInRequiredErrorMessage2" : {
     "title" : "Jeśli to nie pomoże, nadal możesz oglądać ten film na YouTube, jednak bez dodatkowej prywatności, jaką zapewnia Duck Player.",
+    "note" : "More troubleshooting tips for this specific error"
+  },
+  "signInRequiredErrorMessage2a" : {
+    "title" : "Może się tak zdarzyć, jeśli korzystasz z sieci VPN. Spróbuj wyłączyć sieć VPN lub zmienić lokalizację serwera i odświeżyć tę stronę.",
+    "note" : "Explanation on why the error is happening and a suggestions on how to solve it."
+  },
+  "signInRequiredErrorMessage2b" : {
+    "title" : "Jeśli to nie pomoże, możesz się zalogować i obejrzeć ten film na YouTube bez dodatkowej prywatności, jaką zapewnia Duck Player.",
     "note" : "More troubleshooting tips for this specific error"
   },
   "tooltipInfo" : {

--- a/special-pages/pages/duckplayer/public/locales/pt/duckplayer.json
+++ b/special-pages/pages/duckplayer/public/locales/pt/duckplayer.json
@@ -32,6 +32,42 @@
     "title" : "<b>ERRO:</b> ID de vídeo inválido",
     "note" : "Shown when the page URL doesn't match a known video ID. Note for translators: The <b> tag makes the word 'ERROR:' bold. Depending on the grammar of the target language, you might need to move it so that the correct word is emphasized."
   },
+  "unknownErrorHeading2" : {
+    "title" : "O Duck Player não consegue carregar este vídeo",
+    "note" : "Message shown when YouTube has blocked playback of a video"
+  },
+  "unknownErrorMessage2a" : {
+    "title" : "Este vídeo não pode ser visualizado fora do YouTube.",
+    "note" : "Explanation on why the error is happening."
+  },
+  "unknownErrorMessage2b" : {
+    "title" : "Continuas a poder ver este vídeo no YouTube, mas sem a privacidade adicional do Duck Player.",
+    "note" : "A message explaining that the blocked video can be watched directly on YouTube."
+  },
+  "ageRestrictedErrorHeading2" : {
+    "title" : "Desculpa, este vídeo tem restrição de idade",
+    "note" : "Message shown when YouTube has blocked playback of a video"
+  },
+  "ageRestrictedErrorMessage2a" : {
+    "title" : "Para assistir a vídeos com restrição de idade, precisas de iniciar sessão no YouTube para confirmar a tua idade.",
+    "note" : "Explanation on why the error is happening."
+  },
+  "ageRestrictedErrorMessage2b" : {
+    "title" : "Continuas a poder ver este vídeo, mas terás de iniciar sessão e vê-lo no YouTube sem a privacidade adicional do Duck Player.",
+    "note" : "A message explaining that the blocked video can be watched directly on YouTube."
+  },
+  "noEmbedErrorHeading2" : {
+    "title" : "Desculpa, este vídeo só pode ser reproduzido no YouTube",
+    "note" : "Message shown when YouTube has blocked playback of a video"
+  },
+  "noEmbedErrorMessage2a" : {
+    "title" : "O criador deste vídeo optou por não permitir que seja visto em outros sites.",
+    "note" : "Explanation on why the error is happening."
+  },
+  "noEmbedErrorMessage2b" : {
+    "title" : "Continuas a poder vê-lo no YouTube, mas sem a privacidade adicional do Duck Player.",
+    "note" : "A message explaining that the blocked video can be watched directly on YouTube."
+  },
   "blockedVideoErrorHeading" : {
     "title" : "O YouTube não permite que o Duck Player carregue este vídeo",
     "note" : "Message shown when YouTube has blocked playback of a video"
@@ -44,12 +80,24 @@
     "title" : "Continuas a poder ver este vídeo no YouTube, mas sem a privacidade adicional do Duck Player.",
     "note" : "A message explaining that the blocked video can be watched directly on YouTube."
   },
+  "signInRequiredErrorHeading2" : {
+    "title" : "Desculpa, o YouTube acha que és um bot",
+    "note" : "Message shown when YouTube has blocked playback of a video"
+  },
   "signInRequiredErrorMessage1" : {
     "title" : "O YouTube está a bloquear o carregamento deste vídeo. Se estiveres a usar uma VPN, tenta desativá-la e recarregar esta página.",
     "note" : "Explanation on why the error is happening and a suggestions on how to solve it."
   },
   "signInRequiredErrorMessage2" : {
     "title" : "Se isto não funcionar, continuas a poder ver este vídeo no YouTube, mas sem a privacidade adicional do Duck Player.",
+    "note" : "More troubleshooting tips for this specific error"
+  },
+  "signInRequiredErrorMessage2a" : {
+    "title" : "Isto pode acontecer se estiveres a usar uma VPN. Experimenta desativar a VPN ou mudar as localizações do servidor e recarregar esta página.",
+    "note" : "Explanation on why the error is happening and a suggestions on how to solve it."
+  },
+  "signInRequiredErrorMessage2b" : {
+    "title" : "Se isso não funcionar, terás de iniciar sessão e ver este vídeo no YouTube sem a privacidade adicional do Duck Player.",
     "note" : "More troubleshooting tips for this specific error"
   },
   "tooltipInfo" : {

--- a/special-pages/pages/duckplayer/public/locales/ro/duckplayer.json
+++ b/special-pages/pages/duckplayer/public/locales/ro/duckplayer.json
@@ -32,6 +32,42 @@
     "title" : "<b>EROARE:</b> ID video incorect",
     "note" : "Shown when the page URL doesn't match a known video ID. Note for translators: The <b> tag makes the word 'ERROR:' bold. Depending on the grammar of the target language, you might need to move it so that the correct word is emphasized."
   },
+  "unknownErrorHeading2" : {
+    "title" : "Duck Player nu poate încărca acest videoclip.",
+    "note" : "Message shown when YouTube has blocked playback of a video"
+  },
+  "unknownErrorMessage2a" : {
+    "title" : "Acest videoclip nu poate fi vizionat în afara YouTube.",
+    "note" : "Explanation on why the error is happening."
+  },
+  "unknownErrorMessage2b" : {
+    "title" : "Poți viziona în continuare acest videoclip pe YouTube, dar fără confidențialitatea suplimentară oferită de Duck Player.",
+    "note" : "A message explaining that the blocked video can be watched directly on YouTube."
+  },
+  "ageRestrictedErrorHeading2" : {
+    "title" : "Ne pare rău, acest videoclip impune restricții de vârstă",
+    "note" : "Message shown when YouTube has blocked playback of a video"
+  },
+  "ageRestrictedErrorMessage2a" : {
+    "title" : "Pentru a viziona videoclipuri cu restricții de vârstă, trebuie să te conectezi la YouTube pentru a-ți verifica vârsta.",
+    "note" : "Explanation on why the error is happening."
+  },
+  "ageRestrictedErrorMessage2b" : {
+    "title" : "Poți viziona în continuare acest videoclip, dar va trebui să te conectezi și să-l vizionezi pe YouTube, fără confidențialitatea suplimentară oferită de Duck Player.",
+    "note" : "A message explaining that the blocked video can be watched directly on YouTube."
+  },
+  "noEmbedErrorHeading2" : {
+    "title" : "Ne pare rău, acest videoclip poate fi redat doar pe YouTube",
+    "note" : "Message shown when YouTube has blocked playback of a video"
+  },
+  "noEmbedErrorMessage2a" : {
+    "title" : "Creatorul acestui videoclip a ales să nu permită vizionarea lui pe alte site-uri.",
+    "note" : "Explanation on why the error is happening."
+  },
+  "noEmbedErrorMessage2b" : {
+    "title" : "Îl poți viziona în continuare pe YouTube, dar fără confidențialitatea suplimentară oferită de Duck Player.",
+    "note" : "A message explaining that the blocked video can be watched directly on YouTube."
+  },
   "blockedVideoErrorHeading" : {
     "title" : "YouTube nu permite Duck Player să încarce acest videoclip",
     "note" : "Message shown when YouTube has blocked playback of a video"
@@ -44,12 +80,24 @@
     "title" : "Poți viziona în continuare acest videoclip pe YouTube, dar fără confidențialitatea suplimentară oferită de Duck Player.",
     "note" : "A message explaining that the blocked video can be watched directly on YouTube."
   },
+  "signInRequiredErrorHeading2" : {
+    "title" : "Ne pare rău, YouTube crede că ești un robot.",
+    "note" : "Message shown when YouTube has blocked playback of a video"
+  },
   "signInRequiredErrorMessage1" : {
     "title" : "YouTube blochează încărcarea acestui videoclip. Dacă folosești un VPN, încearcă să-l dezactivezi și să reîncarci această pagină.",
     "note" : "Explanation on why the error is happening and a suggestions on how to solve it."
   },
   "signInRequiredErrorMessage2" : {
     "title" : "Dacă acest lucru nu funcționează, poți viziona în continuare acest videoclip pe YouTube, dar fără confidențialitatea suplimentară oferită de Duck Player.",
+    "note" : "More troubleshooting tips for this specific error"
+  },
+  "signInRequiredErrorMessage2a" : {
+    "title" : "Acest lucru se poate întâmpla dacă folosești un VPN. Încearcă să dezactivezi VPN-ul, să schimbi locația serverului sau să reîncarci această pagină.",
+    "note" : "Explanation on why the error is happening and a suggestions on how to solve it."
+  },
+  "signInRequiredErrorMessage2b" : {
+    "title" : "Dacă acest lucru nu funcționează, va trebui să te conectezi și să vizionezi acest videoclip pe YouTube fără confidențialitatea suplimentară oferită de Duck Player.",
     "note" : "More troubleshooting tips for this specific error"
   },
   "tooltipInfo" : {

--- a/special-pages/pages/duckplayer/public/locales/ru/duckplayer.json
+++ b/special-pages/pages/duckplayer/public/locales/ru/duckplayer.json
@@ -32,6 +32,42 @@
     "title" : "<b>ОШИБКА:</b> Неверный идентификатор видео",
     "note" : "Shown when the page URL doesn't match a known video ID. Note for translators: The <b> tag makes the word 'ERROR:' bold. Depending on the grammar of the target language, you might need to move it so that the correct word is emphasized."
   },
+  "unknownErrorHeading2" : {
+    "title" : "Duck Player не удается загрузить это видео",
+    "note" : "Message shown when YouTube has blocked playback of a video"
+  },
+  "unknownErrorMessage2a" : {
+    "title" : "Это видео нельзя смотреть за пределами YouTube.",
+    "note" : "Explanation on why the error is happening."
+  },
+  "unknownErrorMessage2b" : {
+    "title" : "Вы по-прежнему можете посмотреть этот ролик на YouTube, но уже без дополнительной защиты Duck Player.",
+    "note" : "A message explaining that the blocked video can be watched directly on YouTube."
+  },
+  "ageRestrictedErrorHeading2" : {
+    "title" : "К сожалению, это видео имеет возрастные ограничения.",
+    "note" : "Message shown when YouTube has blocked playback of a video"
+  },
+  "ageRestrictedErrorMessage2a" : {
+    "title" : "Чтобы смотреть видео с возрастными ограничениями, нужно подтвердить свой возраст, выполнив вход на YouTube.",
+    "note" : "Explanation on why the error is happening."
+  },
+  "ageRestrictedErrorMessage2b" : {
+    "title" : "Вы все равно можете просмотреть это видео, но на YouTube и только после входа в учетную запись, то есть без дополнительной защиты Duck Player.",
+    "note" : "A message explaining that the blocked video can be watched directly on YouTube."
+  },
+  "noEmbedErrorHeading2" : {
+    "title" : "Извините, но это видео можно воспроизвести только в YouTube",
+    "note" : "Message shown when YouTube has blocked playback of a video"
+  },
+  "noEmbedErrorMessage2a" : {
+    "title" : "Автор этого видео не разрешил просмотр на других сайтах.",
+    "note" : "Explanation on why the error is happening."
+  },
+  "noEmbedErrorMessage2b" : {
+    "title" : "Вы по-прежнему можете посмотреть это видео на YouTube, но уже без дополнительной защиты Duck Player.",
+    "note" : "A message explaining that the blocked video can be watched directly on YouTube."
+  },
   "blockedVideoErrorHeading" : {
     "title" : "YouTube не позволяет проигрывателю Duck Player загрузить это видео",
     "note" : "Message shown when YouTube has blocked playback of a video"
@@ -44,12 +80,24 @@
     "title" : "Вы по-прежнему можете посмотреть этот ролик на YouTube, но уже без дополнительной защиты Duck Player.",
     "note" : "A message explaining that the blocked video can be watched directly on YouTube."
   },
+  "signInRequiredErrorHeading2" : {
+    "title" : "Извините, но YouTube считает вас ботом",
+    "note" : "Message shown when YouTube has blocked playback of a video"
+  },
   "signInRequiredErrorMessage1" : {
     "title" : "YouTube блокирует загрузку этого видео. Если вы используете VPN, отключите ее и перезагрузите страницу.",
     "note" : "Explanation on why the error is happening and a suggestions on how to solve it."
   },
   "signInRequiredErrorMessage2" : {
     "title" : "Если это не даст результата, вы все равно сможете просмотреть это видео на YouTube, но без дополнительной защиты конфиденциальности, обеспечиваемой Duck Player.",
+    "note" : "More troubleshooting tips for this specific error"
+  },
+  "signInRequiredErrorMessage2a" : {
+    "title" : "Подобное иногда случается при использовании VPN. Попробуйте отключить VPN или сменить геопозицию сервера и перезагрузить страницу.",
+    "note" : "Explanation on why the error is happening and a suggestions on how to solve it."
+  },
+  "signInRequiredErrorMessage2b" : {
+    "title" : "Если и в таком случае не удается решить проблему, вам придется войти в учетную запись и посмотреть видео на YouTube без дополнительной защиты Duck Player.",
     "note" : "More troubleshooting tips for this specific error"
   },
   "tooltipInfo" : {

--- a/special-pages/pages/duckplayer/public/locales/sk/duckplayer.json
+++ b/special-pages/pages/duckplayer/public/locales/sk/duckplayer.json
@@ -32,6 +32,42 @@
     "title" : "<b>CHYBA:</b> Neplatný identifikátor videa",
     "note" : "Shown when the page URL doesn't match a known video ID. Note for translators: The <b> tag makes the word 'ERROR:' bold. Depending on the grammar of the target language, you might need to move it so that the correct word is emphasized."
   },
+  "unknownErrorHeading2" : {
+    "title" : "Duck Player nemôže načítať toto video",
+    "note" : "Message shown when YouTube has blocked playback of a video"
+  },
+  "unknownErrorMessage2a" : {
+    "title" : "Toto video nie je možné pozerať mimo YouTube.",
+    "note" : "Explanation on why the error is happening."
+  },
+  "unknownErrorMessage2b" : {
+    "title" : "Toto video si môžeš pozrieť aj na YouTube, ale bez dodatočného súkromia Duck Player.",
+    "note" : "A message explaining that the blocked video can be watched directly on YouTube."
+  },
+  "ageRestrictedErrorHeading2" : {
+    "title" : "Prepáč, toto video je vekovo obmedzené",
+    "note" : "Message shown when YouTube has blocked playback of a video"
+  },
+  "ageRestrictedErrorMessage2a" : {
+    "title" : "Na sledovanie videí s vekovým obmedzením sa musíš prihlásiť na YouTube a overiť svoj vek.",
+    "note" : "Explanation on why the error is happening."
+  },
+  "ageRestrictedErrorMessage2b" : {
+    "title" : "Stále si môžeš pozrieť toto video, ale budeš sa musieť prihlásiť a pozerať ho na YouTube bez dodatočnej ochrany súkromia Duck Player.",
+    "note" : "A message explaining that the blocked video can be watched directly on YouTube."
+  },
+  "noEmbedErrorHeading2" : {
+    "title" : "Prepáč, toto video je možné prehrať iba na YouTube",
+    "note" : "Message shown when YouTube has blocked playback of a video"
+  },
+  "noEmbedErrorMessage2a" : {
+    "title" : "Autor tohto videa sa rozhodol nepovoliť jeho sledovanie na iných lokalitách.",
+    "note" : "Explanation on why the error is happening."
+  },
+  "noEmbedErrorMessage2b" : {
+    "title" : "Stále si ho môžeš pozrieť na YouTube, ale bez dodatočného súkromia Duck Player.",
+    "note" : "A message explaining that the blocked video can be watched directly on YouTube."
+  },
   "blockedVideoErrorHeading" : {
     "title" : "YouTube nedovolí Duck Playeru načítať toto video",
     "note" : "Message shown when YouTube has blocked playback of a video"
@@ -44,12 +80,24 @@
     "title" : "Toto video si môžeš pozrieť aj na YouTube, ale bez dodatočného súkromia Duck Player.",
     "note" : "A message explaining that the blocked video can be watched directly on YouTube."
   },
+  "signInRequiredErrorHeading2" : {
+    "title" : "Prepáč, YouTube si myslí, že si robot",
+    "note" : "Message shown when YouTube has blocked playback of a video"
+  },
   "signInRequiredErrorMessage1" : {
     "title" : "YouTube blokuje načítanie tohto videa. Ak používaš sieť VPN, skús ju vypnúť a znova načítať túto stránku.",
     "note" : "Explanation on why the error is happening and a suggestions on how to solve it."
   },
   "signInRequiredErrorMessage2" : {
     "title" : "Ak to nefunguje, môžeš si toto video pozrieť aj na YouTube, ale bez dodatočnej ochrany súkromia, ktorú poskytuje Duck Player.",
+    "note" : "More troubleshooting tips for this specific error"
+  },
+  "signInRequiredErrorMessage2a" : {
+    "title" : "Toto sa môže stať, ak používaš VPN. Skús vypnúť sieť VPN alebo prepnúť umiestnenia servera a znova načítať túto stránku.",
+    "note" : "Explanation on why the error is happening and a suggestions on how to solve it."
+  },
+  "signInRequiredErrorMessage2b" : {
+    "title" : "Ak to nefunguje, budeš sa musieť prihlásiť a pozrieť si toto video na YouTube bez dodatočnej ochrany súkromia, ktorú poskytuje Duck Player.",
     "note" : "More troubleshooting tips for this specific error"
   },
   "tooltipInfo" : {

--- a/special-pages/pages/duckplayer/public/locales/sl/duckplayer.json
+++ b/special-pages/pages/duckplayer/public/locales/sl/duckplayer.json
@@ -32,6 +32,42 @@
     "title" : "<b>NAPAKA:</b> Neveljaven ID videoposnetka",
     "note" : "Shown when the page URL doesn't match a known video ID. Note for translators: The <b> tag makes the word 'ERROR:' bold. Depending on the grammar of the target language, you might need to move it so that the correct word is emphasized."
   },
+  "unknownErrorHeading2" : {
+    "title" : "Duck Player ne more naložiti tega videa",
+    "note" : "Message shown when YouTube has blocked playback of a video"
+  },
+  "unknownErrorMessage2a" : {
+    "title" : "Tega videoposnetka si ni mogoče ogledati zunaj YouTuba.",
+    "note" : "Explanation on why the error is happening."
+  },
+  "unknownErrorMessage2b" : {
+    "title" : "Ta videoposnetek si lahko še vedno ogledate na YouTubu, vendar brez dodane zasebnosti predvajalnika Duck Player.",
+    "note" : "A message explaining that the blocked video can be watched directly on YouTube."
+  },
+  "ageRestrictedErrorHeading2" : {
+    "title" : "Žal je ta videoposnetek starostno omejen",
+    "note" : "Message shown when YouTube has blocked playback of a video"
+  },
+  "ageRestrictedErrorMessage2a" : {
+    "title" : "Če si želite ogledati starostno omejene videoposnetke, se morate prijaviti v YouTube in potrditi svojo starost.",
+    "note" : "Explanation on why the error is happening."
+  },
+  "ageRestrictedErrorMessage2b" : {
+    "title" : "Ta videoposnetek si lahko še vedno ogledate, vendar se boste morali prijaviti in si ga ogledati v YouTubu brez dodane zasebnosti predvajalnika Duck Player.",
+    "note" : "A message explaining that the blocked video can be watched directly on YouTube."
+  },
+  "noEmbedErrorHeading2" : {
+    "title" : "Žal je ta videoposnetek mogoče predvajati samo na YouTubu",
+    "note" : "Message shown when YouTube has blocked playback of a video"
+  },
+  "noEmbedErrorMessage2a" : {
+    "title" : "Ustvarjalec tega videoposnetka se je odločil, da ne dovoli njegovega ogleda na drugih spletnih mestih.",
+    "note" : "Explanation on why the error is happening."
+  },
+  "noEmbedErrorMessage2b" : {
+    "title" : "Še vedno si ga lahko ogledate na YouTubu, vendar brez dodane zasebnosti predvajalnika Duck Player.",
+    "note" : "A message explaining that the blocked video can be watched directly on YouTube."
+  },
   "blockedVideoErrorHeading" : {
     "title" : "YouTube ne dovoli predvajalniku Duck Player naložiti tega videa",
     "note" : "Message shown when YouTube has blocked playback of a video"
@@ -44,12 +80,24 @@
     "title" : "Ta videoposnetek si lahko še vedno ogledate na YouTubu, vendar brez dodane zasebnosti predvajalnika Duck Player.",
     "note" : "A message explaining that the blocked video can be watched directly on YouTube."
   },
+  "signInRequiredErrorHeading2" : {
+    "title" : "YouTube misli, da ste bot",
+    "note" : "Message shown when YouTube has blocked playback of a video"
+  },
   "signInRequiredErrorMessage1" : {
     "title" : "YouTube preprečuje nalaganje tega videoposnetka. Če uporabljate omrežje VPN, ga poskusite izklopiti in znova naložite to stran.",
     "note" : "Explanation on why the error is happening and a suggestions on how to solve it."
   },
   "signInRequiredErrorMessage2" : {
     "title" : "Če to ne deluje, si lahko ta videoposnetek še vedno ogledate na YouTubu, vendar brez dodane zasebnosti predvajalnika Duck Player.",
+    "note" : "More troubleshooting tips for this specific error"
+  },
+  "signInRequiredErrorMessage2a" : {
+    "title" : "To se lahko zgodi, če uporabljate omrežje VPN. Poskusite izklopiti omrežje VPN ali zamenjati lokacijo strežnika in znova naložite to stran.",
+    "note" : "Explanation on why the error is happening and a suggestions on how to solve it."
+  },
+  "signInRequiredErrorMessage2b" : {
+    "title" : "Če to ne deluje, se boste morali prijaviti in si ogledati ta videoposnetek na YouTubu brez dodane zasebnosti predvajalnika Duck Player.",
     "note" : "More troubleshooting tips for this specific error"
   },
   "tooltipInfo" : {

--- a/special-pages/pages/duckplayer/public/locales/sv/duckplayer.json
+++ b/special-pages/pages/duckplayer/public/locales/sv/duckplayer.json
@@ -32,6 +32,42 @@
     "title" : "<b>FEL:</b> Ogiltigt video-ID",
     "note" : "Shown when the page URL doesn't match a known video ID. Note for translators: The <b> tag makes the word 'ERROR:' bold. Depending on the grammar of the target language, you might need to move it so that the correct word is emphasized."
   },
+  "unknownErrorHeading2" : {
+    "title" : "Duck Player kan inte läsa in den här videon",
+    "note" : "Message shown when YouTube has blocked playback of a video"
+  },
+  "unknownErrorMessage2a" : {
+    "title" : "Den här videon kan inte ses utanför YouTube.",
+    "note" : "Explanation on why the error is happening."
+  },
+  "unknownErrorMessage2b" : {
+    "title" : "Du kan fortfarande se den här videon på YouTube, men utan den extra integriteten från Duck Player.",
+    "note" : "A message explaining that the blocked video can be watched directly on YouTube."
+  },
+  "ageRestrictedErrorHeading2" : {
+    "title" : "Tyvärr, den här videon är åldersbegränsad",
+    "note" : "Message shown when YouTube has blocked playback of a video"
+  },
+  "ageRestrictedErrorMessage2a" : {
+    "title" : "För att titta på åldersbegränsade videor måste du logga in på YouTube för att verifiera din ålder.",
+    "note" : "Explanation on why the error is happening."
+  },
+  "ageRestrictedErrorMessage2b" : {
+    "title" : "Du kan fortfarande titta på den här videon, men du måste logga in och se den på YouTube utan det extra integritetsskyddet från Duck Player.",
+    "note" : "A message explaining that the blocked video can be watched directly on YouTube."
+  },
+  "noEmbedErrorHeading2" : {
+    "title" : "Tyvärr kan den här videon endast visas på YouTube",
+    "note" : "Message shown when YouTube has blocked playback of a video"
+  },
+  "noEmbedErrorMessage2a" : {
+    "title" : "Skaparen av den här videon har valt att inte tillåta att den visas på andra webbplatser.",
+    "note" : "Explanation on why the error is happening."
+  },
+  "noEmbedErrorMessage2b" : {
+    "title" : "Du kan fortfarande se den på YouTube, men utan den extra integriteten från Duck Player.",
+    "note" : "A message explaining that the blocked video can be watched directly on YouTube."
+  },
   "blockedVideoErrorHeading" : {
     "title" : "YouTube låter inte Duck Player läsa in den här videon",
     "note" : "Message shown when YouTube has blocked playback of a video"
@@ -44,12 +80,24 @@
     "title" : "Du kan fortfarande se den här videon på YouTube, men utan den extra integriteten från Duck Player.",
     "note" : "A message explaining that the blocked video can be watched directly on YouTube."
   },
+  "signInRequiredErrorHeading2" : {
+    "title" : "Tyvärr, YouTube tror att du är en bot",
+    "note" : "Message shown when YouTube has blocked playback of a video"
+  },
   "signInRequiredErrorMessage1" : {
     "title" : "YouTube blockerar den här videon från att läsas in. Om du använder ett VPN kan du prova stänga av det och läsa in sidan igen.",
     "note" : "Explanation on why the error is happening and a suggestions on how to solve it."
   },
   "signInRequiredErrorMessage2" : {
     "title" : "Om det inte fungerar kan du fortfarande se den här videon på YouTube, men utan den extra integriteten från Duck Player.",
+    "note" : "More troubleshooting tips for this specific error"
+  },
+  "signInRequiredErrorMessage2a" : {
+    "title" : "Detta kan hända om du använder ett VPN-program. Prova att stänga av VPN-programmet eller byta serverplats och läsa in den här sidan igen.",
+    "note" : "Explanation on why the error is happening and a suggestions on how to solve it."
+  },
+  "signInRequiredErrorMessage2b" : {
+    "title" : "Om det inte fungerar måste du logga in och titta på den här videon på YouTube utan det extra integritetsskyddet från Duck Player.",
     "note" : "More troubleshooting tips for this specific error"
   },
   "tooltipInfo" : {

--- a/special-pages/pages/duckplayer/public/locales/tr/duckplayer.json
+++ b/special-pages/pages/duckplayer/public/locales/tr/duckplayer.json
@@ -32,6 +32,42 @@
     "title" : "<b>HATA:</b> Geçersiz video kimliği",
     "note" : "Shown when the page URL doesn't match a known video ID. Note for translators: The <b> tag makes the word 'ERROR:' bold. Depending on the grammar of the target language, you might need to move it so that the correct word is emphasized."
   },
+  "unknownErrorHeading2" : {
+    "title" : "Duck Player bu videoyu yükleyemiyor",
+    "note" : "Message shown when YouTube has blocked playback of a video"
+  },
+  "unknownErrorMessage2a" : {
+    "title" : "Bu video YouTube dışında izlenemez.",
+    "note" : "Explanation on why the error is happening."
+  },
+  "unknownErrorMessage2b" : {
+    "title" : "Bu videoyu Duck Player'ın sunduğu ek gizlilik olmadan YouTube'da izleyebilirsiniz.",
+    "note" : "A message explaining that the blocked video can be watched directly on YouTube."
+  },
+  "ageRestrictedErrorHeading2" : {
+    "title" : "Üzgünüz, bu videoda yaş sınırlaması var",
+    "note" : "Message shown when YouTube has blocked playback of a video"
+  },
+  "ageRestrictedErrorMessage2a" : {
+    "title" : "Yaş sınırlaması olan videoları izlemek için yaşınızı doğrulamak üzere YouTube'da oturum açmanız gerekir.",
+    "note" : "Explanation on why the error is happening."
+  },
+  "ageRestrictedErrorMessage2b" : {
+    "title" : "Bu videoyu yine izleyebilirsiniz. Ancak Duck Player'ın ek gizliliği olmadan YouTube'da oturum açmanız ve izlemeniz gerekir.",
+    "note" : "A message explaining that the blocked video can be watched directly on YouTube."
+  },
+  "noEmbedErrorHeading2" : {
+    "title" : "Üzgünüz, bu video yalnızca YouTube'da oynatılabilir",
+    "note" : "Message shown when YouTube has blocked playback of a video"
+  },
+  "noEmbedErrorMessage2a" : {
+    "title" : "Bu videoyu oluşturan kişi, videonun başka sitelerde izlenmesine izin vermemeyi seçti.",
+    "note" : "Explanation on why the error is happening."
+  },
+  "noEmbedErrorMessage2b" : {
+    "title" : "Bu videoyu Duck Player'ın sunduğu ek gizlilik olmadan YouTube'da izleyebilirsiniz.",
+    "note" : "A message explaining that the blocked video can be watched directly on YouTube."
+  },
   "blockedVideoErrorHeading" : {
     "title" : "YouTube, Duck Player'ın bu videoyu yüklemesine izin vermiyor",
     "note" : "Message shown when YouTube has blocked playback of a video"
@@ -44,12 +80,24 @@
     "title" : "Bu videoyu Duck Player'ın sunduğu ek gizlilik olmadan YouTube'da izleyebilirsiniz.",
     "note" : "A message explaining that the blocked video can be watched directly on YouTube."
   },
+  "signInRequiredErrorHeading2" : {
+    "title" : "Üzgünüz, YouTube sizin bir bot olduğunuzu sanıyor",
+    "note" : "Message shown when YouTube has blocked playback of a video"
+  },
   "signInRequiredErrorMessage1" : {
     "title" : "YouTube bu videonun yüklenmesini engelliyor. VPN kullanıyorsanız, VPN'i kapatıp bu sayfayı yeniden yüklemeyi deneyin.",
     "note" : "Explanation on why the error is happening and a suggestions on how to solve it."
   },
   "signInRequiredErrorMessage2" : {
     "title" : "Bu işe yaramazsa, videoyu Duck Player'ın sunduğu ek gizlilik olmadan YouTube'da izleyebilirsiniz.",
+    "note" : "More troubleshooting tips for this specific error"
+  },
+  "signInRequiredErrorMessage2a" : {
+    "title" : "VPN kullanıyorsanız bu durum meydana gelebilir. VPN'i kapatmayı veya sunucu konumlarını değiştirmeyi ve bu sayfayı yeniden yüklemeyi deneyin.",
+    "note" : "Explanation on why the error is happening and a suggestions on how to solve it."
+  },
+  "signInRequiredErrorMessage2b" : {
+    "title" : "Bu işe yaramazsa, oturum açmanız ve bu videoyu Duck Player'ın sunduğu ek gizlilik olmadan YouTube'da izlemeniz gerekir.",
     "note" : "More troubleshooting tips for this specific error"
   },
   "tooltipInfo" : {


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/38424471409662/task/1210070940254672?focus=true

## Description

- Updated translations for new custom error copy
- Set all languages to use copy version 2, now that translations exist
- Updated 2 aria snapshots for Spanish

## Testing Steps

Visit the Spanish previews below (or any other language) and confirm that copy matches translations
- [Sign-in error](https://deploy-preview-1732--content-scope-scripts.netlify.app/build/pages/duckplayer/?youtubeError=sign-in-required&videoID=SxTn1cNrSgI&platform=ios&customError=enabled&focusMode=disabled&locale=es)
- [Age restricted](https://deploy-preview-1732--content-scope-scripts.netlify.app/build/pages/duckplayer/?youtubeError=age-restricted&videoID=SxTn1cNrSgI&platform=ios&customError=enabled&focusMode=disabled&locale=es)
- [No embed](https://deploy-preview-1732--content-scope-scripts.netlify.app/build/pages/duckplayer/?youtubeError=no-embed&videoID=SxTn1cNrSgI&platform=ios&customError=enabled&focusMode=disabled&locale=es)
- [Unknown/generic](https://deploy-preview-1732--content-scope-scripts.netlify.app/build/pages/duckplayer/?youtubeError=unknown&videoID=SxTn1cNrSgI&platform=ios&customError=enabled&focusMode=disabled&locale=es)

## Checklist

<!--
  These questions are a friendly reminder to shipping code, if you're uncertain ask the AoR owners.
  It's also totally appropriate to not check some of these boxes, if they don't apply to your change.
-->
*Please tick all that apply:*

- [ ] I have tested this change locally
- [ ] I have tested this change locally in all supported browsers
- [ ] This change will be visible to users
- [ ] I have added automated tests that cover this change
- [ ] I have ensured the change is gated by config
- [ ] This change was covered by a ship review
- [ ] This change was covered by a tech design
- [ ] Any dependent config has been merged

