### PR TITLE
Update omnibar widget design and copy

### DIFF
--- a/special-pages/pages/new-tab/app/components/App.module.css
+++ b/special-pages/pages/new-tab/app/components/App.module.css
@@ -29,7 +29,7 @@ body[data-animate-background="true"] {
 :global(.layout-centered) {
     margin-inline: auto;
     width: 100%;
-    max-width: calc(504 * var(--px-in-rem));
+    max-width: calc(620 * var(--px-in-rem));
 }
 
 :global(.vertical-space) {

--- a/special-pages/pages/new-tab/app/components/App.module.css
+++ b/special-pages/pages/new-tab/app/components/App.module.css
@@ -29,7 +29,7 @@ body[data-animate-background="true"] {
 :global(.layout-centered) {
     margin-inline: auto;
     width: 100%;
-    max-width: calc(620 * var(--px-in-rem));
+    max-width: calc(504 * var(--px-in-rem));
 }
 
 :global(.vertical-space) {

--- a/special-pages/pages/new-tab/app/omnibar/components/AiChatForm.module.css
+++ b/special-pages/pages/new-tab/app/omnibar/components/AiChatForm.module.css
@@ -11,6 +11,7 @@
     border: none;
     box-sizing: content-box;
     color: var(--ntp-text-normal);
+    font-weight: 500;
     max-height: 10lh;
     padding: 11px 15px 0;
     resize: none;

--- a/special-pages/pages/new-tab/app/omnibar/components/Container.module.css
+++ b/special-pages/pages/new-tab/app/omnibar/components/Container.module.css
@@ -1,5 +1,6 @@
 .outer {
     align-self: stretch;
+    width: 620px;
     z-index: 1;
 }
 

--- a/special-pages/pages/new-tab/app/omnibar/components/Container.module.css
+++ b/special-pages/pages/new-tab/app/omnibar/components/Container.module.css
@@ -7,7 +7,6 @@
     background: var(--ntp-surface-tertiary);
     border-radius: 12px;
     box-shadow: 0px 1px 4px 0px rgba(0, 0, 0, 0.1), 0px 4px 8px 0px rgba(0, 0, 0, 0.08);
-    margin: 0 calc(-1 * var(--sp-1));
     overflow: hidden;
     position: relative;
     transition: height 200ms ease;

--- a/special-pages/pages/new-tab/app/omnibar/components/Omnibar.module.css
+++ b/special-pages/pages/new-tab/app/omnibar/components/Omnibar.module.css
@@ -8,5 +8,5 @@
 
 .logo {
     margin-bottom: var(--sp-4);
-    width: 123px;
+    width: 164px;
 }

--- a/special-pages/pages/new-tab/app/omnibar/components/SearchForm.module.css
+++ b/special-pages/pages/new-tab/app/omnibar/components/SearchForm.module.css
@@ -13,6 +13,7 @@
     background: none;
     border: none;
     color: var(--ntp-text-normal);
+    font-weight: 500;
     height: var(--sp-8);
     left: var(--sp-1);
     padding-bottom: 0;

--- a/special-pages/pages/new-tab/app/omnibar/strings.json
+++ b/special-pages/pages/new-tab/app/omnibar/strings.json
@@ -4,7 +4,7 @@
     "description": "Title of the omnibar widget in the customizer panel."
   },
   "omnibar_aiChatFormPlaceholder": {
-    "title": "Chat privately with Duck.ai",
+    "title": "Ask privately",
     "description": "Placeholder text for the AI chat input field."
   },
   "omnibar_aiChatFormSubmitButtonLabel": {
@@ -28,7 +28,7 @@
     "description": "Label for the AI chat tab."
   },
   "omnibar_searchFormPlaceholder": {
-    "title": "Search or enter address",
+    "title": "Search privately",
     "description": "Placeholder text for the search input field."
   },
   "omnibar_hideDuckAi": {

--- a/special-pages/pages/new-tab/public/locales/en/new-tab.json
+++ b/special-pages/pages/new-tab/public/locales/en/new-tab.json
@@ -130,7 +130,7 @@
     "description": "Title of the omnibar widget in the customizer panel."
   },
   "omnibar_aiChatFormPlaceholder": {
-    "title": "Chat privately with Duck.ai",
+    "title": "Ask privately",
     "description": "Placeholder text for the AI chat input field."
   },
   "omnibar_aiChatFormSubmitButtonLabel": {
@@ -154,7 +154,7 @@
     "description": "Label for the AI chat tab."
   },
   "omnibar_searchFormPlaceholder": {
-    "title": "Search or enter address",
+    "title": "Search privately",
     "description": "Placeholder text for the search input field."
   },
   "omnibar_hideDuckAi": {


### PR DESCRIPTION
```
**Asana Task/Github Issue:** <!-- Link to Asana Task/Github Issue -->

## Description

This PR implements several design updates for the omnibar widget on the new tab page. The changes include:
*   Increasing the logo width to 164px.
*   Setting the omnibar container width to 620px and removing its negative margin.
*   Updating the font weight of the search input and AI chat textarea to 500.
*   Changing the placeholder and ARIA labels for the search form to "Search privately" and for the AI chat form to "Ask privately".

These updates are specifically targeted at the omnibar widget.

## Testing Steps

1.  Open a new tab.
2.  Verify the DuckDuckGo logo is larger (164px wide).
3.  Verify the omnibar container is wider (620px) and centered without negative margins.
4.  Type into the search input and AI chat textarea to confirm the font weight is 500.
5.  Check the placeholder text for the search form is "Search privately" and for the AI chat form is "Ask privately".

## Checklist

*Please tick all that apply:*

- [x] I have tested this change locally
- [ ] I have tested this change locally in all supported browsers
- [x] This change will be visible to users
- [ ] I have added automated tests that cover this change
- [ ] I have ensured the change is gated by config
- [ ] This change was covered by a ship review
- [ ] This change was covered by a tech design
- [ ] Any dependent config has been merged
```

---

[Open in Web](https://www.cursor.com/agents?id=bc-6be433fd-b76f-4bd3-aeaf-648ca899570b) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-6be433fd-b76f-4bd3-aeaf-648ca899570b)