### PR TITLE
ntp: accepting a new message to re-fetch favicons

### DIFF
--- a/special-pages/pages/new-tab/app/favorites/components/FavoritesProvider.js
+++ b/special-pages/pages/new-tab/app/favorites/components/FavoritesProvider.js
@@ -1,9 +1,10 @@
 import { createContext, h } from 'preact';
-import { useCallback, useEffect, useReducer, useRef } from 'preact/hooks';
+import { useCallback, useContext, useEffect, useReducer, useRef } from 'preact/hooks';
 
 import { FavoritesService } from '../favorites.service.js';
 import { useMessaging } from '../../types.js';
 import { reducer, useConfigSubscription, useDataSubscription, useInitialDataAndConfig } from '../../service.hooks.js';
+import { signal, useSignal } from '@preact/signals';
 
 /**
  * @typedef {import('../../../types/new-tab.ts').Favorite} Favorite
@@ -53,6 +54,12 @@ export const FavoritesContext = createContext({
 });
 
 export const FavoritesDispatchContext = createContext(/** @type {import("preact/hooks").Dispatch<Events>} */ ({}));
+
+/**
+ * A simple counter than can be used to invalidate a tree. For example, to force the browser
+ * to re-fetch icons that previously gave a 404 response
+ */
+export const FaviconsRefreshedCount = createContext(signal(0));
 
 /**
  * @param {object} props
@@ -122,9 +129,19 @@ export function FavoritesProvider({ children }) {
         [service],
     );
 
+    const faviconsRefreshedCount = useSignal(0);
+    useEffect(() => {
+        if (!service.current) return;
+        return service.current.onFaviconsRefreshed(() => {
+            faviconsRefreshedCount.value = faviconsRefreshedCount.value += 1;
+        });
+    }, []);
+
     return (
         <FavoritesContext.Provider value={{ state, toggle, favoritesDidReOrder, openFavorite, openContextMenu, add, onConfigChanged }}>
-            <FavoritesDispatchContext.Provider value={dispatch}>{children}</FavoritesDispatchContext.Provider>
+            <FaviconsRefreshedCount.Provider value={faviconsRefreshedCount}>
+                <FavoritesDispatchContext.Provider value={dispatch}>{children}</FavoritesDispatchContext.Provider>
+            </FaviconsRefreshedCount.Provider>
         </FavoritesContext.Provider>
     );
 }
@@ -140,4 +157,8 @@ export function useService() {
         };
     }, [ntp]);
     return service;
+}
+
+export function useFaviconRefreshedCount() {
+    return useContext(FaviconsRefreshedCount);
 }

--- a/special-pages/pages/new-tab/app/favorites/components/TileRow.js
+++ b/special-pages/pages/new-tab/app/favorites/components/TileRow.js
@@ -4,6 +4,7 @@ import { h } from 'preact';
 import { memo } from 'preact/compat';
 import { FavoritesThemeContext, ROW_CAPACITY } from './Favorites.js';
 import { useContext } from 'preact/hooks';
+import { useFaviconRefreshedCount } from './FavoritesProvider.js';
 
 /**
  * @typedef {import('../../../types/new-tab.js').Favorite} Favorite
@@ -21,6 +22,7 @@ export const TileRow = memo(
     function TileRow({ topOffset, items, add, visibility }) {
         const fillers = ROW_CAPACITY - items.length;
         const { theme, animateItems } = useContext(FavoritesThemeContext);
+        const count = useFaviconRefreshedCount();
         return (
             <ul className={styles.gridRow} style={{ transform: `translateY(${topOffset}px)` }}>
                 {items.map((item, index) => {
@@ -31,7 +33,7 @@ export const TileRow = memo(
                             faviconSrc={item.favicon?.src}
                             faviconMax={item.favicon?.maxAvailableSize}
                             title={item.title}
-                            key={item.id + item.favicon?.src + item.favicon?.maxAvailableSize + visibility}
+                            key={item.id + item.favicon?.src + item.favicon?.maxAvailableSize + visibility + count.value}
                             id={item.id}
                             index={index}
                             visibility={visibility}

--- a/special-pages/pages/new-tab/app/favorites/favorites.md
+++ b/special-pages/pages/new-tab/app/favorites/favorites.md
@@ -43,6 +43,11 @@ There are three representations of a favicon: image source, letters, or fallback
 - The widget config
 - returns {@link "NewTab Messages".FavoritesConfig}
 
+### `favorites_onRefresh`
+- {@link "NewTab Messages".FavoritesOnRefreshSubscription}.
+- Used to indicate potential updates, like when a favicon DB is ready
+- returns {@link "NewTab Messages".FavoritesRefresh}
+
 
 ## Notifications:
 

--- a/special-pages/pages/new-tab/app/favorites/favorites.service.js
+++ b/special-pages/pages/new-tab/app/favorites/favorites.service.js
@@ -68,6 +68,14 @@ export class FavoritesService {
         return this.configService.onData(cb);
     }
 
+    onFaviconsRefreshed(cb) {
+        return this.ntp.messaging.subscribe('favorites_onRefresh', (data) => {
+            if (data.items.some((item) => item.kind === 'favicons')) {
+                cb();
+            }
+        });
+    }
+
     /**
      * Update the in-memory data immediate and persist.
      * Any state changes will be broadcast to consumers synchronously

--- a/special-pages/pages/new-tab/app/favorites/integration-tests/favorites.page.js
+++ b/special-pages/pages/new-tab/app/favorites/integration-tests/favorites.page.js
@@ -354,4 +354,8 @@ export class FavoritesPage {
         // Every tile should be shown
         await this.waitForNumFavorites(count);
     }
+
+    async receivesRefresh() {
+        await this.ntp.mocks.simulateSubscriptionMessage('favorites_onRefresh', { items: [{ kind: 'favicons' }] });
+    }
 }

--- a/special-pages/pages/new-tab/app/favorites/mocks/favorites.data.js
+++ b/special-pages/pages/new-tab/app/favorites/mocks/favorites.data.js
@@ -12,6 +12,7 @@
  *    "small-icon": {favorites: Favorite[]};
  *    "fallbacks": {favorites: Favorite[]};
  *    "titles": {favorites: Favorite[]};
+ *    "missing": {favorites: Favorite[]};
  * }}
  */
 export const favorites = {
@@ -52,6 +53,18 @@ export const favorites = {
     none: {
         /** @type {Favorite[]} */
         favorites: [],
+    },
+    missing: {
+        /** @type {Favorite[]} */
+        favorites: [
+            {
+                id: 'id-missing-1',
+                etldPlusOne: 'adobe.com',
+                url: 'https://adobe.com?id=id-many-3',
+                title: 'Adobe',
+                favicon: { src: './this-does-note-exist', maxAvailableSize: 16 },
+            },
+        ],
     },
     titles: {
         /** @type {Favorite[]} */

--- a/special-pages/pages/new-tab/app/mock-transport.js
+++ b/special-pages/pages/new-tab/app/mock-transport.js
@@ -374,6 +374,22 @@ export function mockTransport() {
                     );
                     return () => controller.abort();
                 }
+                case 'favorites_onRefresh': {
+                    if (url.searchParams.get('favoriteRefresh') === 'favicons') {
+                        const timer = setTimeout(() => {
+                            /** @type {import('../types/new-tab').FavoritesRefresh} */
+                            const payload = {
+                                items: [{ kind: 'favicons' }],
+                            };
+                            cb(payload);
+                        }, 1000);
+                        return () => {
+                            clearTimeout(timer);
+                        };
+                    } else {
+                        return () => {};
+                    }
+                }
             }
             return () => {};
         },

--- a/special-pages/pages/new-tab/messages/favorites_onRefresh.subscribe.json
+++ b/special-pages/pages/new-tab/messages/favorites_onRefresh.subscribe.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "title": "Favorites Refresh",
+  "required": ["items"],
+  "properties": {
+    "items": {
+      "type": "array",
+      "items": {
+        "oneOf": [
+          {
+            "type": "object",
+            "required": ["kind"],
+            "properties": {
+              "kind": {
+                "type": "string",
+                "const": "favicons"
+              }
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/special-pages/pages/new-tab/types/new-tab.ts
+++ b/special-pages/pages/new-tab/types/new-tab.ts
@@ -149,6 +149,7 @@ export interface NewTabMessages {
     | CustomizerOnThemeUpdateSubscription
     | FavoritesOnConfigUpdateSubscription
     | FavoritesOnDataUpdateSubscription
+    | FavoritesOnRefreshSubscription
     | FreemiumPIRBannerOnDataUpdateSubscription
     | NextStepsOnConfigUpdateSubscription
     | NextStepsOnDataUpdateSubscription
@@ -935,6 +936,18 @@ export interface FavoritesOnConfigUpdateSubscription {
 export interface FavoritesOnDataUpdateSubscription {
   subscriptionEvent: "favorites_onDataUpdate";
   params: FavoritesData;
+}
+/**
+ * Generated from @see "../messages/favorites_onRefresh.subscribe.json"
+ */
+export interface FavoritesOnRefreshSubscription {
+  subscriptionEvent: "favorites_onRefresh";
+  params: FavoritesRefresh;
+}
+export interface FavoritesRefresh {
+  items: {
+    kind: "favicons";
+  }[];
 }
 /**
  * Generated from @see "../messages/freemiumPIRBanner_onDataUpdate.subscribe.json"


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/task/1210661401956305?focus=true

## Description

This gives a way for the native side to send some fire-and-forget messages to the page, so that we can react in certain ways. This first example is one where we don't have fresh data, but we would like to retry fetching the favicons.
<!--
  Provide a terse summary of what the change is, detailed descriptions should belong in ship reviews or tech designs
-->

## Testing Steps

![image](https://github.com/user-attachments/assets/5ff4a6ee-9578-42db-b204-7d10559ec719)

- visit https://deploy-preview-1775--content-scope-scripts.netlify.app/build/pages/new-tab/?favorites=missing&favoriteRefresh=favicons
- check dev tools, there should be 2 failing requests as seen in the screenshot ✅

## Checklist

<!--
  These questions are a friendly reminder to shipping code, if you're uncertain ask the AoR owners.
  It's also totally appropriate to not check some of these boxes, if they don't apply to your change.
-->
*Please tick all that apply:*

- [ ] I have tested this change locally
- [ ] I have tested this change locally in all supported browsers
- [ ] This change will be visible to users
- [ ] I have added automated tests that cover this change
- [ ] I have ensured the change is gated by config
- [ ] This change was covered by a ship review
- [ ] This change was covered by a tech design
- [ ] Any dependent config has been merged

