### PR TITLE
Support Windows permission handling in nested iframes in DDG-WebView

### DIFF
--- a/injected/src/config-feature.js
+++ b/injected/src/config-feature.js
@@ -30,6 +30,7 @@ export default class ConfigFeature {
      *   platform: import('./utils.js').Platform,
      *   desktopModeEnabled?: boolean,
      *   forcedZoomEnabled?: boolean,
+     *   isDdgWebView?: boolean,
      *   featureSettings?: Record<string, unknown>,
      *   assets?: import('./content-feature.js').AssetConfig | undefined,
      *   site: import('./content-feature.js').Site,

--- a/injected/src/features/windows-permission-usage.js
+++ b/injected/src/features/windows-permission-usage.js
@@ -17,8 +17,8 @@ export default class WindowsPermissionUsage extends ContentFeature {
             Paused: 'paused',
         };
 
-        // @ts-expect-error - isDdgWebView is a Windows-specific platform property injected via userPreferences
-        const isDdgWebView = this.args?.platform?.isDdgWebView;
+        // isDdgWebView is a Windows-specific property injected via userPreferences
+        const isDdgWebView = this.args?.isDdgWebView;
 
         const isFrameInsideFrameInWebView2 = isDdgWebView
             ? false // In DDG WebView, we can handle nested frames properly


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1210594645311934/task/1205798754280261?focus=true

## Description
Added support for Windows permission handling in nested iframes when using DDG-WebView. For WebView2 permission handling in nested iframes is still not supported. 
A new Windows-specific bool flag `isDdgWebView` is passed through `userPreferences.platform` to C-S-S. 
Please let me know if there is a better way of passing this between native and C-S-S.

## Testing Steps

- N/A: testing will be done after integrating it in the Windows browser

## Checklist

<!--
  These questions are a friendly reminder to shipping code, if you're uncertain ask the AoR owners.
  It's also totally appropriate to not check some of these boxes, if they don't apply to your change.
-->
*Please tick all that apply:*

- [x] I have tested this change locally
- [ ] I have tested this change locally in all supported browsers
- [ ] This change will be visible to users
- [ ] I have added automated tests that cover this change
- [ ] I have ensured the change is gated by config
- [ ] This change was covered by a ship review
- [ ] This change was covered by a tech design
- [ ] Any dependent config has been merged


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce `isDdgWebView` and update Windows permission logic to allow nested iframes in DDG WebView while still denying them in WebView2.
> 
> - **Windows permission handling**:
>   - Use `args.isDdgWebView` to determine nested iframe behavior.
>   - Allow nested iframes in DDG WebView; continue denying in WebView2 for `geolocation.watchPosition` and `mediaDevices.getUserMedia`.
> - **Config**:
>   - Add `isDdgWebView` to `ConfigFeature` args shape.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ed32eacc59ae28f5b0e66560531806123b9fd29c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->