### PR TITLE
history: Update translation files for "Sites"

### DIFF
--- a/special-pages/pages/history/public/locales/de/history.json
+++ b/special-pages/pages/history/public/locales/de/history.json
@@ -115,5 +115,9 @@
   "range_older" : {
     "title" : "Älter",
     "note" : "Label on a button that shows older history entries."
+  },
+  "range_sites" : {
+    "title" : "Websites",
+    "note" : "Label on a button that shows which sites have been visited"
   }
 }

--- a/special-pages/pages/history/public/locales/es/history.json
+++ b/special-pages/pages/history/public/locales/es/history.json
@@ -115,5 +115,9 @@
   "range_older" : {
     "title" : "Más antiguo",
     "note" : "Label on a button that shows older history entries."
+  },
+  "range_sites" : {
+    "title" : "Sitios",
+    "note" : "Label on a button that shows which sites have been visited"
   }
 }

--- a/special-pages/pages/history/public/locales/fr/history.json
+++ b/special-pages/pages/history/public/locales/fr/history.json
@@ -115,5 +115,9 @@
   "range_older" : {
     "title" : "Anciennes",
     "note" : "Label on a button that shows older history entries."
+  },
+  "range_sites" : {
+    "title" : "Sites",
+    "note" : "Label on a button that shows which sites have been visited"
   }
 }

--- a/special-pages/pages/history/public/locales/it/history.json
+++ b/special-pages/pages/history/public/locales/it/history.json
@@ -115,5 +115,9 @@
   "range_older" : {
     "title" : "Più vecchio",
     "note" : "Label on a button that shows older history entries."
+  },
+  "range_sites" : {
+    "title" : "Siti",
+    "note" : "Label on a button that shows which sites have been visited"
   }
 }

--- a/special-pages/pages/history/public/locales/nl/history.json
+++ b/special-pages/pages/history/public/locales/nl/history.json
@@ -115,5 +115,9 @@
   "range_older" : {
     "title" : "Ouder",
     "note" : "Label on a button that shows older history entries."
+  },
+  "range_sites" : {
+    "title" : "Sites",
+    "note" : "Label on a button that shows which sites have been visited"
   }
 }

--- a/special-pages/pages/history/public/locales/pl/history.json
+++ b/special-pages/pages/history/public/locales/pl/history.json
@@ -17,7 +17,7 @@
     "note" : "Placeholder text when there's no results to show"
   },
   "no_results_title" : {
-    "title" : "Brak wyników dla {term}",
+    "title" : "Brak wyników dla „{term}”",
     "note" : "The placeholder {term} will be dynamically replaced with the search term entered by the user. For example, if the user searches for 'cats', the title will become 'No results found for cats'."
   },
   "no_results_text" : {
@@ -115,5 +115,9 @@
   "range_older" : {
     "title" : "Starsze",
     "note" : "Label on a button that shows older history entries."
+  },
+  "range_sites" : {
+    "title" : "Witryny",
+    "note" : "Label on a button that shows which sites have been visited"
   }
 }

--- a/special-pages/pages/history/public/locales/pt/history.json
+++ b/special-pages/pages/history/public/locales/pt/history.json
@@ -115,5 +115,9 @@
   "range_older" : {
     "title" : "Mais antigas",
     "note" : "Label on a button that shows older history entries."
+  },
+  "range_sites" : {
+    "title" : "Sites",
+    "note" : "Label on a button that shows which sites have been visited"
   }
 }

--- a/special-pages/pages/history/public/locales/ru/history.json
+++ b/special-pages/pages/history/public/locales/ru/history.json
@@ -115,5 +115,9 @@
   "range_older" : {
     "title" : "Более старые записи",
     "note" : "Label on a button that shows older history entries."
+  },
+  "range_sites" : {
+    "title" : "Сайты",
+    "note" : "Label on a button that shows which sites have been visited"
   }
 }


### PR DESCRIPTION
**Asana Task/Github Issue:**

https://app.asana.com/1/137249556945/project/1211592734365220/task/1211676302635375?focus=true

## Description

A follow-up PR for https://github.com/duckduckgo/content-scope-scripts/pull/1954 to add translation files for “Sites”. 


## Testing Steps

Reviewing the changed files should be sufficient for this update.

## Checklist

<!--
  These questions are a friendly reminder to shipping code, if you're uncertain ask the AoR owners.
  It's also totally appropriate to not check some of these boxes, if they don't apply to your change.
-->
*Please tick all that apply:*

- [x] I have tested this change locally
- [x] I have tested this change locally in all supported browsers
- [x] This change will be visible to users
- [ ] I have added automated tests that cover this change
- [ ] I have ensured the change is gated by config
- [ ] This change was covered by a ship review
- [ ] This change was covered by a tech design
- [ ] Any dependent config has been merged


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add `range_sites` translations across history locales and adjust Polish `no_results_title` punctuation.
> 
> - **i18n**:
>   - **History locales**: Add `range_sites` entry (title + note) to `special-pages/pages/history/public/locales/{de,es,fr,it,nl,pl,pt,ru}/history.json`.
>   - **Polish (`pl`)**: Update `no_results_title` to use „{term}” quotes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5ff74a3a5e4fd7b7145f082e208a7e7ec6d354fd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->