### PR TITLE
[Google import] Add resilience to download data

### DIFF
--- a/injected/src/features/autofill-import.js
+++ b/injected/src/features/autofill-import.js
@@ -624,7 +624,8 @@ export default class AutofillImport extends ActionExecutorBase {
         const downloadURL = `${TAKEOUT_DOWNLOAD_URL_BASE}?j=${this.#exportId}&i=0&user=${userId}`;
 
         // Sleep before downloading to ensure the download link is available
-        await new Promise((resolve) => setTimeout(resolve, 2000));
+        const downloadNavigationDelayMs = this.getFeatureSetting('downloadNavigationDelayMs') ?? 2000;
+        await new Promise((resolve) => setTimeout(resolve, downloadNavigationDelayMs));
 
         window.location.href = downloadURL;
     }


### PR DESCRIPTION
**Asana Task/Github Issue:** <!-- Link to Asana Task/Github Issue --> https://app.asana.com/1/137249556945/task/1211588662115293?focus=true

## Description

- [x] Increase sleep before attempting download 
- [x] Poll for the download link forever

<!--
  Provide a terse summary of what the change is, detailed descriptions should belong in ship reviews or tech designs
-->

## Testing Steps

- <!-- Include simple steps on how to check this change is working. Write "N/A" if not applicable. -->

## Checklist

<!--
  These questions are a friendly reminder to shipping code, if you're uncertain ask the AoR owners.
  It's also totally appropriate to not check some of these boxes, if they don't apply to your change.
-->
*Please tick all that apply:*

- [ ] I have tested this change locally
- [ ] I have tested this change locally in all supported browsers
- [ ] This change will be visible to users
- [ ] I have added automated tests that cover this change
- [ ] I have ensured the change is gated by config
- [ ] This change was covered by a ship review
- [ ] This change was covered by a tech design
- [ ] Any dependent config has been merged


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Makes `downloadData` robust by polling for required elements with configurable retry/interval, parsing `user` via URL params, adding a pre-navigation delay, and improving error handling.
> 
> - **Bookmark import resilience** (`injected/src/features/autofill-import.js`):
>   - `downloadData` now:
>     - Uses configurable `downloadRetryLimit` and `downloadRetryInterval` (defaults to Infinity/1000ms) to poll for `userId` element and archive link.
>     - Parses `user` from the `href` via `URL` search params instead of string split.
>     - Returns early with `actionCompleted` error if `userId` or `#exportId` missing (message updated to "User id or export id not found").
>     - Adds configurable `downloadNavigationDelayMs` (default 2000ms) before setting `window.location.href`.
>     - Removes fixed initial 1s sleep in favor of the above logic.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a0a97d845481c2729141fae879974e7e695fd870. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->