### PR TITLE
NTP Omnibar: Update dark search icon

### DIFF
--- a/special-pages/pages/new-tab/app/components/Icons.js
+++ b/special-pages/pages/new-tab/app/components/Icons.js
@@ -224,7 +224,7 @@ export function SearchOnDarkColorIcon(props) {
     return (
         <svg width="16" height="16" fill="none" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg" {...props}>
             <g clip-path="url(#Search-Find-OnDark-Color-16_svg__a)">
-                <path fill="#444" d="M13 7A6 6 0 1 1 1 7a6 6 0 0 1 12 0Z" />
+                <path fill="#000" d="M13 7A6 6 0 1 1 1 7a6 6 0 0 1 12 0Z" opacity=".2" />
                 <path
                     fill="#fff"
                     fill-opacity=".4"


### PR DESCRIPTION
**Asana Task/Github Issue:** <!-- Link to Asana Task/Github Issue -->

## Description

Update search icon in dark mode to be latest at https://dub.duckduckgo.com/duckduckgo/Icons/blob/Main/Color/16px/Search-Find-OnDark-Color-16.svg.

## Testing Steps

## Checklist

*Please tick all that apply:*

- [x] I have tested this change locally
- [ ] I have tested this change locally in all supported browsers
- [ ] This change will be visible to users
- [ ] I have added automated tests that cover this change
- [x] I have ensured the change is gated by config
- [ ] This change was covered by a ship review
- [ ] This change was covered by a tech design
- [x] Any dependent config has been merged

