### PR TITLE
NTP - Fix text cut-off on windows

### DIFF
--- a/special-pages/pages/new-tab/app/omnibar/components/SearchForm.module.css
+++ b/special-pages/pages/new-tab/app/omnibar/components/SearchForm.module.css
@@ -83,7 +83,7 @@
     }
 }
 
-[data-platform-name='windows'] {
+[data-platform='windows'] {
 	.input {
 		line-height: normal;
 	}


### PR DESCRIPTION
**Asana Task/Github Issue:** 
https://app.asana.com/1/137249556945/project/1211592734365220/task/1211616566794262


## Description

- Fix text cut-off issue on Windows

**Before**: Notice that g and j are cut off

<img width="731" height="330" alt="Screenshot 2025-10-22 at 1 10 42 PM" src="https://github.com/user-attachments/assets/4b3c0436-2eed-4748-a72d-e4ee9692fd9a" />


**After**:

<img width="775" height="350" alt="Screenshot 2025-10-22 at 1 12 25 PM" src="https://github.com/user-attachments/assets/bb96a9fb-869a-4e3d-9ca5-c724e8a3d638" />




## Testing Steps

For testing this change, you would need to use Windows.

1. Clone this branch.
2. Run `npm run watch -- --page new-tab`
3. Copy the URL and open it on Windows, adding `?platform=windows&omnibar` query string.
4. Type `g` and `j` 
5. Verify that both letters render correctly without being cut off. Try other letters as well.

If you have windows-browser dev environment,

1. Run `npm run build` command (in this repo).
2. Copy `build/windows` (this repo) directory to `submodules/content-scope-scripts/build/windows` (window-browser repo)
3. Build window-browser and test the input again. 



## Checklist

*Please tick all that apply:*

- [x] I have tested this change locally
- [x] I have tested this change locally in all supported browsers
- [x] This change will be visible to users
- [ ] I have added automated tests that cover this change
- [ ] I have ensured the change is gated by config
- [ ] This change was covered by a ship review
- [ ] This change was covered by a tech design
- [ ] Any dependent config has been merged


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Set a Windows-specific line-height on the omnibar input to prevent text from being cut off, with minor selector quote normalization.
> 
> - **NTP Omnibar CSS** (`special-pages/pages/new-tab/app/omnibar/components/SearchForm.module.css`):
>   - Add Windows-specific rule setting `.input { line-height: normal; }` to prevent glyph clipping.
>   - Normalize attribute selector quoting for Windows and omnibar listbox visibility selectors.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3e0a1f89e95f31756411dd15aab75532c7f6459b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->