### PR TITLE
Add config settings for all page context constants

### DIFF
--- a/injected/src/features/page-context.js
+++ b/injected/src/features/page-context.js
@@ -323,12 +323,23 @@ export default class PageContext extends ContentFeature {
         // Used to avoid large content serialization
         const upperLimit = this.getFeatureSetting('upperLimit') || 500000;
         let excludeSelectors = this.getFeatureSetting('excludeSelectors') || ['.ad', '.sidebar', '.footer', '.nav', '.header'];
-        excludeSelectors = excludeSelectors.concat(['script', 'style', 'link', 'meta', 'noscript', 'svg', 'canvas']);
+        const excludedInertElements = this.getFeatureSetting('excludedInertElements') || [
+            'script',
+            'style',
+            'link',
+            'meta',
+            'noscript',
+            'svg',
+            'canvas',
+        ];
+        excludeSelectors = excludeSelectors.concat(excludedInertElements);
 
         let content = '';
         // Get content from main content areas
-        let mainContent = document.querySelector('main, article, .content, .main, #content, #main');
-        if (mainContent && mainContent.innerHTML.trim().length <= 100) {
+        const mainContentSelector = this.getFeatureSetting('mainContentSelector') || 'main, article, .content, .main, #content, #main';
+        let mainContent = document.querySelector(mainContentSelector);
+        const mainContentLength = this.getFeatureSetting('mainContentLength') || 100;
+        if (mainContent && mainContent.innerHTML.trim().length <= mainContentLength) {
             mainContent = null;
         }
         const contentRoot = mainContent || document.body;
@@ -364,7 +375,8 @@ export default class PageContext extends ContentFeature {
 
     getHeadings() {
         const headings = [];
-        const headingElements = document.querySelectorAll('h1, h2, h3, h4, h5, h6');
+        const headdingSelector = this.getFeatureSetting('headingSelector') || 'h1, h2, h3, h4, h5, h6';
+        const headingElements = document.querySelectorAll(headdingSelector);
 
         headingElements.forEach((heading) => {
             const level = parseInt(heading.tagName.charAt(1));
@@ -379,7 +391,8 @@ export default class PageContext extends ContentFeature {
 
     getLinks() {
         const links = [];
-        const linkElements = document.querySelectorAll('a[href]');
+        const linkSelector = this.getFeatureSetting('linkSelector') || 'a[href]';
+        const linkElements = document.querySelectorAll(linkSelector);
 
         linkElements.forEach((link) => {
             const text = link.textContent?.trim();
@@ -394,7 +407,8 @@ export default class PageContext extends ContentFeature {
 
     getImages() {
         const images = [];
-        const imgElements = document.querySelectorAll('img');
+        const imgSelector = this.getFeatureSetting('imgSelector') || 'img';
+        const imgElements = document.querySelectorAll(imgSelector);
 
         imgElements.forEach((img) => {
             const alt = img.getAttribute('alt') || '';


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/task/1211551437155183?focus=true

## Description

Adds remote settings for everything that is a constant in the page collection feature.

## Testing Steps

- <!-- Include simple steps on how to check this change is working. Write "N/A" if not applicable. -->

## Checklist

<!--
  These questions are a friendly reminder to shipping code, if you're uncertain ask the AoR owners.
  It's also totally appropriate to not check some of these boxes, if they don't apply to your change.
-->
*Please tick all that apply:*

- [ ] I have tested this change locally
- [ ] I have tested this change locally in all supported browsers
- [ ] This change will be visible to users
- [ ] I have added automated tests that cover this change
- [ ] I have ensured the change is gated by config
- [ ] This change was covered by a ship review
- [ ] This change was covered by a tech design
- [ ] Any dependent config has been merged


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds feature settings to configure selectors and thresholds for content, headings, links, and images, including a separate list for inert elements.
> 
> - **Page context (`injected/src/features/page-context.js`)**
>   - Configurable main content extraction:
>     - `mainContentSelector` (default: `main, article, .content, .main, #content, #main`)
>     - `mainContentLength` (default: `100`)
>     - `excludedInertElements` (default: `script, style, link, meta, noscript, svg, canvas`), merged with `excludeSelectors`
>   - Configurable selectors:
>     - `headingSelector` (default: `h1, h2, h3, h4, h5, h6`)
>     - `linkSelector` (default: `a[href]`)
>     - `imgSelector` (default: `img`)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ac7c1b80dc9e58f0f22c39c50ddbceb9c4ac1c69. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->