### PR TITLE
ntp: omnibar states

### DIFF
--- a/special-pages/pages/new-tab/app/customizer/components/CustomizerMenu.js
+++ b/special-pages/pages/new-tab/app/customizer/components/CustomizerMenu.js
@@ -110,5 +110,8 @@ export function useCustomizer({ title, id, icon, toggle, visibility, index }) {
 
     useEffect(() => {
         window.dispatchEvent(new Event(UPDATE_EVENT));
+        return () => {
+            window.dispatchEvent(new Event(UPDATE_EVENT));
+        };
     }, [visibility]);
 }

--- a/special-pages/pages/new-tab/app/customizer/integration-tests/customizer.page.js
+++ b/special-pages/pages/new-tab/app/customizer/integration-tests/customizer.page.js
@@ -20,6 +20,8 @@ export class CustomizerPage {
         this.ntp = ntp;
     }
 
+    context = () => this.ntp.page.locator('aside');
+
     async showsColorSelectionPanel() {
         const { page } = this.ntp;
         await page.locator('aside').getByLabel('Solid Colors').click();
@@ -458,5 +460,35 @@ export class CustomizerPage {
         await page.getByRole('radio', { name: 'Select image 1' }).click({
             button: 'right',
         });
+    }
+
+    /**
+     * @param {string} name
+     * @returns {Promise<void>}
+     */
+    async isChecked(name) {
+        await expect(this.context().getByRole('switch', { name })).toBeChecked();
+    }
+
+    /**
+     * @param {string} name
+     * @returns {Promise<void>}
+     */
+    async isUnchecked(name) {
+        await expect(this.context().getByRole('switch', { name })).not.toBeChecked({ timeout: 1000 });
+    }
+
+    /**
+     * @param {string} name
+     */
+    async hasSwitch(name) {
+        await expect(this.context().getByRole('switch', { name })).toBeVisible();
+    }
+
+    /**
+     * @param {string} name
+     */
+    async doesntHaveSwitch(name) {
+        await expect(this.context().getByRole('switch', { name })).not.toBeVisible();
     }
 }

--- a/special-pages/pages/new-tab/app/customizer/mocks.js
+++ b/special-pages/pages/new-tab/app/customizer/mocks.js
@@ -71,7 +71,6 @@ export function customizerMockTransport() {
                 case 'customizer_onBackgroundUpdate':
                 case 'customizer_onImagesUpdate': {
                     subscriptions.set(sub, cb);
-                    console.log('did add sub', sub);
                     return () => {
                         console.log('-- did remove sub', sub);
                         return subscriptions.delete(sub);

--- a/special-pages/pages/new-tab/app/index.js
+++ b/special-pages/pages/new-tab/app/index.js
@@ -16,6 +16,8 @@ import { CustomizerService } from './customizer/customizer.service.js';
 import { InlineErrorBoundary } from './InlineErrorBoundary.js';
 import { DocumentVisibilityProvider } from '../../../shared/components/DocumentVisibility.js';
 import { applyDefaultStyles } from './customizer/utils.js';
+import { TabsService } from './tabs/tabs.service.js';
+import { TabsDebug, TabsProvider } from './tabs/TabsProvider.js';
 
 /**
  * @import {Telemetry} from "./telemetry/telemetry.js"
@@ -89,6 +91,7 @@ export async function init(root, messaging, telemetry, baseEnvironment) {
 
     // Resolve the entry points for each selected widget
     const entryPoints = await resolveEntryPoints(init.widgets, didCatch);
+    const tabs = new TabsService(messaging, init.tabs || TabsService.DEFAULT);
 
     // Create an instance of the global widget api
     const widgetConfigAPI = new WidgetConfigService(messaging, init.widgetConfigs);
@@ -129,7 +132,10 @@ export async function init(root, messaging, telemetry, baseEnvironment) {
                                                 widgets={init.widgets}
                                                 entryPoints={entryPoints}
                                             >
-                                                <App />
+                                                <TabsProvider service={tabs}>
+                                                    {environment.urlParams.has('tabs.debug') && <TabsDebug />}
+                                                    <App />
+                                                </TabsProvider>
                                             </WidgetConfigProvider>
                                         </DocumentVisibilityProvider>
                                     </CustomizerProvider>

--- a/special-pages/pages/new-tab/app/new-tab.md
+++ b/special-pages/pages/new-tab/app/new-tab.md
@@ -11,6 +11,7 @@ children:
   - ./customizer/customizer.md
   - ./protections/protections.md
   - ./omnibar/omnibar.md
+  - ./tabs/tabs.md
 ---
 
 ## Requests

--- a/special-pages/pages/new-tab/app/omnibar/components/Omnibar.js
+++ b/special-pages/pages/new-tab/app/omnibar/components/Omnibar.js
@@ -10,6 +10,7 @@ import { SearchForm } from './SearchForm';
 import { SearchFormProvider } from './SearchFormProvider';
 import { SuggestionsList } from './SuggestionsList';
 import { TabSwitcher } from './TabSwitcher';
+import { useQueryWithLocalPersistence } from './PersistentOmnibarValuesProvider.js';
 
 /**
  * @typedef {import('../strings.json')} Strings
@@ -23,11 +24,12 @@ import { TabSwitcher } from './TabSwitcher';
  * @param {OmnibarConfig['mode']} props.mode
  * @param {(mode: OmnibarConfig['mode']) => void} props.setMode
  * @param {boolean} props.enableAi
+ * @param {string|null|undefined} props.tabId
  */
-export function Omnibar({ mode, setMode, enableAi }) {
+export function Omnibar({ mode, setMode, enableAi, tabId }) {
     const { t } = useTypedTranslationWith(/** @type {Strings} */ ({}));
 
-    const [query, setQuery] = useState(/** @type {String} */ (''));
+    const [query, setQuery] = useQueryWithLocalPersistence(tabId);
     const [resetKey, setResetKey] = useState(0);
     const [autoFocus, setAutoFocus] = useState(false);
 

--- a/special-pages/pages/new-tab/app/omnibar/components/OmnibarConsumer.js
+++ b/special-pages/pages/new-tab/app/omnibar/components/OmnibarConsumer.js
@@ -6,6 +6,8 @@ import { useVisibility } from '../../widget-list/widget-config.provider.js';
 import { Omnibar } from './Omnibar.js';
 import { OmnibarContext } from './OmnibarProvider.js';
 import { ArrowIndentCenteredIcon } from '../../components/Icons.js';
+import { useModeWithLocalPersistence } from './PersistentOmnibarValuesProvider.js';
+import { useTabState } from '../../tabs/TabsProvider.js';
 
 /**
  * @typedef {import('../strings.json')} Strings
@@ -26,8 +28,9 @@ import { ArrowIndentCenteredIcon } from '../../components/Icons.js';
  */
 export function OmnibarConsumer() {
     const { state } = useContext(OmnibarContext);
+    const { current } = useTabState();
     if (state.status === 'ready') {
-        return <OmnibarReadyState config={state.config} />;
+        return <OmnibarReadyState config={state.config} key={current.value} tabId={current.value} />;
     }
     return null;
 }
@@ -35,13 +38,16 @@ export function OmnibarConsumer() {
 /**
  * @param {object} props
  * @param {OmnibarConfig} props.config
+ * @param {string} props.tabId
  */
-function OmnibarReadyState({ config: { enableAi = true, showAiSetting = true, mode } }) {
+function OmnibarReadyState({ config, tabId }) {
+    const { enableAi = true, showAiSetting = true, mode: defaultMode } = config;
     const { setEnableAi, setMode } = useContext(OmnibarContext);
+    const mode = useModeWithLocalPersistence(tabId, defaultMode);
     return (
         <>
             {showAiSetting && <AiSetting enableAi={enableAi} setEnableAi={setEnableAi} />}
-            <Omnibar mode={mode} setMode={setMode} enableAi={showAiSetting && enableAi} />
+            <Omnibar mode={mode} setMode={setMode} enableAi={showAiSetting && enableAi} tabId={tabId} />
         </>
     );
 }

--- a/special-pages/pages/new-tab/app/omnibar/components/OmnibarConsumer.js
+++ b/special-pages/pages/new-tab/app/omnibar/components/OmnibarConsumer.js
@@ -46,21 +46,10 @@ function OmnibarReadyState({ config, tabId }) {
     const { setEnableAi, setMode } = useContext(OmnibarContext);
     const modeForCurrentTab = useModeWithLocalPersistence(tabId, defaultMode);
 
-    /**
-     * Respect the current tab's mode only if 'enableAi' is on.
-     * Otherwise always search
-     *
-     * @type {Mode}
-     */
-    const mode = (() => {
-        if (enableAi) return modeForCurrentTab;
-        return /** @type {const} */ ('search');
-    })();
-
     return (
         <>
             {showAiSetting && <AiSetting enableAi={enableAi} setEnableAi={setEnableAi} />}
-            <Omnibar mode={mode} setMode={setMode} enableAi={showAiSetting && enableAi} tabId={tabId} />
+            <Omnibar mode={modeForCurrentTab} setMode={setMode} enableAi={showAiSetting && enableAi} tabId={tabId} />
         </>
     );
 }

--- a/special-pages/pages/new-tab/app/omnibar/components/OmnibarConsumer.js
+++ b/special-pages/pages/new-tab/app/omnibar/components/OmnibarConsumer.js
@@ -12,6 +12,7 @@ import { useTabState } from '../../tabs/TabsProvider.js';
 /**
  * @typedef {import('../strings.json')} Strings
  * @typedef {import('../../../types/new-tab.js').OmnibarConfig} OmnibarConfig
+ * @typedef {import('../../../types/new-tab.js').OmnibarMode} Mode
  */
 
 /**
@@ -43,7 +44,19 @@ export function OmnibarConsumer() {
 function OmnibarReadyState({ config, tabId }) {
     const { enableAi = true, showAiSetting = true, mode: defaultMode } = config;
     const { setEnableAi, setMode } = useContext(OmnibarContext);
-    const mode = useModeWithLocalPersistence(tabId, defaultMode);
+    const modeForCurrentTab = useModeWithLocalPersistence(tabId, defaultMode);
+
+    /**
+     * Respect the current tab's mode only if 'enableAi' is on.
+     * Otherwise always search
+     *
+     * @type {Mode}
+     */
+    const mode = (() => {
+        if (enableAi) return modeForCurrentTab;
+        return /** @type {const} */ ('search');
+    })();
+
     return (
         <>
             {showAiSetting && <AiSetting enableAi={enableAi} setEnableAi={setEnableAi} />}

--- a/special-pages/pages/new-tab/app/omnibar/components/OmnibarCustomized.js
+++ b/special-pages/pages/new-tab/app/omnibar/components/OmnibarCustomized.js
@@ -6,6 +6,7 @@ import { h } from 'preact';
 
 import { OmnibarConsumer } from './OmnibarConsumer.js';
 import { SearchIcon } from '../../components/Icons.js';
+import { PersistentModeProvider, PersistentTextInputProvider } from './PersistentOmnibarValuesProvider.js';
 
 /**
  * @import enStrings from "../strings.json"
@@ -30,13 +31,15 @@ export function OmnibarCustomized() {
 
     useCustomizer({ title: sectionTitle, id, icon: <SearchIcon />, toggle, visibility: visibility.value, index });
 
-    if (visibility.value === 'hidden') {
-        return null;
-    }
-
     return (
-        <OmnibarProvider>
-            <OmnibarConsumer />
-        </OmnibarProvider>
+        <PersistentTextInputProvider>
+            <PersistentModeProvider>
+                {visibility.value === 'visible' && (
+                    <OmnibarProvider>
+                        <OmnibarConsumer />
+                    </OmnibarProvider>
+                )}
+            </PersistentModeProvider>
+        </PersistentTextInputProvider>
     );
 }

--- a/special-pages/pages/new-tab/app/omnibar/components/OmnibarProvider.js
+++ b/special-pages/pages/new-tab/app/omnibar/components/OmnibarProvider.js
@@ -1,5 +1,5 @@
 import { createContext, h } from 'preact';
-import { useCallback, useEffect, useReducer, useRef } from 'preact/hooks';
+import { useCallback, useContext, useEffect, useReducer, useRef } from 'preact/hooks';
 import { useMessaging } from '../../types.js';
 import { reducer, useInitialDataAndConfig, useConfigSubscription } from '../../service.hooks.js';
 import { OmnibarService } from '../omnibar.service.js';
@@ -153,7 +153,7 @@ export function OmnibarProvider(props) {
 /**
  * @return {import("preact").RefObject<OmnibarService>}
  */
-export function useService() {
+function useService() {
     const service = useRef(/** @type {OmnibarService|null} */ (null));
     const ntp = useMessaging();
     useEffect(() => {
@@ -164,4 +164,8 @@ export function useService() {
         };
     }, [ntp]);
     return service;
+}
+
+export function useOmnibarService() {
+    return useContext(OmnibarServiceContext);
 }

--- a/special-pages/pages/new-tab/app/omnibar/components/PersistentOmnibarValuesProvider.js
+++ b/special-pages/pages/new-tab/app/omnibar/components/PersistentOmnibarValuesProvider.js
@@ -1,0 +1,123 @@
+import { h, createContext } from 'preact';
+import { useCallback, useContext, useEffect, useState } from 'preact/hooks';
+import { OmnibarContext, useOmnibarService } from './OmnibarProvider.js';
+import { useTabState } from '../../tabs/TabsProvider.js';
+import { PersistentValue } from '../../tabs/PersistentValue.js';
+
+/**
+ * @typedef {import("../../../types/new-tab.js").OmnibarConfig["mode"]} Mode
+ */
+
+const TextInputContext = createContext(/** @type {PersistentValue<string>|null} */ (null));
+const ModeContext = createContext(/** @type {PersistentValue<Mode>|null} */ (null));
+
+/**
+ * @param {object} props
+ * @param {import('preact').ComponentChildren} props.children
+ */
+export function PersistentTextInputProvider({ children }) {
+    const [value] = useState(() => /** @type {PersistentValue<string>} */ (new PersistentValue()));
+    const { all } = useTabState();
+    useEffect(() => {
+        return all.subscribe((tabIds) => {
+            value?.prune({ preserve: tabIds });
+        });
+    }, [all, value]);
+    return <TextInputContext.Provider value={value}>{children}</TextInputContext.Provider>;
+}
+
+/**
+ * @param {object} props
+ * @param {import('preact').ComponentChildren} props.children
+ */
+export function PersistentModeProvider({ children }) {
+    const [value] = useState(() => /** @type {PersistentValue<Mode>} */ (new PersistentValue()));
+    const { all } = useTabState();
+    useEffect(() => {
+        return all.subscribe((tabIds) => {
+            value?.prune({ preserve: tabIds });
+        });
+    }, [all, value]);
+    return <ModeContext.Provider value={value}>{children}</ModeContext.Provider>;
+}
+
+/**
+ * A normal set-state, but with values recorded. Must be used when the Omnibar Service is ready
+ * @param {string|null|undefined} tabId
+ */
+export function useQueryWithLocalPersistence(tabId) {
+    const terms = useContext(TextInputContext);
+
+    invariant(
+        useContext(OmnibarContext).state.status === 'ready',
+        'Cannot use `useQueryWithPersistence` without Omnibar Service being ready.',
+    );
+
+    const [query, setQuery] = useState(() => terms?.byId(tabId) || '');
+
+    /** @type {(term: string) => void} */
+    const setter = useCallback(
+        (term) => {
+            if (tabId) {
+                terms?.update({ id: tabId, value: term });
+            }
+            setQuery(term);
+        },
+        [tabId],
+    );
+
+    return /** @type {const} */ ([query, setter]);
+}
+
+/**
+ * Sets and remembers the 'mode' for many tabs. Mode doesn't update dynamically with config changes
+ * and that's why we use the name 'defaultMode'.
+ *
+ * Each new tab that's opened adopts the most recent 'mode' value that was persisted in the browser.
+ *
+ * @param {string|null|undefined} tabId
+ * @param {Mode} defaultMode - what to apply for a newly created tab
+ * @return {Mode}
+ */
+export function useModeWithLocalPersistence(tabId, defaultMode) {
+    const values = useContext(ModeContext);
+
+    const [mode, setState] = useState(() => {
+        const prev = values?.byId(tabId);
+        if (prev) return prev;
+        if (tabId && defaultMode) {
+            values?.update({ id: tabId, value: defaultMode });
+        }
+        return defaultMode;
+    });
+
+    invariant(
+        useContext(OmnibarContext).state.status === 'ready',
+        'Cannot use `useQueryWithPersistence` without Omnibar Service being ready.',
+    );
+
+    const service = useOmnibarService();
+
+    useEffect(() => {
+        if (!service) return;
+        return service.onConfig((v) => {
+            if (tabId && v.source === 'manual') {
+                values?.update({ id: tabId, value: v.data.mode });
+            }
+            setState(v.data.mode);
+        });
+    }, [service, tabId]);
+
+    return mode;
+}
+
+/**
+ * @param {any} condition
+ * @param {string} [message]
+ * @return {asserts condition}
+ */
+export function invariant(condition, message) {
+    if (condition) return;
+    if (message) throw new Error('Invariant failed: ' + message);
+    throw new Error('Invariant failed');
+}

--- a/special-pages/pages/new-tab/app/omnibar/components/PersistentOmnibarValuesProvider.js
+++ b/special-pages/pages/new-tab/app/omnibar/components/PersistentOmnibarValuesProvider.js
@@ -50,7 +50,7 @@ export function useQueryWithLocalPersistence(tabId) {
 
     invariant(
         useContext(OmnibarContext).state.status === 'ready',
-        'Cannot use `useQueryWithPersistence` without Omnibar Service being ready.',
+        'Cannot use `useQueryWithLocalPersistence` without Omnibar Service being ready.',
     );
 
     const [query, setQuery] = useState(() => terms?.byId(tabId) || '');
@@ -63,7 +63,7 @@ export function useQueryWithLocalPersistence(tabId) {
             }
             setQuery(term);
         },
-        [tabId],
+        [tabId, terms],
     );
 
     return /** @type {const} */ ([query, setter]);
@@ -106,7 +106,7 @@ export function useModeWithLocalPersistence(tabId, defaultMode) {
             }
             setState(v.data.mode);
         });
-    }, [service, tabId]);
+    }, [service, tabId, values]);
 
     return mode;
 }

--- a/special-pages/pages/new-tab/app/omnibar/components/PersistentOmnibarValuesProvider.js
+++ b/special-pages/pages/new-tab/app/omnibar/components/PersistentOmnibarValuesProvider.js
@@ -101,13 +101,18 @@ export function useModeWithLocalPersistence(tabId, defaultMode) {
     useEffect(() => {
         if (!service) return;
         return service.onConfig((v) => {
-            if (tabId && v.source === 'manual') {
-                if (v.data.enableAi === false) {
-                    values?.updateAll({ value: 'search' });
-                } else {
-                    values?.update({ id: tabId, value: v.data.mode });
-                }
+            if (!tabId) return;
+
+            // when manually updated + enableAi === 'true', allow this tab to be recorded
+            if (v.source === 'manual') {
+                values?.update({ id: tabId, value: v.data.mode });
             }
+
+            // when `enableAi` is false, we reset ALL tabs to 'search'
+            if (v.data.enableAi === false) {
+                values?.updateAll({ value: 'search' });
+            }
+
             setState(v.data.mode);
         });
     }, [service, tabId, values, defaultMode]);

--- a/special-pages/pages/new-tab/app/omnibar/components/PersistentOmnibarValuesProvider.js
+++ b/special-pages/pages/new-tab/app/omnibar/components/PersistentOmnibarValuesProvider.js
@@ -102,11 +102,15 @@ export function useModeWithLocalPersistence(tabId, defaultMode) {
         if (!service) return;
         return service.onConfig((v) => {
             if (tabId && v.source === 'manual') {
-                values?.update({ id: tabId, value: v.data.mode });
+                if (v.data.enableAi === false) {
+                    values?.updateAll({ value: 'search' });
+                } else {
+                    values?.update({ id: tabId, value: v.data.mode });
+                }
             }
             setState(v.data.mode);
         });
-    }, [service, tabId, values]);
+    }, [service, tabId, values, defaultMode]);
 
     return mode;
 }

--- a/special-pages/pages/new-tab/app/omnibar/integration-tests/omnibar.page.js
+++ b/special-pages/pages/new-tab/app/omnibar/integration-tests/omnibar.page.js
@@ -186,9 +186,41 @@ export class OmnibarPage {
      * @returns {Promise<void>}
      */
     async didSwitchToTab(tabId, tabIds) {
-        await test.step('simulate tab change event', async () => {
+        await test.step(`simulate tab change event, to: ${tabId} `, async () => {
             await this.ntp.mocks.simulateSubscriptionMessage(sub('tabs_onDataUpdate'), tabs({ tabId, tabIds }));
         });
+    }
+
+    /**
+     * @param {object} props
+     * @param {Mode} props.mode
+     * @returns {Promise<void>}
+     */
+    switchMode({ mode }) {
+        switch (mode) {
+            case 'ai': {
+                return this.aiTab().click();
+            }
+            case 'search': {
+                return this.searchTab().click();
+            }
+        }
+    }
+
+    /**
+     * @param {object} props
+     * @param {Mode} props.mode
+     * @param {string} props.value
+     */
+    async expectValue({ mode, value }) {
+        switch (mode) {
+            case 'ai': {
+                return await expect(this.chatInput()).toHaveValue(value);
+            }
+            case 'search': {
+                return await expect(this.searchInput()).toHaveValue(value);
+            }
+        }
     }
 
     /**
@@ -197,7 +229,7 @@ export class OmnibarPage {
      * @param {string} props.value
      * @returns {Promise<void>}
      */
-    input({ mode, value }) {
+    types({ mode, value }) {
         switch (mode) {
             case 'ai': {
                 return this.chatInput().fill(value);

--- a/special-pages/pages/new-tab/app/omnibar/integration-tests/omnibar.page.js
+++ b/special-pages/pages/new-tab/app/omnibar/integration-tests/omnibar.page.js
@@ -2,6 +2,7 @@ import { expect, test } from '@playwright/test';
 
 /**
  * @typedef {import("../../../types/new-tab.js").OmnibarMode} Mode
+ * @typedef {import("../../../types/new-tab.js").OmnibarConfig} Config
  */
 
 export class OmnibarPage {
@@ -193,10 +194,11 @@ export class OmnibarPage {
     }
 
     /**
+     * @param {Config} config
      * @returns {Promise<void>}
      */
-    async didDisableGlobally() {
-        const event = sub('omnibar_onConfigUpdate').payload({ mode: 'search', enableAi: false, showAiSetting: false });
+    async didReceiveConfig(config) {
+        const event = sub('omnibar_onConfigUpdate').payload(config);
         await test.step(`simulates global disabled (eg: settings): ${JSON.stringify(event.name)} ${JSON.stringify(event.payload)} `, async () => {
             await this.ntp.mocks.simulateSubscriptionEvent(event);
         });
@@ -229,7 +231,6 @@ export class OmnibarPage {
                 return await expect(this.chatInput()).toHaveValue(value);
             }
             case 'search': {
-                await this.searchInput().waitFor({ timeout: 1000 });
                 return await expect(this.searchInput()).toHaveValue(value);
             }
         }

--- a/special-pages/pages/new-tab/app/omnibar/integration-tests/omnibar.persistence.spec.js
+++ b/special-pages/pages/new-tab/app/omnibar/integration-tests/omnibar.persistence.spec.js
@@ -1,0 +1,50 @@
+import { test } from '@playwright/test';
+import { NewtabPage } from '../../../integration-tests/new-tab.page.js';
+import { OmnibarPage } from './omnibar.page.js';
+
+test.describe('omnibar widget persistence', () => {
+    test('remembers input across tabs', async ({ page }, workerInfo) => {
+        const ntp = NewtabPage.create(page, workerInfo);
+        const omnibar = new OmnibarPage(ntp);
+        await ntp.reducedMotion();
+        await ntp.openPage({ additional: { omnibar: true, tabs: true, 'tabs.debug': true } });
+        await omnibar.ready();
+
+        // first fill
+        await omnibar.input({ mode: 'search', value: 'shoes' });
+
+        // switch
+        await omnibar.didSwitchToTab('02', ['01', '02']);
+        await omnibar.expectInputValue('');
+
+        // second fill
+        await omnibar.input({ mode: 'search', value: 'dresses' });
+
+        // back to first
+        await omnibar.didSwitchToTab('01', ['01', '02']);
+        await omnibar.expectInputValue('shoes');
+
+        // back to second again
+        await omnibar.didSwitchToTab('02', ['01', '02']);
+        await omnibar.expectInputValue('dresses');
+    });
+    test('remembers `mode` across tabs', async ({ page }, workerInfo) => {
+        const ntp = NewtabPage.create(page, workerInfo);
+        const omnibar = new OmnibarPage(ntp);
+        await ntp.reducedMotion();
+        await ntp.openPage({ additional: { omnibar: true, tabs: true, 'tabs.debug': true } });
+        await omnibar.ready();
+
+        // first fill
+        await omnibar.input({ mode: 'search', value: 'shoes' });
+        await page.getByRole('tab', { name: 'Duck.ai' }).click();
+
+        // new tab, should be opened with duck.ai input still visible
+        await omnibar.didSwitchToTab('02', ['01', '02']);
+        await omnibar.expectChatValue('');
+
+        // switch back
+        await omnibar.didSwitchToTab('01', ['01', '02']);
+        await omnibar.expectChatValue('shoes');
+    });
+});

--- a/special-pages/pages/new-tab/app/omnibar/integration-tests/omnibar.persistence.spec.js
+++ b/special-pages/pages/new-tab/app/omnibar/integration-tests/omnibar.persistence.spec.js
@@ -73,4 +73,26 @@ test.describe('omnibar widget persistence', () => {
         await omnibar.didSwitchToTab('01', ['01', '02']);
         await omnibar.expectValue({ value: '', mode: 'search' });
     });
+    test('adjusts mode of other tabs when duck.ai is globally disabled', async ({ page }, workerInfo) => {
+        const ntp = NewtabPage.create(page, workerInfo);
+        const omnibar = new OmnibarPage(ntp);
+        await ntp.reducedMotion();
+        await ntp.openPage({ additional: { omnibar: true, tabs: true, 'tabs.debug': true } });
+        await omnibar.ready();
+
+        // first tab, switch to ai mode
+        await omnibar.switchMode({ mode: 'ai' });
+
+        // switch to second tab, should be empty but still on duck.ai
+        await omnibar.didSwitchToTab('02', ['01', '02']);
+        await omnibar.expectValue({ value: '', mode: 'ai' });
+
+        // disable globally
+        await omnibar.didDisableGlobally();
+        await omnibar.expectValue({ value: '', mode: 'search' });
+
+        // back to first tab, should now also be search
+        await omnibar.didSwitchToTab('01', ['01', '02']);
+        await omnibar.expectValue({ value: '', mode: 'search' });
+    });
 });

--- a/special-pages/pages/new-tab/app/protections/mocks/protections.mock-transport.js
+++ b/special-pages/pages/new-tab/app/protections/mocks/protections.mock-transport.js
@@ -68,6 +68,9 @@ export function protectionsMockTransport() {
                 subs.set(sub, cb);
                 return () => {};
             }
+            if (sub === 'protections_onDataUpdate') {
+                return () => {};
+            }
             console.warn('unhandled sub', sub);
             return () => {};
         },

--- a/special-pages/pages/new-tab/app/tabs/PersistentValue.js
+++ b/special-pages/pages/new-tab/app/tabs/PersistentValue.js
@@ -1,0 +1,73 @@
+/**
+ * @template {string} T - the value to hold.
+ */
+export class PersistentValue {
+    /** @type {Map<string, T>} */
+    #values = new Map();
+
+    name() {
+        return 'PersistentValue';
+    }
+
+    /**
+     * Updates the value associated with a given identifier.
+     *
+     * @param {object} args
+     * @param {string} args.id
+     * @param {T} args.value
+     */
+    update({ id, value }) {
+        if (string(id) && string(value)) {
+            this.#values.set(id, value);
+        }
+    }
+
+    /**
+     * @param {object} params
+     * @param {string[]} params.preserve
+     */
+    prune({ preserve }) {
+        for (const key of this.#values.keys()) {
+            if (!preserve.includes(key)) {
+                this.#values.delete(key);
+            }
+        }
+    }
+
+    /**
+     * @param {object} args
+     * @param {string} args.id
+     */
+    remove({ id }) {
+        if (string(id)) {
+            this.#values.delete(id);
+        }
+    }
+
+    /**
+     * @param {string|null|undefined} id
+     * @return {T | null}
+     */
+    byId(id) {
+        if (typeof id !== 'string') return null;
+        const value = this.#values.get(id);
+        if (!value || !string(value)) return null;
+        return value;
+    }
+
+    print() {
+        for (const [key, value] of this.#values) {
+            console.log(`key: ${key}, value: ${value}`);
+        }
+        console.log('--');
+    }
+}
+
+/**
+ * @param {unknown} input
+ */
+function string(input) {
+    if (typeof input !== 'string') return '';
+    if (input.trim().length < 1) return '';
+    return input;
+}

--- a/special-pages/pages/new-tab/app/tabs/PersistentValue.js
+++ b/special-pages/pages/new-tab/app/tabs/PersistentValue.js
@@ -23,6 +23,18 @@ export class PersistentValue {
     }
 
     /**
+     * Updates the value with every entry
+     *
+     * @param {object} args
+     * @param {T} args.value
+     */
+    updateAll({ value }) {
+        for (const [key] of this.#values) {
+            this.#values.set(key, value);
+        }
+    }
+
+    /**
      * @param {object} params
      * @param {string[]} params.preserve
      */

--- a/special-pages/pages/new-tab/app/tabs/TabsProvider.js
+++ b/special-pages/pages/new-tab/app/tabs/TabsProvider.js
@@ -1,0 +1,39 @@
+import { h, createContext } from 'preact';
+import { useContext, useEffect } from 'preact/hooks';
+import { TabsService } from './tabs.service';
+import { CustomizerThemesContext } from '../customizer/CustomizerProvider.js';
+import { signal, useComputed, useSignal } from '@preact/signals';
+
+const TabsStateContext = createContext(signal(/** @type {import('../../types/new-tab').Tabs} */ (TabsService.DEFAULT)));
+
+/**
+ * @param {object} props
+ * @param {import("preact").ComponentChild} props.children
+ * @param {import('./tabs.service').TabsService} props.service
+ */
+export function TabsProvider({ children, service }) {
+    const tabs = useSignal(service.snapshot());
+    useEffect(() => {
+        return service.onData(({ data }) => {
+            tabs.value = data;
+        });
+    }, [service, tabs]);
+    return <TabsStateContext.Provider value={tabs}>{children}</TabsStateContext.Provider>;
+}
+
+export function useTabState() {
+    const tabs = useContext(TabsStateContext);
+    const current = useComputed(() => tabs.value.tabId);
+    const all = useComputed(() => tabs.value.tabIds);
+    return { current, all };
+}
+
+export function TabsDebug() {
+    const theme = useContext(CustomizerThemesContext);
+    const state = useTabState();
+    return (
+        <pre style="width: 200px; position: fixed; top: 0; left: 0;" data-theme={theme.main}>
+            <code style="color: var(--ntp-text-normal)">{JSON.stringify(state, null, 2)}</code>
+        </pre>
+    );
+}

--- a/special-pages/pages/new-tab/app/tabs/TabsProvider.js
+++ b/special-pages/pages/new-tab/app/tabs/TabsProvider.js
@@ -1,15 +1,29 @@
 import { h, createContext } from 'preact';
 import { useContext, useEffect } from 'preact/hooks';
-import { TabsService } from './tabs.service';
 import { CustomizerThemesContext } from '../customizer/CustomizerProvider.js';
 import { signal, useComputed, useSignal } from '@preact/signals';
-
-const TabsStateContext = createContext(signal(/** @type {import('../../types/new-tab').Tabs} */ (TabsService.DEFAULT)));
+import { TabsService } from './tabs.service';
 
 /**
+ * @template T
+ * @typedef {import('@preact/signals').ReadonlySignal<T>} ReadonlySignal<T>
+ */
+
+/**
+ * @typedef {import("preact").ComponentChild} ComponentChild
+ * @typedef {import('../../types/new-tab').Tabs} Tabs
+ */
+
+const TabsStateContext = createContext(signal(/** @type {Tabs} */ (TabsService.DEFAULT)));
+
+/**
+ * Global state provider for tab information.
+ *
+ * This exposes a signal to the Tabs object. use the hook below to access the individual fields.
+ *
  * @param {object} props
- * @param {import("preact").ComponentChild} props.children
- * @param {import('./tabs.service').TabsService} props.service
+ * @param {ComponentChild} props.children
+ * @param {TabsService} props.service
  */
 export function TabsProvider({ children, service }) {
     const tabs = useSignal(service.snapshot());
@@ -21,6 +35,19 @@ export function TabsProvider({ children, service }) {
     return <TabsStateContext.Provider value={tabs}>{children}</TabsStateContext.Provider>;
 }
 
+/**
+ * Exposes 2 signals - one for the current tab ID and one for the list of tabIds.
+ *
+ * In a component, if you want to trigger a re-render based on the current tab, you can
+ * access the .value field directly.
+ *
+ * ```js
+ * const { current } = useTabState();
+ * return <MyComponent key={current.value} />
+ * ```
+ *
+ * @returns {{current: ReadonlySignal<string>, all: ReadonlySignal<string[]>}}
+ */
 export function useTabState() {
     const tabs = useContext(TabsStateContext);
     const current = useComputed(() => tabs.value.tabId);

--- a/special-pages/pages/new-tab/app/tabs/tabs.md
+++ b/special-pages/pages/new-tab/app/tabs/tabs.md
@@ -1,0 +1,55 @@
+---
+title: Tabs
+---
+
+# Tabs
+
+This feature allows native sides to indicate which 'tab' is currently active. 
+
+The fields `tabId` and `tabIds` are used together to indicate which tabs are open and which is active.
+
+For example, the following indicates that there are three tabs and `def` is the visible one.
+
+```json
+{
+  "tabId": "def",
+  "tabIds": ["abc", "def", "ghi"]
+}
+```
+
+To remove a tab you would send a shorter list. To add a tab, send a longer list. To switch between tabs, send the 
+entire list still, but update `tabId` to reflect the currently active tab.
+
+**NOTE: you MUST send both fields every time.**
+
+## Setup
+
+Since this data is global in nature, you must add the initial tab state to {@link "NewTab Messages".InitialSetupResponse}  
+
+- Add {@link "NewTab Messages".Tabs} to the `tabs` field on {@link "NewTab Messages".InitialSetupResponse}
+- Example:
+
+```json
+{
+  "...": "...",
+  "tabs": {
+    "tabId": "abc",
+    "tabIds": ["abc", "def"]
+  }
+}
+```
+
+## Subscriptions:
+
+Once the page is running, you can send `tabs_onDataUpdate` updates as often as you need to.
+
+### `tabs_onDataUpdate` 
+- {@link "NewTab Messages".TabsOnDataUpdateSubscription}.
+- Updates for tab information including active tab ID and list of available tab IDs.
+- returns {@link "NewTab Messages".Tabs} 
+```json
+{
+   "tabId": "string",
+   "tabIds": ["string", "string"]
+}
+```

--- a/special-pages/pages/new-tab/app/tabs/tabs.md
+++ b/special-pages/pages/new-tab/app/tabs/tabs.md
@@ -44,9 +44,7 @@ Since this data is global in nature, you must add the initial tab state to {@lin
 Once the page is running, you can send `tabs_onDataUpdate` updates as often as you need to.
 
 ### `tabs_onDataUpdate` 
-- {@link "NewTab Messages".TabsOnDataUpdateSubscription}.
-- Updates for tab information including active tab ID and list of available tab IDs.
-- returns {@link "NewTab Messages".Tabs} 
+- {@link "NewTab Messages".TabsOnDataUpdateSubscription}. 
 ```json
 {
    "tabId": "string",

--- a/special-pages/pages/new-tab/app/tabs/tabs.mock-transport.js
+++ b/special-pages/pages/new-tab/app/tabs/tabs.mock-transport.js
@@ -1,0 +1,58 @@
+import { TestTransportConfig } from '@duckduckgo/messaging';
+import { initialSetup } from '../mock-transport.js';
+import { TabsService } from './tabs.service.js';
+
+/**
+ * @typedef {import('../../types/new-tab').NewTabMessages["subscriptions"]} Subs
+ * @typedef {import('../../types/new-tab').Tabs} Tabs
+ * @typedef {Subs['subscriptionEvent']} Names
+ */
+const url = new URL(window.location.href);
+
+/**
+ *
+ */
+export function tabsMockTransport() {
+    const initial = initialSetup(url);
+    const memory = initial.tabs ? structuredClone(initial.tabs) : TabsService.DEFAULT;
+    return new TestTransportConfig({
+        request() {
+            return Promise.reject(new Error('not implemented yet'));
+        },
+        notify() {
+            return Promise.reject(new Error('not implemented yet'));
+        },
+        /**
+         * @template {Names} K
+         * @template {{ subscriptionName: K, context: string, featureName: string }} Msg
+         * @param {Msg} msg
+         */
+        subscribe(msg, cb) {
+            if (msg.subscriptionName === 'tabs_onDataUpdate') {
+                /** @type {any} */ (window)._tabs = {
+                    add: (id) => {
+                        memory.tabId = id;
+                        memory.tabIds.push(id);
+                        memory.tabIds = [...new Set(memory.tabIds)];
+                        cb(structuredClone(memory));
+                    },
+                    tabs: ({ tabId, tabIds }) => {
+                        memory.tabId = tabId;
+                        memory.tabIds = tabIds;
+                        cb(structuredClone(memory));
+                    },
+                    delete: (id) => {
+                        memory.tabIds = memory.tabIds.filter((x) => x !== id);
+                        cb(structuredClone(memory));
+                    },
+                    switch: (id) => {
+                        memory.tabId = id;
+                        cb(structuredClone(memory));
+                    },
+                };
+                return () => {};
+            }
+            return () => {};
+        },
+    });
+}

--- a/special-pages/pages/new-tab/app/tabs/tabs.service.js
+++ b/special-pages/pages/new-tab/app/tabs/tabs.service.js
@@ -1,0 +1,66 @@
+import { Service } from '../service.js';
+
+/**
+ * @typedef {import("../../types/new-tab.js").Tabs} Tabs
+ */
+
+export class TabsService {
+    /** @type {Tabs} */
+    static DEFAULT = {
+        tabId: 'unknown',
+        tabIds: ['unknown'],
+    };
+    /**
+     * @param {import("../../src/index.js").NewTabPage} ntp - The internal data feed, expected to have a `subscribe` method.
+     * @param {Tabs} tabs
+     * @internal
+     */
+    constructor(ntp, tabs) {
+        this.ntp = ntp;
+
+        /** @type {Service<Tabs>} */
+        this.tabsService = new Service(
+            {
+                subscribe: (cb) => ntp.messaging.subscribe('tabs_onDataUpdate', cb),
+            },
+            tabs,
+        );
+    }
+
+    name() {
+        return 'TabsService';
+    }
+
+    /**
+     * @returns {Promise<{data: Tabs; config: null}>}
+     * @internal
+     */
+    async getInitial() {
+        const tabs = await this.tabsService.fetchInitial();
+        return { data: tabs, config: null };
+    }
+
+    /**
+     * @param {(evt: {data: Tabs, source: import('../service.js').InvocationSource}) => void} cb
+     * @internal
+     */
+    onData(cb) {
+        return this.tabsService.onData(cb);
+    }
+
+    /**
+     * @internal
+     */
+    destroy() {
+        this.tabsService.destroy();
+    }
+
+    /**
+     * @returns {Tabs}
+     */
+    snapshot() {
+        if (!this.tabsService.data) throw new Error('unreachable');
+        console.log('did read');
+        return this.tabsService.data;
+    }
+}

--- a/special-pages/pages/new-tab/app/tabs/tabs.service.js
+++ b/special-pages/pages/new-tab/app/tabs/tabs.service.js
@@ -32,15 +32,6 @@ export class TabsService {
     }
 
     /**
-     * @returns {Promise<{data: Tabs; config: null}>}
-     * @internal
-     */
-    async getInitial() {
-        const tabs = await this.tabsService.fetchInitial();
-        return { data: tabs, config: null };
-    }
-
-    /**
      * @param {(evt: {data: Tabs, source: import('../service.js').InvocationSource}) => void} cb
      * @internal
      */
@@ -60,7 +51,6 @@ export class TabsService {
      */
     snapshot() {
         if (!this.tabsService.data) throw new Error('unreachable');
-        console.log('did read');
         return this.tabsService.data;
     }
 }

--- a/special-pages/pages/new-tab/messages/initialSetup.response.json
+++ b/special-pages/pages/new-tab/messages/initialSetup.response.json
@@ -41,6 +41,16 @@
           "$ref": "types/update-notification.json"
         }
       ]
+    },
+    "tabs": {
+      "oneOf": [
+        {
+          "type": "null"
+        },
+        {
+          "$ref": "types/tabs.json"
+        }
+      ]
     }
   }
 }

--- a/special-pages/pages/new-tab/messages/tabs_onDataUpdate.subscribe.json
+++ b/special-pages/pages/new-tab/messages/tabs_onDataUpdate.subscribe.json
@@ -1,0 +1,8 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "allOf": [
+        {
+            "$ref": "types/tabs.json"
+        }
+    ]
+}

--- a/special-pages/pages/new-tab/messages/types/tabs.json
+++ b/special-pages/pages/new-tab/messages/types/tabs.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Tabs",
+  "type": "object",
+  "required": [
+    "tabId",
+    "tabIds"
+  ],
+  "properties": {
+    "tabId": {
+      "type": "string"
+    },
+    "tabIds": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    }
+  }
+}

--- a/special-pages/pages/new-tab/types/new-tab.ts
+++ b/special-pages/pages/new-tab/types/new-tab.ts
@@ -174,6 +174,7 @@ export interface NewTabMessages {
     | ProtectionsOnDataUpdateSubscription
     | RmfOnDataUpdateSubscription
     | StatsOnDataUpdateSubscription
+    | TabsOnDataUpdateSubscription
     | UpdateNotificationOnDataUpdateSubscription
     | WidgetsOnConfigUpdatedSubscription;
 }
@@ -821,6 +822,7 @@ export interface InitialSetupResponse {
   };
   customizer?: CustomizerData;
   updateNotification: null | UpdateNotificationData;
+  tabs?: null | Tabs;
 }
 export interface WidgetListItem {
   /**
@@ -863,6 +865,10 @@ export interface UpdateNotificationData {
 export interface UpdateNotification {
   version: string;
   notes: string[];
+}
+export interface Tabs {
+  tabId: string;
+  tabIds: string[];
 }
 /**
  * Generated from @see "../messages/nextSteps_getConfig.request.json"
@@ -1137,6 +1143,13 @@ export interface RmfOnDataUpdateSubscription {
 export interface StatsOnDataUpdateSubscription {
   subscriptionEvent: "stats_onDataUpdate";
   params: PrivacyStatsData;
+}
+/**
+ * Generated from @see "../messages/tabs_onDataUpdate.subscribe.json"
+ */
+export interface TabsOnDataUpdateSubscription {
+  subscriptionEvent: "tabs_onDataUpdate";
+  params: Tabs;
 }
 /**
  * Generated from @see "../messages/updateNotification_onDataUpdate.subscribe.json"

--- a/special-pages/playwright.config.js
+++ b/special-pages/playwright.config.js
@@ -38,6 +38,7 @@ export default defineConfig({
                 'protections.spec.js',
                 'protections.screenshots.spec.js',
                 'omnibar.spec.js',
+                'omnibar.persistence.spec.js',
             ],
             use: {
                 ...devices['Desktop Chrome'],

--- a/special-pages/shared/mocks.js
+++ b/special-pages/shared/mocks.js
@@ -93,6 +93,20 @@ export class Mocks {
     }
 
     /**
+     * @param {object} props
+     * @param {string} props.name
+     * @param {Record<string, any>} props.payload
+     */
+    async simulateSubscriptionEvent(props) {
+        await this.page.evaluate(simulateSubscriptionMessage, {
+            messagingContext: this.messagingContext,
+            name: props.name,
+            payload: props.payload,
+            injectName: this.build.name,
+        });
+    }
+
+    /**
      * @param {{names: string[]}} [opts]
      * @returns {Promise<any[]>}
      */


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1201141132935289/task/1211139368306662?focus=true

## Description

Support persistent state for omnibar input.

- A mapping of `<tab id>: <value>` is maintained outside of the lifecycle of the omnibar widget. 
- This solution will allow us to solve the scroll problem soon too 😢 

## Testing Steps (windows)

- visit https://deploy-preview-1882--content-scope-scripts.netlify.app/build/pages/new-tab/?omnibar&tabs&tabs.debug=true
- notice the debug in top left, it will read current: '01'
- Enter some text in the search box, don't hit enter
- now in the console, run `window._tabs.add('02', ['01', '02'])` to simulate a new tab opening on windows
- notice top left reads current: '02' now, and the input should be empty
- now switch to Duck.ai and enter some text
- back in the console, switch back to tab 1 with `window._tabs.add('01', ['01', '02'])`
- the original text you entered should be there. 

Also, see the integration tests for more info.

## Checklist

<!--
  These questions are a friendly reminder to shipping code, if you're uncertain ask the AoR owners.
  It's also totally appropriate to not check some of these boxes, if they don't apply to your change.
-->
*Please tick all that apply:*

- [ ] I have tested this change locally
- [ ] I have tested this change locally in all supported browsers
- [ ] This change will be visible to users
- [ ] I have added automated tests that cover this change
- [ ] I have ensured the change is gated by config
- [ ] This change was covered by a ship review
- [ ] This change was covered by a tech design
- [ ] Any dependent config has been merged

