### PR TITLE
Open up canShare some more

### DIFF
--- a/injected/integration-test/web-compat-android.spec.js
+++ b/injected/integration-test/web-compat-android.spec.js
@@ -152,7 +152,6 @@ test.describe('Web Share API', () => {
                 });
                 expect(canShare).toEqual(true);
             });
-
         });
 
         test.describe('navigator.share()', () => {
@@ -250,7 +249,10 @@ test.describe('Web Share API', () => {
                 test('should throw when sharing non-empty files arrays', async ({ page }) => {
                     await navigate(page);
                     await beforeEach(page);
-                    const { result, message } = await checkShare(page, { title: 'title', files: [new File([''], 'test.txt', { type: 'text/plain' })] });
+                    const { result, message } = await checkShare(page, {
+                        title: 'title',
+                        files: [new File([''], 'test.txt', { type: 'text/plain' })],
+                    });
                     expect(message).toBeNull();
                     expect(result.threw.message).toContain('TypeError: Invalid share data');
                 });

--- a/injected/integration-test/web-compat-android.spec.js
+++ b/injected/integration-test/web-compat-android.spec.js
@@ -76,12 +76,32 @@ test.describe('Web Share API', () => {
         });
 
         test.describe('navigator.canShare()', () => {
-            test('should not let you share files', async ({ page }) => {
+            test('should allow empty files arrays', async ({ page }) => {
                 await navigate(page);
-                const refuseFileShare = await page.evaluate(() => {
+                const allowEmptyFiles = await page.evaluate(() => {
                     return navigator.canShare({ text: 'xxx', files: [] });
                 });
+                expect(allowEmptyFiles).toEqual(true);
+            });
+
+            test('should not let you share non-empty files arrays', async ({ page }) => {
+                await navigate(page);
+                const refuseFileShare = await page.evaluate(() => {
+                    // Create a mock File object
+                    const mockFile = new File([''], 'test.txt', { type: 'text/plain' });
+                    return navigator.canShare({ text: 'xxx', files: [mockFile] });
+                });
                 expect(refuseFileShare).toEqual(false);
+            });
+
+            test('should reject non-array files values', async ({ page }) => {
+                await navigate(page);
+                const rejectNonArrayFiles = await page.evaluate(() => {
+                    // eslint-disable-next-line
+                    // @ts-ignore intentionally testing invalid files type
+                    return navigator.canShare({ text: 'xxx', files: 'not-an-array' });
+                });
+                expect(rejectNonArrayFiles).toEqual(false);
             });
 
             test('should not let you share non-http urls', async ({ page }) => {
@@ -132,6 +152,7 @@ test.describe('Web Share API', () => {
                 });
                 expect(canShare).toEqual(true);
             });
+
         });
 
         test.describe('navigator.share()', () => {
@@ -218,10 +239,18 @@ test.describe('Web Share API', () => {
                     expect(result).toBeUndefined();
                 });
 
-                test('should throw when sharing files', async ({ page }) => {
+                test('should allow sharing with empty files array', async ({ page }) => {
                     await navigate(page);
                     await beforeEach(page);
                     const { result, message } = await checkShare(page, { title: 'title', files: [] });
+                    expect(message).toMatchObject({ featureName: 'webCompat', method: 'webShare', params: { title: 'title', text: '' } });
+                    expect(result).toBeUndefined();
+                });
+
+                test('should throw when sharing non-empty files arrays', async ({ page }) => {
+                    await navigate(page);
+                    await beforeEach(page);
+                    const { result, message } = await checkShare(page, { title: 'title', files: [new File([''], 'test.txt', { type: 'text/plain' })] });
                     expect(message).toBeNull();
                     expect(result.threw.message).toContain('TypeError: Invalid share data');
                 });

--- a/injected/src/features/web-compat.js
+++ b/injected/src/features/web-compat.js
@@ -21,9 +21,18 @@ const MSG_DEVICE_ENUMERATION = 'deviceEnumeration';
 
 function canShare(data) {
     if (typeof data !== 'object') return false;
-    if (!('url' in data) && !('title' in data) && !('text' in data)) return false; // At least one of these is required
+    // Make an in-place shallow copy of the data
+    data = Object.assign({}, data);
+    // Delete undefined or null values
+    for (const key of ['url', 'title', 'text', 'files']) {
+        if (data[key] === undefined || data[key] === null) {
+            delete data[key];
+        }
+    }
+    // After pruning we should still have at least one of these
+    if (!('url' in data) && !('title' in data) && !('text' in data)) return false;
     if ('files' in data) {
-        if (!Array.isArray(data.files)) return false;
+        if (!(Array.isArray(data.files) || data.files instanceof FileList)) return false;
         if (data.files.length > 0) return false; // File sharing is not supported at the moment
     }
     if ('title' in data && typeof data.title !== 'string') return false;

--- a/injected/src/features/web-compat.js
+++ b/injected/src/features/web-compat.js
@@ -23,8 +23,8 @@ function canShare(data) {
     if (typeof data !== 'object') return false;
     if (!('url' in data) && !('title' in data) && !('text' in data)) return false; // At least one of these is required
     if ('files' in data) {
-        if (typeof data.files !== 'object' || data.files === null) return false;
-        if (Object.keys(data.files).length > 0) return false; // File sharing is not supported at the moment
+        if (!Array.isArray(data.files)) return false;
+        if (data.files.length > 0) return false; // File sharing is not supported at the moment
     }
     if ('title' in data && typeof data.title !== 'string') return false;
     if ('text' in data && typeof data.text !== 'string') return false;

--- a/injected/src/features/web-compat.js
+++ b/injected/src/features/web-compat.js
@@ -22,7 +22,10 @@ const MSG_DEVICE_ENUMERATION = 'deviceEnumeration';
 function canShare(data) {
     if (typeof data !== 'object') return false;
     if (!('url' in data) && !('title' in data) && !('text' in data)) return false; // At least one of these is required
-    if ('files' in data) return false; // File sharing is not supported at the moment
+    if ('files' in data) {
+        if (typeof data.files !== 'object' || data.files === null) return false;
+        if (Object.keys(data.files).length > 0) return false; // File sharing is not supported at the moment
+    }
     if ('title' in data && typeof data.title !== 'string') return false;
     if ('text' in data && typeof data.text !== 'string') return false;
     if ('url' in data) {


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/72649045549333/task/1211078754350004?focus=true

## Description

Fast follow from: https://github.com/duckduckgo/content-scope-scripts/pull/1899
Makes the following changes:
- Allows all fields to be undefined or null
- Ensures that one of url, title or text are still present and a string.
- Allows for `FileList` also that are empty.

## Testing Steps

- <!-- Include simple steps on how to check this change is working. Write "N/A" if not applicable. -->

## Checklist

<!--
  These questions are a friendly reminder to shipping code, if you're uncertain ask the AoR owners.
  It's also totally appropriate to not check some of these boxes, if they don't apply to your change.
-->
*Please tick all that apply:*

- [ ] I have tested this change locally
- [ ] I have tested this change locally in all supported browsers
- [ ] This change will be visible to users
- [ ] I have added automated tests that cover this change
- [ ] I have ensured the change is gated by config
- [ ] This change was covered by a ship review
- [ ] This change was covered by a tech design
- [ ] Any dependent config has been merged

