### PR TITLE
cache the result of isAppleSilicon()

### DIFF
--- a/injected/src/utils.js
+++ b/injected/src/utils.js
@@ -305,7 +305,7 @@ const functionMap = {
         debugger;
     },
 
-    noop: () => { },
+    noop: () => {},
 };
 
 /**

--- a/injected/src/utils.js
+++ b/injected/src/utils.js
@@ -269,7 +269,8 @@ function isAppleSilicon() {
 
     // Best guess if the device is an Apple Silicon
     // https://stackoverflow.com/a/65412357
-    isAppleSiliconCache = gl?.getSupportedExtensions()?.indexOf('WEBGL_compressed_texture_etc') !== -1;
+    const compressedTextureValue = gl?.getSupportedExtensions()?.indexOf('WEBGL_compressed_texture_etc');
+    isAppleSiliconCache = typeof compressedTextureValue === 'number' && compressedTextureValue !== -1;
     return isAppleSiliconCache;
 }
 

--- a/injected/src/utils.js
+++ b/injected/src/utils.js
@@ -7,6 +7,8 @@ let globalObj = typeof window === 'undefined' ? globalThis : window;
 let Error = globalObj.Error;
 let messageSecret;
 
+let isAppleSiliconCache = null;
+
 // save a reference to original CustomEvent amd dispatchEvent so they can't be overriden to forge messages
 export const OriginalCustomEvent = typeof CustomEvent === 'undefined' ? null : CustomEvent;
 export const originalWindowDispatchEvent = typeof window === 'undefined' ? null : window.dispatchEvent.bind(window);
@@ -258,13 +260,17 @@ export function camelcase(dashCaseText) {
 
 // We use this method to detect M1 macs and set appropriate API values to prevent sites from detecting fingerprinting protections
 function isAppleSilicon() {
+    // Cache the result since hardware doesn't change
+    if (isAppleSiliconCache !== null) {
+        return isAppleSiliconCache;
+    }
     const canvas = document.createElement('canvas');
     const gl = canvas.getContext('webgl');
 
     // Best guess if the device is an Apple Silicon
     // https://stackoverflow.com/a/65412357
-    // @ts-expect-error - Object is possibly 'null'
-    return gl.getSupportedExtensions().indexOf('WEBGL_compressed_texture_etc') !== -1;
+    isAppleSiliconCache = gl?.getSupportedExtensions()?.indexOf('WEBGL_compressed_texture_etc') !== -1;
+    return isAppleSiliconCache;
 }
 
 /**
@@ -299,7 +305,7 @@ const functionMap = {
         debugger;
     },
 
-    noop: () => {},
+    noop: () => { },
 };
 
 /**


### PR DESCRIPTION
**Asana Task/Github Issue:** <!-- Link to Asana Task/Github Issue -->

## Description

noticed this when working on https://app.asana.com/1/137249556945/project/1206777341262243/task/1210285801262935?focus=true. It causes "too many gl contexts" errors in Outlook

## Testing Steps

- <!-- Include simple steps on how to check this change is working. Write "N/A" if not applicable. -->

## Checklist

<!--
  These questions are a friendly reminder to shipping code, if you're uncertain ask the AoR owners.
  It's also totally appropriate to not check some of these boxes, if they don't apply to your change.
-->
*Please tick all that apply:*

- [ ] I have tested this change locally
- [ ] I have tested this change locally in all supported browsers
- [ ] This change will be visible to users
- [ ] I have added automated tests that cover this change
- [ ] I have ensured the change is gated by config
- [ ] This change was covered by a ship review
- [ ] This change was covered by a tech design
- [ ] Any dependent config has been merged

