### PR TITLE
Default disable page-context features that aren't currently used

### DIFF
--- a/injected/src/features/page-context.js
+++ b/injected/src/features/page-context.js
@@ -424,16 +424,25 @@ export default class PageContext extends ContentFeature {
         const content = {
             favicon: getFaviconList(),
             title: this.getPageTitle(),
-            metaDescription: this.getMetaDescription(),
             content: mainContent,
             truncated,
             fullContentLength: this.fullContentLength, // Include full content length before truncation
-            headings: this.getHeadings(),
-            links: this.getLinks(),
-            images: this.getImages(),
             timestamp: Date.now(),
             url: window.location.href,
         };
+
+        if (this.getFeatureSettingEnabled('includeMetaDescription', 'disabled')) {
+            content.metaDescription = this.getMetaDescription();
+        }
+        if (this.getFeatureSettingEnabled('includeHeadings', 'disabled')) {
+            content.headings = this.getHeadings();
+        }
+        if (this.getFeatureSettingEnabled('includeLinks', 'disabled')) {
+            content.links = this.getLinks();
+        }
+        if (this.getFeatureSettingEnabled('includeImages', 'disabled')) {
+            content.images = this.getImages();
+        }
 
         // Cache the result - setter handles timestamp and observer
         this.cachedContent = content;


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/72649045549333/task/1211383639881300?focus=true

## Description

Disable features we don't use.

## Testing Steps

- <!-- Include simple steps on how to check this change is working. Write "N/A" if not applicable. -->

## Checklist

<!--
  These questions are a friendly reminder to shipping code, if you're uncertain ask the AoR owners.
  It's also totally appropriate to not check some of these boxes, if they don't apply to your change.
-->
*Please tick all that apply:*

- [ ] I have tested this change locally
- [ ] I have tested this change locally in all supported browsers
- [ ] This change will be visible to users
- [ ] I have added automated tests that cover this change
- [ ] I have ensured the change is gated by config
- [ ] This change was covered by a ship review
- [ ] This change was covered by a tech design
- [ ] Any dependent config has been merged


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Conditionally include `metaDescription`, `headings`, `links`, and `images` in collected page content only when corresponding feature flags are enabled.
> 
> - **Page content collection (`injected/src/features/page-context.js`)**:
>   - Gate optional fields via feature flags (default disabled):
>     - `includeMetaDescription` → adds `metaDescription`
>     - `includeHeadings` → adds `headings`
>     - `includeLinks` → adds `links`
>     - `includeImages` → adds `images`
>   - Core fields unchanged: `favicon`, `title`, `content`, `truncated`, `fullContentLength`, `timestamp`, `url`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7230c5f1cc15e05b73d71e4d79232998dafb5345. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->