### PR TITLE
Fix textarea resize bug after tab switch

### DIFF
--- a/special-pages/pages/new-tab/app/omnibar/components/AiChatForm.js
+++ b/special-pages/pages/new-tab/app/omnibar/components/AiChatForm.js
@@ -28,11 +28,40 @@ export function AiChatForm({ chat, autoFocus, onFocus, onBlur, onInput, onChange
     const formRef = useRef(/** @type {HTMLFormElement|null} */ (null));
     const textAreaRef = useRef(/** @type {HTMLTextAreaElement|null} */ (null));
 
+    /**
+     * Calculate and apply the appropriate height for the textarea based on its content
+     * @param {HTMLTextAreaElement} textArea
+     */
+    const resizeTextArea = (textArea) => {
+        const form = formRef.current;
+        
+        const { paddingTop, paddingBottom } = window.getComputedStyle(textArea);
+        textArea.style.height = 'auto'; // Reset height
+        textArea.style.height = `calc(${textArea.scrollHeight}px - ${paddingTop} - ${paddingBottom})`;
+
+        if (textArea.scrollHeight > textArea.clientHeight) {
+            form?.classList.add(styles.hasScroll);
+        } else {
+            form?.classList.remove(styles.hasScroll);
+        }
+    };
+
     useEffect(() => {
         if (autoFocus && textAreaRef.current) {
             textAreaRef.current.focus();
         }
     }, [autoFocus]);
+
+    // Recalculate textarea height when chat content changes or component mounts
+    useEffect(() => {
+        const textArea = textAreaRef.current;
+        if (textArea && chat) {
+            // Use setTimeout to ensure the textarea has rendered with the new value
+            setTimeout(() => {
+                resizeTextArea(textArea);
+            }, 0);
+        }
+    }, [chat]);
 
     const disabled = chat.length === 0;
 
@@ -71,19 +100,8 @@ export function AiChatForm({ chat, autoFocus, onFocus, onBlur, onInput, onChange
 
     /** @type {(event: import('preact').JSX.TargetedEvent<HTMLTextAreaElement>) => void} */
     const handleChange = (event) => {
-        const form = formRef.current;
         const textArea = event.currentTarget;
-
-        const { paddingTop, paddingBottom } = window.getComputedStyle(textArea);
-        textArea.style.height = 'auto'; // Reset height
-        textArea.style.height = `calc(${textArea.scrollHeight}px - ${paddingTop} - ${paddingBottom})`;
-
-        if (textArea.scrollHeight > textArea.clientHeight) {
-            form?.classList.add(styles.hasScroll);
-        } else {
-            form?.classList.remove(styles.hasScroll);
-        }
-
+        resizeTextArea(textArea);
         onChange(textArea.value);
     };
 


### PR DESCRIPTION
<pr_request_template>**Asana Task/Github Issue:** N/A

## Description

Fixes an issue where the `AiChatForm` textarea would not correctly resize to display multiline content after switching tabs away and back.

The problem occurred because the component would unmount and remount, losing the dynamically set inline height, and the resize logic only triggered on user input, not on remount with existing content.

This change extracts the textarea resize logic into a reusable function and adds a `useEffect` hook to `AiChatForm` to ensure the textarea height is recalculated when the `chat` content changes or the component mounts.

## Testing Steps

- Navigate to the AI chat tab.
- Enter multiline text into the AI chat input (e.g., by pressing Shift+Enter multiple times).
- Switch to the "Search" tab.
- Switch back to the "AI Chat" tab.
- Verify that the textarea correctly displays all multiline content and is not cut off.

## Checklist

*Please tick all that apply:*

- [x] I have tested this change locally
- [ ] I have tested this change locally in all supported browsers
- [x] This change will be visible to users
- [ ] I have added automated tests that cover this change
- [ ] I have ensured the change is gated by config
- [ ] This change was covered by a ship review
- [ ] This change was covered by a tech design
- [ ] Any dependent config has been merged</pr_request_template>

---
<a href="https://cursor.com/background-agent?bcId=bc-5e336ac7-cbad-4e26-a8f7-9875b20dbf08">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5e336ac7-cbad-4e26-a8f7-9875b20dbf08">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>