### PR TITLE
NTP: Deprecate visibilityMenuItems in contextMenu notification

### DIFF
--- a/special-pages/pages/new-tab/app/new-tab.md
+++ b/special-pages/pages/new-tab/app/new-tab.md
@@ -34,6 +34,7 @@ children:
 - Sent when the user right-clicks in the page
 - Note: Other widgets might prevent this (and send their own, eg: favorites)
 - Sends: {@link "NewTab Messages".ContextMenuNotify}
+- **DEPRECATED**: The `visibilityMenuItems` property is deprecated and will be removed in a future version. Native apps should populate the context menu themselves instead of relying on frontend to tell it what widgets exist in the New Tab Page.
 - Example:
 
 ```json

--- a/special-pages/pages/new-tab/messages/contextMenu.notify.json
+++ b/special-pages/pages/new-tab/messages/contextMenu.notify.json
@@ -5,6 +5,8 @@
   "properties": {
     "visibilityMenuItems": {
       "type": "array",
+      "deprecated": true,
+      "description": "DEPRECATED: This property is deprecated and will be removed in a future version. Native apps should populate the context menu themselves instead of relying on frontend to tell it what widgets exist in the New Tab Page.",
       "items": {
         "type": "object",
         "title": "Visibility Menu Item",

--- a/special-pages/pages/new-tab/types/new-tab.ts
+++ b/special-pages/pages/new-tab/types/new-tab.ts
@@ -239,6 +239,10 @@ export interface ContextMenuNotification {
   params: ContextMenuNotify;
 }
 export interface ContextMenuNotify {
+  /**
+   * @deprecated
+   * DEPRECATED: This property is deprecated and will be removed in a future version. Native apps should populate the context menu themselves instead of relying on frontend to tell it what widgets exist in the New Tab Page.
+   */
   visibilityMenuItems: VisibilityMenuItem[];
 }
 export interface VisibilityMenuItem {


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1209121419454298/task/1211244321502449?focus=true

## Description

Add deprecation notes to `visibilityMenuItems` property in New Tab Page context menu documentation and JSON schema. Native apps should populate context menus themselves rather than relying on frontend widget information.

## Testing Steps

N/A

## Checklist

*Please tick all that apply:*

- [x] I have tested this change locally
- [ ] I have tested this change locally in all supported browsers
- [ ] This change will be visible to users
- [ ] I have added automated tests that cover this change
- [ ] I have ensured the change is gated by config
- [ ] This change was covered by a ship review
- [ ] This change was covered by a tech design
- [x] Any dependent config has been merged

