### PR TITLE
NTP: Set target to 'new-tab' and 'new-window' properly when submitting Omnibar

### DIFF
--- a/special-pages/pages/new-tab/app/omnibar/components/AiChatForm.js
+++ b/special-pages/pages/new-tab/app/omnibar/components/AiChatForm.js
@@ -48,6 +48,17 @@ export function AiChatForm({ chat, setChat }) {
         }
     };
 
+    /** @type {(event: MouseEvent) => void} */
+    const handleClickSubmit = (event) => {
+        event.preventDefault();
+        if (disabled) return;
+        event.stopPropagation();
+        submitChat({
+            chat,
+            target: eventToTarget(event, platformName),
+        });
+    };
+
     /** @type {(event: import('preact').JSX.TargetedEvent<HTMLTextAreaElement>) => void} */
     const onChange = (event) => {
         const form = formRef.current;
@@ -85,6 +96,8 @@ export function AiChatForm({ chat, setChat }) {
                     class={styles.submitButton}
                     aria-label={t('aiChatForm_submitButtonLabel')}
                     disabled={chat.length === 0}
+                    onClick={handleClickSubmit}
+                    onAuxClick={handleClickSubmit}
                 >
                     <ArrowRightIcon />
                 </button>

--- a/special-pages/pages/new-tab/app/omnibar/components/useSuggestions.js
+++ b/special-pages/pages/new-tab/app/omnibar/components/useSuggestions.js
@@ -121,7 +121,7 @@ function reducer(state, action) {
  * @param {(term: string) => void} props.setTerm
  */
 export function useSuggestions({ term, setTerm }) {
-    const { onSuggestions, getSuggestions, openSuggestion } = useContext(OmnibarContext);
+    const { onSuggestions, getSuggestions, openSuggestion, submitSearch } = useContext(OmnibarContext);
     const platformName = usePlatformName();
     const [state, dispatch] = useReducer(reducer, initialState);
 
@@ -220,9 +220,11 @@ export function useSuggestions({ term, setTerm }) {
                 dispatch({ type: 'hideSuggestions' });
                 break;
             case 'Enter':
+                event.preventDefault();
                 if (selectedSuggestion) {
-                    event.preventDefault();
                     openSuggestion({ suggestion: selectedSuggestion, target: eventToTarget(event, platformName) });
+                } else {
+                    submitSearch({ term, target: eventToTarget(event, platformName) });
                 }
                 break;
         }

--- a/special-pages/pages/new-tab/app/omnibar/integration-tests/omnibar.spec.js
+++ b/special-pages/pages/new-tab/app/omnibar/integration-tests/omnibar.spec.js
@@ -46,7 +46,7 @@ test.describe('omnibar widget', () => {
         });
     });
 
-    test('search form submission with cmd+enter (mac) or ctrl+enter (non-mac) submits to new-tab', async ({ page }, workerInfo) => {
+    test('search form submission with cmd+enter submits to new-tab', async ({ page }, workerInfo) => {
         const ntp = NewtabPage.create(page, workerInfo);
         const omnibar = new OmnibarPage(ntp);
 
@@ -55,13 +55,7 @@ test.describe('omnibar widget', () => {
         await omnibar.ready();
 
         await omnibar.searchInput().fill('pizza');
-
-        const isMac = process.platform === 'darwin';
-        if (isMac) {
-            await omnibar.searchInput().press('Meta+Enter');
-        } else {
-            await omnibar.searchInput().press('Control+Enter');
-        }
+        await omnibar.searchInput().press('Meta+Enter');
 
         await omnibar.expectMethodCalledWith('omnibar_submitSearch', {
             term: 'pizza',
@@ -109,7 +103,7 @@ test.describe('omnibar widget', () => {
         });
     });
 
-    test('AI chat submit button with cmd+click (mac) or ctrl+click (non-mac) submits to new-tab', async ({ page }, workerInfo) => {
+    test('AI chat submit button with cmd+click submits to new-tab', async ({ page }, workerInfo) => {
         const ntp = NewtabPage.create(page, workerInfo);
         const omnibar = new OmnibarPage(ntp);
         await ntp.reducedMotion();
@@ -121,13 +115,7 @@ test.describe('omnibar widget', () => {
         await omnibar.expectMode('ai');
 
         await omnibar.chatInput().fill('pizza');
-
-        const isMac = process.platform === 'darwin';
-        if (isMac) {
-            await omnibar.chatSubmitButton().click({ modifiers: ['Meta'] });
-        } else {
-            await omnibar.chatSubmitButton().click({ modifiers: ['Control'] });
-        }
+        await omnibar.chatSubmitButton().click({ modifiers: ['Meta'] });
 
         await omnibar.expectMethodCalledWith('omnibar_submitChat', {
             chat: 'pizza',
@@ -166,7 +154,7 @@ test.describe('omnibar widget', () => {
         });
     });
 
-    test('AI chat sumission with cmd+enter (mac) or ctrl+enter (non-mac) submits to new-tab', async ({ page }, workerInfo) => {
+    test('AI chat sumission with cmd+enter submits to new-tab', async ({ page }, workerInfo) => {
         const ntp = NewtabPage.create(page, workerInfo);
         const omnibar = new OmnibarPage(ntp);
         await ntp.reducedMotion();
@@ -178,13 +166,7 @@ test.describe('omnibar widget', () => {
         await omnibar.expectMode('ai');
 
         await omnibar.chatInput().fill('pizza');
-
-        const isMac = process.platform === 'darwin';
-        if (isMac) {
-            await omnibar.chatInput().press('Meta+Enter');
-        } else {
-            await omnibar.chatInput().press('Control+Enter');
-        }
+        await omnibar.chatInput().press('Meta+Enter');
 
         await omnibar.expectMethodCalledWith('omnibar_submitChat', {
             chat: 'pizza',

--- a/special-pages/pages/new-tab/app/omnibar/integration-tests/omnibar.spec.js
+++ b/special-pages/pages/new-tab/app/omnibar/integration-tests/omnibar.spec.js
@@ -29,7 +29,47 @@ test.describe('omnibar widget', () => {
         });
     });
 
-    test('AI chat form submission via button click', async ({ page }, workerInfo) => {
+    test('search form submission with shift+enter submits to new-window', async ({ page }, workerInfo) => {
+        const ntp = NewtabPage.create(page, workerInfo);
+        const omnibar = new OmnibarPage(ntp);
+
+        await ntp.reducedMotion();
+        await ntp.openPage({ additional: { omnibar: true } });
+        await omnibar.ready();
+
+        await omnibar.searchInput().fill('pizza');
+        await omnibar.searchInput().press('Shift+Enter');
+
+        await omnibar.expectMethodCalledWith('omnibar_submitSearch', {
+            term: 'pizza',
+            target: 'new-window',
+        });
+    });
+
+    test('search form submission with cmd+enter (mac) or ctrl+enter (non-mac) submits to new-tab', async ({ page }, workerInfo) => {
+        const ntp = NewtabPage.create(page, workerInfo);
+        const omnibar = new OmnibarPage(ntp);
+
+        await ntp.reducedMotion();
+        await ntp.openPage({ additional: { omnibar: true } });
+        await omnibar.ready();
+
+        await omnibar.searchInput().fill('pizza');
+
+        const isMac = process.platform === 'darwin';
+        if (isMac) {
+            await omnibar.searchInput().press('Meta+Enter');
+        } else {
+            await omnibar.searchInput().press('Control+Enter');
+        }
+
+        await omnibar.expectMethodCalledWith('omnibar_submitSearch', {
+            term: 'pizza',
+            target: 'new-tab',
+        });
+    });
+
+    test('AI chat submit button', async ({ page }, workerInfo) => {
         const ntp = NewtabPage.create(page, workerInfo);
         const omnibar = new OmnibarPage(ntp);
         await ntp.reducedMotion();
@@ -46,6 +86,52 @@ test.describe('omnibar widget', () => {
         await omnibar.expectMethodCalledWith('omnibar_submitChat', {
             chat: 'pizza',
             target: 'same-tab',
+        });
+    });
+
+    test('AI chat submit button with shift+click submits to new-window', async ({ page }, workerInfo) => {
+        const ntp = NewtabPage.create(page, workerInfo);
+        const omnibar = new OmnibarPage(ntp);
+        await ntp.reducedMotion();
+
+        await ntp.openPage({ additional: { omnibar: true } });
+        await omnibar.ready();
+
+        await omnibar.aiTab().click();
+        await omnibar.expectMode('ai');
+
+        await omnibar.chatInput().fill('pizza');
+        await omnibar.chatSubmitButton().click({ modifiers: ['Shift'] });
+
+        await omnibar.expectMethodCalledWith('omnibar_submitChat', {
+            chat: 'pizza',
+            target: 'new-window',
+        });
+    });
+
+    test('AI chat submit button with cmd+click (mac) or ctrl+click (non-mac) submits to new-tab', async ({ page }, workerInfo) => {
+        const ntp = NewtabPage.create(page, workerInfo);
+        const omnibar = new OmnibarPage(ntp);
+        await ntp.reducedMotion();
+
+        await ntp.openPage({ additional: { omnibar: true } });
+        await omnibar.ready();
+
+        await omnibar.aiTab().click();
+        await omnibar.expectMode('ai');
+
+        await omnibar.chatInput().fill('pizza');
+
+        const isMac = process.platform === 'darwin';
+        if (isMac) {
+            await omnibar.chatSubmitButton().click({ modifiers: ['Meta'] });
+        } else {
+            await omnibar.chatSubmitButton().click({ modifiers: ['Control'] });
+        }
+
+        await omnibar.expectMethodCalledWith('omnibar_submitChat', {
+            chat: 'pizza',
+            target: 'new-tab',
         });
     });
 
@@ -77,6 +163,32 @@ test.describe('omnibar widget', () => {
         await omnibar.expectMethodCalledWith('omnibar_submitChat', {
             chat: 'first line\nsecond line',
             target: 'same-tab',
+        });
+    });
+
+    test('AI chat sumission with cmd+enter (mac) or ctrl+enter (non-mac) submits to new-tab', async ({ page }, workerInfo) => {
+        const ntp = NewtabPage.create(page, workerInfo);
+        const omnibar = new OmnibarPage(ntp);
+        await ntp.reducedMotion();
+
+        await ntp.openPage({ additional: { omnibar: true } });
+        await omnibar.ready();
+
+        await omnibar.aiTab().click();
+        await omnibar.expectMode('ai');
+
+        await omnibar.chatInput().fill('pizza');
+
+        const isMac = process.platform === 'darwin';
+        if (isMac) {
+            await omnibar.chatInput().press('Meta+Enter');
+        } else {
+            await omnibar.chatInput().press('Control+Enter');
+        }
+
+        await omnibar.expectMethodCalledWith('omnibar_submitChat', {
+            chat: 'pizza',
+            target: 'new-tab',
         });
     });
 


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1209121419454298/task/1210783311211753?focus=true

## Description

`target` in `omnibar_submitSearch` and `omnibar_submitChat` should be `new-window` if shift is held down or `new-tab` if cmd is held down.

## Testing Steps

Tests are included. You can manually verify by loading https://deploy-preview-1824--content-scope-scripts.netlify.app/build/pages/new-tab/?omnibar=true and inspecting the `target` field of the payload in the `omnibar_submitSearch` and `omnibar_submitSearch` notifications that are logged in DevTools when submitting the Search or Duck.ai inputs.

## Checklist

*Please tick all that apply:*

- [x] I have tested this change locally
- [ ] I have tested this change locally in all supported browsers
- [ ] This change will be visible to users
- [x] I have added automated tests that cover this change
- [x] I have ensured the change is gated by config
- [ ] This change was covered by a ship review
- [ ] This change was covered by a tech design
- [x] Any dependent config has been merged

