### PR TITLE
Reset release build to clear out old contents

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,8 +51,11 @@ jobs:
 
             - name: Ensure clean release branch from main
               run: |
-                  git reset --hard origin/main
-                  git clean -fxd
+                # Remove all tracked and untracked files except .git and .github
+                find . -mindepth 1 -maxdepth 1 ! -name '.git' ! -name '.github' -exec rm -rf {} +
+
+                # Copy files from main branch
+                git checkout main -- .
 
             - name: Build release
               run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,10 +49,10 @@ jobs:
                   cat ${{ github.workspace }}/CHANGELOG.txt
                   echo "Current tag is: $(git rev-list --tags --max-count=1)"
 
-            - name: Checkout code from main into release branch
+            - name: Ensure clean release branch from main
               run: |
-                  # Checkout the code of main onto releases
-                  git checkout main -- .
+                  git reset --hard origin/main
+                  git clean -fxd
 
             - name: Build release
               run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,11 +51,11 @@ jobs:
 
             - name: Ensure clean release branch from main
               run: |
-                # Remove all tracked and untracked files except .git and .github
-                find . -mindepth 1 -maxdepth 1 ! -name '.git' ! -name '.github' -exec rm -rf {} +
+                  # Remove all tracked and untracked files except .git and .github
+                  find . -mindepth 1 -maxdepth 1 ! -name '.git' ! -name '.github' -exec rm -rf {} +
 
-                # Copy files from main branch
-                git checkout main -- .
+                  # Copy files from main branch
+                  git checkout main -- .
 
             - name: Build release
               run: |


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1201614831475344/task/1210394080628545?focus=true

## Description

Resets the release to only contain files from main.

## Testing Steps

- Checkout releases
- Check the build contents
- Copy them to another directory outside the repo perhaps `cp -r build ../checkBuild`
- Run the changed commands:
    - `find . -mindepth 1 -maxdepth 1 ! -name '.git' ! -name '.github' -exec rm -rf {} +`
    - `git checkout main -- .`
- Run the build: `npm install && npm run build`
- See that `build/chrome` is now no-longer in the output. This is **expected**.

## Checklist

<!--
  These questions are a friendly reminder to shipping code, if you're uncertain ask the AoR owners.
  It's also totally appropriate to not check some of these boxes, if they don't apply to your change.
-->
*Please tick all that apply:*

- [ ] I have tested this change locally
- [ ] I have tested this change locally in all supported browsers
- [ ] This change will be visible to users
- [ ] I have added automated tests that cover this change
- [ ] I have ensured the change is gated by config
- [ ] This change was covered by a ship review
- [ ] This change was covered by a tech design
- [ ] Any dependent config has been merged

