### PR TITLE
NTP - Fix blurry customizer text on Windows

### DIFF
--- a/special-pages/pages/new-tab/app/customizer/components/CustomizerDrawerInner.module.css
+++ b/special-pages/pages/new-tab/app/customizer/components/CustomizerDrawerInner.module.css
@@ -176,12 +176,10 @@
 
 @keyframes fade-in {
     0% {
-        opacity: 0;
         visibility: hidden;
     }
 
     100% {
-        opacity: 1;
         visibility: visible;
     }
 }


### PR DESCRIPTION
**Asana Task/Github Issue:** 

https://app.asana.com/1/137249556945/project/1211592734365220/task/1211664088579926

## Description

- Fix blurry text in the Customizer on Chromium-based Windows browsers

**Background**

It seems there’s a bug in Chromium engine where animated elements become blurry in certain situations. Firefox does not have the same issue.

See: https://issues.chromium.org/issues/40431598#comment104

The issue has been fixed, but some users still report that it occasionally occurs.

I understand it’s related to opacity and animation, but I don’t fully grasp what’s happening internally, to be honest :(

Since `visibility` is set to `hidden` at 0%, `opacity` has no effect. I removed it to fix the blurriness issue. I don't see any visual difference after removing it.


**Before & After:**

![beforeafter](https://github.com/user-attachments/assets/3881dbcb-3b41-442b-9cb1-4f99e16397b1)


<!--
  Provide a terse summary of what the change is, detailed descriptions should belong in ship reviews or tech designs
-->

## Testing Steps

Make sure your display scale is set to 100%. I wasn't able to reproduce the issue at 200% or 300% scale.

1. Checkout this branch.
2. Navigate to `special-pages` directory and run `npm run watch -- --page new-tab`
3. Add `?platform=windows` to the URL and open it in Windows using the Canary version of DuckDuckGo browser.
4. Click “Customize”
5. Verify that the texts are not blurry. 
6. Open `CustomizerDrawerInner.module.css` file and reapply the `opacity` changes. 
7. Reload the page and compare the results.


## Checklist

*Please tick all that apply:*

- [x] I have tested this change locally
- [x] I have tested this change locally in all supported browsers
- [x] This change will be visible to users
- [ ] I have added automated tests that cover this change
- [ ] I have ensured the change is gated by config
- [ ] This change was covered by a ship review
- [ ] This change was covered by a tech design
- [ ] Any dependent config has been merged

