### PR TITLE
fix: Add Sources/ContentScopeScripts/dist/ to ESLint ignores

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -23,6 +23,7 @@ export default tseslint.config(
             'test-results',
             'injected/src/types',
             '.idea',
+            'Sources/ContentScopeScripts/dist/',
         ],
     },
     {


### PR DESCRIPTION
## Summary
- Fixed ESLint parsing errors by adding `Sources/ContentScopeScripts/dist/` to the ignores configuration
- This directory contains build output files that should not be linted, similar to other dist/build directories already in the config

## Test plan
- [x] Verified `npm run lint` now passes without errors
- [x] The ignored directory is already in `.gitignore` and contains only generated build files

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add `Sources/ContentScopeScripts/dist/` to ESLint ignores to avoid linting generated build files.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f4e93fc16e823fcdb513625f683c87cec9885f92. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->