### PR TITLE
Add `url-changed` to `WebTelemetry`

### DIFF
--- a/injected/src/content-scope-features.js
+++ b/injected/src/content-scope-features.js
@@ -77,7 +77,7 @@ export async function init(args) {
             featureInstance.callInit(args);
             // Either listenForUrlChanges or urlChanged ensures the feature listens.
             if (featureInstance.listenForUrlChanges || featureInstance.urlChanged) {
-                registerForURLChanges(navigationType => {
+                registerForURLChanges((navigationType) => {
                     // The rationale for the two separate call here is to ensure that
                     // extensions to the class don't need to call super.urlChanged()
                     featureInstance.recomputeSiteObject();

--- a/injected/src/content-scope-features.js
+++ b/injected/src/content-scope-features.js
@@ -77,12 +77,12 @@ export async function init(args) {
             featureInstance.callInit(args);
             // Either listenForUrlChanges or urlChanged ensures the feature listens.
             if (featureInstance.listenForUrlChanges || featureInstance.urlChanged) {
-                registerForURLChanges(() => {
+                registerForURLChanges(navigationType => {
                     // The rationale for the two separate call here is to ensure that
                     // extensions to the class don't need to call super.urlChanged()
                     featureInstance.recomputeSiteObject();
                     // Called if the feature instance has a urlChanged method
-                    featureInstance?.urlChanged();
+                    featureInstance?.urlChanged(navigationType);
                 });
             }
         }

--- a/injected/src/features/web-telemetry.js
+++ b/injected/src/features/web-telemetry.js
@@ -1,8 +1,11 @@
 import ContentFeature from '../content-feature.js';
 
 const MSG_VIDEO_PLAYBACK = 'video-playback';
+const MSG_URL_CHANGED = 'url-changed';
 
 export class WebTelemetry extends ContentFeature {
+    listenForUrlChanges = true;
+
     constructor(featureName, importConfig, args) {
         super(featureName, importConfig, args);
         this.seenVideoElements = new WeakSet();
@@ -13,6 +16,10 @@ export class WebTelemetry extends ContentFeature {
         if (this.getFeatureSettingEnabled('videoPlayback')) {
             this.videoPlaybackObserve();
         }
+    }
+
+    urlChanged(navigationType = 'unknown') {
+        this.fireTelemetryForUrlChanged(navigationType);
     }
 
     getVideoUrl(video) {
@@ -29,6 +36,13 @@ export class WebTelemetry extends ContentFeature {
             return source.src;
         }
         return null;
+    }
+
+    fireTelemetryForUrlChanged(navigationType) {
+        this.messaging.notify(MSG_URL_CHANGED, {
+            url: window.location.href,
+            navigationType
+        });
     }
 
     fireTelemetryForVideo(video) {

--- a/injected/src/features/web-telemetry.js
+++ b/injected/src/features/web-telemetry.js
@@ -19,7 +19,9 @@ export class WebTelemetry extends ContentFeature {
     }
 
     urlChanged(navigationType = 'unknown') {
-        this.fireTelemetryForUrlChanged(navigationType);
+        if (this.getFeatureSettingEnabled('urlChanged')) {
+            this.fireTelemetryForUrlChanged(navigationType);
+        }
     }
 
     getVideoUrl(video) {

--- a/injected/src/features/web-telemetry.js
+++ b/injected/src/features/web-telemetry.js
@@ -43,7 +43,7 @@ export class WebTelemetry extends ContentFeature {
     fireTelemetryForUrlChanged(navigationType) {
         this.messaging.notify(MSG_URL_CHANGED, {
             url: window.location.href,
-            navigationType
+            navigationType,
         });
     }
 

--- a/injected/src/url-change.js
+++ b/injected/src/url-change.js
@@ -13,21 +13,30 @@ export function registerForURLChanges(listener) {
     urlChangeListeners.add(listener);
 }
 
-function handleURLChange() {
+function handleURLChange(navigationType = 'unknown') {
     for (const listener of urlChangeListeners) {
-        listener();
+        listener(navigationType);
     }
 }
 
 function listenForURLChanges() {
     const urlChangedInstance = new ContentFeature('urlChanged', {}, {});
+    //
+    // if the browser supports the navigation API, use that to listen for URL changes
     if ('navigation' in globalThis && 'addEventListener' in globalThis.navigation) {
-        // if the browser supports the navigation API, we can use that to listen for URL changes
-        // Listening to navigatesuccess instead of navigate to ensure the navigation is committed.
-        globalThis.navigation.addEventListener('navigatesuccess', () => {
-            handleURLChange();
+        // We listen to `navigatesuccess` instead of `navigate` to ensure the navigation is committed.
+        // But, `navigatesuccess` does not provide the navigationType, so we capture it at `navigate` time
+        // then look it up later.  This allows consumers to filter on navigationType.
+        // WeakMap ensures we don't hold onto the event.target longer than necessary and can be freed.
+        const navigations = new WeakMap();
+        globalThis.navigation.addEventListener('navigate', (event) => {
+            navigations.set(event.target, event.navigationType);
+        });      
+        globalThis.navigation.addEventListener('navigatesuccess', (event) => {
+            const navigationType = navigations.get(event.target) || 'navigate';
+            handleURLChange(navigationType);
         });
-        // Exit early if the navigation API is supported
+        // Exit early if the navigation API is supported, i.e. history proxy and popState listener aren't created.
         return;
     }
     if (isBeingFramed()) {
@@ -39,13 +48,15 @@ function listenForURLChanges() {
     const historyMethodProxy = new DDGProxy(urlChangedInstance, History.prototype, 'pushState', {
         apply(target, thisArg, args) {
             const changeResult = DDGReflect.apply(target, thisArg, args);
-            handleURLChange();
+            console.log('pushstate event');
+            handleURLChange('pushState');
             return changeResult;
         },
     });
     historyMethodProxy.overload();
     // listen for popstate events in order to run on back/forward navigations
     window.addEventListener('popstate', () => {
-        handleURLChange();
+        console.log('popstate event');
+        handleURLChange('popState');
     });
 }

--- a/injected/src/url-change.js
+++ b/injected/src/url-change.js
@@ -30,7 +30,7 @@ function listenForURLChanges() {
         const navigations = new WeakMap();
         globalThis.navigation.addEventListener('navigate', (event) => {
             navigations.set(event.target, event.navigationType);
-        });      
+        });
         globalThis.navigation.addEventListener('navigatesuccess', (event) => {
             const navigationType = navigations.get(event.target) || 'unknown';
             handleURLChange(navigationType);

--- a/injected/src/url-change.js
+++ b/injected/src/url-change.js
@@ -21,7 +21,6 @@ function handleURLChange(navigationType = 'unknown') {
 
 function listenForURLChanges() {
     const urlChangedInstance = new ContentFeature('urlChanged', {}, {});
-    //
     // if the browser supports the navigation API, use that to listen for URL changes
     if ('navigation' in globalThis && 'addEventListener' in globalThis.navigation) {
         // We listen to `navigatesuccess` instead of `navigate` to ensure the navigation is committed.
@@ -33,7 +32,7 @@ function listenForURLChanges() {
             navigations.set(event.target, event.navigationType);
         });      
         globalThis.navigation.addEventListener('navigatesuccess', (event) => {
-            const navigationType = navigations.get(event.target) || 'navigate';
+            const navigationType = navigations.get(event.target) || 'unknown';
             handleURLChange(navigationType);
         });
         // Exit early if the navigation API is supported, i.e. history proxy and popState listener aren't created.
@@ -49,14 +48,13 @@ function listenForURLChanges() {
         apply(target, thisArg, args) {
             const changeResult = DDGReflect.apply(target, thisArg, args);
             console.log('pushstate event');
-            handleURLChange('pushState');
+            handleURLChange('push');
             return changeResult;
         },
     });
     historyMethodProxy.overload();
     // listen for popstate events in order to run on back/forward navigations
     window.addEventListener('popstate', () => {
-        console.log('popstate event');
         handleURLChange('popState');
     });
 }

--- a/injected/src/url-change.js
+++ b/injected/src/url-change.js
@@ -34,6 +34,7 @@ function listenForURLChanges() {
         globalThis.navigation.addEventListener('navigatesuccess', (event) => {
             const navigationType = navigations.get(event.target) || 'unknown';
             handleURLChange(navigationType);
+            navigations.delete(event.target);
         });
         // Exit early if the navigation API is supported, i.e. history proxy and popState listener aren't created.
         return;


### PR DESCRIPTION
**Asana Task/Github Issue:** <!-- Link to Asana Task/Github Issue -->

## Description

Uses JK's suggestion to get at the event type.

If I add this to `urlChanged` (in web-telemetry.js) I see that neither of these are true, which confuses me.  It may be that we need a check here, or perhaps this is working because the WebTelemetry feature is enabled and that's by design.

```js
console.log('WebTelemetry: URL changed', navigationType, this.getFeatureSettingEnabled('urlChanged'), this.getFeatureSettingEnabled('listenForUrlChanges'));
```

## Testing Steps

N/A - tested by https://github.com/duckduckgo/windows-browser/pull/4527

## Checklist

<!--
  These questions are a friendly reminder to shipping code, if you're uncertain ask the AoR owners.
  It's also totally appropriate to not check some of these boxes, if they don't apply to your change.
-->
*Please tick all that apply:*

- [x] I have tested this change locally
- [ ] I have tested this change locally in all supported browsers
- [ ] This change will be visible to users - NO
- [ ] I have added automated tests that cover this change - NO
- [ ] I have ensured the change is gated by config - NOT SURE
- [ ] This change was covered by a ship review - NO
- [ ] This change was covered by a tech design - NO
- [ ] Any dependent config has been merged - NOT SURE

