### PR TITLE
NTP: Reset omnibar after form submission

### DIFF
--- a/special-pages/pages/new-tab/app/omnibar/components/AiChatForm.js
+++ b/special-pages/pages/new-tab/app/omnibar/components/AiChatForm.js
@@ -1,23 +1,23 @@
 import { h } from 'preact';
-import { useContext, useRef } from 'preact/hooks';
+import { useRef } from 'preact/hooks';
 import { eventToTarget } from '../../../../../shared/handlers';
 import { ArrowRightIcon } from '../../components/Icons';
 import { usePlatformName } from '../../settings.provider';
 import { useTypedTranslationWith } from '../../types';
 import styles from './AiChatForm.module.css';
-import { OmnibarContext } from './OmnibarProvider';
 
 /**
  * @typedef {import('../strings.json')} Strings
+ * @typedef {import('../../../types/new-tab.js').OpenTarget} OpenTarget
  */
 
 /**
  * @param {object} props
  * @param {string} props.chat
  * @param {(chat: string) => void} props.setChat
+ * @param {(params: { chat: string, target: OpenTarget }) => void} props.onSubmitChat
  */
-export function AiChatForm({ chat, setChat }) {
-    const { submitChat } = useContext(OmnibarContext);
+export function AiChatForm({ chat, setChat, onSubmitChat }) {
     const { t } = useTypedTranslationWith(/** @type {Strings} */ ({}));
     const platformName = usePlatformName();
 
@@ -30,7 +30,7 @@ export function AiChatForm({ chat, setChat }) {
     const onSubmit = (event) => {
         event.preventDefault();
         if (disabled) return;
-        submitChat({
+        onSubmitChat({
             chat,
             target: 'same-tab',
         });
@@ -41,7 +41,7 @@ export function AiChatForm({ chat, setChat }) {
         if (event.key === 'Enter' && !event.shiftKey) {
             event.preventDefault();
             if (disabled) return;
-            submitChat({
+            onSubmitChat({
                 chat,
                 target: eventToTarget(event, platformName),
             });

--- a/special-pages/pages/new-tab/app/omnibar/components/AiChatForm.js
+++ b/special-pages/pages/new-tab/app/omnibar/components/AiChatForm.js
@@ -14,10 +14,10 @@ import styles from './AiChatForm.module.css';
 /**
  * @param {object} props
  * @param {string} props.chat
- * @param {(chat: string) => void} props.setChat
- * @param {(params: { chat: string, target: OpenTarget }) => void} props.onSubmitChat
+ * @param {(chat: string) => void} props.onChange
+ * @param {(params: { chat: string, target: OpenTarget }) => void} props.onSubmit
  */
-export function AiChatForm({ chat, setChat, onSubmitChat }) {
+export function AiChatForm({ chat, onChange, onSubmit }) {
     const { t } = useTypedTranslationWith(/** @type {Strings} */ ({}));
     const platformName = usePlatformName();
 
@@ -27,21 +27,21 @@ export function AiChatForm({ chat, setChat, onSubmitChat }) {
     const disabled = chat.length === 0;
 
     /** @type {(event: SubmitEvent) => void} */
-    const onSubmit = (event) => {
+    const handleSubmit = (event) => {
         event.preventDefault();
         if (disabled) return;
-        onSubmitChat({
+        onSubmit({
             chat,
             target: 'same-tab',
         });
     };
 
     /** @type {(event: KeyboardEvent) => void} */
-    const onKeyDown = (event) => {
+    const handleKeyDown = (event) => {
         if (event.key === 'Enter' && !event.shiftKey) {
             event.preventDefault();
             if (disabled) return;
-            onSubmitChat({
+            onSubmit({
                 chat,
                 target: eventToTarget(event, platformName),
             });
@@ -49,7 +49,7 @@ export function AiChatForm({ chat, setChat, onSubmitChat }) {
     };
 
     /** @type {(event: import('preact').JSX.TargetedEvent<HTMLTextAreaElement>) => void} */
-    const onChange = (event) => {
+    const handleChange = (event) => {
         const form = formRef.current;
         const textArea = event.currentTarget;
 
@@ -63,11 +63,11 @@ export function AiChatForm({ chat, setChat, onSubmitChat }) {
             form?.classList.remove(styles.hasScroll);
         }
 
-        setChat(textArea.value);
+        onChange(textArea.value);
     };
 
     return (
-        <form ref={formRef} class={styles.form} onClick={() => textAreaRef.current?.focus()} onSubmit={onSubmit}>
+        <form ref={formRef} class={styles.form} onClick={() => textAreaRef.current?.focus()} onSubmit={handleSubmit}>
             <textarea
                 ref={textAreaRef}
                 class={styles.textarea}
@@ -76,8 +76,8 @@ export function AiChatForm({ chat, setChat, onSubmitChat }) {
                 aria-label={t('aiChatForm_placeholder')}
                 autoComplete="off"
                 rows={1}
-                onKeyDown={onKeyDown}
-                onChange={onChange}
+                onKeyDown={handleKeyDown}
+                onChange={handleChange}
             />
             <div class={styles.buttons}>
                 <button

--- a/special-pages/pages/new-tab/app/omnibar/components/Omnibar.js
+++ b/special-pages/pages/new-tab/app/omnibar/components/Omnibar.js
@@ -35,19 +35,19 @@ export function Omnibar({ mode, setMode, enableAi }) {
     };
 
     /** @type {(params: {suggestion: Suggestion, target: OpenTarget}) => void} */
-    const onOpenSuggestion = (params) => {
+    const handleOpenSuggestion = (params) => {
         openSuggestion(params);
         resetForm();
     };
 
     /** @type {(params: {term: string, target: OpenTarget}) => void} */
-    const onSubmitSearch = (params) => {
+    const handleSubmitSearch = (params) => {
         submitSearch(params);
         resetForm();
     };
 
     /** @type {(params: {chat: string, target: OpenTarget}) => void} */
-    const onSubmitChat = (params) => {
+    const handleSubmitChat = (params) => {
         submitChat(params);
         resetForm();
     };
@@ -55,18 +55,18 @@ export function Omnibar({ mode, setMode, enableAi }) {
     return (
         <div class={styles.root} data-mode={mode}>
             <LogoStacked class={styles.logo} aria-label={t('omnibar_logoAlt')} />
-            {enableAi && <TabSwitcher mode={mode} setMode={setMode} />}
+            {enableAi && <TabSwitcher mode={mode} onChange={setMode} />}
             <Container overflow={mode === 'search'}>
                 {mode === 'search' ? (
                     <SearchForm
                         key={`search-${resetKey}`}
                         term={query}
-                        setTerm={setQuery}
-                        onOpenSuggestion={onOpenSuggestion}
-                        onSubmitSearch={onSubmitSearch}
+                        onChangeTerm={setQuery}
+                        onOpenSuggestion={handleOpenSuggestion}
+                        onSubmitSearch={handleSubmitSearch}
                     />
                 ) : (
-                    <AiChatForm key={`chat-${resetKey}`} chat={query} setChat={setQuery} onSubmitChat={onSubmitChat} />
+                    <AiChatForm key={`chat-${resetKey}`} chat={query} onChange={setQuery} onSubmit={handleSubmitChat} />
                 )}
             </Container>
         </div>

--- a/special-pages/pages/new-tab/app/omnibar/components/SearchForm.js
+++ b/special-pages/pages/new-tab/app/omnibar/components/SearchForm.js
@@ -1,8 +1,7 @@
 import { h } from 'preact';
-import { useContext, useId } from 'preact/hooks';
+import { useId } from 'preact/hooks';
 import { SearchIcon } from '../../components/Icons.js';
 import { useTypedTranslationWith } from '../../types';
-import { OmnibarContext } from './OmnibarProvider';
 import styles from './SearchForm.module.css';
 import { SuggestionsList } from './SuggestionsList.js';
 import { useSuggestionInput } from './useSuggestionInput.js';
@@ -10,16 +9,18 @@ import { useSuggestions } from './useSuggestions';
 
 /**
  * @typedef {import('../strings.json')} Strings
+ * @typedef {import('../../../types/new-tab.js').Suggestion} Suggestion
+ * @typedef {import('../../../types/new-tab.js').OpenTarget} OpenTarget
  */
 
 /**
  * @param {object} props
  * @param {string} props.term
  * @param {(term: string) => void} props.setTerm
+ * @param {(params: {suggestion: Suggestion, target: OpenTarget}) => void} props.onOpenSuggestion
+ * @param {(params: {term: string, target: OpenTarget}) => void} props.onSubmitSearch
  */
-export function SearchForm({ term, setTerm }) {
-    const { submitSearch } = useContext(OmnibarContext);
-
+export function SearchForm({ term, setTerm, onOpenSuggestion, onSubmitSearch }) {
     const { t } = useTypedTranslationWith(/** @type {Strings} */ ({}));
     const suggestionsListId = useId();
 
@@ -37,6 +38,7 @@ export function SearchForm({ term, setTerm }) {
     } = useSuggestions({
         term,
         setTerm,
+        onOpenSuggestion,
     });
 
     const inputRef = useSuggestionInput(inputBase, inputSuggestion);
@@ -44,7 +46,7 @@ export function SearchForm({ term, setTerm }) {
     /** @type {(event: SubmitEvent) => void} */
     const onFormSubmit = (event) => {
         event.preventDefault();
-        submitSearch({
+        onSubmitSearch({
             term,
             target: 'same-tab',
         });
@@ -81,6 +83,7 @@ export function SearchForm({ term, setTerm }) {
                     selectedSuggestion={selectedSuggestion}
                     setSelectedSuggestion={setSelectedSuggestion}
                     clearSelectedSuggestion={clearSelectedSuggestion}
+                    onOpenSuggestion={onOpenSuggestion}
                 />
             )}
         </form>

--- a/special-pages/pages/new-tab/app/omnibar/components/SearchForm.js
+++ b/special-pages/pages/new-tab/app/omnibar/components/SearchForm.js
@@ -16,11 +16,11 @@ import { useSuggestions } from './useSuggestions';
 /**
  * @param {object} props
  * @param {string} props.term
- * @param {(term: string) => void} props.setTerm
+ * @param {(term: string) => void} props.onChangeTerm
  * @param {(params: {suggestion: Suggestion, target: OpenTarget}) => void} props.onOpenSuggestion
  * @param {(params: {term: string, target: OpenTarget}) => void} props.onSubmitSearch
  */
-export function SearchForm({ term, setTerm, onOpenSuggestion, onSubmitSearch }) {
+export function SearchForm({ term, onChangeTerm, onOpenSuggestion, onSubmitSearch }) {
     const { t } = useTypedTranslationWith(/** @type {Strings} */ ({}));
     const suggestionsListId = useId();
 
@@ -29,22 +29,22 @@ export function SearchForm({ term, setTerm, onOpenSuggestion, onSubmitSearch }) 
         selectedSuggestion,
         setSelectedSuggestion,
         clearSelectedSuggestion,
-        inputBase,
-        inputSuggestion,
-        onInputChange,
-        onInputKeyDown,
-        onInputClick,
-        onFormBlur,
+        termBase,
+        termSuggestion,
+        handleChange,
+        handleKeyDown,
+        handleClick,
+        handleBlur,
     } = useSuggestions({
         term,
-        setTerm,
+        onChangeTerm,
         onOpenSuggestion,
     });
 
-    const inputRef = useSuggestionInput(inputBase, inputSuggestion);
+    const inputRef = useSuggestionInput(termBase, termSuggestion);
 
     /** @type {(event: SubmitEvent) => void} */
-    const onFormSubmit = (event) => {
+    const handleSubmit = (event) => {
         event.preventDefault();
         onSubmitSearch({
             term,
@@ -53,7 +53,7 @@ export function SearchForm({ term, setTerm, onOpenSuggestion, onSubmitSearch }) 
     };
 
     return (
-        <form class={styles.form} onClick={() => inputRef.current?.focus()} onBlur={onFormBlur} onSubmit={onFormSubmit}>
+        <form class={styles.form} onClick={() => inputRef.current?.focus()} onBlur={handleBlur} onSubmit={handleSubmit}>
             <div class={styles.inputContainer}>
                 <SearchIcon inert />
                 <input
@@ -71,9 +71,9 @@ export function SearchForm({ term, setTerm, onOpenSuggestion, onSubmitSearch }) 
                     autoComplete="off"
                     autoCorrect="off"
                     autoCapitalize="off"
-                    onChange={onInputChange}
-                    onKeyDown={onInputKeyDown}
-                    onClick={onInputClick}
+                    onChange={handleChange}
+                    onKeyDown={handleKeyDown}
+                    onClick={handleClick}
                 />
             </div>
             {suggestions.length > 0 && (
@@ -81,8 +81,8 @@ export function SearchForm({ term, setTerm, onOpenSuggestion, onSubmitSearch }) 
                     id={suggestionsListId}
                     suggestions={suggestions}
                     selectedSuggestion={selectedSuggestion}
-                    setSelectedSuggestion={setSelectedSuggestion}
-                    clearSelectedSuggestion={clearSelectedSuggestion}
+                    onSelectSuggestion={setSelectedSuggestion}
+                    onClearSuggestion={clearSelectedSuggestion}
                     onOpenSuggestion={onOpenSuggestion}
                 />
             )}

--- a/special-pages/pages/new-tab/app/omnibar/components/SuggestionsList.js
+++ b/special-pages/pages/new-tab/app/omnibar/components/SuggestionsList.js
@@ -15,11 +15,11 @@ import styles from './SuggestionsList.module.css';
  * @param {string} props.id
  * @param {SuggestionModel[]} props.suggestions
  * @param {SuggestionModel | null} props.selectedSuggestion
- * @param {(suggestion: SuggestionModel) => void} props.setSelectedSuggestion
- * @param {() => void} props.clearSelectedSuggestion
+ * @param {(suggestion: SuggestionModel) => void} props.onSelectSuggestion
+ * @param {() => void} props.onClearSuggestion
  * @param {(params: {suggestion: Suggestion, target: OpenTarget}) => void} props.onOpenSuggestion
  */
-export function SuggestionsList({ id, suggestions, selectedSuggestion, setSelectedSuggestion, clearSelectedSuggestion, onOpenSuggestion }) {
+export function SuggestionsList({ id, suggestions, selectedSuggestion, onSelectSuggestion, onClearSuggestion, onOpenSuggestion }) {
     const platformName = usePlatformName();
     return (
         <div role="listbox" id={id} class={styles.list}>
@@ -31,12 +31,9 @@ export function SuggestionsList({ id, suggestions, selectedSuggestion, setSelect
                         id={suggestion.id}
                         class={styles.item}
                         aria-selected={suggestion === selectedSuggestion}
-                        onMouseOver={() => setSelectedSuggestion(suggestion)}
-                        onMouseLeave={() => clearSelectedSuggestion()}
-                        onClick={(event) => {
-                            event.preventDefault();
-                            onOpenSuggestion({ suggestion, target: eventToTarget(event, platformName) });
-                        }}
+                        onMouseOver={() => onSelectSuggestion(suggestion)}
+                        onMouseLeave={() => onClearSuggestion()}
+                        onClick={(event) => onOpenSuggestion({ suggestion, target: eventToTarget(event, platformName) })}
                     >
                         <SuggestionIcon suggestion={suggestion} />
                         {suggestion.title}

--- a/special-pages/pages/new-tab/app/omnibar/components/SuggestionsList.js
+++ b/special-pages/pages/new-tab/app/omnibar/components/SuggestionsList.js
@@ -1,13 +1,13 @@
 import { h } from 'preact';
-import { useContext } from 'preact/hooks';
 import { eventToTarget } from '../../../../../shared/handlers';
 import { BookmarkIcon, BrowserIcon, FavoriteIcon, GlobeIcon, HistoryIcon, SearchIcon } from '../../components/Icons';
 import { usePlatformName } from '../../settings.provider';
-import { OmnibarContext } from './OmnibarProvider';
 import styles from './SuggestionsList.module.css';
 
 /**
  * @typedef {import('./useSuggestions').SuggestionModel} SuggestionModel
+ * @typedef {import('../../../types/new-tab.js').Suggestion} Suggestion
+ * @typedef {import('../../../types/new-tab.js').OpenTarget} OpenTarget
  */
 
 /**
@@ -17,9 +17,9 @@ import styles from './SuggestionsList.module.css';
  * @param {SuggestionModel | null} props.selectedSuggestion
  * @param {(suggestion: SuggestionModel) => void} props.setSelectedSuggestion
  * @param {() => void} props.clearSelectedSuggestion
+ * @param {(params: {suggestion: Suggestion, target: OpenTarget}) => void} props.onOpenSuggestion
  */
-export function SuggestionsList({ id, suggestions, selectedSuggestion, setSelectedSuggestion, clearSelectedSuggestion }) {
-    const { openSuggestion } = useContext(OmnibarContext);
+export function SuggestionsList({ id, suggestions, selectedSuggestion, setSelectedSuggestion, clearSelectedSuggestion, onOpenSuggestion }) {
     const platformName = usePlatformName();
     return (
         <div role="listbox" id={id} class={styles.list}>
@@ -35,7 +35,7 @@ export function SuggestionsList({ id, suggestions, selectedSuggestion, setSelect
                         onMouseLeave={() => clearSelectedSuggestion()}
                         onClick={(event) => {
                             event.preventDefault();
-                            openSuggestion({ suggestion, target: eventToTarget(event, platformName) });
+                            onOpenSuggestion({ suggestion, target: eventToTarget(event, platformName) });
                         }}
                     >
                         <SuggestionIcon suggestion={suggestion} />

--- a/special-pages/pages/new-tab/app/omnibar/components/TabSwitcher.js
+++ b/special-pages/pages/new-tab/app/omnibar/components/TabSwitcher.js
@@ -13,20 +13,20 @@ import styles from './TabSwitcher.module.css';
 /**
  * @param {object} props
  * @param {OmnibarConfig['mode']} props.mode
- * @param {(mode: OmnibarConfig['mode']) => void} props.setMode
+ * @param {(mode: OmnibarConfig['mode']) => void} props.onChange
  */
-export function TabSwitcher({ mode, setMode }) {
+export function TabSwitcher({ mode, onChange }) {
     const { t } = useTypedTranslationWith(/** @type {Strings} */ ({}));
     const { main } = useContext(CustomizerThemesContext);
     const Blob = main.value === 'light' ? BlobLight : BlobDark;
     return (
         <div class={styles.tabSwitcher} role="tablist" aria-label={t('omnibar_tabSwitcherLabel')}>
             <Blob class={styles.blob} style={{ translate: mode === 'search' ? 0 : 92 }} />
-            <button class={styles.tab} role="tab" aria-selected={mode === 'search'} onClick={() => setMode('search')}>
+            <button class={styles.tab} role="tab" aria-selected={mode === 'search'} onClick={() => onChange('search')}>
                 {mode === 'search' ? <SearchColorIcon /> : <SearchIcon />}
                 <span class={styles.tabLabel}>{t('omnibar_searchTabLabel')}</span>
             </button>
-            <button class={styles.tab} role="tab" aria-selected={mode === 'ai'} onClick={() => setMode('ai')}>
+            <button class={styles.tab} role="tab" aria-selected={mode === 'ai'} onClick={() => onChange('ai')}>
                 {mode === 'ai' ? <AiChatColorIcon /> : <AiChatIcon />}
                 <span class={styles.tabLabel}>{t('omnibar_aiTabLabel')}</span>
             </button>

--- a/special-pages/pages/new-tab/app/omnibar/components/useSuggestions.js
+++ b/special-pages/pages/new-tab/app/omnibar/components/useSuggestions.js
@@ -5,6 +5,7 @@ import { OmnibarContext } from './OmnibarProvider.js';
 
 /**
  * @typedef {import('../../../types/new-tab.js').Suggestion} Suggestion
+ * @typedef {import('../../../types/new-tab.js').OpenTarget} OpenTarget
  */
 
 /**
@@ -119,9 +120,10 @@ function reducer(state, action) {
  * @param {object} props
  * @param {string} props.term
  * @param {(term: string) => void} props.setTerm
+ * @param {(params: {suggestion: Suggestion, target: OpenTarget}) => void} props.onOpenSuggestion
  */
-export function useSuggestions({ term, setTerm }) {
-    const { onSuggestions, getSuggestions, openSuggestion } = useContext(OmnibarContext);
+export function useSuggestions({ term, setTerm, onOpenSuggestion }) {
+    const { onSuggestions, getSuggestions } = useContext(OmnibarContext);
     const platformName = usePlatformName();
     const [state, dispatch] = useReducer(reducer, initialState);
 
@@ -222,7 +224,7 @@ export function useSuggestions({ term, setTerm }) {
             case 'Enter':
                 if (selectedSuggestion) {
                     event.preventDefault();
-                    openSuggestion({ suggestion: selectedSuggestion, target: eventToTarget(event, platformName) });
+                    onOpenSuggestion({ suggestion: selectedSuggestion, target: eventToTarget(event, platformName) });
                 }
                 break;
         }

--- a/special-pages/pages/new-tab/app/omnibar/components/useSuggestions.js
+++ b/special-pages/pages/new-tab/app/omnibar/components/useSuggestions.js
@@ -119,10 +119,10 @@ function reducer(state, action) {
 /**
  * @param {object} props
  * @param {string} props.term
- * @param {(term: string) => void} props.setTerm
+ * @param {(term: string) => void} props.onChangeTerm
  * @param {(params: {suggestion: Suggestion, target: OpenTarget}) => void} props.onOpenSuggestion
  */
-export function useSuggestions({ term, setTerm, onOpenSuggestion }) {
+export function useSuggestions({ term, onChangeTerm: setTerm, onOpenSuggestion }) {
     const { onSuggestions, getSuggestions } = useContext(OmnibarContext);
     const platformName = usePlatformName();
     const [state, dispatch] = useReducer(reducer, initialState);
@@ -139,19 +139,19 @@ export function useSuggestions({ term, setTerm, onOpenSuggestion }) {
         dispatch({ type: 'clearSelectedSuggestion' });
     };
 
-    let inputBase, inputSuggestion;
+    let termBase, termSuggestion;
     if (!selectedSuggestion) {
-        inputBase = term;
-        inputSuggestion = '';
+        termBase = term;
+        termSuggestion = '';
     } else if ('url' in selectedSuggestion && startsWithIgnoreCase(selectedSuggestion.url, term)) {
-        inputBase = term;
-        inputSuggestion = selectedSuggestion.url.slice(term.length);
+        termBase = term;
+        termSuggestion = selectedSuggestion.url.slice(term.length);
     } else if (startsWithIgnoreCase(selectedSuggestion.title, term)) {
-        inputBase = term;
-        inputSuggestion = selectedSuggestion.title.slice(term.length);
+        termBase = term;
+        termSuggestion = selectedSuggestion.title.slice(term.length);
     } else {
-        inputBase = '';
-        inputSuggestion = selectedSuggestion.title;
+        termBase = '';
+        termSuggestion = selectedSuggestion.title;
     }
 
     useEffect(() => {
@@ -174,7 +174,7 @@ export function useSuggestions({ term, setTerm, onOpenSuggestion }) {
     }, [onSuggestions]);
 
     /** @type {(event: import('preact').JSX.TargetedEvent<HTMLInputElement>) => void} */
-    const onInputChange = (event) => {
+    const handleChange = (event) => {
         const term = event.currentTarget.value;
         setTerm(term);
 
@@ -188,7 +188,7 @@ export function useSuggestions({ term, setTerm, onOpenSuggestion }) {
     };
 
     /** @type {(event: KeyboardEvent) => void} */
-    const onInputKeyDown = (event) => {
+    const handleKeyDown = (event) => {
         switch (event.key) {
             case 'ArrowUp':
                 if (!state.suggestionsVisible) {
@@ -213,7 +213,7 @@ export function useSuggestions({ term, setTerm, onOpenSuggestion }) {
             case 'ArrowLeft':
             case 'ArrowRight':
                 if (selectedSuggestion) {
-                    setTerm(inputBase + inputSuggestion);
+                    setTerm(termBase + termSuggestion);
                     dispatch({ type: 'clearSelectedSuggestion' });
                 }
                 break;
@@ -230,15 +230,15 @@ export function useSuggestions({ term, setTerm, onOpenSuggestion }) {
         }
     };
 
-    const onInputClick = () => {
+    const handleClick = () => {
         if (selectedSuggestion) {
-            setTerm(inputBase + inputSuggestion);
+            setTerm(termBase + termSuggestion);
             dispatch({ type: 'clearSelectedSuggestion' });
         }
     };
 
     /** @type {(event: import('preact').JSX.TargetedFocusEvent<HTMLFormElement>) => void} */
-    const onFormBlur = (event) => {
+    const handleBlur = (event) => {
         // Ignore blur events cauesd by moving focus to an element inside the form
         if (event.relatedTarget instanceof Node && event.currentTarget.contains(event.relatedTarget)) {
             return;
@@ -252,12 +252,12 @@ export function useSuggestions({ term, setTerm, onOpenSuggestion }) {
         selectedSuggestion,
         setSelectedSuggestion,
         clearSelectedSuggestion,
-        inputBase,
-        inputSuggestion,
-        onInputChange,
-        onInputKeyDown,
-        onInputClick,
-        onFormBlur,
+        termBase,
+        termSuggestion,
+        handleChange,
+        handleKeyDown,
+        handleClick,
+        handleBlur,
     };
 }
 

--- a/special-pages/pages/new-tab/app/omnibar/integration-tests/omnibar.spec.js
+++ b/special-pages/pages/new-tab/app/omnibar/integration-tests/omnibar.spec.js
@@ -27,6 +27,9 @@ test.describe('omnibar widget', () => {
             term: 'pizza',
             target: 'same-tab',
         });
+
+        // Form should be reset to blank state after submission
+        await omnibar.expectInputValue('');
     });
 
     test('AI chat form submission via button click', async ({ page }, workerInfo) => {
@@ -47,6 +50,9 @@ test.describe('omnibar widget', () => {
             chat: 'pizza',
             target: 'same-tab',
         });
+
+        // Form should be reset to blank state after submission
+        await expect(omnibar.chatInput()).toHaveValue('');
     });
 
     test('AI chat keyboard behavior', async ({ page }, workerInfo) => {
@@ -78,6 +84,9 @@ test.describe('omnibar widget', () => {
             chat: 'first line\nsecond line',
             target: 'same-tab',
         });
+
+        // Form should be reset to blank state after submission
+        await expect(omnibar.chatInput()).toHaveValue('');
     });
 
     test('mode switching preserves query state', async ({ page }, workerInfo) => {
@@ -204,6 +213,9 @@ test.describe('omnibar widget', () => {
             }),
             target: 'same-tab',
         });
+
+        // Form should be reset to blank state after suggestion selection
+        await omnibar.expectInputValue('');
     });
 
     test('clicking on a suggestion should open it', async ({ page }, workerInfo) => {
@@ -228,6 +240,9 @@ test.describe('omnibar widget', () => {
             }),
             target: 'same-tab',
         });
+
+        // Form should be reset to blank state after suggestion selection
+        await omnibar.expectInputValue('');
     });
 
     test('mouse over should select suggestion, mouse out should clear selection', async ({ page }, workerInfo) => {


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1209121419454298/task/1210771515454552?focus=true

## Description

Resets the omnibar component after submitting the form or selecting a suggestion.

Also renames props/handlers to use `handleVerbNoun` and `onVerbNoun` consistently. 

## Testing Steps

- <!-- Include simple steps on how to check this change is working. Write "N/A" if not applicable. -->

## Checklist

*Please tick all that apply:*

- [x] I have tested this change locally
- [ ] I have tested this change locally in all supported browsers
- [ ] This change will be visible to users
- [x] I have added automated tests that cover this change
- [x] I have ensured the change is gated by config
- [ ] This change was covered by a ship review
- [ ] This change was covered by a tech design
- [x] Any dependent config has been merged

