### PR TITLE
Error: Stub out support for theming

### DIFF
--- a/special-pages/pages/errorpage/public/index.html
+++ b/special-pages/pages/errorpage/public/index.html
@@ -7,7 +7,7 @@
     <meta http-equiv="X-UA-Compatible" content="ie=edge">
     <link rel="stylesheet" href="style.css">
 </head>
-<body>
+<body data-theme-variant="$THEME_VARIANT$">
     <div class="content-container">
         <div class="error-container">
             <div class="header-container">
@@ -21,5 +21,16 @@
             <img src="img/logo-horizontal.svg" alt="DuckDuckGo" class="watermark">
         </div>
     </div>
+    <script>
+        /**
+         * Called by native to update the page theme at runtime
+         * @param {{ themeVariant: string }} payload
+         */
+        window.onChangeTheme = function(payload) {
+            if (payload && payload.themeVariant) {
+                document.body.dataset.themeVariant = payload.themeVariant;
+            }
+        };
+    </script>
 </body>
 </html>

--- a/special-pages/pages/errorpage/public/style.css
+++ b/special-pages/pages/errorpage/public/style.css
@@ -66,3 +66,25 @@ body {
         color: rgb(210, 210, 210);
     }
 }
+
+/* TODO: Use colour variables from design-tokens */
+
+/* Theme variants - light mode */
+[data-theme-variant="coolGray"] { background: #d2d5e3; }
+[data-theme-variant="slateBlue"] { background: #d2e5f3; }
+[data-theme-variant="green"] { background: #e3eee1; }
+[data-theme-variant="violet"] { background: #e7e4f5; }
+[data-theme-variant="rose"] { background: #f8ebf5; }
+[data-theme-variant="orange"] { background: #fcedd8; }
+[data-theme-variant="desert"] { background: #eee9e1; }
+
+/* Theme variants - dark mode */
+@media (prefers-color-scheme: dark) {
+    [data-theme-variant="coolGray"] { background: #2b2f45; }
+    [data-theme-variant="slateBlue"] { background: #1e3347; }
+    [data-theme-variant="green"] { background: #203b30; }
+    [data-theme-variant="violet"] { background: #2e2158; }
+    [data-theme-variant="rose"] { background: #5b194b; }
+    [data-theme-variant="orange"] { background: #54240c; }
+    [data-theme-variant="desert"] { background: #3c3833; }
+}

--- a/special-pages/pages/errorpage/readme.md
+++ b/special-pages/pages/errorpage/readme.md
@@ -10,6 +10,34 @@ So far, the following platforms are supported
 
 - macOS
 
+### Theming
+
+The error page supports theming through two mechanisms:
+
+#### Template Variable: `$THEME_VARIANT$`
+
+Native performs string interpolation to replace `$THEME_VARIANT$` in the HTML with a theme variant name.
+
+If string interpolation is not performed (i.e., `$THEME_VARIANT$` is left as-is), the page falls back to the default styling.
+
+**Supported variants:** `default`, `coolGray`, `slateBlue`, `green`, `violet`, `rose`, `orange`, `desert`
+
+#### Callback: `window.onChangeTheme`
+
+Native can call `window.onChangeTheme(payload)` to update the theme at runtime.
+
+**Payload:**
+```json
+{
+  "themeVariant": "coolGray"
+}
+```
+
+**Example native usage:**
+```javascript
+window.onChangeTheme({ themeVariant: 'coolGray' });
+```
+
 ---
 
 ## Contributing
@@ -26,4 +54,3 @@ Don't edit the generated files directly - any changes you make will not be refle
 
 Instead, make your changes in `src/` and then run `npm run build` from the root folder
   - or to build the special pages only (faster), run `npm run postbuild` instead
-


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1209121419454298/task/1211842297547581

- Updates the error special page (`errorpage`) to accept `$THEME_VARIANT$` as an interpolated string and expose `window.onChangeTheme({ themeVariant })` as a method native can use to adjust the variant in realtime.

- Adjusts the default background colour according to the set variant so that something observable happens when setting a theme.

Intention here is to do the minimal amount needed to unblock the native apps. In follow up PRs I’ll import theme variables from the design-tokens repo and update more than just the background colour.

## Testing Steps

1. Browse to https://deploy-preview-2077--content-scope-scripts.netlify.app/build/pages/errorpage/.
2. Check that background colour is light grey (as before).
3. Switch theme to dark using System Settings.
2. Check that background colour is dark grey (as before).
1. Manually modify `data-theme-variant` to `”rose”` (or any valid variant).
3. Check that background colour is pink (or whatever).
3. Switch theme to dark using System Settings.
2. Check that background colour is purple (or whatever).
1. Run `window.onChangeTheme({ themeVariant: ‘desert’ })` (or any valid variant) in DevTools.
3. Check that background colour is pink (or whatever).
3. Switch theme to dark using System Settings.
2. Check that background colour is purple (or whatever).

## Checklist

<!—
  These questions are a friendly reminder to shipping code, if you're uncertain ask the AoR owners.
  It's also totally appropriate to not check some of these boxes, if they don't apply to your change.
—>
*Please tick all that apply:*

- [x] I have tested this change locally
- [ ] I have tested this change locally in all supported browsers
- [ ] This change will be visible to users
- [ ] I have added automated tests that cover this change
- [x] I have ensured the change is gated by config
- [ ] This change was covered by a ship review
- [x] This change was covered by a tech design
- [x] Any dependent config has been merged

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds theme variant support to the error page via `data-theme-variant`, a `window.onChangeTheme` runtime hook, and variant-specific backgrounds for light/dark modes.
> 
> - **Theming support for `pages/errorpage`**
>   - **HTML (`public/index.html`)**: Initialize `body` with `data-theme-variant="$THEME_VARIANT$"`; add `window.onChangeTheme(payload)` to update `document.body.dataset.themeVariant` at runtime.
>   - **CSS (`public/style.css`)**: Define background colors for theme variants (`coolGray`, `slateBlue`, `green`, `violet`, `rose`, `orange`, `desert`) in light and dark modes via `[data-theme-variant="..."]` selectors.
>   - **Docs (`readme.md`)**: Document theming mechanisms, supported variants, payload format, and example usage.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 956e1681516b60207daa925fd33900ddb2293724. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->