### PR TITLE
Improve telemetry gathering for page context

### DIFF
--- a/injected/src/features/duck-ai-listener.js
+++ b/injected/src/features/duck-ai-listener.js
@@ -819,7 +819,6 @@ export default class DuckAiListener extends ContentFeature {
             const handleClick = this.handleSendMessage.bind(this);
 
             sendButton.addEventListener('click', handleClick, true); // Capture phase
-            // sendButton.addEventListener('click', handleClick, false); // Bubble phase
 
             this.log.info('Set up message interception with multiple event listeners', sendButton);
         }
@@ -985,7 +984,7 @@ export default class DuckAiListener extends ContentFeature {
         this.mutationObserver = null;
 
         // Callback function to execute when mutations are observed
-        const callback = (_, observer) => {
+        const callback = (/** @type {MutationRecord[]} */ _, observer) => {
             this.findTextBox();
             this.setupMessageInterception();
             if (this.textBox && this.pageData && this.sendButton && !this.hasContextBeenUsed) {
@@ -1013,13 +1012,17 @@ export default class DuckAiListener extends ContentFeature {
                 this.textBox = element;
                 this.log.info('Found AI text box');
 
-                // Add enter key handler to call handleSendMessage
-                element.addEventListener('keyup', (event) => {
-                    if (event.key === 'Enter' && !event.shiftKey) {
-                        this.log.info('Enter key pressed');
-                        this.handleSendMessage();
-                    }
-                });
+                // Add enter key handler using keydown with capture phase
+                element.addEventListener(
+                    'keydown',
+                    (event) => {
+                        if (event.key === 'Enter' && !event.shiftKey) {
+                            this.log.info('Enter key pressed');
+                            this.handleSendMessage();
+                        }
+                    },
+                    true,
+                );
 
                 // Set up property descriptor to intercept value reads for context appending
                 this.setupValuePropertyDescriptor(element);

--- a/injected/src/features/duck-ai-listener.js
+++ b/injected/src/features/duck-ai-listener.js
@@ -1378,7 +1378,7 @@ class DuckAiPromptTelemetry {
      * @param {Object} contextData - Context data object
      */
     sendContextPixelInfo(contextData, pixelName) {
-        if (!contextData?.content) {
+        if (!contextData?.content || contextData.content.length === 0) {
             this.log.warn('sendContextPixelInfo: No content available for pixel tracking');
             return;
         }


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1201520793593668/task/1211141698856303?focus=true

## Description

- Change telemetry into two events attach and send.
- Round by 100s for the bucketing.
- Use absolute values for pings instead of bucketing.
- Fix key event on keydown to prevent being swallowed by react.


## Testing Steps

- <!-- Include simple steps on how to check this change is working. Write "N/A" if not applicable. -->

## Checklist

<!--
  These questions are a friendly reminder to shipping code, if you're uncertain ask the AoR owners.
  It's also totally appropriate to not check some of these boxes, if they don't apply to your change.
-->
*Please tick all that apply:*

- [ ] I have tested this change locally
- [ ] I have tested this change locally in all supported browsers
- [ ] This change will be visible to users
- [ ] I have added automated tests that cover this change
- [ ] I have ensured the change is gated by config
- [ ] This change was covered by a ship review
- [ ] This change was covered by a tech design
- [ ] Any dependent config has been merged

