### PR TITLE
NTP: Fix input styling on Windows

### DIFF
--- a/special-pages/pages/new-tab/app/omnibar/components/AiChatForm.module.css
+++ b/special-pages/pages/new-tab/app/omnibar/components/AiChatForm.module.css
@@ -20,6 +20,11 @@
         color: var(--ntp-text-muted);
     }
 
+    [data-platform="windows"] &::selection {
+        background: var(--ntp-selection-background-color);
+        color: var(--ntp-selection-color);
+    }
+
     &:focus {
         outline: none;
     }

--- a/special-pages/pages/new-tab/app/omnibar/components/AiChatForm.module.css
+++ b/special-pages/pages/new-tab/app/omnibar/components/AiChatForm.module.css
@@ -11,10 +11,13 @@
     border: none;
     box-sizing: content-box;
     color: var(--ntp-text-normal);
-    font-weight: 500;
     max-height: 10lh;
     padding: 11px 15px 0;
     resize: none;
+
+    [data-platform="macos"] & {
+        font-weight: 500;
+    }
 
     &::placeholder {
         color: var(--ntp-text-muted);

--- a/special-pages/pages/new-tab/app/omnibar/components/SearchForm.module.css
+++ b/special-pages/pages/new-tab/app/omnibar/components/SearchForm.module.css
@@ -27,6 +27,11 @@
         color: var(--ntp-text-muted);
     }
 
+    [data-platform="windows"] &::selection {
+        background: var(--ntp-selection-background-color);
+        color: var(--ntp-selection-color);
+    }
+
     &:focus {
         outline: none;
     }

--- a/special-pages/pages/new-tab/app/omnibar/components/SearchForm.module.css
+++ b/special-pages/pages/new-tab/app/omnibar/components/SearchForm.module.css
@@ -13,7 +13,7 @@
     background: none;
     border: none;
     color: var(--ntp-text-normal);
-    font-weight: 500;
+    font: var(--input-font);
     height: var(--sp-8);
     left: 7px;
     padding-bottom: 0;
@@ -38,7 +38,7 @@
 }
 
 .suffixSpacer {
-    font-weight: 500;
+    font: var(--input-font);
     overflow: hidden;
     visibility: hidden;
     white-space: nowrap;
@@ -47,4 +47,5 @@
 .suffix {
     color: var(--ntp-color-primary);
     flex: none;
+    font: var(--input-font);
 }

--- a/special-pages/pages/new-tab/app/styles/ntp-theme.css
+++ b/special-pages/pages/new-tab/app/styles/ntp-theme.css
@@ -58,6 +58,8 @@ body {
     --ntp-surface-tertiary: var(--color-white);
     --ntp-controls-raised-backdrop: var(--color-black-at-9);
     --ntp-controls-raised-fill-primary: var(--color-white);
+    --ntp-selection-color: var(--color-white);
+    --ntp-selection-background-color: #3A69EF;
 }
 
 [data-theme=dark] {
@@ -75,6 +77,8 @@ body {
     --ntp-surface-tertiary: rgba(71, 71, 71, 0.66);
     --ntp-controls-raised-backdrop: var(--color-black-at-60);
     --ntp-controls-raised-fill-primary: var(--color-white-at-18);
+    --ntp-selection-color: var(--color-white);
+    --ntp-selection-background-color: var(--color-blue-30);
 }
 
 /* This comes from the application settings */


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1209121419454298/task/1210872043151933?focus=true

## Description

Two Windows specific fixes:

1. Style input and textarea selection colour to match how it looks in Windows browser.
2. Reduce font weight (which I bumped in https://github.com/duckduckgo/content-scope-scripts/pull/1843) on Windows where its address bar uses 400 instead of 500.

I’m also putting the font into a CSS variable to prevent an easy-to-make mistake where you update the font in the CSS but forget about `measureText`.

## Testing Steps

https://deploy-preview-XXXX--content-scope-scripts.netlify.app/build/pages/new-tab/?omnibar=true

Test the Search tab and Duck.ai tabs in DuckDuckGo on Windows and macOS. Ensure that the text in both inputs matches what’s in the address bar. Ensure that the selected text in both inputs matches selected text in the address bar.

## Checklist

*Please tick all that apply:*

- [x] I have tested this change locally
- [x] I have tested this change locally in all supported browsers
- [ ] This change will be visible to users
- [ ] I have added automated tests that cover this change
- [x] I have ensured the change is gated by config
- [ ] This change was covered by a ship review
- [ ] This change was covered by a tech design
- [x] Any dependent config has been merged

