### PR TITLE
Enum the release version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,14 +57,14 @@ jobs:
                   fi
 
                   echo "Latest tag found: $LATEST_TAG"
-                  
+
                   # Extract version numbers (remove 'v' prefix if present for backwards compatibility)
                   VERSION_WITHOUT_V=${LATEST_TAG#v}
-                  
+
                   # Parse major and minor (ignore patch since we don't support it)
                   MAJOR=$(echo $VERSION_WITHOUT_V | cut -d. -f1)
                   MINOR=$(echo $VERSION_WITHOUT_V | cut -d. -f2)
-                  
+
                   # Calculate next version based on input
                   if [ "${{ github.event.inputs.version_bump }}" = "major" ]; then
                     NEXT_MAJOR=$((MAJOR + 1))
@@ -73,10 +73,10 @@ jobs:
                     NEXT_MAJOR=$MAJOR
                     NEXT_MINOR=$((MINOR + 1))
                   fi
-                  
+
                   # Create new version (always without v prefix)
                   NEXT_VERSION="${NEXT_MAJOR}.${NEXT_MINOR}.0"
-                  
+
                   echo "Next version: $NEXT_VERSION"
                   echo "RELEASE_VERSION=$NEXT_VERSION" >> $GITHUB_ENV
                   echo "version=$NEXT_VERSION" >> $GITHUB_OUTPUT


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1201614831475344/task/1208768018420970?focus=true

## Description

Force all releases to just be major and minor only (adds validation and simplifies doing a release).

## Testing Steps

- <!-- Include simple steps on how to check this change is working. Write "N/A" if not applicable. -->

## Checklist

<!--
  These questions are a friendly reminder to shipping code, if you're uncertain ask the AoR owners.
  It's also totally appropriate to not check some of these boxes, if they don't apply to your change.
-->
*Please tick all that apply:*

- [ ] I have tested this change locally
- [ ] I have tested this change locally in all supported browsers
- [ ] This change will be visible to users
- [ ] I have added automated tests that cover this change
- [ ] I have ensured the change is gated by config
- [ ] This change was covered by a ship review
- [ ] This change was covered by a tech design
- [ ] Any dependent config has been merged


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Release workflow now accepts a major/minor bump type and auto-calculates the next X.Y.0 version, using it for commits and the release tag.
> 
> - **CI/CD (GitHub Actions)**
>   - **Inputs**: Replace `version` with `version_bump` (choice: `major`/`minor`).
>   - **Versioning**: Add step to compute next version from latest numeric tag (ignores legacy `v` prefix); bumps major or minor and formats as `X.Y.0`; exports as outputs.
>   - **Usage**: Use computed version in commit message and `gh-release` `tag_name`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 675c6d47b930d90459a8f1aea5717a20164a86b1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->