### PR TITLE
NTP: Fix context menu by filtering fake widgets starting with underscore

### DIFF
--- a/special-pages/pages/new-tab/app/customizer/components/CustomizerMenu.js
+++ b/special-pages/pages/new-tab/app/customizer/components/CustomizerMenu.js
@@ -47,7 +47,7 @@ export function useContextMenu() {
             const items = getItems();
             /** @type {VisibilityMenuItem[]} */
             const simplified = items
-                .filter((x) => x.id !== 'debug')
+                .filter((x) => !x.id.startsWith('_'))
                 .map((item) => {
                     return {
                         id: item.id,

--- a/special-pages/pages/new-tab/app/omnibar/integration-tests/omnibar.spec.js
+++ b/special-pages/pages/new-tab/app/omnibar/integration-tests/omnibar.spec.js
@@ -936,4 +936,25 @@ test.describe('omnibar widget', () => {
         await omnibar.closeButton().click();
         await omnibar.expectInputValue('');
     });
+
+    test('context menu only includes real widgets, not fake ones', async ({ page }, workerInfo) => {
+        const ntp = NewtabPage.create(page, workerInfo);
+        const omnibar = new OmnibarPage(ntp);
+
+        await ntp.reducedMotion();
+        await ntp.openPage({ additional: { omnibar: true } });
+        await omnibar.ready();
+
+        // Right-click on the page to trigger context menu
+        await page.click('body', { button: 'right' });
+
+        // Assert that contextMenu notification is sent with real widgets and not e.g. the Duck.ai toggle
+        await omnibar.expectMethodCalledWith('contextMenu', {
+            visibilityMenuItems: [
+                { id: 'omnibar', title: 'Search' },
+                { id: 'favorites', title: 'Favorites' },
+                { id: 'protections', title: 'Protections Report' },
+            ],
+        });
+    });
 });

--- a/special-pages/pages/new-tab/app/telemetry/Debug.js
+++ b/special-pages/pages/new-tab/app/telemetry/Debug.js
@@ -10,7 +10,7 @@ export function DebugCustomized({ index, isOpenInitially = false }) {
     const telemetry = useTelemetry();
     useCustomizer({
         title: '🐞 Debug',
-        id: 'debug',
+        id: '_debug',
         icon: <DuckFoot />,
         visibility: isOpen ? 'visible' : 'hidden',
         toggle: (_id) => setOpen((prev) => !prev),


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1209121419454298/task/1211025931603094?focus=true

## Description

Fixed context menu including fake widgets that caused issues with native app integration. The Duck.ai toggle feature registers a fake widget with ID `_omnibar-toggleAi`, but `useContextMenu()` was only filtering out the `debug` widget, so fake widgets were being passed to the native app via `contextMenu` notifications.

Changes:
- Updated `useContextMenu()` to filter out widgets with IDs starting with `_` instead of just filtering `debug`
- Renamed debug widget ID from `debug` to `_debug` for consistency
- Added integration test to verify only real widgets appear in context menu

## Testing Steps

- Visit https://deploy-preview-1888--content-scope-scripts.netlify.app/build/pages/new-tab/?omnibar=true
- Test Duck.ai toggle still works in customizer panel
- Right click and check that event in DevTools no longer includes `_omnibar-toggleAi` widget

## Checklist

*Please tick all that apply:*

- [x] I have tested this change locally
- [ ] I have tested this change locally in all supported browsers
- [ ] This change will be visible to users
- [x] I have added automated tests that cover this change
- [x] I have ensured the change is gated by config
- [ ] This change was covered by a ship review
- [ ] This change was covered by a tech design
- [x] Any dependent config has been merged