### PR TITLE
Enhance breakage reporting with opener and reload checks

### DIFF
--- a/injected/src/features/breakage-reporting.js
+++ b/injected/src/features/breakage-reporting.js
@@ -20,7 +20,7 @@ export default class BreakageReporting extends ContentFeature {
             if (getOpener) {
                 result.opener = !!window.opener;
             }
-            const getReloaded = this.getFeatureSettingEnabled('getReloaded', 'enabled');
+            const getReloaded = this.getFeatureSettingEnabled('reloaded', 'enabled');
             if (getReloaded) {
                 result.pageReloaded =
                     (window.performance.navigation && window.performance.navigation.type === 1) ||


### PR DESCRIPTION
Added checks for opener and page reload status based on feature settings.

**Asana Task/Github Issue:**  https://app.asana.com/1/137249556945/project/312629933896096/task/1212316965518834?focus=true

## Description

Moves over: [github.com/duckduckgo/duckduckgo-privacy-extension/blob/c78d96f4738b4cb2c99831a20e7186a161f8b446/shared/js/content-scripts/breakage-stats.js#L30](https://github.com/duckduckgo/duckduckgo-privacy-extension/blob/c78d96f4738b4cb2c99831a20e7186a161f8b446/shared/js/content-scripts/breakage-stats.js#L30) so we can have it on all platforms.

## Testing Steps

- <!-- Include simple steps on how to check this change is working. Write "N/A" if not applicable. -->

## Checklist

<!--
  These questions are a friendly reminder to shipping code, if you're uncertain ask the AoR owners.
  It's also totally appropriate to not check some of these boxes, if they don't apply to your change.
-->
*Please tick all that apply:*

- [ ] I have tested this change locally
- [ ] I have tested this change locally in all supported browsers
- [ ] This change will be visible to users
- [ ] I have added automated tests that cover this change
- [ ] I have ensured the change is gated by config
- [ ] This change was covered by a ship review
- [ ] This change was covered by a tech design
- [ ] Any dependent config has been merged


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Collects `opener` and `pageReloaded` values in breakage reports when corresponding feature settings are enabled.
> 
> - **Breakage reporting (`injected/src/features/breakage-reporting.js`)**:
>   - Adds optional `opener` metric (`!!window.opener`) when `opener` setting is enabled.
>   - Adds optional `pageReloaded` metric using `performance.navigation.type === 1` or `performance.getEntriesByType('navigation')` includes `reload` when `reloaded` setting is enabled.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 993eac73ec606f2b89b3d6962e98b9e2920e5fd4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->