### PR TITLE
NTP: Fix omnibar styling in Windows

### DIFF
--- a/special-pages/pages/new-tab/app/omnibar/components/AiChatForm.module.css
+++ b/special-pages/pages/new-tab/app/omnibar/components/AiChatForm.module.css
@@ -11,6 +11,7 @@
     border: none;
     box-sizing: content-box;
     color: var(--ntp-text-primary);
+    line-height: 16px;
     max-height: 10lh;
     padding: var(--sp-3) var(--sp-3) 0;
     resize: none;

--- a/special-pages/pages/new-tab/app/omnibar/components/SearchForm.js
+++ b/special-pages/pages/new-tab/app/omnibar/components/SearchForm.js
@@ -61,7 +61,7 @@ export function SearchForm({ autoFocus, onOpenSuggestion, onSubmit, onSubmitChat
     const inputRef = useCompletionInput(inputBase, inputCompletion);
     const inputSuffix = getInputSuffix(term, selectedSuggestion);
     const inputSuffixText = useSuffixText(inputSuffix);
-    const inputFont = platformName === 'windows' ? '400 13px / 16px system-ui' : '500 13px / 16px system-ui';
+    const inputFont = platformName === 'windows' ? '400 14px / 16px system-ui' : '500 13px / 16px system-ui';
     const inputSuffixWidth = useMemo(() => measureText(inputSuffixText, inputFont), [inputSuffixText, inputFont]);
 
     useEffect(() => {


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/414235014887631/task/1211333825434481?focus=true

## Description

Fixes the omnibar input/textarea styling in Windows.

- The input’s font size should be 13px → 14px to match the textarea’s and all other body text.
- The text area’s line height should be 20px → 16px because the omnibar is a fixed 40px height.

## Testing Steps

https://deploy-preview-1963--content-scope-scripts.netlify.app/build/pages/new-tab/?omnibar=true&platform=windows

https://deploy-preview-1963--content-scope-scripts.netlify.app/build/pages/new-tab/?omnibar=true&platform=macos

Toggle between Search and Duck.ai and check that the input text doesn’t move or wriggle around. Transition should be seamless.

## Checklist

*Please tick all that apply:*

- [x] I have tested this change locally
- [x] I have tested this change locally in all supported browsers
- [x] This change will be visible to users
- [ ] I have added automated tests that cover this change
- [x] I have ensured the change is gated by config
- [ ] This change was covered by a ship review
- [ ] This change was covered by a tech design
- [x] Any dependent config has been merged

