### PR TITLE
NTP Omnibar: Refactor TabSwitcher to use CSS for blob and CSS grid for sizing

### DIFF
--- a/special-pages/pages/new-tab/app/omnibar/components/TabSwitcher.js
+++ b/special-pages/pages/new-tab/app/omnibar/components/TabSwitcher.js
@@ -1,7 +1,5 @@
 import { h } from 'preact';
-import { useContext } from 'preact/hooks';
 import { AiChatColorIcon, AiChatIcon, SearchColorIcon, SearchIcon } from '../../components/Icons.js';
-import { CustomizerThemesContext } from '../../customizer/CustomizerProvider.js';
 import { useTypedTranslationWith } from '../../types';
 import styles from './TabSwitcher.module.css';
 
@@ -17,11 +15,14 @@ import styles from './TabSwitcher.module.css';
  */
 export function TabSwitcher({ mode, onChange }) {
     const { t } = useTypedTranslationWith(/** @type {Strings} */ ({}));
-    const { main } = useContext(CustomizerThemesContext);
-    const Blob = main.value === 'light' ? BlobLight : BlobDark;
     return (
-        <div class={styles.tabSwitcher} role="tablist" aria-label={t('omnibar_tabSwitcherLabel')}>
-            <Blob class={styles.blob} style={{ translate: mode === 'search' ? 0 : 92 }} />
+        <div
+            class={styles.tabSwitcher}
+            style={{ '--tab-count': 2, '--tab-index': mode === 'search' ? 0 : 1 }}
+            role="tablist"
+            aria-label={t('omnibar_tabSwitcherLabel')}
+        >
+            <div class={styles.blob} />
             <button class={styles.tab} role="tab" aria-selected={mode === 'search'} onClick={() => onChange('search')}>
                 {mode === 'search' ? <SearchColorIcon /> : <SearchIcon />}
                 <span class={styles.tabLabel}>{t('omnibar_searchTabLabel')}</span>
@@ -31,99 +32,5 @@ export function TabSwitcher({ mode, onChange }) {
                 <span class={styles.tabLabel}>{t('omnibar_aiTabLabel')}</span>
             </button>
         </div>
-    );
-}
-
-/**
- * @param {import('preact').JSX.SVGAttributes<SVGSVGElement>} props
- */
-function BlobLight(props) {
-    return (
-        <svg xmlns="http://www.w3.org/2000/svg" width="102" height="36" viewBox="0 0 102 36" fill="none" {...props}>
-            <g filter="url(#filter0_ddi_9483_24565)">
-                <path
-                    d="M2 18C2 9.16344 9.16344 2 18 2H78C86.8366 2 94 9.16344 94 18C94 26.8366 86.8366 34 78 34H18C9.16345 34 2 26.8366 2 18Z"
-                    fill="white"
-                />
-            </g>
-            <defs>
-                <filter
-                    id="filter0_ddi_9483_24565"
-                    x="-6"
-                    y="-2"
-                    width="108"
-                    height="48"
-                    filterUnits="userSpaceOnUse"
-                    color-interpolation-filters="sRGB"
-                >
-                    <feFlood flood-opacity="0" result="BackgroundImageFix" />
-                    <feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha" />
-                    <feOffset dy="4" />
-                    <feGaussianBlur stdDeviation="4" />
-                    <feComposite in2="hardAlpha" operator="out" />
-                    <feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.08 0" />
-                    <feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_9483_24565" />
-                    <feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha" />
-                    <feOffset dy="1" />
-                    <feGaussianBlur stdDeviation="2" />
-                    <feComposite in2="hardAlpha" operator="out" />
-                    <feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.08 0" />
-                    <feBlend mode="normal" in2="effect1_dropShadow_9483_24565" result="effect2_dropShadow_9483_24565" />
-                    <feBlend mode="normal" in="SourceGraphic" in2="effect2_dropShadow_9483_24565" result="shape" />
-                    <feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha" />
-                    <feOffset dy="1" />
-                    <feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1" />
-                    <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.48 0" />
-                    <feBlend mode="normal" in2="shape" result="effect3_innerShadow_9483_24565" />
-                </filter>
-            </defs>
-        </svg>
-    );
-}
-
-/**
- * @param {import('preact').JSX.SVGAttributes<SVGSVGElement>} props
- */
-function BlobDark(props) {
-    return (
-        <svg xmlns="http://www.w3.org/2000/svg" width="102" height="36" viewBox="0 0 102 36" fill="none" {...props}>
-            <g filter="url(#filter0_ddi_9483_35175)">
-                <path
-                    d="M2 18C2 9.16344 9.16344 2 18 2H78C86.8366 2 94 9.16344 94 18C94 26.8366 86.8366 34 78 34H18C9.16345 34 2 26.8366 2 18Z"
-                    fill="#6B6B6B"
-                />
-            </g>
-            <defs>
-                <filter
-                    id="filter0_ddi_9483_35175"
-                    x="-6"
-                    y="-2"
-                    width="108"
-                    height="48"
-                    filterUnits="userSpaceOnUse"
-                    color-interpolation-filters="sRGB"
-                >
-                    <feFlood flood-opacity="0" result="BackgroundImageFix" />
-                    <feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha" />
-                    <feOffset dy="4" />
-                    <feGaussianBlur stdDeviation="4" />
-                    <feComposite in2="hardAlpha" operator="out" />
-                    <feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.24 0" />
-                    <feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_9483_35175" />
-                    <feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha" />
-                    <feOffset dy="1" />
-                    <feGaussianBlur stdDeviation="2" />
-                    <feComposite in2="hardAlpha" operator="out" />
-                    <feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.24 0" />
-                    <feBlend mode="normal" in2="effect1_dropShadow_9483_35175" result="effect2_dropShadow_9483_35175" />
-                    <feBlend mode="normal" in="SourceGraphic" in2="effect2_dropShadow_9483_35175" result="shape" />
-                    <feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha" />
-                    <feOffset dy="1" />
-                    <feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1" />
-                    <feColorMatrix type="matrix" values="0 0 0 0 0.976471 0 0 0 0 0.976471 0 0 0 0 0.976471 0 0 0 0.06 0" />
-                    <feBlend mode="normal" in2="shape" result="effect3_innerShadow_9483_35175" />
-                </filter>
-            </defs>
-        </svg>
     );
 }

--- a/special-pages/pages/new-tab/app/omnibar/components/TabSwitcher.module.css
+++ b/special-pages/pages/new-tab/app/omnibar/components/TabSwitcher.module.css
@@ -2,7 +2,9 @@
     background: var(--ntp-controls-raised-backdrop);
     border-radius: 99px;
     box-shadow: 0px 1px 0px 0px  rgba(0, 0, 0, 0.05) inset;
-    display: flex;
+    display: grid;
+    grid-template-columns: repeat(var(--tab-count), 1fr);
+    overflow: hidden;
     padding: var(--sp-0_5);
     position: relative;
 }
@@ -17,8 +19,7 @@
     gap: 6px;
     height: var(--sp-8);
     justify-content: center;
-    padding: 0;
-    width: 92px;
+    padding: 0 var(--sp-3);
     z-index: 1;
 }
 
@@ -27,12 +28,23 @@
 }
 
 .blob {
+    background-color: var(--color-white);
+    border-radius: 18px;
+    box-shadow: 0 4px 4px rgba(0, 0, 0, 0.08), 0 1px 2px rgba(0, 0, 0, 0.08), inset 0 1px 0 rgba(255, 255, 255, 0.48);
     color: var(--ntp-controls-raised-fill-primary);
+    height: var(--sp-8);
     left: 0;
     position: absolute;
-    top: 0;
+    top: 2px;
     transition: translate 200ms ease;
+    translate: calc(2px + var(--tab-index) * 100%);
+    width: calc((100% - 4px) / var(--tab-count));
     will-change: translate;
+
+    [data-theme="dark"] & {
+        background-color: #6B6B6B;
+        box-shadow: 0 4px 4px rgba(0, 0, 0, 0.24), 0 1px 2px rgba(0, 0, 0, 0.24), inset 0 1px 0 rgba(255, 255, 255, 0.06);
+    }
 
     @media (prefers-reduced-motion: reduce) {
         transition: none;


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/task/1210842882517733

## Description

Refactors TabSwitcher styles to use CSS instead of SVG for the “blob” (the animated rounded rectangle) and to use CSS grid layout for sizing the tabs.

This lets us remove the hardcoded width and support locales with longer label names (e.g. French).

| Before | After | 
| - | - |
| <img width="1008" height="540" alt="deploy-preview-1831--content-scope-scripts netlify app_build_pages_new-tab__omnibar=true locale=fr" src="https://github.com/user-attachments/assets/95b4b106-d963-4e03-8ae6-52e069a15fbb" /> | <img width="1008" height="540" alt="localhost_8000__omnibar=true locale=fr" src="https://github.com/user-attachments/assets/9377fed0-6915-4785-ae64-8cdbbf5a8842" /> |

## Testing Steps

Go to https://deploy-preview-1840--content-scope-scripts.netlify.app/build/pages/new-tab/?omnibar=true&locale=fr and play with the tab switcher. Check out other locales, too.

## Checklist

*Please tick all that apply:*

- [x] I have tested this change locally
- [x] I have tested this change locally in all supported browsers
- [ ] This change will be visible to users
- [ ] I have added automated tests that cover this change
- [x] I have ensured the change is gated by config
- [ ] This change was covered by a ship review
- [ ] This change was covered by a tech design
- [x] Any dependent config has been merged

