### PR TITLE
NTP: Basic omnibar integration tests

### DIFF
--- a/special-pages/pages/new-tab/app/omnibar/integration-tests/omnibar.page.js
+++ b/special-pages/pages/new-tab/app/omnibar/integration-tests/omnibar.page.js
@@ -41,6 +41,36 @@ export class OmnibarPage {
         return this.context().getByRole('button', { name: /Duck\.ai/i });
     }
 
+    suggestionsList() {
+        return this.context().getByRole('listbox');
+    }
+
+    suggestions() {
+        return this.suggestionsList().getByRole('option');
+    }
+
+    /**
+     * @param {number} count
+     */
+    async expectSuggestionsCount(count) {
+        await expect(this.suggestions()).toHaveCount(count);
+    }
+
+    selectedSuggestion() {
+        return this.suggestionsList().getByRole('option', { selected: true });
+    }
+
+    /**
+     * @param {string} text
+     */
+    async expectSelectedSuggestion(text) {
+        await expect(this.selectedSuggestion()).toHaveText(text);
+    }
+
+    async expectNoSelection() {
+        await expect(this.selectedSuggestion()).toHaveCount(0);
+    }
+
     /**
      * @param {'search' | 'ai'} mode
      */

--- a/special-pages/pages/new-tab/app/omnibar/integration-tests/omnibar.page.js
+++ b/special-pages/pages/new-tab/app/omnibar/integration-tests/omnibar.page.js
@@ -22,7 +22,7 @@ export class OmnibarPage {
     }
 
     chatInput() {
-        return this.context().getByRole('textbox', { name: /Chat privately with Duck\.ai/i });
+        return this.context().getByRole('textbox', { name: 'Chat privately with Duck.ai' });
     }
 
     tabList() {
@@ -30,15 +30,15 @@ export class OmnibarPage {
     }
 
     searchTab() {
-        return this.context().getByRole('tab', { name: /Search/i });
+        return this.context().getByRole('tab', { name: 'Search' });
     }
 
     aiTab() {
-        return this.context().getByRole('tab', { name: /Duck\.ai/i });
+        return this.context().getByRole('tab', { name: 'Duck.ai' });
     }
 
     aiChatButton() {
-        return this.context().getByRole('button', { name: /Duck\.ai/i });
+        return this.context().getByRole('button', { name: 'Duck.ai' });
     }
 
     suggestionsList() {

--- a/special-pages/pages/new-tab/app/omnibar/integration-tests/omnibar.page.js
+++ b/special-pages/pages/new-tab/app/omnibar/integration-tests/omnibar.page.js
@@ -1,0 +1,71 @@
+import { expect } from '@playwright/test';
+
+export class OmnibarPage {
+    /**
+     * @param {import("../../../integration-tests/new-tab.page.js").NewtabPage} ntp
+     */
+    constructor(ntp) {
+        this.ntp = ntp;
+        this.page = this.ntp.page;
+    }
+
+    context() {
+        return this.page.locator('[data-entry-point="omnibar"]');
+    }
+
+    async ready() {
+        await this.ntp.mocks.waitForCallCount({ method: 'omnibar_getConfig', count: 1 });
+    }
+
+    searchInput() {
+        return this.context().getByRole('combobox');
+    }
+
+    chatInput() {
+        return this.context().getByRole('textbox', { name: /Chat privately with Duck\.ai/i });
+    }
+
+    tabList() {
+        return this.context().getByRole('tablist');
+    }
+
+    searchTab() {
+        return this.context().getByRole('tab', { name: /Search/i });
+    }
+
+    aiTab() {
+        return this.context().getByRole('tab', { name: /Duck\.ai/i });
+    }
+
+    aiChatButton() {
+        return this.context().getByRole('button', { name: /Duck\.ai/i });
+    }
+
+    /**
+     * @param {'search' | 'ai'} mode
+     */
+    async expectMode(mode) {
+        if (mode === 'search') {
+            await expect(this.searchTab()).toHaveAttribute('aria-selected', 'true');
+        } else {
+            await expect(this.aiTab()).toHaveAttribute('aria-selected', 'true');
+        }
+    }
+
+    /**
+     * @param {string} method
+     * @param {number} count
+     */
+    async expectMethodCallCount(method, count) {
+        await this.ntp.mocks.waitForCallCount({ method, count });
+    }
+
+    /**
+     * @param {string} method
+     * @param {object} expectedParams
+     */
+    async expectMethodCalledWith(method, expectedParams) {
+        const calls = await this.ntp.mocks.waitForCallCount({ method, count: 1 });
+        expect(calls[0].payload.params).toEqual(expectedParams);
+    }
+}

--- a/special-pages/pages/new-tab/app/omnibar/integration-tests/omnibar.page.js
+++ b/special-pages/pages/new-tab/app/omnibar/integration-tests/omnibar.page.js
@@ -71,6 +71,53 @@ export class OmnibarPage {
         await expect(this.selectedSuggestion()).toHaveCount(0);
     }
 
+    async waitForSuggestions() {
+        await expect(this.suggestions().first()).toBeVisible();
+    }
+
+    /**
+     * @param {string} value
+     */
+    async expectInputValue(value) {
+        await expect(this.searchInput()).toHaveValue(value);
+    }
+
+    /**
+     * @param {number} startIndex
+     * @param {number} endIndex
+     */
+    async expectInputSelection(startIndex, endIndex) {
+        const input = this.searchInput();
+        const selectionStart = await input.evaluate((el) => {
+            if (!(el instanceof HTMLInputElement)) {
+                throw new Error('Element is not an HTMLInputElement');
+            }
+            return el.selectionStart;
+        });
+        const selectionEnd = await input.evaluate((el) => {
+            if (!(el instanceof HTMLInputElement)) {
+                throw new Error('Element is not an HTMLInputElement');
+            }
+            return el.selectionEnd;
+        });
+        expect(selectionStart).toBe(startIndex);
+        expect(selectionEnd).toBe(endIndex);
+    }
+
+    /**
+     * @param {string} selectedText
+     */
+    async expectInputSelectionText(selectedText) {
+        const input = this.searchInput();
+        const selection = await input.evaluate((el) => {
+            if (!(el instanceof HTMLInputElement)) {
+                throw new Error('Element is not an HTMLInputElement');
+            }
+            return el.value.slice(el.selectionStart ?? 0, el.selectionEnd ?? 0);
+        });
+        expect(selection).toBe(selectedText);
+    }
+
     /**
      * @param {'search' | 'ai'} mode
      */

--- a/special-pages/pages/new-tab/app/omnibar/integration-tests/omnibar.spec.js
+++ b/special-pages/pages/new-tab/app/omnibar/integration-tests/omnibar.spec.js
@@ -1,0 +1,102 @@
+import { test, expect } from '@playwright/test';
+import { NewtabPage } from '../../../integration-tests/new-tab.page.js';
+import { OmnibarPage } from './omnibar.page.js';
+
+test.describe('omnibar widget', () => {
+    test('fetches config on load', async ({ page }, workerInfo) => {
+        const ntp = NewtabPage.create(page, workerInfo);
+        await ntp.reducedMotion();
+
+        await ntp.openPage({ additional: { omnibar: true, 'omnibar.enableAi': true } });
+        await ntp.mocks.waitForCallCount({ method: 'initialSetup', count: 1 });
+        await ntp.mocks.waitForCallCount({ method: 'omnibar_getConfig', count: 1 });
+    });
+
+    test('search form submission', async ({ page }, workerInfo) => {
+        const ntp = NewtabPage.create(page, workerInfo);
+        const omnibar = new OmnibarPage(ntp);
+        await ntp.reducedMotion();
+
+        await ntp.openPage({ additional: { omnibar: true } });
+        await omnibar.ready();
+
+        await omnibar.searchInput().fill('pizza');
+        await omnibar.searchInput().press('Enter');
+
+        await omnibar.expectMethodCalledWith('omnibar_submitSearch', {
+            term: 'pizza',
+            target: 'same-tab',
+        });
+    });
+
+    test('AI chat form submission', async ({ page }, workerInfo) => {
+        const ntp = NewtabPage.create(page, workerInfo);
+        const omnibar = new OmnibarPage(ntp);
+        await ntp.reducedMotion();
+
+        await ntp.openPage({ additional: { omnibar: true } });
+        await omnibar.ready();
+
+        await omnibar.aiTab().click();
+        await omnibar.expectMode('ai');
+
+        await omnibar.chatInput().fill('pizza');
+        await omnibar.chatInput().press('Enter');
+
+        await omnibar.expectMethodCalledWith('omnibar_submitChat', {
+            chat: 'pizza',
+            target: 'same-tab',
+        });
+    });
+
+    test('AI chat button in search form submits chat message', async ({ page }, workerInfo) => {
+        const ntp = NewtabPage.create(page, workerInfo);
+        const omnibar = new OmnibarPage(ntp);
+        await ntp.reducedMotion();
+
+        await ntp.openPage({ additional: { omnibar: true } });
+        await omnibar.ready();
+
+        await omnibar.searchInput().fill('pizza');
+        await omnibar.aiChatButton().click();
+
+        await omnibar.expectMethodCalledWith('omnibar_submitChat', {
+            chat: 'pizza',
+            target: 'same-tab',
+        });
+    });
+
+    test('mode switching preserves query state', async ({ page }, workerInfo) => {
+        const ntp = NewtabPage.create(page, workerInfo);
+        const omnibar = new OmnibarPage(ntp);
+        await ntp.reducedMotion();
+
+        await ntp.openPage({ additional: { omnibar: true } });
+        await omnibar.ready();
+
+        // Start in search mode, type query
+        await omnibar.searchInput().fill('pizza');
+        await expect(omnibar.searchInput()).toHaveValue('pizza');
+
+        // Switch to AI mode
+        await omnibar.aiTab().click();
+        await omnibar.expectMode('ai');
+        await expect(omnibar.chatInput()).toHaveValue('pizza');
+
+        // Switch back to search mode
+        await omnibar.searchTab().click();
+        await omnibar.expectMode('search');
+        await expect(omnibar.searchInput()).toHaveValue('pizza');
+    });
+
+    test('omnibar without AI enabled does not show tab list', async ({ page }, workerInfo) => {
+        const ntp = NewtabPage.create(page, workerInfo);
+        const omnibar = new OmnibarPage(ntp);
+        await ntp.reducedMotion();
+
+        await ntp.openPage({ additional: { omnibar: true, 'omnibar.enableAi': false } });
+        await omnibar.ready();
+
+        await expect(omnibar.tabList()).toHaveCount(0);
+    });
+});

--- a/special-pages/pages/new-tab/integration-tests/new-tab.page.js
+++ b/special-pages/pages/new-tab/integration-tests/new-tab.page.js
@@ -49,6 +49,12 @@ export class NewtabPage {
             nextSteps_getData: {},
             rmf_getData: {},
             widgets_setConfig: {},
+            omnibar_getConfig: { mode: 'search', enableAi: false },
+            omnibar_getSuggestions: { suggestions: { topHits: [], duckduckgoSuggestions: [], localSuggestions: [] } },
+            omnibar_setConfig: {},
+            omnibar_openSuggestion: {},
+            omnibar_submitSearch: {},
+            omnibar_submitChat: {},
         });
     }
 

--- a/special-pages/playwright.config.js
+++ b/special-pages/playwright.config.js
@@ -37,6 +37,7 @@ export default defineConfig({
                 'history.screenshots.spec.js',
                 'protections.spec.js',
                 'protections.screenshots.spec.js',
+                'omnibar.spec.js',
             ],
             use: {
                 ...devices['Desktop Chrome'],


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1209121419454298/task/1210670669716050

## Description

Adds integration tests for some omnibar widget flows that _currently work_.

- Basic Form Submission
  - Search form submission with Enter key
  - AI chat form submission with Enter key  
  - AI chat button in search form submits chat message
  - Configuration fetching on page load
- Mode Switching & State Management
  - Mode switching preserves query state (bidirectional)
  - AI tab disabled when AI is not enabled
  - Query preservation between search and chat modes
- Keyboard Navigation
  - Arrow down navigation through suggestions (with wraparound)
  - Arrow up navigation through suggestions (with wraparound) 
  - Arrow down + Enter opens selected suggestion
  - Tab key moves focus away from input
- Mouse Interactions
  - Clicking on suggestion opens it
  - Mouse hover selects suggestion
  - Mouse out clears selection
- Input Suggestion/Autocomplete
  - Title prefix matching: "pizza" + "pizza near me" → "pizza[ near me]"
  - URL prefix matching: "pizza" + "pizzahut.com" → "pizza[hut.com]"
  - No prefix match: "pizza" + "Italian Pizza History" → "[Italian Pizza History]”

There’s a few flows that don’t currently work. I’ll fix these and add tests for them in follow-up PRs:

- Hint text (shown after the input value in blue).
- Pressing arrow up / arrow down after pressing arrow left / arrow right should restore search to original search term.
- Pressing ESC should keep suggestion text but close suggestions dropdown.
- Clicking / focusing outside should close suggestions dropdown.

## Testing Steps

n/a

## Checklist

*Please tick all that apply:*

- [ ] I have tested this change locally
- [ ] I have tested this change locally in all supported browsers
- [ ] This change will be visible to users
- [x] I have added automated tests that cover this change
- [x] I have ensured the change is gated by config
- [ ] This change was covered by a ship review
- [x] This change was covered by a tech design
- [x] Any dependent config has been merged
