### PR TITLE
NTP: Replace newlines with spaces when switching from Duck.ai to Search tab

### DIFF
--- a/special-pages/pages/new-tab/app/omnibar/components/SearchForm.js
+++ b/special-pages/pages/new-tab/app/omnibar/components/SearchForm.js
@@ -27,7 +27,7 @@ export function SearchForm({ autoFocus, onOpenSuggestion, onSubmit }) {
     const platformName = usePlatformName();
 
     const {
-        term,
+        term: _term,
         setTerm,
         suggestionsListId,
         suggestions,
@@ -38,6 +38,9 @@ export function SearchForm({ autoFocus, onOpenSuggestion, onSubmit }) {
         clearSelectedSuggestion,
         hideSuggestions,
     } = useSearchFormContext();
+
+    // When switching from Duck.ai to Search, there may be newlines in the term. Remove these.
+    const term = _term.replace(/\n/g, ' ');
 
     let inputBase, inputCompletion;
     if (selectedSuggestion) {
@@ -153,8 +156,7 @@ export function SearchForm({ autoFocus, onOpenSuggestion, onSubmit }) {
             {inputSuffix && (
                 <>
                     <span class={styles.suffixSpacer} inert>
-                        {/* Strip newlines to match <input> behaviour which doesn't render them */}
-                        {(inputBase + inputCompletion).replace(/\n/g, '') || t('omnibar_searchFormPlaceholder')}
+                        {inputBase + inputCompletion || t('omnibar_searchFormPlaceholder')}
                     </span>
                     <span class={styles.suffix} inert>
                         {inputSuffixText}

--- a/special-pages/pages/new-tab/app/omnibar/integration-tests/omnibar.spec.js
+++ b/special-pages/pages/new-tab/app/omnibar/integration-tests/omnibar.spec.js
@@ -206,6 +206,31 @@ test.describe('omnibar widget', () => {
         await expect(omnibar.searchInput()).toHaveValue('pizza');
     });
 
+    test('mode switching preserves multiline text with proper formatting', async ({ page }, workerInfo) => {
+        const ntp = NewtabPage.create(page, workerInfo);
+        const omnibar = new OmnibarPage(ntp);
+        await ntp.reducedMotion();
+
+        await ntp.openPage({ additional: { omnibar: true } });
+        await omnibar.ready();
+
+        // Start in Duck.ai mode, type multiline text
+        await omnibar.aiTab().click();
+        await omnibar.expectMode('ai');
+        await omnibar.chatInput().fill('hello\nworld');
+        await expect(omnibar.chatInput()).toHaveValue('hello\nworld');
+
+        // Switch to Search mode - newlines should become spaces
+        await omnibar.searchTab().click();
+        await omnibar.expectMode('search');
+        await expect(omnibar.searchInput()).toHaveValue('hello world');
+
+        // Switch back to Duck.ai mode - newlines should be restored
+        await omnibar.aiTab().click();
+        await omnibar.expectMode('ai');
+        await expect(omnibar.chatInput()).toHaveValue('hello\nworld');
+    });
+
     test('omnibar without AI enabled does not show tab list', async ({ page }, workerInfo) => {
         const ntp = NewtabPage.create(page, workerInfo);
         const omnibar = new OmnibarPage(ntp);


### PR DESCRIPTION
This matches how SERP behaves

**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1209121419454298/task/1211031149604584

## Description

Replace newlines with spaces when switching from the Duck.ai tab to the Search tab. This matches how SERP handles it.

## Testing Steps

https://deploy-preview-1894--content-scope-scripts.netlify.app/build/pages/new-tab/?omnibar=true

1. Switch to the Duck.ai tab.
1. Enter text with multiple lines.
1. Switch to the Search tab.

The lines are collapsed into a single string (“asdfasdf”) but should be separated by spaces (“asdf asdf”).

## Checklist

*Please tick all that apply:*

- [x] I have tested this change locally
- [x] I have tested this change locally in all supported browsers
- [ ] This change will be visible to users
- [x] I have added automated tests that cover this change
- [x] I have ensured the change is gated by config
- [ ] This change was covered by a ship review
- [ ] This change was covered by a tech design
- [x] Any dependent config has been merged

