### PR TITLE
Gates console.warn statements behind debug flag in Duck Player Native

### DIFF
--- a/injected/src/features/duck-player-native.js
+++ b/injected/src/features/duck-player-native.js
@@ -37,7 +37,7 @@ export class DuckPlayerNativeFeature extends ContentFeature {
 
         const selectors = this.getFeatureSetting('selectors');
         if (!selectors) {
-            console.warn('No selectors found. Check remote config. Feature will not be initialized.');
+            if (this.isDebug) console.warn('No selectors found. Check remote config. Feature will not be initialized.');
             return;
         }
 
@@ -64,7 +64,7 @@ export class DuckPlayerNativeFeature extends ContentFeature {
         try {
             initialSetup = await messages.initialSetup();
         } catch (e) {
-            console.warn('Failed to get initial setup', e);
+            if (this.isDebug) console.warn('Failed to get initial setup', e);
             return;
         }
 
@@ -103,7 +103,7 @@ export class DuckPlayerNativeFeature extends ContentFeature {
                 break;
             case 'UNKNOWN':
             default:
-                console.warn('No known pageType');
+                logger.warn('No known pageType');
         }
 
         if (this.currentPage) {


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1203249713006009/task/1210889176929371?focus=true

## Description

Duck Player Native was sending console.warn messages when not in debug mode.

## Testing Steps

- Run locally on a browser that doesn't support Duck Player Native (anything but iOS)
- Set Duck Player to ASK
- Visit a YouTube video e.g. https://www.youtube.com/watch?v=8BXd47ni7VU
- Check the console unexpected console.warn messages such as `Failed to get initial setup`

## Checklist

<!--
  These questions are a friendly reminder to shipping code, if you're uncertain ask the AoR owners.
  It's also totally appropriate to not check some of these boxes, if they don't apply to your change.
-->
*Please tick all that apply:*

- [ ] I have tested this change locally
- [ ] I have tested this change locally in all supported browsers
- [ ] This change will be visible to users
- [ ] I have added automated tests that cover this change
- [ ] I have ensured the change is gated by config
- [ ] This change was covered by a ship review
- [ ] This change was covered by a tech design
- [ ] Any dependent config has been merged

