### PR TITLE
NTP: Fix Omnibar TabSwitcher icon shifting by 1px when animating in WebKit

### DIFF
--- a/special-pages/pages/new-tab/app/omnibar/components/TabSwitcher.module.css
+++ b/special-pages/pages/new-tab/app/omnibar/components/TabSwitcher.module.css
@@ -17,7 +17,6 @@
     gap: 6px;
     height: var(--sp-8);
     justify-content: center;
-    padding: 0 var(--sp-4);
     padding: 0;
     width: 92px;
     z-index: 1;
@@ -38,6 +37,7 @@
     position: absolute;
     top: 0;
     transition: translate 200ms ease;
+    will-change: translate;
 
     @media (prefers-reduced-motion: reduce) {
         transition: none;


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1209121419454298/task/1210785568574508?focus=true

## Description

In Safari/WebKit, toggling between the Search and Duck.ai tabs causes the icon to shift by 1px. Likely due to a subpixel / compositing bug. Adding `will-change` seems to fix it.

## Testing Steps

1. Go to https://deploy-preview-1822--content-scope-scripts.netlify.app/build/pages/new-tab/?omnibar=true in Safari or DuckDuckGo on macOS.
2. Toggle between the Search and Duck.ai tabs. Icon in the tab switcher should not move.

## Checklist

*Please tick all that apply:*

- [x] I have tested this change locally
- [x] I have tested this change locally in all supported browsers
- [ ] This change will be visible to users
- [ ] I have added automated tests that cover this change
- [x] I have ensured the change is gated by config
- [ ] This change was covered by a ship review
- [ ] This change was covered by a tech design
- [x] Any dependent config has been merged

