### PR TITLE
NTP Omnibar: Grow container when focused to accomodate focus ring

### DIFF
--- a/special-pages/pages/new-tab/app/omnibar/components/Container.module.css
+++ b/special-pages/pages/new-tab/app/omnibar/components/Container.module.css
@@ -19,6 +19,8 @@
     &:focus-within {
         border-radius: 14px;
         box-shadow: 0 0 0 2px var(--ntp-color-primary), 0 0 0 4px rgba(57, 105, 239, 0.2);
+        margin: 0 calc(-1 * var(--sp-1) - 3px);
+        padding: 0 3px;
     }
 
     &:has([role="listbox"]) {


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1209121419454298/task/1210842882517724?focus=true

## Description

Grow the container by 3px when focused to accomodate the focus ring.

## Testing Steps

Browse to https://deploy-preview-1839--content-scope-scripts.netlify.app/build/pages/new-tab/?omnibar=true and type into the Search or Duck.ai fields.

## Checklist

*Please tick all that apply:*

- [x] I have tested this change locally
- [x] I have tested this change locally in all supported browsers
- [ ] This change will be visible to users
- [ ] I have added automated tests that cover this change
- [x] I have ensured the change is gated by config
- [ ] This change was covered by a ship review
- [ ] This change was covered by a tech design
- [x] Any dependent config has been merged

