### PR TITLE
Add breakageReporting to Apple

### DIFF
--- a/injected/src/features.js
+++ b/injected/src/features.js
@@ -42,6 +42,7 @@ export const platformSupport = {
         'duckPlayer',
         'duckPlayerNative',
         'brokerProtection',
+        'breakageReporting',
         'performanceMetrics',
         'clickToLoad',
         'messageBridge',

--- a/injected/src/features/performance-metrics.js
+++ b/injected/src/features/performance-metrics.js
@@ -28,9 +28,13 @@ export default class PerformanceMetrics extends ContentFeature {
         if (document.readyState === 'complete') {
             this.waitForNextTask(callback);
         } else {
-            window.addEventListener('load', () => {
-                this.waitForNextTask(callback);
-            }, { once: true });
+            window.addEventListener(
+                'load',
+                () => {
+                    this.waitForNextTask(callback);
+                },
+                { once: true },
+            );
         }
     }
 

--- a/injected/src/features/performance-metrics.js
+++ b/injected/src/features/performance-metrics.js
@@ -14,17 +14,23 @@ export default class PerformanceMetrics extends ContentFeature {
 
         // If the feature is enabled, we want to collect expanded performance metrics
         if (this.getFeatureSettingEnabled('expandedPerformanceMetricsOnLoad', 'enabled')) {
-            this.waitForPageLoad(() => {
+            this.waitForAfterPageLoad(() => {
                 this.triggerExpandedPerformanceMetrics();
             });
         }
     }
 
-    waitForPageLoad(callback) {
+    waitForNextTask(callback) {
+        setTimeout(callback, 0);
+    }
+
+    waitForAfterPageLoad(callback) {
         if (document.readyState === 'complete') {
-            callback();
+            this.waitForNextTask(callback);
         } else {
-            window.addEventListener('load', callback, { once: true });
+            window.addEventListener('load', () => {
+                this.waitForNextTask(callback);
+            }, { once: true });
         }
     }
 


### PR DESCRIPTION
**Asana Task/Github Issue:**  https://app.asana.com/1/137249556945/project/72649045549333/task/1211308540286888?focus=true

## Description

- Adds `breakageReporting` in the JS bundle for apple.
- Delays posting perf values until after next task from `load`.

## Testing Steps

- <!-- Include simple steps on how to check this change is working. Write "N/A" if not applicable. -->

## Checklist

<!--
  These questions are a friendly reminder to shipping code, if you're uncertain ask the AoR owners.
  It's also totally appropriate to not check some of these boxes, if they don't apply to your change.
-->
*Please tick all that apply:*

- [ ] I have tested this change locally
- [ ] I have tested this change locally in all supported browsers
- [ ] This change will be visible to users
- [ ] I have added automated tests that cover this change
- [ ] I have ensured the change is gated by config
- [ ] This change was covered by a ship review
- [ ] This change was covered by a tech design
- [ ] Any dependent config has been merged




<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enables `breakageReporting` for `apple-isolated` and defers expanded performance metrics until the next task after `load`.
> 
> - **Platforms**:
>   - Add `breakageReporting` to `platformSupport.apple-isolated` in `injected/src/features.js`.
> - **Performance Metrics**:
>   - Defer expanded metrics collection until the next task after `load` in `injected/src/features/performance-metrics.js`:
>     - Replace `waitForPageLoad` with `waitForAfterPageLoad` and introduce `waitForNextTask` (`setTimeout(..., 0)`).
>     - Update init flow to use `waitForAfterPageLoad` before triggering `triggerExpandedPerformanceMetrics()`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4e3350845d67c6332b18a2ffc80b98a11ee2d8de. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->