### PR TITLE
Fire pixel on context send once and setup telemetry earlier

### DIFF
--- a/injected/src/features/duck-ai-listener.js
+++ b/injected/src/features/duck-ai-listener.js
@@ -1380,6 +1380,7 @@ class DuckAiPromptTelemetry {
     /**
      * Send context pixel info when context is used
      * @param {Object} contextData - Context data object
+     * @param {string} pixelName - Name of pixel to fire
      */
     sendContextPixelInfo(contextData, pixelName) {
         if (!contextData?.content || contextData.content.length === 0) {
@@ -1388,7 +1389,7 @@ class DuckAiPromptTelemetry {
         }
 
         this.sendPixel(pixelName, {
-            contextLength: contextData.content.length,
+            contextLength: contextData.fullContentLength
         });
     }
 

--- a/injected/src/features/duck-ai-listener.js
+++ b/injected/src/features/duck-ai-listener.js
@@ -1389,7 +1389,7 @@ class DuckAiPromptTelemetry {
         }
 
         this.sendPixel(pixelName, {
-            contextLength: contextData.fullContentLength
+            contextLength: contextData.fullContentLength,
         });
     }
 


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/task/1211375156305524?focus=true

## Description

- Sets up the telemetry to prevent page init race conditions.
- Adds logging for this code.
- Triggers initial send pixel only on first send.

## Testing Steps

- <!-- Include simple steps on how to check this change is working. Write "N/A" if not applicable. -->

## Checklist

<!--
  These questions are a friendly reminder to shipping code, if you're uncertain ask the AoR owners.
  It's also totally appropriate to not check some of these boxes, if they don't apply to your change.
-->
*Please tick all that apply:*

- [ ] I have tested this change locally
- [ ] I have tested this change locally in all supported browsers
- [ ] This change will be visible to users
- [ ] I have added automated tests that cover this change
- [ ] I have ensured the change is gated by config
- [ ] This change was covered by a ship review
- [ ] This change was covered by a tech design
- [ ] Any dependent config has been merged

