### PR TITLE
Duck Player: Add support for new YouTube Player UI links

### DIFF
--- a/special-pages/pages/duckplayer/app/components/Components.jsx
+++ b/special-pages/pages/duckplayer/app/components/Components.jsx
@@ -22,7 +22,7 @@ export function Components() {
         platform: { name: 'macos' },
         customError: { state: 'enabled' },
     });
-    let embed = EmbedSettings.fromHref('https://localhost?videoID=123');
+    let embed = /** @type {EmbedSettings} */ (EmbedSettings.fromHref('https://localhost?videoID=123'));
     let url = embed?.toEmbedUrl();
     if (!url) throw new Error('unreachable');
     return (
@@ -76,7 +76,7 @@ export function Components() {
                 </h2>
                 <SettingsProvider settings={settings}>
                     <PlayerContainer>
-                        <Player src={url} layout={'desktop'} />
+                        <Player src={url} layout={'desktop'} embed={embed} />
                         <InfoBarContainer>
                             <InfoBar embed={embed} />
                         </InfoBarContainer>

--- a/special-pages/pages/duckplayer/app/components/DesktopApp.jsx
+++ b/special-pages/pages/duckplayer/app/components/DesktopApp.jsx
@@ -4,7 +4,7 @@ import { InfoBar, InfoBarContainer } from './InfoBar.jsx';
 import { PlayerContainer } from './PlayerContainer.jsx';
 import { Player, PlayerError } from './Player.jsx';
 import { YouTubeError } from './YouTubeError';
-import { useSettings } from '../providers/SettingsProvider.jsx';
+import { useSettings, useReplaceWatchLinks } from '../providers/SettingsProvider.jsx';
 import { createAppFeaturesFrom } from '../features/app.js';
 import { HideInFocusMode } from './FocusMode.jsx';
 import { useShowCustomError } from '../providers/YouTubeErrorProvider';
@@ -17,6 +17,7 @@ export function DesktopApp({ embed }) {
     const settings = useSettings();
     const features = createAppFeaturesFrom(settings);
     const showCustomError = useShowCustomError();
+    useReplaceWatchLinks(embed);
 
     return (
         <>

--- a/special-pages/pages/duckplayer/app/components/DesktopApp.jsx
+++ b/special-pages/pages/duckplayer/app/components/DesktopApp.jsx
@@ -40,7 +40,7 @@ function DesktopLayout({ embed }) {
             <PlayerContainer>
                 {embed === null && <PlayerError layout={'desktop'} kind={'invalid-id'} />}
                 {embed !== null && showCustomError && <YouTubeError layout={'desktop'} embed={embed} />}
-                {embed !== null && !showCustomError && <Player src={embed.toEmbedUrl()} layout={'desktop'} />}
+                {embed !== null && !showCustomError && <Player src={embed.toEmbedUrl()} layout={'desktop'} embed={embed} />}
                 <HideInFocusMode style={'slide'}>
                     <InfoBarContainer>
                         <InfoBar embed={embed} />

--- a/special-pages/pages/duckplayer/app/components/DesktopApp.jsx
+++ b/special-pages/pages/duckplayer/app/components/DesktopApp.jsx
@@ -4,7 +4,7 @@ import { InfoBar, InfoBarContainer } from './InfoBar.jsx';
 import { PlayerContainer } from './PlayerContainer.jsx';
 import { Player, PlayerError } from './Player.jsx';
 import { YouTubeError } from './YouTubeError';
-import { useSettings, useReplaceWatchLinks } from '../providers/SettingsProvider.jsx';
+import { useSettings } from '../providers/SettingsProvider.jsx';
 import { createAppFeaturesFrom } from '../features/app.js';
 import { HideInFocusMode } from './FocusMode.jsx';
 import { useShowCustomError } from '../providers/YouTubeErrorProvider';
@@ -17,7 +17,6 @@ export function DesktopApp({ embed }) {
     const settings = useSettings();
     const features = createAppFeaturesFrom(settings);
     const showCustomError = useShowCustomError();
-    useReplaceWatchLinks(embed);
 
     return (
         <>

--- a/special-pages/pages/duckplayer/app/components/MobileApp.jsx
+++ b/special-pages/pages/duckplayer/app/components/MobileApp.jsx
@@ -33,7 +33,6 @@ export function MobileApp({ embed }) {
     useEffect(() => {
         window.addEventListener(WATCH_LINK_CLICK_EVENT, () => {
             if (embed) {
-                console.log('ddg-iframe-watch-link-click', embed);
                 openOnYoutube(embed);
             }
         });
@@ -78,7 +77,7 @@ function MobileLayout({ embed }) {
             <div class={styles.embed}>
                 {embed === null && <PlayerError layout={'mobile'} kind={'invalid-id'} />}
                 {embed !== null && showCustomError && <YouTubeError layout={'mobile'} embed={embed} />}
-                {embed !== null && !showCustomError && <Player src={embed.toEmbedUrl()} layout={'mobile'} />}
+                {embed !== null && !showCustomError && <Player src={embed.toEmbedUrl()} layout={'mobile'} embed={embed} />}
             </div>
             <div class={cn(styles.logo, styles.hideInFocus)}>
                 <MobileWordmark />

--- a/special-pages/pages/duckplayer/app/components/MobileApp.jsx
+++ b/special-pages/pages/duckplayer/app/components/MobileApp.jsx
@@ -1,4 +1,5 @@
 import { h, Fragment } from 'preact';
+import { useEffect } from 'preact/hooks';
 import cn from 'classnames';
 import styles from './MobileApp.module.css';
 import { Player, PlayerError } from './Player.jsx';
@@ -13,6 +14,8 @@ import { OrientationProvider } from '../providers/OrientationProvider.jsx';
 import { FocusMode } from './FocusMode.jsx';
 import { useTelemetry } from '../types.js';
 import { useShowCustomError } from '../providers/YouTubeErrorProvider';
+import { useOpenOnYoutubeHandler } from '../providers/SettingsProvider.jsx';
+import { WATCH_LINK_CLICK_EVENT } from '../features/replace-watch-links.js';
 
 const DISABLED_HEIGHT = 450;
 
@@ -24,8 +27,18 @@ export function MobileApp({ embed }) {
     const settings = useSettings();
     const telemetry = useTelemetry();
     const showCustomError = useShowCustomError();
-
+    const openOnYoutube = useOpenOnYoutubeHandler();
     const features = createAppFeaturesFrom(settings);
+
+    useEffect(() => {
+        window.addEventListener(WATCH_LINK_CLICK_EVENT, () => {
+            if (embed) {
+                console.log('ddg-iframe-watch-link-click', embed);
+                openOnYoutube(embed);
+            }
+        });
+    }, [embed, openOnYoutube]);
+
     return (
         <>
             {!showCustomError && features.focusMode()}

--- a/special-pages/pages/duckplayer/app/components/MobileApp.jsx
+++ b/special-pages/pages/duckplayer/app/components/MobileApp.jsx
@@ -14,8 +14,7 @@ import { OrientationProvider } from '../providers/OrientationProvider.jsx';
 import { FocusMode } from './FocusMode.jsx';
 import { useTelemetry } from '../types.js';
 import { useShowCustomError } from '../providers/YouTubeErrorProvider';
-import { useOpenOnYoutubeHandler } from '../providers/SettingsProvider.jsx';
-import { WATCH_LINK_CLICK_EVENT } from '../features/replace-watch-links.js';
+import { useReplaceWatchLinks } from '../providers/SettingsProvider.jsx';
 
 const DISABLED_HEIGHT = 450;
 
@@ -27,16 +26,8 @@ export function MobileApp({ embed }) {
     const settings = useSettings();
     const telemetry = useTelemetry();
     const showCustomError = useShowCustomError();
-    const openOnYoutube = useOpenOnYoutubeHandler();
     const features = createAppFeaturesFrom(settings);
-
-    useEffect(() => {
-        window.addEventListener(WATCH_LINK_CLICK_EVENT, () => {
-            if (embed) {
-                openOnYoutube(embed);
-            }
-        });
-    }, [embed, openOnYoutube]);
+    useReplaceWatchLinks(embed);
 
     return (
         <>

--- a/special-pages/pages/duckplayer/app/components/MobileApp.jsx
+++ b/special-pages/pages/duckplayer/app/components/MobileApp.jsx
@@ -1,5 +1,4 @@
 import { h, Fragment } from 'preact';
-import { useEffect } from 'preact/hooks';
 import cn from 'classnames';
 import styles from './MobileApp.module.css';
 import { Player, PlayerError } from './Player.jsx';
@@ -14,7 +13,6 @@ import { OrientationProvider } from '../providers/OrientationProvider.jsx';
 import { FocusMode } from './FocusMode.jsx';
 import { useTelemetry } from '../types.js';
 import { useShowCustomError } from '../providers/YouTubeErrorProvider';
-import { useReplaceWatchLinks } from '../providers/SettingsProvider.jsx';
 
 const DISABLED_HEIGHT = 450;
 
@@ -27,7 +25,6 @@ export function MobileApp({ embed }) {
     const telemetry = useTelemetry();
     const showCustomError = useShowCustomError();
     const features = createAppFeaturesFrom(settings);
-    useReplaceWatchLinks(embed);
 
     return (
         <>

--- a/special-pages/pages/duckplayer/app/components/Player.jsx
+++ b/special-pages/pages/duckplayer/app/components/Player.jsx
@@ -6,7 +6,10 @@ import { useSettings } from '../providers/SettingsProvider.jsx';
 import { createIframeFeatures } from '../features/iframe.js';
 import { Settings } from '../settings';
 import { useTypedTranslation } from '../types.js';
-import { EmbedSettings } from '../embed-settings';
+
+/**
+ * @import {EmbedSettings} from '../embed-settings.js';
+ */
 
 /**
  * Player component renders an embedded media player.

--- a/special-pages/pages/duckplayer/app/components/Player.jsx
+++ b/special-pages/pages/duckplayer/app/components/Player.jsx
@@ -112,18 +112,15 @@ function useIframeEffects(src, embed) {
             features.titleCapture(),
             features.mouseCapture(),
             features.errorDetection(),
+            features.replaceWatchLinks(),
         ];
 
-        // Replace watch links on mobile only
-        const shouldReplaceLinks = platformName === 'android' || platformName === 'ios' || platformName === 'windows';
-        if (shouldReplaceLinks) {
-            iframeFeatures.push(features.replaceWatchLinks());
-            window.addEventListener(WATCH_LINK_CLICK_EVENT, () => {
-                if (embed) {
-                    openOnYoutube(embed);
-                }
-            });
-        }
+        // Handle watch link clicks in iframe
+        window.addEventListener(WATCH_LINK_CLICK_EVENT, () => {
+            if (embed) {
+                openOnYoutube(embed);
+            }
+        });
 
         /**
          * @type {ReturnType<import("../features/pip").IframeFeature['iframeDidLoad']>[]}

--- a/special-pages/pages/duckplayer/app/components/Player.jsx
+++ b/special-pages/pages/duckplayer/app/components/Player.jsx
@@ -103,6 +103,7 @@ function useIframeEffects(src) {
             features.titleCapture(),
             features.mouseCapture(),
             features.errorDetection(),
+            features.replaceWatchLinks(),
         ];
 
         /**

--- a/special-pages/pages/duckplayer/app/components/Player.jsx
+++ b/special-pages/pages/duckplayer/app/components/Player.jsx
@@ -115,7 +115,7 @@ function useIframeEffects(src, embed) {
         ];
 
         // Replace watch links on mobile only
-        const shouldReplaceLinks = platformName === 'android' || platformName === 'ios';
+        const shouldReplaceLinks = platformName === 'android' || platformName === 'ios' || platformName === 'windows';
         if (shouldReplaceLinks) {
             iframeFeatures.push(features.replaceWatchLinks());
             window.addEventListener(WATCH_LINK_CLICK_EVENT, () => {

--- a/special-pages/pages/duckplayer/app/components/Player.jsx
+++ b/special-pages/pages/duckplayer/app/components/Player.jsx
@@ -2,11 +2,10 @@ import { h } from 'preact';
 import cn from 'classnames';
 import styles from './Player.module.css';
 import { useEffect, useRef } from 'preact/hooks';
-import { useSettings, usePlatformName, useOpenOnYoutubeHandler } from '../providers/SettingsProvider.jsx';
+import { useSettings, useOpenOnYoutubeHandler } from '../providers/SettingsProvider.jsx';
 import { createIframeFeatures } from '../features/iframe.js';
 import { Settings } from '../settings';
 import { useTypedTranslation } from '../types.js';
-import { WATCH_LINK_CLICK_EVENT } from '../features/replace-watch-links';
 
 /**
  * @import {EmbedSettings} from '../embed-settings.js';
@@ -96,7 +95,6 @@ function useIframeEffects(src, embed) {
     const ref = useRef(/** @type {HTMLIFrameElement|null} */ (null));
     const didLoad = useRef(/** @type {boolean} */ (false));
     const settings = useSettings();
-    const platformName = usePlatformName();
     const openOnYoutube = useOpenOnYoutubeHandler();
 
     useEffect(() => {
@@ -112,15 +110,8 @@ function useIframeEffects(src, embed) {
             features.titleCapture(),
             features.mouseCapture(),
             features.errorDetection(),
-            features.replaceWatchLinks(),
+            features.replaceWatchLinks(() => openOnYoutube(embed)),
         ];
-
-        // Handle watch link clicks in iframe
-        window.addEventListener(WATCH_LINK_CLICK_EVENT, () => {
-            if (embed) {
-                openOnYoutube(embed);
-            }
-        });
 
         /**
          * @type {ReturnType<import("../features/pip").IframeFeature['iframeDidLoad']>[]}

--- a/special-pages/pages/duckplayer/app/components/Player.jsx
+++ b/special-pages/pages/duckplayer/app/components/Player.jsx
@@ -6,6 +6,7 @@ import { useSettings } from '../providers/SettingsProvider.jsx';
 import { createIframeFeatures } from '../features/iframe.js';
 import { Settings } from '../settings';
 import { useTypedTranslation } from '../types.js';
+import { EmbedSettings } from '../embed-settings';
 
 /**
  * Player component renders an embedded media player.
@@ -13,9 +14,10 @@ import { useTypedTranslation } from '../types.js';
  * @param {object} props
  * @param {string} props.src - The source URL of the media to be played.
  * @param {Settings['layout']} props.layout
+ * @param {EmbedSettings} props.embed
  */
-export function Player({ src, layout }) {
-    const { ref, didLoad } = useIframeEffects(src);
+export function Player({ src, layout, embed }) {
+    const { ref, didLoad } = useIframeEffects(src, embed);
     const wrapperClasses = cn({
         [styles.root]: true,
         [styles.player]: true,
@@ -80,12 +82,13 @@ export function PlayerError({ kind, layout }) {
  * When either event occurs, we proceed to apply our list of features.
  *
  * @param {string} src - the iframe `src` attribute
+ * @param {EmbedSettings} embed
  * @return {{
  *   ref: import("preact/hooks").MutableRef<HTMLIFrameElement|null>,
  *   didLoad: () => void
  * }}
  */
-function useIframeEffects(src) {
+function useIframeEffects(src, embed) {
     const ref = useRef(/** @type {HTMLIFrameElement|null} */ (null));
     const didLoad = useRef(/** @type {boolean} */ (false));
     const settings = useSettings();
@@ -93,7 +96,7 @@ function useIframeEffects(src) {
     useEffect(() => {
         if (!ref.current) return;
         const iframe = ref.current;
-        const features = createIframeFeatures(settings);
+        const features = createIframeFeatures(settings, embed);
 
         /** @type {import("../features/iframe.js").IframeFeature[]} */
         const iframeFeatures = [
@@ -132,7 +135,7 @@ function useIframeEffects(src) {
             }
             iframe.removeEventListener('load', loadHandler);
         };
-    }, [src, settings]);
+    }, [src, settings, embed]);
 
     return { ref, didLoad: () => (didLoad.current = true) };
 }

--- a/special-pages/pages/duckplayer/app/features/iframe.js
+++ b/special-pages/pages/duckplayer/app/features/iframe.js
@@ -4,6 +4,8 @@ import { ClickCapture } from './click-capture.js';
 import { TitleCapture } from './title-capture.js';
 import { MouseCapture } from './mouse-capture.js';
 import { ErrorDetection } from './error-detection.js';
+import { ReplaceWatchLinks } from './replace-watch-links.js';
+import { EmbedSettings } from '../embed-settings.js';
 
 /**
  * Represents an individual piece of functionality in the iframe.
@@ -80,6 +82,15 @@ export function createIframeFeatures(settings) {
          */
         errorDetection: () => {
             return new ErrorDetection(settings.customError);
+        },
+        /**
+         * @return {IframeFeature}
+         */
+        replaceWatchLinks: () => {
+            const embed = EmbedSettings.fromHref(window.location.href);
+            const videoId = embed?.videoId?.id || '';
+
+            return new ReplaceWatchLinks(videoId);
         },
     };
 }

--- a/special-pages/pages/duckplayer/app/features/iframe.js
+++ b/special-pages/pages/duckplayer/app/features/iframe.js
@@ -5,7 +5,10 @@ import { TitleCapture } from './title-capture.js';
 import { MouseCapture } from './mouse-capture.js';
 import { ErrorDetection } from './error-detection.js';
 import { ReplaceWatchLinks } from './replace-watch-links.js';
-import { EmbedSettings } from '../embed-settings.js';
+
+/**
+ * @import {EmbedSettings} from '../embed-settings.js';
+ */
 
 /**
  * Represents an individual piece of functionality in the iframe.
@@ -38,9 +41,10 @@ export class IframeFeature {
  * global `Settings`
  *
  * @param {import("../settings").Settings} settings
+ * @param {EmbedSettings} embed
  * @returns {Record<string, () => IframeFeature>}
  */
-export function createIframeFeatures(settings) {
+export function createIframeFeatures(settings, embed) {
     return {
         /**
          * @return {IframeFeature}
@@ -87,10 +91,7 @@ export function createIframeFeatures(settings) {
          * @return {IframeFeature}
          */
         replaceWatchLinks: () => {
-            const embed = EmbedSettings.fromHref(window.location.href);
-            const videoId = embed?.videoId?.id || '';
-
-            return new ReplaceWatchLinks(videoId);
+            return new ReplaceWatchLinks(embed.videoId.id);
         },
     };
 }

--- a/special-pages/pages/duckplayer/app/features/iframe.js
+++ b/special-pages/pages/duckplayer/app/features/iframe.js
@@ -42,7 +42,6 @@ export class IframeFeature {
  *
  * @param {import("../settings").Settings} settings
  * @param {EmbedSettings} embed
- * @returns {Record<string, () => IframeFeature>}
  */
 export function createIframeFeatures(settings, embed) {
     return {
@@ -88,10 +87,11 @@ export function createIframeFeatures(settings, embed) {
             return new ErrorDetection(settings.customError);
         },
         /**
+         * @param {() => void} handler - what to invoke when a watch-link was clicked
          * @return {IframeFeature}
          */
-        replaceWatchLinks: () => {
-            return new ReplaceWatchLinks(embed.videoId.id);
+        replaceWatchLinks: (handler) => {
+            return new ReplaceWatchLinks(embed.videoId.id, handler);
         },
     };
 }

--- a/special-pages/pages/duckplayer/app/features/replace-watch-links.js
+++ b/special-pages/pages/duckplayer/app/features/replace-watch-links.js
@@ -32,10 +32,10 @@ export class ReplaceWatchLinks {
             doc.addEventListener(
                 'click',
                 (e) => {
-                    if (!(e.target instanceof Element)) return;
+                    if (!(e.target instanceof /** @type {any} */(win).Element)) return;
 
                     /** @type {HTMLLinkElement|null} */
-                    const closestLink = e.target.closest('a[href]');
+                    const closestLink = /** @type {Element} */ (e.target).closest('a[href]');
                     if (closestLink && this.isWatchLink(closestLink.href)) {
                         e.preventDefault();
                         e.stopPropagation();

--- a/special-pages/pages/duckplayer/app/features/replace-watch-links.js
+++ b/special-pages/pages/duckplayer/app/features/replace-watch-links.js
@@ -26,55 +26,18 @@ export class ReplaceWatchLinks {
             return () => {};
         }
 
-        const updateLink = (elem) => {
-            if (elem.href && this.isWatchLink(elem.href)) {
-                console.log('Adding click listener to', elem);
-                elem.addEventListener('click', (e) => {
-                    console.log('Watch link clicked', e);
+        if (win && doc) {
+            console.log('adding click listener to', doc);
+            doc.addEventListener('click', (e) => {
+                console.log('click event', e);
+                /** @type {HTMLLinkElement|null} */
+                const closestLink = /** @type {Element} */(e.target).closest('a[href]');
+                console.log('closestLink', closestLink);
+                if (closestLink && this.isWatchLink(closestLink.href)) {
                     e.preventDefault();
                     e.stopPropagation();
                     window.dispatchEvent(new CustomEvent(WATCH_LINK_CLICK_EVENT));
-                });
-            }
-        };
-
-        if (win && doc) {
-            const clickableElements = Array.from(doc.querySelectorAll('a'));
-            console.log('LinkCapture: Found clickable elements:', clickableElements);
-            clickableElements.forEach((/** @type {HTMLAnchorElement} */ elem) => {
-                updateLink(elem);
-            });
-
-            // Create a MutationObserver instance
-            const observer = new MutationObserver((mutations) => {
-                for (const mutation of mutations) {
-                    // Check for added nodes
-                    if (mutation.type === 'childList' && mutation.addedNodes.length > 0) {
-                        mutation.addedNodes.forEach((node) => {
-                            // If the node is an element, check for a tags
-                            if (node.nodeType === Node.ELEMENT_NODE) {
-                                const element = /** @type {Element} */ (node);
-
-                                // Check if the added node itself is an anchor tag
-                                if (element.tagName === 'A') {
-                                    updateLink(element);
-                                }
-
-                                // Check for anchor tags within the added node
-                                const anchorTags = element.querySelectorAll('a');
-                                anchorTags.forEach((/** @type {HTMLAnchorElement} */ anchor) => {
-                                    updateLink(anchor);
-                                });
-                            }
-                        });
-                    }
                 }
-            });
-
-            // Start observing the iframe's document for changes
-            observer.observe(doc, {
-                childList: true,
-                subtree: true, // Observe all descendants of the body
             });
         } else {
             console.warn('could not access iframe?.contentWindow && iframe?.contentDocument');

--- a/special-pages/pages/duckplayer/app/features/replace-watch-links.js
+++ b/special-pages/pages/duckplayer/app/features/replace-watch-links.js
@@ -32,7 +32,7 @@ export class ReplaceWatchLinks {
             doc.addEventListener(
                 'click',
                 (e) => {
-                    if (!(e.target instanceof /** @type {any} */(win).Element)) return;
+                    if (!(e.target instanceof /** @type {any} */ (win).Element)) return;
 
                     /** @type {HTMLLinkElement|null} */
                     const closestLink = /** @type {Element} */ (e.target).closest('a[href]');

--- a/special-pages/pages/duckplayer/app/features/replace-watch-links.js
+++ b/special-pages/pages/duckplayer/app/features/replace-watch-links.js
@@ -4,17 +4,17 @@
 
 import { VideoParams } from 'injected/src/features/duckplayer/util';
 
-export const WATCH_LINK_CLICK_EVENT = 'ddg-iframe-watch-link-click';
-
 /**
  * @implements IframeFeature
  */
 export class ReplaceWatchLinks {
     /**
      * @param {string} videoId
+     * @param {() => void} handler - what to invoke when a watch-link was clicked
      */
-    constructor(videoId) {
+    constructor(videoId, handler) {
         this.videoId = videoId;
+        this.handler = handler;
     }
     /**
      * @param {HTMLIFrameElement} iframe
@@ -32,12 +32,14 @@ export class ReplaceWatchLinks {
             doc.addEventListener(
                 'click',
                 (e) => {
+                    if (!(e.target instanceof Element)) return;
+
                     /** @type {HTMLLinkElement|null} */
-                    const closestLink = /** @type {Element} */ (e.target).closest('a[href]');
+                    const closestLink = e.target.closest('a[href]');
                     if (closestLink && this.isWatchLink(closestLink.href)) {
                         e.preventDefault();
                         e.stopPropagation();
-                        window.dispatchEvent(new CustomEvent(WATCH_LINK_CLICK_EVENT));
+                        this.handler();
                     }
                 },
                 {

--- a/special-pages/pages/duckplayer/app/features/replace-watch-links.js
+++ b/special-pages/pages/duckplayer/app/features/replace-watch-links.js
@@ -2,6 +2,8 @@
  * @typedef {import("./iframe").IframeFeature} IframeFeature
  */
 
+import { VideoParams } from 'injected/src/features/duckplayer/util';
+
 export const WATCH_LINK_CLICK_EVENT = 'ddg-iframe-watch-link-click';
 
 /**
@@ -28,17 +30,23 @@ export class ReplaceWatchLinks {
 
         if (win && doc) {
             console.log('adding click listener to', doc);
-            doc.addEventListener('click', (e) => {
-                console.log('click event', e);
-                /** @type {HTMLLinkElement|null} */
-                const closestLink = /** @type {Element} */(e.target).closest('a[href]');
-                console.log('closestLink', closestLink);
-                if (closestLink && this.isWatchLink(closestLink.href)) {
-                    e.preventDefault();
-                    e.stopPropagation();
-                    window.dispatchEvent(new CustomEvent(WATCH_LINK_CLICK_EVENT));
-                }
-            });
+            doc.addEventListener(
+                'click',
+                (e) => {
+                    console.log('click event', e);
+                    /** @type {HTMLLinkElement|null} */
+                    const closestLink = /** @type {Element} */ (e.target).closest('a[href]');
+                    console.log('closestLink', closestLink);
+                    if (closestLink && this.isWatchLink(closestLink.href)) {
+                        e.preventDefault();
+                        e.stopPropagation();
+                        window.dispatchEvent(new CustomEvent(WATCH_LINK_CLICK_EVENT));
+                    }
+                },
+                {
+                    capture: true,
+                },
+            );
         } else {
             console.warn('could not access iframe?.contentWindow && iframe?.contentDocument');
         }
@@ -51,10 +59,7 @@ export class ReplaceWatchLinks {
      * @return {boolean}
      */
     isWatchLink(href) {
-        if (!this.videoId || !href) {
-            return false;
-        }
-        const url = new URL(href);
-        return url.hostname.endsWith('youtube.com') && url.pathname.includes('/watch') && url.searchParams.get('v') === this.videoId;
+        const videoParams = VideoParams.forWatchPage(href);
+        return videoParams?.id === this.videoId;
     }
 }

--- a/special-pages/pages/duckplayer/app/features/replace-watch-links.js
+++ b/special-pages/pages/duckplayer/app/features/replace-watch-links.js
@@ -29,14 +29,11 @@ export class ReplaceWatchLinks {
         }
 
         if (win && doc) {
-            console.log('adding click listener to', doc);
             doc.addEventListener(
                 'click',
                 (e) => {
-                    console.log('click event', e);
                     /** @type {HTMLLinkElement|null} */
                     const closestLink = /** @type {Element} */ (e.target).closest('a[href]');
-                    console.log('closestLink', closestLink);
                     if (closestLink && this.isWatchLink(closestLink.href)) {
                         e.preventDefault();
                         e.stopPropagation();

--- a/special-pages/pages/duckplayer/app/features/replace-watch-links.js
+++ b/special-pages/pages/duckplayer/app/features/replace-watch-links.js
@@ -1,0 +1,97 @@
+/**
+ * @typedef {import("./iframe").IframeFeature} IframeFeature
+ */
+
+export const WATCH_LINK_CLICK_EVENT = 'ddg-iframe-watch-link-click';
+
+/**
+ * @implements IframeFeature
+ */
+export class ReplaceWatchLinks {
+    /**
+     * @param {string} videoId
+     */
+    constructor(videoId) {
+        this.videoId = videoId;
+    }
+    /**
+     * @param {HTMLIFrameElement} iframe
+     */
+    iframeDidLoad(iframe) {
+        const doc = iframe.contentDocument;
+        const win = iframe.contentWindow;
+
+        if (!doc) {
+            console.log('could not access contentDocument');
+            return () => {};
+        }
+
+        const updateLink = (elem) => {
+            if (elem.href && this.isWatchLink(elem.href)) {
+                console.log('Adding click listener to', elem);
+                elem.addEventListener('click', (e) => {
+                    console.log('Watch link clicked', e);
+                    e.preventDefault();
+                    e.stopPropagation();
+                    window.dispatchEvent(new CustomEvent(WATCH_LINK_CLICK_EVENT));
+                });
+            }
+        };
+
+        if (win && doc) {
+            const clickableElements = Array.from(doc.querySelectorAll('a'));
+            console.log('LinkCapture: Found clickable elements:', clickableElements);
+            clickableElements.forEach((/** @type {HTMLAnchorElement} */ elem) => {
+                updateLink(elem);
+            });
+
+            // Create a MutationObserver instance
+            const observer = new MutationObserver((mutations) => {
+                for (const mutation of mutations) {
+                    // Check for added nodes
+                    if (mutation.type === 'childList' && mutation.addedNodes.length > 0) {
+                        mutation.addedNodes.forEach((node) => {
+                            // If the node is an element, check for a tags
+                            if (node.nodeType === Node.ELEMENT_NODE) {
+                                const element = /** @type {Element} */ (node);
+
+                                // Check if the added node itself is an anchor tag
+                                if (element.tagName === 'A') {
+                                    updateLink(element);
+                                }
+
+                                // Check for anchor tags within the added node
+                                const anchorTags = element.querySelectorAll('a');
+                                anchorTags.forEach((/** @type {HTMLAnchorElement} */ anchor) => {
+                                    updateLink(anchor);
+                                });
+                            }
+                        });
+                    }
+                }
+            });
+
+            // Start observing the iframe's document for changes
+            observer.observe(doc, {
+                childList: true,
+                subtree: true, // Observe all descendants of the body
+            });
+        } else {
+            console.warn('could not access iframe?.contentWindow && iframe?.contentDocument');
+        }
+
+        return null;
+    }
+
+    /**
+     * @param {string} href
+     * @return {boolean}
+     */
+    isWatchLink(href) {
+        if (!this.videoId || !href) {
+            return false;
+        }
+        const url = new URL(href);
+        return url.hostname.endsWith('youtube.com') && url.pathname.includes('/watch') && url.searchParams.get('v') === this.videoId;
+    }
+}

--- a/special-pages/pages/duckplayer/app/providers/SettingsProvider.jsx
+++ b/special-pages/pages/duckplayer/app/providers/SettingsProvider.jsx
@@ -1,9 +1,8 @@
 import { h } from 'preact';
 import { createContext } from 'preact';
 import { Settings } from '../settings';
-import { useContext, useEffect } from 'preact/hooks';
+import { useContext } from 'preact/hooks';
 import { useMessaging } from '../types.js';
-import { WATCH_LINK_CLICK_EVENT } from '../features/replace-watch-links';
 
 const SettingsContext = createContext(/** @type {{settings: Settings}} */ ({}));
 

--- a/special-pages/pages/duckplayer/app/providers/SettingsProvider.jsx
+++ b/special-pages/pages/duckplayer/app/providers/SettingsProvider.jsx
@@ -94,20 +94,3 @@ export function useOpenOnYoutubeHandler() {
         }
     };
 }
-
-/**
- * @param {EmbedSettings|null} embed
- */
-export function useReplaceWatchLinks(embed) {
-    if (!embed) return;
-
-    const openOnYoutube = useOpenOnYoutubeHandler();
-    useEffect(() => {
-        window.addEventListener(WATCH_LINK_CLICK_EVENT, () => {
-            if (embed) {
-                openOnYoutube(embed);
-            }
-        });
-    }, [embed, openOnYoutube]);
-}
-

--- a/special-pages/pages/duckplayer/app/providers/SettingsProvider.jsx
+++ b/special-pages/pages/duckplayer/app/providers/SettingsProvider.jsx
@@ -1,11 +1,15 @@
 import { h } from 'preact';
 import { createContext } from 'preact';
 import { Settings } from '../settings';
-import { useContext } from 'preact/hooks';
+import { useContext, useEffect } from 'preact/hooks';
 import { useMessaging } from '../types.js';
-import { EmbedSettings } from '../embed-settings';
+import { WATCH_LINK_CLICK_EVENT } from '../features/replace-watch-links';
 
 const SettingsContext = createContext(/** @type {{settings: Settings}} */ ({}));
+
+/**
+ * @import {EmbedSettings} from '../embed-settings.js';
+ */
 
 /**
  * @param {object} params
@@ -90,3 +94,20 @@ export function useOpenOnYoutubeHandler() {
         }
     };
 }
+
+/**
+ * @param {EmbedSettings|null} embed
+ */
+export function useReplaceWatchLinks(embed) {
+    if (!embed) return;
+
+    const openOnYoutube = useOpenOnYoutubeHandler();
+    useEffect(() => {
+        window.addEventListener(WATCH_LINK_CLICK_EVENT, () => {
+            if (embed) {
+                openOnYoutube(embed);
+            }
+        });
+    }, [embed, openOnYoutube]);
+}
+


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1207252092703676/task/1210128066798037?focus=true

## Description

Adds a click handler to links to the current video within the embed


## Testing Steps

- Run this branch on a native app (or check [test builds here](https://app.asana.com/1/137249556945/project/1207252092703676/task/1210572366557467?focus=true))
- Set Duck Player to Always On
- Play a video on Duck Player
- Click on the video title or YouTube logo
- Confirm that new tab opens in YouTube and not Duck Player

## Checklist

<!--
  These questions are a friendly reminder to shipping code, if you're uncertain ask the AoR owners.
  It's also totally appropriate to not check some of these boxes, if they don't apply to your change.
-->
*Please tick all that apply:*

- [ ] I have tested this change locally
- [ ] I have tested this change locally in all supported browsers
- [ ] This change will be visible to users
- [ ] I have added automated tests that cover this change
- [ ] I have ensured the change is gated by config
- [ ] This change was covered by a ship review
- [ ] This change was covered by a tech design
- [ ] Any dependent config has been merged

