### PR TITLE
Remove blank page collection cache

### DIFF
--- a/injected/src/features/page-context.js
+++ b/injected/src/features/page-context.js
@@ -381,11 +381,7 @@ export default class PageContext extends ContentFeature {
 
     startObserving() {
         this.log.info('Starting observing', this.mutationObserver, this.#cachedContent);
-        if (this.mutationObserver &&
-            this.#cachedContent &&
-            !this.isObserving &&
-            document.body
-        ) {
+        if (this.mutationObserver && this.#cachedContent && !this.isObserving && document.body) {
             this.isObserving = true;
             this.mutationObserver.observe(document.body, {
                 childList: true,


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/task/1211745324203561?focus=true

## Description

Ignores both:
- cache when no body
- cache when body is empty

## Testing Steps

- <!-- Include simple steps on how to check this change is working. Write "N/A" if not applicable. -->

## Checklist

<!--
  These questions are a friendly reminder to shipping code, if you're uncertain ask the AoR owners.
  It's also totally appropriate to not check some of these boxes, if they don't apply to your change.
-->
*Please tick all that apply:*

- [ ] I have tested this change locally
- [ ] I have tested this change locally in all supported browsers
- [ ] This change will be visible to users
- [ ] I have added automated tests that cover this change
- [ ] I have ensured the change is gated by config
- [ ] This change was covered by a ship review
- [ ] This change was covered by a tech design
- [ ] Any dependent config has been merged


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Prevents caching blank page content and guards MutationObserver to start only when `document.body` is available.
> 
> - **Page context (`injected/src/features/page-context.js`)**:
>   - **Observation Guard**: Start `MutationObserver` only if `document.body` exists.
>   - **Cache Logic**: Cache collection results only when `content.content.length > 0` (skip empty content).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ff4983e5ced5de59c812a0a78f7463ab81892147. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->