### PR TITLE
NTP: Swap “Show Duck.ai” / “Hide Duck.ai” link for a Duck.ai toggle

### DIFF
--- a/special-pages/pages/new-tab/app/components/Icons.js
+++ b/special-pages/pages/new-tab/app/components/Icons.js
@@ -484,3 +484,18 @@ export function LogoStacked(props) {
         </svg>
     );
 }
+
+/**
+ * From https://dub.duckduckgo.com/duckduckgo/Icons/blob/Main/Glyphs/16px/Arrow-Indent-Centerd-16.svg
+ * @param {import('preact').JSX.SVGAttributes<SVGSVGElement>} props
+ */
+export function ArrowIndentCenteredIcon(props) {
+    return (
+        <svg width="16" height="16" fill="none" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg" {...props}>
+            <path
+                fill="currentColor"
+                d="M3.625 1c.345 0 .625.28.625.625V5c0 1.52 1.23 2.75 2.749 2.75h7.117l-2.683-2.683a.625.625 0 0 1 .86-.906l.024.022 2.69 2.69c.83.83.83 2.175 0 3.005l-2.69 2.689a.625.625 0 1 1-.884-.884L14.116 9H7a3.999 3.999 0 0 1-4-4V1.625C3 1.28 3.28 1 3.625 1Z"
+            />
+        </svg>
+    );
+}

--- a/special-pages/pages/new-tab/app/customizer/CustomizerProvider.js
+++ b/special-pages/pages/new-tab/app/customizer/CustomizerProvider.js
@@ -55,10 +55,6 @@ export const CustomizerContext = createContext({
      * @param {UserImageContextMenu} _params
      */
     customizerContextMenu: (_params) => {},
-    /**
-     * @type {import('@preact/signals').Signal<Record<string, SettingsLinkData>>}
-     */
-    settingsLinks: signal({}),
 });
 
 /**
@@ -138,11 +134,8 @@ export function CustomizerProvider({ service, initialData, children }) {
     /** @type {(p: UserImageContextMenu) => void} */
     const customizerContextMenu = useCallback((params) => service.contextMenu(params), [service]);
 
-    /** @type {import('@preact/signals').Signal<Record<string, SettingsLinkData>>} */
-    const settingsLinks = useSignal({});
-
     return (
-        <CustomizerContext.Provider value={{ data, select, upload, setTheme, deleteImage, customizerContextMenu, settingsLinks }}>
+        <CustomizerContext.Provider value={{ data, select, upload, setTheme, deleteImage, customizerContextMenu }}>
             <CustomizerThemesContext.Provider value={{ main, browser }}>{children}</CustomizerThemesContext.Provider>
         </CustomizerContext.Provider>
     );

--- a/special-pages/pages/new-tab/app/customizer/components/CustomizerDrawer.js
+++ b/special-pages/pages/new-tab/app/customizer/components/CustomizerDrawer.js
@@ -13,7 +13,7 @@ export function CustomizerDrawer({ displayChildren }) {
 }
 
 function CustomizerConsumer() {
-    const { data, select, upload, setTheme, deleteImage, customizerContextMenu, settingsLinks } = useContext(CustomizerContext);
+    const { data, select, upload, setTheme, deleteImage, customizerContextMenu } = useContext(CustomizerContext);
     return (
         <CustomizerDrawerInner
             data={data}
@@ -22,7 +22,6 @@ function CustomizerConsumer() {
             setTheme={setTheme}
             deleteImage={deleteImage}
             customizerContextMenu={customizerContextMenu}
-            settingsLinks={settingsLinks}
         />
     );
 }

--- a/special-pages/pages/new-tab/app/customizer/components/CustomizerDrawerInner.js
+++ b/special-pages/pages/new-tab/app/customizer/components/CustomizerDrawerInner.js
@@ -30,9 +30,8 @@ import { Open } from '../../components/icons/Open.js';
  * @param {(theme: import('../../../types/new-tab').ThemeData) => void} props.setTheme
  * @param {(id: string) => void} props.deleteImage
  * @param {(p: UserImageContextMenu) => void} props.customizerContextMenu
- * @param {import('@preact/signals').Signal<Record<string, SettingsLinkData>>} props.settingsLinks
  */
-export function CustomizerDrawerInner({ data, select, onUpload, setTheme, deleteImage, customizerContextMenu, settingsLinks }) {
+export function CustomizerDrawerInner({ data, select, onUpload, setTheme, deleteImage, customizerContextMenu }) {
     const { close } = useDrawerControls();
     const { t } = useTypedTranslationWith(/** @type {enStrings} */ ({}));
     const messaging = useMessaging();
@@ -69,9 +68,6 @@ export function CustomizerDrawerInner({ data, select, onUpload, setTheme, delete
                                 <VisibilityMenuSection />
                             </CustomizerSection>
                             <BorderedSection>
-                                {Object.entries(settingsLinks.value).map(([key, link]) => (
-                                    <SettingsLink key={key} title={link.title} icon={link.icon} onClick={() => link.onClick()} />
-                                ))}
                                 <SettingsLink
                                     title={t('customizer_settings_link')}
                                     icon={<Open />}

--- a/special-pages/pages/new-tab/app/customizer/components/CustomizerMenu.js
+++ b/special-pages/pages/new-tab/app/customizer/components/CustomizerMenu.js
@@ -90,7 +90,7 @@ export class VisibilityRowData {
      * @param {object} params
      * @param {string} params.id - a unique id
      * @param {string} params.title - the title as it should appear in the menu
-     * @param {'shield' | 'star' | 'search'} params.icon - known icon name, maps to an SVG
+     * @param {'shield' | 'star' | 'search' | 'arrow-indent'} params.icon - known icon name, maps to an SVG
      * @param {(id: string) => void} params.toggle - toggle function for this item
      * @param {number} params.index - position in the menu
      * @param {WidgetVisibility} params.visibility - known icon name, maps to an SVG

--- a/special-pages/pages/new-tab/app/customizer/components/CustomizerMenu.js
+++ b/special-pages/pages/new-tab/app/customizer/components/CustomizerMenu.js
@@ -5,7 +5,17 @@ import { CustomizeIcon } from '../../components/Icons.js';
 import { useMessaging, useTypedTranslation } from '../../types.js';
 
 /**
- * @import { Widgets, WidgetConfigItem, WidgetVisibility, VisibilityMenuItem } from '../../../types/new-tab.js'
+ * @import { WidgetVisibility, VisibilityMenuItem } from '../../../types/new-tab.js'
+ */
+
+/**
+ * @typedef {object} VisibilityRowData
+ * @property {string} id - a unique id
+ * @property {string} title - the title as it should appear in the menu
+ * @property {import('preact').ComponentChild} icon - icon to display in the menu
+ * @property {(id: string) => void} toggle - toggle function for this item
+ * @property {number} index - position in the menu
+ * @property {WidgetVisibility} visibility - known icon name, maps to an SVG
  */
 
 export const OPEN_EVENT = 'ntp-customizer-open';
@@ -83,26 +93,6 @@ export function CustomizerButton({ menuId, buttonId, isOpen, toggleMenu, buttonR
 
 export function CustomizerMenuPositionedFixed({ children }) {
     return <div class={styles.lowerRightFixed}>{children}</div>;
-}
-
-export class VisibilityRowData {
-    /**
-     * @param {object} params
-     * @param {string} params.id - a unique id
-     * @param {string} params.title - the title as it should appear in the menu
-     * @param {'shield' | 'star' | 'search' | 'arrow-indent'} params.icon - known icon name, maps to an SVG
-     * @param {(id: string) => void} params.toggle - toggle function for this item
-     * @param {number} params.index - position in the menu
-     * @param {WidgetVisibility} params.visibility - known icon name, maps to an SVG
-     */
-    constructor({ id, title, icon, toggle, visibility, index }) {
-        this.id = id;
-        this.title = title;
-        this.icon = icon;
-        this.toggle = toggle;
-        this.index = index;
-        this.visibility = visibility;
-    }
 }
 
 /**

--- a/special-pages/pages/new-tab/app/customizer/components/VisibilityMenu.js
+++ b/special-pages/pages/new-tab/app/customizer/components/VisibilityMenu.js
@@ -2,7 +2,7 @@ import { h } from 'preact';
 import cn from 'classnames';
 import { useContext } from 'preact/hooks';
 
-import { DuckFoot, SearchIcon, Shield } from '../../components/Icons.js';
+import { ArrowIndentCenteredIcon, DuckFoot, SearchIcon, Shield } from '../../components/Icons.js';
 import styles from './VisibilityMenu.module.css';
 import { Switch } from '../../../../../shared/components/Switch/Switch.js';
 import { usePlatformName } from '../../settings.provider.js';
@@ -30,6 +30,7 @@ export function EmbeddedVisibilityMenu({ rows }) {
                                 {row.icon === 'shield' && <DuckFoot />}
                                 {row.icon === 'star' && <Shield />}
                                 {row.icon === 'search' && <SearchIcon />}
+                                {row.icon === 'arrow-indent' && <ArrowIndentCenteredIcon />}
                             </span>
                             <span>{row.title ?? row.id}</span>
                             <Switch

--- a/special-pages/pages/new-tab/app/customizer/components/VisibilityMenu.js
+++ b/special-pages/pages/new-tab/app/customizer/components/VisibilityMenu.js
@@ -1,16 +1,14 @@
-import { h } from 'preact';
 import cn from 'classnames';
+import { h } from 'preact';
 import { useContext } from 'preact/hooks';
 
-import { ArrowIndentCenteredIcon, DuckFoot, SearchIcon, Shield } from '../../components/Icons.js';
-import styles from './VisibilityMenu.module.css';
 import { Switch } from '../../../../../shared/components/Switch/Switch.js';
 import { usePlatformName } from '../../settings.provider.js';
 import { CustomizerThemesContext } from '../CustomizerProvider.js';
+import styles from './VisibilityMenu.module.css';
 
 /**
- * @import { Widgets, WidgetConfigItem } from '../../../types/new-tab.js'
- * @import { VisibilityRowData } from './CustomizerMenu.js'
+ * @import { VisibilityRowData } from './CustomizerMenu.js';
  */
 
 /**
@@ -26,12 +24,7 @@ export function EmbeddedVisibilityMenu({ rows }) {
                 return (
                     <li key={row.id}>
                         <div class={cn(styles.menuItemLabel, styles.menuItemLabelEmbedded)}>
-                            <span className={styles.svg}>
-                                {row.icon === 'shield' && <DuckFoot />}
-                                {row.icon === 'star' && <Shield />}
-                                {row.icon === 'search' && <SearchIcon />}
-                                {row.icon === 'arrow-indent' && <ArrowIndentCenteredIcon />}
-                            </span>
+                            <span className={styles.svg}>{row.icon}</span>
                             <span>{row.title ?? row.id}</span>
                             <Switch
                                 theme={browser.value}

--- a/special-pages/pages/new-tab/app/favorites/components/FavoritesCustomized.js
+++ b/special-pages/pages/new-tab/app/favorites/components/FavoritesCustomized.js
@@ -10,6 +10,7 @@ import { PragmaticDND } from './PragmaticDND.js';
 import { FavoritesMemo } from './Favorites.js';
 import { viewTransition } from '../../utils.js';
 import { CustomizerContext } from '../../customizer/CustomizerProvider.js';
+import { Shield } from '../../components/Icons.js';
 
 /**
  * @typedef {import('../../../types/new-tab.ts').Favorite} Favorite
@@ -66,7 +67,7 @@ export function FavoritesCustomized() {
 
     // register with the visibility menu
     const title = t('favorites_menu_title');
-    useCustomizer({ title, id, icon: 'star', toggle, visibility: visibility.value, index });
+    useCustomizer({ title, id, icon: <Shield />, toggle, visibility: visibility.value, index });
 
     if (visibility.value === 'hidden') {
         return null;

--- a/special-pages/pages/new-tab/app/omnibar/components/OmnibarConsumer.js
+++ b/special-pages/pages/new-tab/app/omnibar/components/OmnibarConsumer.js
@@ -5,6 +5,7 @@ import { useTypedTranslationWith } from '../../types.js';
 import { useVisibility } from '../../widget-list/widget-config.provider.js';
 import { Omnibar } from './Omnibar.js';
 import { OmnibarContext } from './OmnibarProvider.js';
+import { ArrowIndentCenteredIcon } from '../../components/Icons.js';
 
 /**
  * @typedef {import('../strings.json')} Strings
@@ -56,7 +57,7 @@ function AiSetting({ enableAi, setEnableAi }) {
     useCustomizer({
         title: t('omnibar_toggleDuckAi'),
         id: `_${id}-toggleAi`,
-        icon: 'arrow-indent',
+        icon: <ArrowIndentCenteredIcon />,
         toggle: () => setEnableAi(!enableAi),
         visibility: enableAi ? 'visible' : 'hidden',
         index: index + 0.1,

--- a/special-pages/pages/new-tab/app/omnibar/components/OmnibarConsumer.js
+++ b/special-pages/pages/new-tab/app/omnibar/components/OmnibarConsumer.js
@@ -57,7 +57,7 @@ function AiSetting({ enableAi, setEnableAi }) {
     useCustomizer({
         title: t('omnibar_toggleDuckAi'),
         id: `_${id}-toggleAi`,
-        icon: <ArrowIndentCenteredIcon />,
+        icon: <ArrowIndentCenteredIcon style={{ color: 'var(--ntp-icons-tertiary)' }} />,
         toggle: () => setEnableAi(!enableAi),
         visibility: enableAi ? 'visible' : 'hidden',
         index: index + 0.1,

--- a/special-pages/pages/new-tab/app/omnibar/components/OmnibarConsumer.js
+++ b/special-pages/pages/new-tab/app/omnibar/components/OmnibarConsumer.js
@@ -1,10 +1,10 @@
-import { useContext, useEffect } from 'preact/hooks';
-import { OmnibarContext } from './OmnibarProvider.js';
-import { h } from 'preact';
-import { Omnibar } from './Omnibar.js';
-import { CustomizerContext } from '../../customizer/CustomizerProvider.js';
-import { AiChatIcon } from '../../components/Icons.js';
+import { Fragment, h } from 'preact';
+import { useContext } from 'preact/hooks';
+import { useCustomizer } from '../../customizer/components/CustomizerMenu.js';
 import { useTypedTranslationWith } from '../../types.js';
+import { useVisibility } from '../../widget-list/widget-config.provider.js';
+import { Omnibar } from './Omnibar.js';
+import { OmnibarContext } from './OmnibarProvider.js';
 
 /**
  * @typedef {import('../strings.json')} Strings
@@ -36,29 +36,30 @@ export function OmnibarConsumer() {
  * @param {OmnibarConfig} props.config
  */
 function OmnibarReadyState({ config: { enableAi = true, showAiSetting = true, mode } }) {
+    const { setEnableAi, setMode } = useContext(OmnibarContext);
+    return (
+        <>
+            {showAiSetting && <AiSetting enableAi={enableAi} setEnableAi={setEnableAi} />}
+            <Omnibar mode={mode} setMode={setMode} enableAi={enableAi} />
+        </>
+    );
+}
+
+/**
+ * @param {object} props
+ * @param {boolean} props.enableAi
+ * @param {(enable: boolean) => void} props.setEnableAi
+ */
+function AiSetting({ enableAi, setEnableAi }) {
     const { t } = useTypedTranslationWith(/** @type {Strings} */ ({}));
-
-    const { settingsLinks } = useContext(CustomizerContext);
-    const { setMode, setEnableAi } = useContext(OmnibarContext);
-
-    useEffect(() => {
-        if (!showAiSetting) {
-            return;
-        }
-
-        settingsLinks.value = {
-            ...settingsLinks.value,
-            duckAi: {
-                title: enableAi ? t('omnibar_hideDuckAi') : t('omnibar_showDuckAi'),
-                icon: <AiChatIcon />,
-                onClick: () => setEnableAi(!enableAi),
-            },
-        };
-        return () => {
-            const { duckAi: _, ...rest } = settingsLinks.value;
-            settingsLinks.value = rest;
-        };
-    }, [enableAi, showAiSetting]);
-
-    return <Omnibar mode={mode} setMode={setMode} enableAi={enableAi} />;
+    const { id, index } = useVisibility();
+    useCustomizer({
+        title: t('omnibar_toggleDuckAi'),
+        id: `_${id}-toggleAi`,
+        icon: 'arrow-indent',
+        toggle: () => setEnableAi(!enableAi),
+        visibility: enableAi ? 'visible' : 'hidden',
+        index: index + 0.1,
+    });
+    return null;
 }

--- a/special-pages/pages/new-tab/app/omnibar/components/OmnibarCustomized.js
+++ b/special-pages/pages/new-tab/app/omnibar/components/OmnibarCustomized.js
@@ -5,6 +5,7 @@ import { OmnibarProvider } from './OmnibarProvider.js';
 import { h } from 'preact';
 
 import { OmnibarConsumer } from './OmnibarConsumer.js';
+import { SearchIcon } from '../../components/Icons.js';
 
 /**
  * @import enStrings from "../strings.json"
@@ -27,7 +28,7 @@ export function OmnibarCustomized() {
 
     const { visibility, id, toggle, index } = useVisibility();
 
-    useCustomizer({ title: sectionTitle, id, icon: 'search', toggle, visibility: visibility.value, index });
+    useCustomizer({ title: sectionTitle, id, icon: <SearchIcon />, toggle, visibility: visibility.value, index });
 
     if (visibility.value === 'hidden') {
         return null;

--- a/special-pages/pages/new-tab/app/omnibar/integration-tests/omnibar.page.js
+++ b/special-pages/pages/new-tab/app/omnibar/integration-tests/omnibar.page.js
@@ -61,12 +61,8 @@ export class OmnibarPage {
         return this.page.getByRole('switch', { name: 'Toggle Search' });
     }
 
-    showDuckAiButton() {
-        return this.page.getByRole('link', { name: 'Show Duck.ai' });
-    }
-
-    hideDuckAiButton() {
-        return this.page.getByRole('link', { name: 'Hide Duck.ai' });
+    toggleDuckAiButton() {
+        return this.page.getByRole('switch', { name: 'Toggle Duck.ai' });
     }
 
     /**

--- a/special-pages/pages/new-tab/app/omnibar/integration-tests/omnibar.spec.js
+++ b/special-pages/pages/new-tab/app/omnibar/integration-tests/omnibar.spec.js
@@ -230,7 +230,7 @@ test.describe('omnibar widget', () => {
 
         // Enable Duck.ai via Customize panel
         await omnibar.customizeButton().click();
-        await omnibar.showDuckAiButton().click();
+        await omnibar.toggleDuckAiButton().click();
 
         // Tab selector is now visible
         await expect(omnibar.tabList()).toBeVisible();
@@ -249,7 +249,7 @@ test.describe('omnibar widget', () => {
 
         // Disable Duck.ai via Customize panel
         await omnibar.customizeButton().click();
-        await omnibar.hideDuckAiButton().click();
+        await omnibar.toggleDuckAiButton().click();
 
         // Tab selector is now gone
         await expect(omnibar.tabList()).toHaveCount(0);
@@ -265,11 +265,11 @@ test.describe('omnibar widget', () => {
 
         // Open Customize panel - Duck.ai toggle should be visible
         await omnibar.customizeButton().click();
-        await expect(omnibar.hideDuckAiButton()).toBeVisible();
+        await expect(omnibar.toggleDuckAiButton()).toBeVisible();
 
         // Hide the Omnibar widget - Duck.ai toggle should be hidden
         await omnibar.toggleSearchButton().click();
-        await expect(omnibar.hideDuckAiButton()).toHaveCount(0);
+        await expect(omnibar.toggleDuckAiButton()).toHaveCount(0);
     });
 
     test('Duck.ai toggle is hidden when showAiSetting is false', async ({ page }, workerInfo) => {
@@ -284,8 +284,7 @@ test.describe('omnibar widget', () => {
         await omnibar.customizeButton().click();
 
         // The Duck.ai toggle button should not be visible
-        await expect(omnibar.hideDuckAiButton()).toHaveCount(0);
-        await expect(omnibar.showDuckAiButton()).toHaveCount(0);
+        await expect(omnibar.toggleDuckAiButton()).toHaveCount(0);
     });
 
     test('suggestions list arrow down navigation', async ({ page }, workerInfo) => {

--- a/special-pages/pages/new-tab/app/omnibar/strings.json
+++ b/special-pages/pages/new-tab/app/omnibar/strings.json
@@ -35,14 +35,6 @@
     "title": "Duck.ai",
     "description": "Label for the button to toggle the Duck.ai chat interface."
   },
-  "omnibar_hideDuckAi": {
-    "title": "Hide Duck.ai",
-    "description": "Label for the button to hide the Duck.ai chat interface."
-  },
-  "omnibar_showDuckAi": {
-    "title": "Show Duck.ai",
-    "description": "Label for the button to show the Duck.ai chat interface."
-  },
   "omnibar_searchDuckDuckGoSuffix": {
     "title": "Search DuckDuckGo",
     "description": "Text placed after suggestions that will search DuckDuckGo."

--- a/special-pages/pages/new-tab/app/omnibar/strings.json
+++ b/special-pages/pages/new-tab/app/omnibar/strings.json
@@ -31,6 +31,10 @@
     "title": "Search privately",
     "description": "Placeholder text for the search input field."
   },
+  "omnibar_toggleDuckAi": {
+    "title": "Duck.ai",
+    "description": "Label for the button to toggle the Duck.ai chat interface."
+  },
   "omnibar_hideDuckAi": {
     "title": "Hide Duck.ai",
     "description": "Label for the button to hide the Duck.ai chat interface."

--- a/special-pages/pages/new-tab/app/protections/components/ProtectionsCustomized.js
+++ b/special-pages/pages/new-tab/app/protections/components/ProtectionsCustomized.js
@@ -5,6 +5,7 @@ import { ProtectionsProvider } from './ProtectionsProvider.js';
 import { h } from 'preact';
 
 import { ProtectionsConsumer } from './ProtectionsConsumer.js';
+import { DuckFoot } from '../../components/Icons.js';
 
 /**
  * @import enStrings from "../strings.json"
@@ -27,7 +28,7 @@ export function ProtectionsCustomized() {
 
     const { visibility, id, toggle, index } = useVisibility();
 
-    useCustomizer({ title: sectionTitle, id, icon: 'shield', toggle, visibility: visibility.value, index });
+    useCustomizer({ title: sectionTitle, id, icon: <DuckFoot />, toggle, visibility: visibility.value, index });
 
     if (visibility.value === 'hidden') {
         return null;

--- a/special-pages/pages/new-tab/app/styles/ntp-theme.css
+++ b/special-pages/pages/new-tab/app/styles/ntp-theme.css
@@ -64,6 +64,7 @@ body {
     --ntp-text-primary: #1F1F1F;
     --ntp-text-tertiary: rgba(31, 31, 31, 0.4);
     --ntp-icons-primary: rgba(31, 31, 31, 0.84);
+    --ntp-icons-tertiary: rgba(0, 0, 0, 0.36);
     --ntp-accent-primary: var(--color-blue-50);
     --ntp-accent-secondary: var(--color-blue-60);
     --ntp-accent-glow: rgba(57, 105, 239, 0.2);
@@ -97,6 +98,7 @@ body {
     --ntp-text-primary: rgba(255, 255, 255, 0.9);
     --ntp-text-tertiary: rgba(255, 255, 255, 0.4);
     --ntp-icons-primary: rgba(255, 255, 255, 0.78);
+    --ntp-icons-tertiary: rgba(255, 255, 255, 0.24);
     --ntp-accent-primary: var(--color-blue-20);
     --ntp-accent-secondary: var(--color-blue-30);
     --ntp-accent-glow: rgba(114, 149, 246, 0.2);

--- a/special-pages/pages/new-tab/app/telemetry/Debug.js
+++ b/special-pages/pages/new-tab/app/telemetry/Debug.js
@@ -3,6 +3,7 @@ import { useEffect, useRef, useState } from 'preact/hooks';
 import { useTelemetry } from '../types.js';
 import { useCustomizer } from '../customizer/components/CustomizerMenu.js';
 import { Telemetry } from './telemetry.js';
+import { DuckFoot } from '../components/Icons.js';
 
 export function DebugCustomized({ index, isOpenInitially = false }) {
     const [isOpen, setOpen] = useState(isOpenInitially);
@@ -10,7 +11,7 @@ export function DebugCustomized({ index, isOpenInitially = false }) {
     useCustomizer({
         title: '🐞 Debug',
         id: 'debug',
-        icon: 'shield',
+        icon: <DuckFoot />,
         visibility: isOpen ? 'visible' : 'hidden',
         toggle: (_id) => setOpen((prev) => !prev),
         index,

--- a/special-pages/pages/new-tab/public/locales/de/new-tab.json
+++ b/special-pages/pages/new-tab/public/locales/de/new-tab.json
@@ -156,14 +156,7 @@
     "title" : "Privat suchen",
     "description" : "Placeholder text for the search input field."
   },
-  "omnibar_hideDuckAi" : {
-    "title" : "Duck.ai ausblenden",
-    "description" : "Label for the button to hide the Duck.ai chat interface."
-  },
-  "omnibar_showDuckAi" : {
-    "title" : "Duck.ai anzeigen",
-    "description" : "Label for the button to show the Duck.ai chat interface."
-  },
+
   "omnibar_searchDuckDuckGoSuffix" : {
     "title" : "Mit DuckDuckGo suchen",
     "description" : "Text placed after suggestions that will search DuckDuckGo."

--- a/special-pages/pages/new-tab/public/locales/de/new-tab.json
+++ b/special-pages/pages/new-tab/public/locales/de/new-tab.json
@@ -156,7 +156,10 @@
     "title" : "Privat suchen",
     "description" : "Placeholder text for the search input field."
   },
-
+  "omnibar_toggleDuckAi" : {
+    "title" : "Duck.ai",
+    "description" : "Label for the button to toggle the Duck.ai chat interface."
+  },
   "omnibar_searchDuckDuckGoSuffix" : {
     "title" : "Mit DuckDuckGo suchen",
     "description" : "Text placed after suggestions that will search DuckDuckGo."

--- a/special-pages/pages/new-tab/public/locales/en/new-tab.json
+++ b/special-pages/pages/new-tab/public/locales/en/new-tab.json
@@ -157,6 +157,10 @@
     "title": "Search privately",
     "description": "Placeholder text for the search input field."
   },
+  "omnibar_toggleDuckAi": {
+    "title": "Duck.ai",
+    "description": "Label for the button to toggle the Duck.ai chat interface."
+  },
   "omnibar_hideDuckAi": {
     "title": "Hide Duck.ai",
     "description": "Label for the button to hide the Duck.ai chat interface."

--- a/special-pages/pages/new-tab/public/locales/en/new-tab.json
+++ b/special-pages/pages/new-tab/public/locales/en/new-tab.json
@@ -161,14 +161,6 @@
     "title": "Duck.ai",
     "description": "Label for the button to toggle the Duck.ai chat interface."
   },
-  "omnibar_hideDuckAi": {
-    "title": "Hide Duck.ai",
-    "description": "Label for the button to hide the Duck.ai chat interface."
-  },
-  "omnibar_showDuckAi": {
-    "title": "Show Duck.ai",
-    "description": "Label for the button to show the Duck.ai chat interface."
-  },
   "omnibar_searchDuckDuckGoSuffix": {
     "title": "Search DuckDuckGo",
     "description": "Text placed after suggestions that will search DuckDuckGo."

--- a/special-pages/pages/new-tab/public/locales/es/new-tab.json
+++ b/special-pages/pages/new-tab/public/locales/es/new-tab.json
@@ -156,14 +156,6 @@
     "title" : "Busca de manera privada",
     "description" : "Placeholder text for the search input field."
   },
-  "omnibar_hideDuckAi" : {
-    "title" : "Ocultar Duck.ai",
-    "description" : "Label for the button to hide the Duck.ai chat interface."
-  },
-  "omnibar_showDuckAi" : {
-    "title" : "Mostrar Duck.ai",
-    "description" : "Label for the button to show the Duck.ai chat interface."
-  },
   "omnibar_searchDuckDuckGoSuffix" : {
     "title" : "Buscar en DuckDuckGo",
     "description" : "Text placed after suggestions that will search DuckDuckGo."

--- a/special-pages/pages/new-tab/public/locales/es/new-tab.json
+++ b/special-pages/pages/new-tab/public/locales/es/new-tab.json
@@ -156,6 +156,10 @@
     "title" : "Busca de manera privada",
     "description" : "Placeholder text for the search input field."
   },
+  "omnibar_toggleDuckAi" : {
+    "title" : "Duck.ai",
+    "description" : "Label for the button to toggle the Duck.ai chat interface."
+  },
   "omnibar_searchDuckDuckGoSuffix" : {
     "title" : "Buscar en DuckDuckGo",
     "description" : "Text placed after suggestions that will search DuckDuckGo."

--- a/special-pages/pages/new-tab/public/locales/fr/new-tab.json
+++ b/special-pages/pages/new-tab/public/locales/fr/new-tab.json
@@ -156,14 +156,6 @@
     "title" : "Faites une recherche privée",
     "description" : "Placeholder text for the search input field."
   },
-  "omnibar_hideDuckAi" : {
-    "title" : "Masquer Duck.ai",
-    "description" : "Label for the button to hide the Duck.ai chat interface."
-  },
-  "omnibar_showDuckAi" : {
-    "title" : "Afficher Duck.ai",
-    "description" : "Label for the button to show the Duck.ai chat interface."
-  },
   "omnibar_searchDuckDuckGoSuffix" : {
     "title" : "Rechercher avec DuckDuckGo",
     "description" : "Text placed after suggestions that will search DuckDuckGo."

--- a/special-pages/pages/new-tab/public/locales/fr/new-tab.json
+++ b/special-pages/pages/new-tab/public/locales/fr/new-tab.json
@@ -156,6 +156,10 @@
     "title" : "Faites une recherche privée",
     "description" : "Placeholder text for the search input field."
   },
+  "omnibar_toggleDuckAi" : {
+    "title" : "Duck.ai",
+    "description" : "Label for the button to toggle the Duck.ai chat interface."
+  },
   "omnibar_searchDuckDuckGoSuffix" : {
     "title" : "Rechercher avec DuckDuckGo",
     "description" : "Text placed after suggestions that will search DuckDuckGo."

--- a/special-pages/pages/new-tab/public/locales/it/new-tab.json
+++ b/special-pages/pages/new-tab/public/locales/it/new-tab.json
@@ -156,14 +156,6 @@
     "title" : "Cerca privatamente",
     "description" : "Placeholder text for the search input field."
   },
-  "omnibar_hideDuckAi" : {
-    "title" : "Nascondi Duck.ai",
-    "description" : "Label for the button to hide the Duck.ai chat interface."
-  },
-  "omnibar_showDuckAi" : {
-    "title" : "Mostra Duck.ai",
-    "description" : "Label for the button to show the Duck.ai chat interface."
-  },
   "omnibar_searchDuckDuckGoSuffix" : {
     "title" : "Cerca con DuckDuckGo",
     "description" : "Text placed after suggestions that will search DuckDuckGo."

--- a/special-pages/pages/new-tab/public/locales/it/new-tab.json
+++ b/special-pages/pages/new-tab/public/locales/it/new-tab.json
@@ -156,6 +156,10 @@
     "title" : "Cerca privatamente",
     "description" : "Placeholder text for the search input field."
   },
+  "omnibar_toggleDuckAi" : {
+    "title" : "Duck.ai",
+    "description" : "Label for the button to toggle the Duck.ai chat interface."
+  },
   "omnibar_searchDuckDuckGoSuffix" : {
     "title" : "Cerca con DuckDuckGo",
     "description" : "Text placed after suggestions that will search DuckDuckGo."

--- a/special-pages/pages/new-tab/public/locales/nl/new-tab.json
+++ b/special-pages/pages/new-tab/public/locales/nl/new-tab.json
@@ -156,6 +156,10 @@
     "title" : "Privé zoeken",
     "description" : "Placeholder text for the search input field."
   },
+  "omnibar_toggleDuckAi" : {
+    "title" : "Duck.ai",
+    "description" : "Label for the button to toggle the Duck.ai chat interface."
+  },
   "omnibar_searchDuckDuckGoSuffix" : {
     "title" : "Zoek in DuckDuckGo",
     "description" : "Text placed after suggestions that will search DuckDuckGo."

--- a/special-pages/pages/new-tab/public/locales/nl/new-tab.json
+++ b/special-pages/pages/new-tab/public/locales/nl/new-tab.json
@@ -156,14 +156,6 @@
     "title" : "Privé zoeken",
     "description" : "Placeholder text for the search input field."
   },
-  "omnibar_hideDuckAi" : {
-    "title" : "Duck.ai verbergen",
-    "description" : "Label for the button to hide the Duck.ai chat interface."
-  },
-  "omnibar_showDuckAi" : {
-    "title" : "Duck.ai weergeven",
-    "description" : "Label for the button to show the Duck.ai chat interface."
-  },
   "omnibar_searchDuckDuckGoSuffix" : {
     "title" : "Zoek in DuckDuckGo",
     "description" : "Text placed after suggestions that will search DuckDuckGo."

--- a/special-pages/pages/new-tab/public/locales/pl/new-tab.json
+++ b/special-pages/pages/new-tab/public/locales/pl/new-tab.json
@@ -156,6 +156,10 @@
     "title" : "Szukaj prywatnie",
     "description" : "Placeholder text for the search input field."
   },
+  "omnibar_toggleDuckAi" : {
+    "title" : "Duck.ai",
+    "description" : "Label for the button to toggle the Duck.ai chat interface."
+  },
   "omnibar_searchDuckDuckGoSuffix" : {
     "title" : "Szukaj w DuckDuckGo",
     "description" : "Text placed after suggestions that will search DuckDuckGo."

--- a/special-pages/pages/new-tab/public/locales/pl/new-tab.json
+++ b/special-pages/pages/new-tab/public/locales/pl/new-tab.json
@@ -156,14 +156,6 @@
     "title" : "Szukaj prywatnie",
     "description" : "Placeholder text for the search input field."
   },
-  "omnibar_hideDuckAi" : {
-    "title" : "Ukryj Duck.ai",
-    "description" : "Label for the button to hide the Duck.ai chat interface."
-  },
-  "omnibar_showDuckAi" : {
-    "title" : "Pokaż Duck.ai",
-    "description" : "Label for the button to show the Duck.ai chat interface."
-  },
   "omnibar_searchDuckDuckGoSuffix" : {
     "title" : "Szukaj w DuckDuckGo",
     "description" : "Text placed after suggestions that will search DuckDuckGo."

--- a/special-pages/pages/new-tab/public/locales/pt/new-tab.json
+++ b/special-pages/pages/new-tab/public/locales/pt/new-tab.json
@@ -156,14 +156,6 @@
     "title" : "Pesquisar em privado",
     "description" : "Placeholder text for the search input field."
   },
-  "omnibar_hideDuckAi" : {
-    "title" : "Ocultar Duck.ai",
-    "description" : "Label for the button to hide the Duck.ai chat interface."
-  },
-  "omnibar_showDuckAi" : {
-    "title" : "Mostrar Duck.ai",
-    "description" : "Label for the button to show the Duck.ai chat interface."
-  },
   "omnibar_searchDuckDuckGoSuffix" : {
     "title" : "Pesquisar no DuckDuckGo",
     "description" : "Text placed after suggestions that will search DuckDuckGo."

--- a/special-pages/pages/new-tab/public/locales/pt/new-tab.json
+++ b/special-pages/pages/new-tab/public/locales/pt/new-tab.json
@@ -156,6 +156,10 @@
     "title" : "Pesquisar em privado",
     "description" : "Placeholder text for the search input field."
   },
+  "omnibar_toggleDuckAi" : {
+    "title" : "Duck.ai",
+    "description" : "Label for the button to toggle the Duck.ai chat interface."
+  },
   "omnibar_searchDuckDuckGoSuffix" : {
     "title" : "Pesquisar no DuckDuckGo",
     "description" : "Text placed after suggestions that will search DuckDuckGo."

--- a/special-pages/pages/new-tab/public/locales/ru/new-tab.json
+++ b/special-pages/pages/new-tab/public/locales/ru/new-tab.json
@@ -156,6 +156,10 @@
     "title" : "Конфиденциальный поиск",
     "description" : "Placeholder text for the search input field."
   },
+  "omnibar_toggleDuckAi" : {
+    "title" : "Duck.ai",
+    "description" : "Label for the button to toggle the Duck.ai chat interface."
+  },
   "omnibar_searchDuckDuckGoSuffix" : {
     "title" : "Поиск в DuckDuckGo",
     "description" : "Text placed after suggestions that will search DuckDuckGo."

--- a/special-pages/pages/new-tab/public/locales/ru/new-tab.json
+++ b/special-pages/pages/new-tab/public/locales/ru/new-tab.json
@@ -156,14 +156,6 @@
     "title" : "Конфиденциальный поиск",
     "description" : "Placeholder text for the search input field."
   },
-  "omnibar_hideDuckAi" : {
-    "title" : "Скрыть Duck.ai",
-    "description" : "Label for the button to hide the Duck.ai chat interface."
-  },
-  "omnibar_showDuckAi" : {
-    "title" : "Показать Duck.ai",
-    "description" : "Label for the button to show the Duck.ai chat interface."
-  },
   "omnibar_searchDuckDuckGoSuffix" : {
     "title" : "Поиск в DuckDuckGo",
     "description" : "Text placed after suggestions that will search DuckDuckGo."


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1209121419454298/task/1210958290044910?focus=true

## Description

https://github.com/user-attachments/assets/d2352e4b-2029-4d5f-9268-ebb514489334

Removes the “Show Duck.ai” / “Hide Duck.ai” link in the sidebar in favour of a “nested” toggle for Duck.ai. The toggle is still shown conditionally depending on whether the widget is visible. Nesting is faked using an indented arrow icon.

## Testing Steps

https://deploy-preview-1866--content-scope-scripts.netlify.app/build/pages/new-tab/?omnibar=true

1. Open the Customize sidebar.
2. Toggle Search widget on/off.
3. Toggle Duck.ai on/off.

## Checklist

*Please tick all that apply:*

- [x] I have tested this change locally
- [ ] I have tested this change locally in all supported browsers
- [ ] This change will be visible to users
- [x] I have added automated tests that cover this change
- [x] I have ensured the change is gated by config
- [ ] This change was covered by a ship review
- [ ] This change was covered by a tech design
- [x] Any dependent config has been merged

