### PR TITLE
NTP: Display URL in if Omnibar suggestion title is empty

### DIFF
--- a/special-pages/package.json
+++ b/special-pages/package.json
@@ -10,7 +10,7 @@
     "build": "node index.mjs",
     "build.dev": "npm run build -- --env development",
     "lint-fix": "cd ../ && npm run lint-fix",
-    "test-unit": "node --test \"unit-test/*\" \"pages/history/unit-tests/*\" \"pages/duckplayer/unit-tests/*\" \"pages/new-tab/unit-tests/*\" \"pages/new-tab/app/freemium-pir-banner/unit-tests/*\"",
+    "test-unit": "node --test \"unit-test/*\" \"pages/history/unit-tests/*\" \"pages/duckplayer/unit-tests/*\" \"pages/new-tab/app/freemium-pir-banner/unit-tests/*\" \"pages/new-tab/app/omnibar/unit-tests/*\"",
     "test-int": "playwright test --grep-invert '@screenshots'",
     "test-int-x": "npm run test-int",
     "test-int-snapshots": "playwright test --grep '@screenshots'",

--- a/special-pages/pages/new-tab/app/omnibar/components/useSuggestions.js
+++ b/special-pages/pages/new-tab/app/omnibar/components/useSuggestions.js
@@ -1,6 +1,7 @@
 import { useContext, useEffect, useReducer } from 'preact/hooks';
 import { eventToTarget } from '../../../../../shared/handlers.js';
 import { usePlatformName } from '../../settings.provider.js';
+import { getSuggestionTitle } from '../utils.js';
 import { OmnibarContext } from './OmnibarProvider.js';
 
 /**
@@ -262,36 +263,6 @@ export function useSuggestions({ term, onChangeTerm, onOpenSuggestion, onSubmitS
         handleClick,
         handleBlur,
     };
-}
-
-/**
- * @param {Suggestion} suggestion
- * @returns {string}
- */
-export function getSuggestionTitle(suggestion) {
-    switch (suggestion.kind) {
-        case 'bookmark':
-        case 'historyEntry':
-        case 'internalPage':
-            return suggestion.title || getDisplayURL(suggestion.url);
-        case 'phrase':
-            return suggestion.phrase;
-        case 'openTab':
-            return suggestion.title;
-        case 'website':
-            return getDisplayURL(suggestion.url);
-        default:
-            throw new Error('Unknown suggestion kind');
-    }
-}
-
-/**
- * @param {string} url
- * @returns {string}
- */
-function getDisplayURL(url) {
-    const { host, pathname, search, hash } = new URL(url);
-    return host + pathname + search + hash;
 }
 
 /**

--- a/special-pages/pages/new-tab/app/omnibar/unit-tests/utils.spec.js
+++ b/special-pages/pages/new-tab/app/omnibar/unit-tests/utils.spec.js
@@ -1,9 +1,9 @@
 import { test } from 'node:test';
 import { equal, throws } from 'node:assert/strict';
-import { getSuggestionTitle } from '../app/omnibar/components/useSuggestions.js';
+import { getSuggestionTitle } from '../utils.js';
 
 /**
- * @typedef {import('../types/new-tab.js').Suggestion} Suggestion
+ * @typedef {import('../../../types/new-tab.js').Suggestion} Suggestion
  */
 
 test.describe('getSuggestionTitle', () => {
@@ -15,7 +15,7 @@ test.describe('getSuggestionTitle', () => {
 
     test('returns display URL for bookmark without title', () => {
         /** @type {Suggestion} */
-        const suggestion = { kind: 'bookmark', title: '', url: 'dominos.com/order?pizza#special', isFavorite: false, score: 96 };
+        const suggestion = { kind: 'bookmark', title: '', url: 'https://dominos.com/order?pizza#special', isFavorite: false, score: 96 };
         equal(getSuggestionTitle(suggestion), 'dominos.com/order?pizza#special');
     });
 

--- a/special-pages/pages/new-tab/app/omnibar/utils.js
+++ b/special-pages/pages/new-tab/app/omnibar/utils.js
@@ -1,0 +1,33 @@
+/**
+ * @typedef {import('../../types/new-tab.js').Suggestion} Suggestion
+ */
+
+/**
+ * @param {Suggestion} suggestion
+ * @returns {string}
+ */
+export function getSuggestionTitle(suggestion) {
+    switch (suggestion.kind) {
+        case 'bookmark':
+        case 'historyEntry':
+        case 'internalPage':
+            return suggestion.title || getDisplayURL(suggestion.url);
+        case 'phrase':
+            return suggestion.phrase;
+        case 'openTab':
+            return suggestion.title;
+        case 'website':
+            return getDisplayURL(suggestion.url);
+        default:
+            throw new Error('Unknown suggestion kind');
+    }
+}
+
+/**
+ * @param {string} url
+ * @returns {string}
+ */
+function getDisplayURL(url) {
+    const { host, pathname, search, hash } = new URL(url);
+    return host + pathname + search + hash;
+}


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1209121419454298/task/1210784594537118

## Description

Show `suggestion.title || suggestion.url` instead of simply `suggestion.title`.

## Testing Steps

I couldn’t reproduce this, but unit tests are included.

## Checklist

*Please tick all that apply:*

- [x] I have tested this change locally
- [ ] I have tested this change locally in all supported browsers
- [ ] This change will be visible to users
- [x] I have added automated tests that cover this change
- [x] I have ensured the change is gated by config
- [] This change was covered by a ship review
- [ ] This change was covered by a tech design
- [x] Any dependent config has been merged

