### PR TITLE
NTP: Fix disappearing search icon in WebKit

### DIFF
--- a/special-pages/pages/new-tab/app/omnibar/components/TabSwitcher.module.css
+++ b/special-pages/pages/new-tab/app/omnibar/components/TabSwitcher.module.css
@@ -26,6 +26,7 @@
     justify-content: center;
     padding: 0 var(--sp-3);
     position: relative;
+    transform: translateZ(0); /* Force .tab into its own stacking context. Workaround for WebKit mistakenly layering .blob on top of .tab when .App_mainLayout animates. */
     z-index: 1;
 
     &:hover:not([aria-selected="true"])::before {
@@ -53,6 +54,7 @@
     translate: calc(2px + var(--tab-index) * (100% + 2px));
     width: calc((100% - 4px - (var(--tab-count) - 1) * 2px) / var(--tab-count));
     will-change: translate;
+    z-index: 0;
 
     [data-theme="dark"] & {
         box-shadow: 0 4px 4px rgba(0, 0, 0, 0.24), 0 1px 2px rgba(0, 0, 0, 0.24), inset 0 1px 0 rgba(255, 255, 255, 0.06);


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1209121419454298/task/1210868202766664?focus=true

## Description

Fixes `.tab` being obscured by `.blob` when the user opens the customize sidebar.

This seems to be a WebKit rendering bug caused by both `.App_mainLayout` having a stacking context (from `will-change: transform`) and `.blob` having a stacking context (from `will-change: translate`).

Removing either `will-change` fixes the issue but causes other issues (see https://github.com/duckduckgo/content-scope-scripts/pull/1822). Instead, I’m forcing a third stacking context onto `.tab` using the `translateZ()` hack. 

## Testing Steps

1. In Safari/DuckDuckGo, navigate to https://deploy-preview-1858--content-scope-scripts.netlify.app/build/pages/new-tab/?omnibar=true.
2. Open the Customize sidebar.
3. The Search tab and icon in the omnibar widget should not disappear.

## Checklist

*Please tick all that apply:*

- [x] I have tested this change locally
- [x] I have tested this change locally in all supported browsers
- [ ] This change will be visible to users
- [ ] I have added automated tests that cover this change
- [x] I have ensured the change is gated by config
- [ ] This change was covered by a ship review
- [ ] This change was covered by a tech design
- [x] Any dependent config has been merged

