### PR TITLE
NTP: Adjust omnibar colours to match native apps and Figma

### DIFF
--- a/special-pages/pages/new-tab/app/omnibar/components/AiChatForm.module.css
+++ b/special-pages/pages/new-tab/app/omnibar/components/AiChatForm.module.css
@@ -10,14 +10,14 @@
     background: none;
     border: none;
     box-sizing: content-box;
-    color: var(--ntp-text-normal);
+    color: var(--ntp-text-primary);
     font-weight: 500;
     max-height: 10lh;
     padding: 11px 15px 0;
     resize: none;
 
     &::placeholder {
-        color: var(--ntp-text-muted);
+        color: var(--ntp-text-tertiary);
     }
 
     &:focus {
@@ -25,7 +25,7 @@
     }
 
     .hasScroll & {
-        border-bottom: 1px solid var(--ntp-surface-border-color);
+        border-bottom: 1px solid var(--ntp-decoration-tertiary);
         padding-bottom: 11px;
     }
 }

--- a/special-pages/pages/new-tab/app/omnibar/components/AiChatForm.module.css
+++ b/special-pages/pages/new-tab/app/omnibar/components/AiChatForm.module.css
@@ -42,10 +42,10 @@
 
 .submitButton {
     align-items: center;
-    background: var(--color-blue-50);
+    background: var(--ntp-accent-primary);
     border-radius: 100%;
     border: none;
-    color: var(--color-white);
+    color: var(--ntp-accent-content-primary);
     cursor: pointer;
     display: flex;
     height: var(--sp-7);
@@ -56,8 +56,9 @@
 
     &[disabled] {
         background: none;
-        color: rgba(0, 0, 0, 0.3);
+        color: var(--ntp-icons-primary);
         cursor: default;
+        opacity: 0.3;
     }
 
     &:focus-visible {

--- a/special-pages/pages/new-tab/app/omnibar/components/Container.module.css
+++ b/special-pages/pages/new-tab/app/omnibar/components/Container.module.css
@@ -4,6 +4,7 @@
 }
 
 .inner {
+    backdrop-filter: blur(48px);
     background: var(--ntp-surface-tertiary);
     border-radius: var(--border-radius-lg);
     box-shadow: 0px 1px 4px 0px rgba(0, 0, 0, 0.1), 0px 4px 8px 0px rgba(0, 0, 0, 0.08);

--- a/special-pages/pages/new-tab/app/omnibar/components/Container.module.css
+++ b/special-pages/pages/new-tab/app/omnibar/components/Container.module.css
@@ -5,7 +5,7 @@
 
 .inner {
     background: var(--ntp-surface-tertiary);
-    border-radius: 15px;
+    border-radius: var(--border-radius-lg);
     box-shadow: 0px 1px 4px 0px rgba(0, 0, 0, 0.1), 0px 4px 8px 0px rgba(0, 0, 0, 0.08);
     overflow: hidden;
     position: relative;

--- a/special-pages/pages/new-tab/app/omnibar/components/Container.module.css
+++ b/special-pages/pages/new-tab/app/omnibar/components/Container.module.css
@@ -17,7 +17,7 @@
 
     &:not(:has([role="listbox"])).focusRing,
     &:not(:has([role="listbox"])):focus-within:not(.noFocusRing) {
-        box-shadow: 0 0 0 1px var(--ntp-surface-tertiary), 0 0 0 3px var(--ntp-color-primary), 0 0 0 5px rgba(57, 105, 239, 0.2);
+        box-shadow: 0 0 0 1px var(--ntp-surface-tertiary), 0 0 0 3px var(--ntp-accent-primary), 0 0 0 5px var(--ntp-accent-glow);
     }
 
     &:has([role="listbox"]) {

--- a/special-pages/pages/new-tab/app/omnibar/components/SearchForm.module.css
+++ b/special-pages/pages/new-tab/app/omnibar/components/SearchForm.module.css
@@ -12,7 +12,7 @@
 .input {
     background: none;
     border: none;
-    color: var(--ntp-text-normal);
+    color: var(--ntp-text-primary);
     font-weight: 500;
     height: var(--sp-8);
     left: 7px;
@@ -24,7 +24,7 @@
     right: 7px;
 
     &::placeholder {
-        color: var(--ntp-text-muted);
+        color: var(--ntp-text-tertiary);
     }
 
     &:focus {
@@ -40,6 +40,6 @@
 }
 
 .suffix {
-    color: var(--ntp-color-primary);
+    color: var(--ntp-accent-primary);
     flex: none;
 }

--- a/special-pages/pages/new-tab/app/omnibar/components/SuggestionsList.module.css
+++ b/special-pages/pages/new-tab/app/omnibar/components/SuggestionsList.module.css
@@ -10,7 +10,7 @@
     background: none;
     border-radius: 4px;
     border: none;
-    color: var(--ntp-text-normal);
+    color: var(--ntp-text-primary);
     cursor: pointer;
     display: flex;
     height: var(--sp-8);
@@ -24,23 +24,23 @@
 
     &[aria-selected="true"],
     &:active {
-        color: var(--color-white);
+        color: var(--ntp-accent-content-primary);
 
         .suffix {
-            color: var(--color-white);
+            color: var(--ntp-accent-content-primary);
         }
 
         .badge {
-            background: var(--color-white-at-30);
+            background: var(--color-white-at-30); /* @fixme: Should use a --ntp theme variable for this. This pill design differs from Figma, though */
         }
     }
 
     &[aria-selected="true"] {
-        background: var(--ddg-color-primary);
+        background: var(--ntp-accent-primary);
     }
 
     &:active {
-        background: var(--color-blue-60);
+        background: var(--ntp-accent-secondary);
     }
 }
 
@@ -53,7 +53,7 @@
 }
 
 .suffix {
-    color: var(--ntp-text-muted);
+    color: var(--ntp-text-tertiary);
     flex: initial;
     font-size: 12px;
     overflow: hidden;

--- a/special-pages/pages/new-tab/app/omnibar/components/TabSwitcher.module.css
+++ b/special-pages/pages/new-tab/app/omnibar/components/TabSwitcher.module.css
@@ -30,7 +30,7 @@
     z-index: 1;
 
     &:hover:not([aria-selected="true"])::before {
-        background: var(--ntp-controls-raised-backdrop);
+        background: var(--ntp-controls-fill-primary);
         border-radius: 99px;
         content: '';
         inset: 0;

--- a/special-pages/pages/new-tab/app/omnibar/components/TabSwitcher.module.css
+++ b/special-pages/pages/new-tab/app/omnibar/components/TabSwitcher.module.css
@@ -1,4 +1,5 @@
 .tabSwitcher {
+    backdrop-filter: blur(48px);
     background: var(--ntp-controls-raised-backdrop);
     border-radius: 99px;
     box-shadow: 0px 1px 0px 0px var(--ntp-shadow-primary) inset;

--- a/special-pages/pages/new-tab/app/omnibar/components/TabSwitcher.module.css
+++ b/special-pages/pages/new-tab/app/omnibar/components/TabSwitcher.module.css
@@ -1,24 +1,20 @@
 .tabSwitcher {
     background: var(--ntp-controls-raised-backdrop);
     border-radius: 99px;
-    box-shadow: 0px 1px 0px 0px  rgba(0, 0, 0, 0.05) inset;
+    box-shadow: 0px 1px 0px 0px var(--ntp-shadow-primary) inset;
     display: grid;
-    gap: 2px;
+    gap: var(--sp-0_5);
     grid-template-columns: repeat(var(--tab-count), 1fr);
     overflow: hidden;
     padding: var(--sp-0_5);
     position: relative;
-
-    [data-theme="dark"] & {
-        box-shadow: 0 1px 0 0  rgba(0, 0, 0, 0.16) inset;
-    }
 }
 
 .tab {
     align-items: center;
     background: none;
     border: none;
-    color: var(--ntp-text-normal);
+    color: var(--ntp-text-primary);
     cursor: pointer;
     display: flex;
     gap: 6px;
@@ -45,7 +41,7 @@
 .blob {
     background-color: var(--ntp-controls-raised-fill-primary);
     border-radius: 18px;
-    box-shadow: 0 4px 4px rgba(0, 0, 0, 0.08), 0 1px 2px rgba(0, 0, 0, 0.08), inset 0 1px 0 rgba(255, 255, 255, 0.48);
+    box-shadow: 0 4px 4px var(--ntp-shadow-secondary), 0 1px 2px var(--ntp-shadow-secondary), inset 0 1px 0 rgba(255, 255, 255, 0.48);
     height: var(--sp-8);
     left: 0;
     position: absolute;
@@ -57,7 +53,7 @@
     z-index: 0;
 
     [data-theme="dark"] & {
-        box-shadow: 0 4px 4px rgba(0, 0, 0, 0.24), 0 1px 2px rgba(0, 0, 0, 0.24), inset 0 1px 0 rgba(255, 255, 255, 0.06);
+        box-shadow: 0 4px 4px var(--ntp-shadow-secondary), 0 1px 2px var(--ntp-shadow-secondary), inset 0 1px 0 rgba(255, 255, 255, 0.06);
     }
 
     @media (prefers-reduced-motion: reduce) {

--- a/special-pages/pages/new-tab/app/styles/ntp-theme.css
+++ b/special-pages/pages/new-tab/app/styles/ntp-theme.css
@@ -55,7 +55,13 @@ body {
     --focus-ring: 0px 0px 0px 1px var(--color-white), 0px 0px 0px 3px var(--ntp-focus-outline-color);
     --focus-ring-thin: 0px 0px 0px 1px var(--ntp-focus-outline-color), 0px 0px 0px 1px  var(--color-white);
     --focus-ring-primary: 0px 0px 0px 1px var(--color-white), 0px 0px 0px 3px var(--ntp-color-primary);
+
+    /* Global Colors & Styles - https://www.figma.com/design/3W4vi0zX8hrpQc7zInQQB6/%F0%9F%8E%A8-Global-Colors---Styles?node-id=11-1&p=f&vars=1&m=dev */
+    /* @todo: This palette is what the native apps use, we should gradually move over to it */
     --ntp-surface-tertiary: var(--color-white);
+    --ntp-icons-primary: rgba(31, 31, 31, 0.84);
+    --ntp-accent-primary: var(--color-blue-50);
+    --ntp-accent-content-primary: var(--color-white);
     --ntp-controls-fill-primary: rgba(31, 31, 31, 0.09);
     --ntp-controls-raised-backdrop: var(--color-black-at-9);
     --ntp-controls-raised-fill-primary: var(--color-white);
@@ -73,7 +79,13 @@ body {
     --focus-ring: 0px 0px 0px 1px var(--ntp-focus-outline-color), 0px 0px 0px 3px var(--color-white);
     --focus-ring-thin: 0px 0px 0px 1px  var(--color-white), 0px 0px 0px 1px var(--ntp-focus-outline-color);
     --focus-ring-primary: 0px 0px 0px 1px var(--default-dark-background-color), 0px 0px 0px 3px var(--ntp-color-primary);
+
+    /* Global Colors & Styles - https://www.figma.com/design/3W4vi0zX8hrpQc7zInQQB6/%F0%9F%8E%A8-Global-Colors---Styles?node-id=11-1&p=f&vars=1&m=dev */
+    /* @todo: This palette is what the native apps use, we should gradually move over to it */
     --ntp-surface-tertiary: rgba(71, 71, 71, 0.66);
+    --ntp-icons-primary: rgba(255, 255, 255, 0.78);
+    --ntp-accent-primary: var(--color-blue-20);
+    --ntp-accent-content-primary: var(--color-blue-80);
     --ntp-controls-fill-primary: rgba(249, 249, 249, 0.12);
     --ntp-controls-raised-backdrop: var(--color-black-at-60);
     --ntp-controls-raised-fill-primary: var(--color-white-at-18);

--- a/special-pages/pages/new-tab/app/styles/ntp-theme.css
+++ b/special-pages/pages/new-tab/app/styles/ntp-theme.css
@@ -58,13 +58,20 @@ body {
 
     /* Global Colors & Styles - https://www.figma.com/design/3W4vi0zX8hrpQc7zInQQB6/%F0%9F%8E%A8-Global-Colors---Styles?node-id=11-1&p=f&vars=1&m=dev */
     /* @todo: This palette is what the native apps use, we should gradually move over to it */
-    --ntp-surface-tertiary: var(--color-white);
+    --ntp-surface-tertiary: #FFFFFF;
+    --ntp-text-primary: #1F1F1F;
+    --ntp-text-tertiary: rgba(31, 31, 31, 0.4);
     --ntp-icons-primary: rgba(31, 31, 31, 0.84);
     --ntp-accent-primary: var(--color-blue-50);
-    --ntp-accent-content-primary: var(--color-white);
+    --ntp-accent-secondary: var(--color-blue-60);
+    --ntp-accent-glow: rgba(57, 105, 239, 0.2);
+    --ntp-accent-content-primary: #FFFFFF;
     --ntp-controls-fill-primary: rgba(31, 31, 31, 0.09);
-    --ntp-controls-raised-backdrop: var(--color-black-at-9);
-    --ntp-controls-raised-fill-primary: var(--color-white);
+    --ntp-controls-raised-backdrop: rgba(0, 0, 0, 0.09);
+    --ntp-controls-raised-fill-primary: #FFFFFF;
+    --ntp-decoration-tertiary: rgba(0, 0, 0, 0.09);
+    --ntp-shadow-primary: rgba(0, 0, 0, 0.05);
+    --ntp-shadow-secondary: rgba(0, 0, 0, 0.08);
 }
 
 [data-theme=dark] {
@@ -82,13 +89,20 @@ body {
 
     /* Global Colors & Styles - https://www.figma.com/design/3W4vi0zX8hrpQc7zInQQB6/%F0%9F%8E%A8-Global-Colors---Styles?node-id=11-1&p=f&vars=1&m=dev */
     /* @todo: This palette is what the native apps use, we should gradually move over to it */
-    --ntp-surface-tertiary: rgba(71, 71, 71, 0.66);
+    --ntp-surface-tertiary: rgba(71, 71, 71, 0.66); /* @fixme: This differs from Figma. We're adding alpha so that surfaces blend with custom backgrounds. */
+    --ntp-text-primary: rgba(255, 255, 255, 0.9);
+    --ntp-text-tertiary: rgba(255, 255, 255, 0.4);
     --ntp-icons-primary: rgba(255, 255, 255, 0.78);
     --ntp-accent-primary: var(--color-blue-20);
+    --ntp-accent-secondary: var(--color-blue-30);
+    --ntp-accent-glow: rgba(114, 149, 246, 0.2);
     --ntp-accent-content-primary: var(--color-blue-80);
     --ntp-controls-fill-primary: rgba(249, 249, 249, 0.12);
-    --ntp-controls-raised-backdrop: var(--color-black-at-60);
-    --ntp-controls-raised-fill-primary: var(--color-white-at-18);
+    --ntp-controls-raised-backdrop: rgba(0, 0, 0, 0.6);
+    --ntp-controls-raised-fill-primary: rgba(255, 255, 255, 0.18);
+    --ntp-decoration-tertiary: rgba(255, 255, 255, 0.12);
+    --ntp-shadow-primary: rgba(0, 0, 0, 0.16);
+    --ntp-shadow-secondary: rgba(0, 0, 0, 0.24);
 }
 
 /* This comes from the application settings */

--- a/special-pages/pages/new-tab/app/styles/ntp-theme.css
+++ b/special-pages/pages/new-tab/app/styles/ntp-theme.css
@@ -56,6 +56,7 @@ body {
     --focus-ring-thin: 0px 0px 0px 1px var(--ntp-focus-outline-color), 0px 0px 0px 1px  var(--color-white);
     --focus-ring-primary: 0px 0px 0px 1px var(--color-white), 0px 0px 0px 3px var(--ntp-color-primary);
     --ntp-surface-tertiary: var(--color-white);
+    --ntp-controls-fill-primary: rgba(31, 31, 31, 0.09);
     --ntp-controls-raised-backdrop: var(--color-black-at-9);
     --ntp-controls-raised-fill-primary: var(--color-white);
 }
@@ -73,6 +74,7 @@ body {
     --focus-ring-thin: 0px 0px 0px 1px  var(--color-white), 0px 0px 0px 1px var(--ntp-focus-outline-color);
     --focus-ring-primary: 0px 0px 0px 1px var(--default-dark-background-color), 0px 0px 0px 3px var(--ntp-color-primary);
     --ntp-surface-tertiary: rgba(71, 71, 71, 0.66);
+    --ntp-controls-fill-primary: rgba(249, 249, 249, 0.12);
     --ntp-controls-raised-backdrop: var(--color-black-at-60);
     --ntp-controls-raised-fill-primary: var(--color-white-at-18);
 }


### PR DESCRIPTION
**Asana Task/Github Issue:** <!-- Link to Asana Task/Github Issue -->

## Description

Biting the bullet and introducing new CSS variables to the NTP that exactly match the variables that the desktop apps use and that exist in Figma. This makes it easier to match the colours with the native apps.

I don’t want to change any of the other widgets (omnibar is behind a feature flag) so I figure add the new variable palette and gradually move over to it.

Doing this has the nice side effect of fixing some colouring bugs in dark mode.

## Testing Steps

https://deploy-preview-1863--content-scope-scripts.netlify.app/build/pages/new-tab/?omnibar=true

Check that the colours look right in light mode and dark mode.

## Checklist

*Please tick all that apply:*

- [x] I have tested this change locally
- [x] I have tested this change locally in all supported browsers
- [ ] This change will be visible to users
- [ ] I have added automated tests that cover this change
- [x] I have ensured the change is gated by config
- [ ] This change was covered by a ship review
- [ ] This change was covered by a tech design
- [x] Any dependent config has been merged
