### PR TITLE
Fix shadow rendering issue in popover when mousing over Customize link

### DIFF
--- a/special-pages/pages/new-tab/app/components/Popover.module.css
+++ b/special-pages/pages/new-tab/app/components/Popover.module.css
@@ -77,6 +77,7 @@
         color: var(--ntp-accent-primary);
         cursor: pointer;
         padding: 0;
+        transform: translateZ(0); /* Fix shadow rendering issue on .popover in WebKit */
 
         &:hover {
             color: var(--ntp-accent-secondary);


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/414235014887631/task/1211321283124288?focus=true

## Description

Fixes shadow rendering issue when hovering over the Customize link in WebKit.

## Testing Steps

1. Visit https://deploy-preview-1958--content-scope-scripts.netlify.app/build/pages/new-tab/?omnibar=true&omnibar.showCustomizePopover=true in a WebKit browser
2. Mouse over the blue Customize link in the popover

## Checklist

*Please tick all that apply:*

- [x] I have tested this change locally
- [ ] I have tested this change locally in all supported browsers
- [x] This change will be visible to users
- [ ] I have added automated tests that cover this change
- [x] I have ensured the change is gated by config
- [ ] This change was covered by a ship review
- [ ] This change was covered by a tech design
- [x] Any dependent config has been merged

