### PR TITLE
NTP: Fix omnibar colour when using a custom background

### DIFF
--- a/special-pages/pages/new-tab/app/omnibar/components/AiChatForm.module.css
+++ b/special-pages/pages/new-tab/app/omnibar/components/AiChatForm.module.css
@@ -16,6 +16,10 @@
     padding: 11px 15px 0;
     resize: none;
 
+    &::placeholder {
+        color: var(--ntp-text-muted);
+    }
+
     &:focus {
         outline: none;
     }

--- a/special-pages/pages/new-tab/app/omnibar/components/SearchForm.module.css
+++ b/special-pages/pages/new-tab/app/omnibar/components/SearchForm.module.css
@@ -23,6 +23,10 @@
     position: absolute;
     right: var(--sp-1);
 
+    &::placeholder {
+        color: var(--ntp-text-muted);
+    }
+
     &:focus {
         outline: none;
     }

--- a/special-pages/pages/new-tab/app/omnibar/components/TabSwitcher.module.css
+++ b/special-pages/pages/new-tab/app/omnibar/components/TabSwitcher.module.css
@@ -7,6 +7,10 @@
     overflow: hidden;
     padding: var(--sp-0_5);
     position: relative;
+
+    [data-theme="dark"] & {
+        box-shadow: 0 1px 0 0  rgba(0, 0, 0, 0.16) inset;
+    }
 }
 
 .tab {
@@ -28,10 +32,9 @@
 }
 
 .blob {
-    background-color: var(--color-white);
+    background-color: var(--ntp-controls-raised-fill-primary);
     border-radius: 18px;
     box-shadow: 0 4px 4px rgba(0, 0, 0, 0.08), 0 1px 2px rgba(0, 0, 0, 0.08), inset 0 1px 0 rgba(255, 255, 255, 0.48);
-    color: var(--ntp-controls-raised-fill-primary);
     height: var(--sp-8);
     left: 0;
     position: absolute;
@@ -42,7 +45,6 @@
     will-change: translate;
 
     [data-theme="dark"] & {
-        background-color: #6B6B6B;
         box-shadow: 0 4px 4px rgba(0, 0, 0, 0.24), 0 1px 2px rgba(0, 0, 0, 0.24), inset 0 1px 0 rgba(255, 255, 255, 0.06);
     }
 

--- a/special-pages/pages/new-tab/app/styles/ntp-theme.css
+++ b/special-pages/pages/new-tab/app/styles/ntp-theme.css
@@ -72,9 +72,9 @@ body {
     --focus-ring: 0px 0px 0px 1px var(--ntp-focus-outline-color), 0px 0px 0px 3px var(--color-white);
     --focus-ring-thin: 0px 0px 0px 1px  var(--color-white), 0px 0px 0px 1px var(--ntp-focus-outline-color);
     --focus-ring-primary: 0px 0px 0px 1px var(--default-dark-background-color), 0px 0px 0px 3px var(--ntp-color-primary);
-    --ntp-surface-tertiary: #474747;
-    --ntp-controls-raised-backdrop: var(--color-white-at-12);
-    --ntp-controls-raised-fill-primary: #6B6B6B;
+    --ntp-surface-tertiary: rgba(71, 71, 71, 0.66);
+    --ntp-controls-raised-backdrop: var(--color-black-at-60);
+    --ntp-controls-raised-fill-primary: var(--color-white-at-18);
 }
 
 /* This comes from the application settings */


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1209121419454298/task/1210769573066734?focus=true

## Description

Changes the tertiary backdrop colour used by the omnibar to work better with custom backgrounds. Nothing too scientific here, I just played around with different alpha values until it looked reasonable on different background colours.

Also fixes the tab switcher’s styling in dark mode – this wasn’t using the proper variables.

https://github.com/user-attachments/assets/e49fcbbc-4c10-4a6d-a929-9362ee6596b7


## Testing Steps

Navigate to https://deploy-preview-1846--content-scope-scripts.netlify.app/build/pages/new-tab/?omnibar=true, open the customize drawer, and then play with different background colours.

## Checklist

<!--
  These questions are a friendly reminder to shipping code, if you're uncertain ask the AoR owners.
  It's also totally appropriate to not check some of these boxes, if they don't apply to your change.
-->
*Please tick all that apply:*

- [x] I have tested this change locally
- [ ] I have tested this change locally in all supported browsers
- [ ] This change will be visible to users
- [ ] I have added automated tests that cover this change
- [x] I have ensured the change is gated by config
- [ ] This change was covered by a ship review
- [ ] This change was covered by a tech design
- [x] Any dependent config has been merged

