### PR TITLE
Change omnibar icon based on input suffix

### DIFF
--- a/special-pages/pages/new-tab/app/omnibar/components/SearchForm.js
+++ b/special-pages/pages/new-tab/app/omnibar/components/SearchForm.js
@@ -1,6 +1,6 @@
 import { h, Fragment } from 'preact';
 import { useEffect, useId } from 'preact/hooks';
-import { SearchIcon } from '../../components/Icons.js';
+import { SearchIcon, GlobeIcon } from '../../components/Icons.js';
 import { useTypedTranslationWith } from '../../types';
 import styles from './SearchForm.module.css';
 import { SuggestionsList } from './SuggestionsList.js';
@@ -68,7 +68,7 @@ export function SearchForm({ term, autoFocus, onChangeTerm, onOpenSuggestion, on
     return (
         <form class={styles.form} onBlur={handleBlur} onSubmit={handleSubmit}>
             <div class={styles.inputContainer} style={{ '--suffix-text-width': `${measureText(inputSuffixText)}px` }}>
-                <SearchIcon inert />
+                {inputSuffix?.kind === 'visit' ? <GlobeIcon inert /> : <SearchIcon inert />}
                 <input
                     ref={inputRef}
                     type="text"


### PR DESCRIPTION
```
**Asana Task/Github Issue:** <!-- Link to Asana Task/Github Issue -->

## Description

This PR updates the omnibar widget in the new tab page to change the icon on the left of the SearchForm's input. The icon will now display a globe (🌐) instead of a search icon (🔍) when the input suffix has `kind = "visit"`.

This provides a clearer visual indicator to users that their input will result in navigating to a website (e.g., typing a URL, selecting a website suggestion) rather than performing a search.

## Testing Steps

-   Open the New Tab Page.
-   **To see the globe icon:**
    -   Type a URL-like string (e.g., `example.com`, `https://duckduckgo.com`).
    -   Select a suggestion that leads to a website visit (e.g., a "website" suggestion, a bookmark, or history entry).
-   **To see the search icon:**
    -   Type a regular search query (e.g., `weather`, `how to bake a cake`).

## Checklist

*Please tick all that apply:*

-   [ ] I have tested this change locally
-   [ ] I have tested this change locally in all supported browsers
-   [x] This change will be visible to users
-   [ ] I have added automated tests that cover this change
-   [ ] I have ensured the change is gated by config
-   [ ] This change was covered by a ship review
-   [ ] This change was covered by a tech design
-   [ ] Any dependent config has been merged
```

---

[Open in Web](https://www.cursor.com/agents?id=bc-cf6d29c1-c222-4489-a5e7-ec76c376dbc3) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-cf6d29c1-c222-4489-a5e7-ec76c376dbc3)