### PR TITLE
Use rgba() for disabled text color in AiChatForm styles

### DIFF
--- a/special-pages/pages/new-tab/app/omnibar/components/AiChatForm.module.css
+++ b/special-pages/pages/new-tab/app/omnibar/components/AiChatForm.module.css
@@ -55,7 +55,7 @@
 
     &[disabled] {
         background: none;
-        color: var(--color-black-at-30);
+        color: rgba(0, 0, 0, 0.3);
         cursor: default;
     }
 


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1209121419454298/task/1210842882517716?focus=true

## Description

Fix the colour of the AI Chat form’s submit button when disabled. `--color-black-at-30` doesn’t exist.

## Testing Steps

Browse to https://deploy-preview-1837--content-scope-scripts.netlify.app/build/pages/new-tab/?omnibar=true and click on the Duck.ai tab.

## Checklist

*Please tick all that apply:*

- [x] I have tested this change locally
- [x] I have tested this change locally in all supported browsers
- [ ] This change will be visible to users
- [ ] I have added automated tests that cover this change
- [x] I have ensured the change is gated by config
- [ ] This change was covered by a ship review
- [ ] This change was covered by a tech design
- [x] Any dependent config has been merged

