### PR TITLE
Element hiding: Ensure styletags aren't injected more than once on SPAs

### DIFF
--- a/injected/src/features/element-hiding.js
+++ b/injected/src/features/element-hiding.js
@@ -7,6 +7,7 @@ let hiddenElements = new WeakMap();
 let modifiedElements = new WeakMap();
 let appliedRules = new Set();
 let shouldInjectStyleTag = false;
+let styleTagInjected = false;
 let mediaAndFormSelectors = 'video,canvas,embed,object,audio,map,form,input,textarea,select,option,button';
 let hideTimeouts = [0, 100, 300, 500, 1000, 2000, 3000];
 let unhideTimeouts = [1250, 2250, 3000];
@@ -242,6 +243,10 @@ function extractTimeoutRules(rules) {
  * @param {string} rules[].type
  */
 function injectStyleTag(rules) {
+    // if style tag already injected on SPA url change, don't inject again
+    if (styleTagInjected) {
+        return;
+    }
     // wrap selector list in :is(...) to make it a forgiving selector list. this enables
     // us to use selectors not supported in all browsers, eg :has in Firefox
     let selector = '';
@@ -257,6 +262,7 @@ function injectStyleTag(rules) {
     const styleTagContents = `${forgivingSelector(selector)} {${styleTagProperties}}`;
 
     injectGlobalStyles(styleTagContents);
+    styleTagInjected = true;
 }
 
 /**


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/task/1211293030903764?focus=true

## Description
Ensures that style tags aren't injected again on SPA url changes.

## Testing Steps
- Build from this branch of C-S-S locally, then build any client and point at the local C-S-S
- Navigate to a SPA (eg https://www.squarespace.com/templates/browse/topic/real-estate-properties/type/courses)
- Check that styletag is properly injected on first page load by opening inspector
- Perform an SPA navigation (eg click a result on the squarespace page)
- Check that additional styletag isn't added to the document after the url change

## Checklist

<!--
  These questions are a friendly reminder to shipping code, if you're uncertain ask the AoR owners.
  It's also totally appropriate to not check some of these boxes, if they don't apply to your change.
-->
*Please tick all that apply:*

- [ ] I have tested this change locally
- [ ] I have tested this change locally in all supported browsers
- [ ] This change will be visible to users
- [ ] I have added automated tests that cover this change
- [ ] I have ensured the change is gated by config
- [ ] This change was covered by a ship review
- [ ] This change was covered by a tech design
- [ ] Any dependent config has been merged

