### PR TITLE
NTP: Add omnibar page to new tab children list

### DIFF
--- a/special-pages/pages/new-tab/app/new-tab.md
+++ b/special-pages/pages/new-tab/app/new-tab.md
@@ -1,6 +1,6 @@
 ---
 title: New Tab Page
-children: 
+children:
   - ./widget-list/widget-config.md
   - ./remote-messaging-framework/rmf.md
   - ./update-notification/update-notification.md
@@ -10,6 +10,7 @@ children:
   - ./next-steps/next-steps.md
   - ./customizer/customizer.md
   - ./protections/protections.md
+  - ./omnibar/omnibar.md
 ---
 
 ## Requests
@@ -27,7 +28,7 @@ children:
 
 ## Notifications
 
-### `contextMenu` 
+### `contextMenu`
 - {@link "NewTab Messages".ContextMenuNotification}
 - Sent when the user right-clicks in the page
 - Note: Other widgets might prevent this (and send their own, eg: favorites)


### PR DESCRIPTION
**Asana Task/Github Issue:** <!-- Link to Asana Task/Github Issue -->

## Description

Omnibar docs aren’t appearing in https://duckduckgo.github.io/content-scope-scripts/documents/New_Tab_Page.html. I need to list `omnibar.md` as a child of `new-tab.md`.

## Testing Steps



## Checklist

*Please tick all that apply:*

- [ ] I have tested this change locally
- [ ] I have tested this change locally in all supported browsers
- [ ] This change will be visible to users
- [ ] I have added automated tests that cover this change
- [ ] I have ensured the change is gated by config
- [ ] This change was covered by a ship review
- [ ] This change was covered by a tech design
- [ ] Any dependent config has been merged

