### PR TITLE
PoC: ApiManipulation: fix getter toString masking

### DIFF
--- a/injected/src/features/api-manipulation.js
+++ b/injected/src/features/api-manipulation.js
@@ -151,13 +151,17 @@ export default class ApiManipulation extends ContentFeature {
                 valueDescriptor.value = this.maskMethodReplacement(valueDescriptor.value, origDescriptor.value);
             }
         } else if (descriptorKind === 'getter') {
-            // Mask the new setter against the original native setter (if any) so that
-            // descriptor inspection (`getOwnPropertyDescriptor(...).set.toString()` /
-            // `.set.name`) still resembles the original accessor. Event-handler IDL
-            // attributes such as `Element.prototype.onclick` and
-            // `MediaDevices.prototype.ondevicechange` expose a native setter; without
-            // masking, descriptor probes would see our JS `setter(v) {...}` shape.
+            // Mask the new getter/setter against the original native getter/setter (if
+            // any) so that descriptor inspection
+            // (`getOwnPropertyDescriptor(...).{get,set}.toString()` / `.name`) still
+            // resembles the original accessor. Event-handler IDL attributes such as
+            // `Element.prototype.onclick` and `MediaDevices.prototype.ondevicechange`
+            // expose native getter/setter pairs; without masking, descriptor probes
+            // would see our JS `(v) => ...` shape and trivially detect the override.
             const accessorDescriptor = /** @type {{ get?: () => any, set?: (v: any) => void }} */ (descriptor);
+            if (typeof accessorDescriptor.get === 'function' && typeof origDescriptor.get === 'function') {
+                accessorDescriptor.get = /** @type {() => any} */ (this.maskMethodReplacement(accessorDescriptor.get, origDescriptor.get));
+            }
             if (typeof accessorDescriptor.set === 'function' && typeof origDescriptor.set === 'function') {
                 accessorDescriptor.set = /** @type {(v: any) => void} */ (
                     this.maskMethodReplacement(accessorDescriptor.set, origDescriptor.set)


### PR DESCRIPTION
Preserve existing getter toString when overriding, and return a native-code string when defining a new getter.

**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1209253361096901/task/1210715342149343?focus=true

## Description

<!--
  Provide a terse summary of what the change is, detailed descriptions should belong in ship reviews or tech designs
-->

## Testing Steps

- <!-- Include simple steps on how to check this change is working. Write "N/A" if not applicable. -->

## Checklist

<!--
  These questions are a friendly reminder to shipping code, if you're uncertain ask the AoR owners.
  It's also totally appropriate to not check some of these boxes, if they don't apply to your change.
-->
*Please tick all that apply:*

- [ ] I have tested this change locally
- [ ] I have tested this change locally in all supported browsers
- [ ] This change will be visible to users
- [ ] I have added automated tests that cover this change
- [ ] I have ensured the change is gated by config
- [ ] This change was covered by a ship review
- [ ] This change was covered by a tech design
- [ ] Any dependent config has been merged


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches injected API spoofing used broadly across features; incorrect masking could break sites or leave detection vectors, but the change mirrors existing setter/value masking logic.
> 
> **Overview**
> Extends **ApiManipulation** accessor overrides so **getters** are masked the same way setters already were when replacing native accessor descriptors.
> 
> When `wrapApiDescriptor` installs a getter/setter pair, it now runs `maskMethodReplacement` on the new **getter** (when a native getter exists), so `getOwnPropertyDescriptor(...).get.toString()` / `.name` still look native. Comments were updated to describe masking both sides of event-handler–style IDL attributes (e.g. `onclick`, `ondevicechange`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 497ccb7f393d335782c7195c3e85bb404815c251. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->