### PR TITLE
Ignore unknown card IDs in next steps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,6 @@ test-results/
 playwright-report/
 Sources/ContentScopeScripts/dist/
 test-results
-!Sources/ContentScopeScripts/dist/pages/.gitignore
 
 # Test output files (generated during tests)
 injected/unit-test/fixtures/page-context/output/

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -14,6 +14,7 @@ export default tseslint.config(
             'injected/playwright-report/',
             'injected/integration-test/extension/contentScope.js',
             'injected/integration-test/test-pages/duckplayer/scripts/dist',
+            'Sources/ContentScopeScripts/dist',
             'special-pages/pages/**/public',
             'special-pages/pages/**/types',
             'special-pages/pages/**/messages',

--- a/special-pages/pages/new-tab/app/index.js
+++ b/special-pages/pages/new-tab/app/index.js
@@ -22,9 +22,12 @@ import { TabsDebug, TabsProvider } from './tabs/TabsProvider.js';
 /**
  * @import {Telemetry} from "./telemetry/telemetry.js"
  * @import { Environment } from "../../../shared/environment";
+ */
+
+/**
  * @param {Element} root
  * @param {import("../src/index.js").NewTabPage} messaging
- * @param {import("./telemetry/telemetry.js").Telemetry} telemetry
+ * @param {Telemetry} telemetry
  * @param {Environment} baseEnvironment
  * @throws Error
  */

--- a/special-pages/pages/new-tab/app/mock-transport.js
+++ b/special-pages/pages/new-tab/app/mock-transport.js
@@ -456,17 +456,7 @@ export function mockTransport() {
                     if (ids.length) {
                         /** @type {NextStepsData} */
                         data = {
-                            content: ids
-                                .filter((id) => {
-                                    if (!(id in nextSteps)) {
-                                        console.warn(`${id} missing in nextSteps data`);
-                                        return false;
-                                    }
-                                    return true;
-                                })
-                                .map((id) => {
-                                    return { id: /** @type {any} */ (id) };
-                                }),
+                            content: ids.map((id) => ({ id: /** @type {any} */ (id) })),
                         };
                         write('nextSteps_data', data);
                     }

--- a/special-pages/pages/new-tab/app/next-steps/NextSteps.js
+++ b/special-pages/pages/new-tab/app/next-steps/NextSteps.js
@@ -1,6 +1,7 @@
 import { h } from 'preact';
 import { NextStepsContext, NextStepsProvider } from './NextStepsProvider.js';
 import { useContext } from 'preact/hooks';
+import { variants as nextSteps } from './nextsteps.data.js';
 import { NextStepsCardGroup } from './components/NextStepsGroup.js';
 
 /**
@@ -32,7 +33,7 @@ export function NextStepsCustomized() {
 export function NextStepsConsumer() {
     const { state, toggle } = useContext(NextStepsContext);
     if (state.status === 'ready' && state.data.content) {
-        const ids = state.data.content.map((x) => x.id);
+        const ids = state.data.content.filter((x) => x.id in nextSteps).map((x) => x.id);
         const { action, dismiss } = useContext(NextStepsContext);
         return <NextStepsCardGroup types={ids} toggle={toggle} expansion={state.config.expansion} action={action} dismiss={dismiss} />;
     }


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1198915719297225/task/1212407966771546?focus=true

## Description

<!--
  Provide a terse summary of what the change is, detailed descriptions should belong in ship reviews or tech designs
-->

In the future we’ll be adding new card IDs for a new next steps visualisation. For card Ids passed in URL params, we filter out unknown IDs, but not when they’re passed from the message. We should align these instead.

## Testing Steps

- Try an invalid card ID in the URL param and confirm it still works
- https://deploy-preview-2114--content-scope-scripts.netlify.app/build/pages/new-tab/?next-steps=unknownID

<!-- Include simple steps on how to check this change is working. Write "N/A" if not applicable. -->


## Checklist

<!--
  These questions are a friendly reminder to shipping code, if you're uncertain ask the AoR owners.
  It's also totally appropriate to not check some of these boxes, if they don't apply to your change.
-->
*Please tick all that apply:*

- [ ] I have tested this change locally
- [ ] I have tested this change locally in all supported browsers
- [ ] This change will be visible to users
- [ ] I have added automated tests that cover this change
- [ ] I have ensured the change is gated by config
- [ ] This change was covered by a ship review
- [ ] This change was covered by a tech design
- [ ] Any dependent config has been merged



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures unknown `NextSteps` card IDs are ignored in the UI and aligns mock behavior.
> 
> - Filter unknown IDs in `NextStepsConsumer` by checking against `nextsteps.data` before rendering `NextStepsCardGroup`
> - Simplify `nextSteps_getData` in `mock-transport.js` to pass through requested IDs and rely on UI filtering; persists data to localStorage
> - Minor tooling updates: add `Sources/ContentScopeScripts/dist` to ESLint ignores and adjust `.gitignore`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0042e45d56ae33963a00549681b45a7d7002a364. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->