### PR TITLE
Integration test subscription error

### DIFF
--- a/messaging/lib/test-utils.mjs
+++ b/messaging/lib/test-utils.mjs
@@ -434,8 +434,14 @@ export function simulateSubscriptionMessage(params) {
         }
         case 'apple':
         case 'apple-isolated': {
-            if (!(params.name in window)) throw new Error('subscription fn not found for: ' + params.injectName);
-            window[params.name](subscriptionEvent);
+            // WebKit subscriptions are delivered via `navigator.duckduckgo[subscriptionName](event)`
+            // (see WebkitMessagingTransport.subscribe). For backwards compatibility in tests, also
+            // support the legacy `window[subscriptionName]` exposure.
+            const fn = navigator?.duckduckgo?.[params.name] ?? window?.[params.name];
+            if (typeof fn !== 'function') {
+                throw new Error(`subscription fn not found for: ${params.name} (${params.injectName})`);
+            }
+            fn(subscriptionEvent);
             break;
         }
         case 'integration': {

--- a/special-pages/pages/duckplayer/integration-tests/duck-player.js
+++ b/special-pages/pages/duckplayer/integration-tests/duck-player.js
@@ -478,6 +478,14 @@ export class DuckPlayerPage {
      * @return {Promise<void>}
      */
     async enabledViaSettings() {
+        // Wait for the subscription handler to appear before trying to simulate push events.
+        // On WebKit platforms this is exposed via `navigator.duckduckgo[subscriptionName]`.
+        await this.page.waitForFunction(() => {
+            const ddg = navigator && navigator.duckduckgo;
+            const fn = (ddg && ddg.onUserValuesChanged) || window.onUserValuesChanged;
+            return typeof fn === 'function';
+        });
+
         await this.mocks.simulateSubscriptionMessage('onUserValuesChanged', {
             privatePlayerMode: {
                 enabled: {},

--- a/special-pages/pages/release-notes/integration-tests/release-notes.js
+++ b/special-pages/pages/release-notes/integration-tests/release-notes.js
@@ -97,7 +97,11 @@ export class ReleaseNotesPage {
     async sendSubscriptionMessage(messageType, dataOverrides) {
         // Wait for the subscription handler to appear before trying to simulate push events.
         // This prevents a race condition where playwright is sending data before `.subscribe` was called
-        await this.page.waitForFunction(() => 'onUpdate' in window && typeof window.onUpdate === 'function');
+        await this.page.waitForFunction(() => {
+            const ddg = navigator && navigator.duckduckgo;
+            const fn = (ddg && ddg.onUpdate) || window.onUpdate;
+            return typeof fn === 'function';
+        });
 
         const data = dataOverrides
             ? { ...sampleData[messageType], .../** @type {object} */ (dataOverrides) }

--- a/special-pages/pages/special-error/integration-tests/special-error.js
+++ b/special-pages/pages/special-error/integration-tests/special-error.js
@@ -401,12 +401,16 @@ export class SpecialErrorPage {
 
     async overrideTestLinks() {
         const { page } = this;
-        await page.context().route(/dub\.duckduckgo\.com|use-devtesting..\.duckduckgo\.com/, (route) =>
+        await page
+            .context()
+            .route(
+                /dub\.duckduckgo\.com|use-devtesting..\.duckduckgo\.com|duckduckgo\.com\/duckduckgo-help-pages\/|duckduckgo\.com\/malicious-site-protection\/report-error/,
+                (route) =>
             route.fulfill({
                 status: 200,
                 body: 'OK',
             }),
-        );
+            );
     }
 
     /**


### PR DESCRIPTION
**Asana Task/Github Issue:**

## Description

Fixes Playwright integration test failures for `apple` and `apple-isolated` contexts. The `simulateSubscriptionMessage` helper now correctly dispatches WebKit subscription events to `navigator.duckduckgo` (with a `window` fallback). Additionally, `release-notes` and `duckplayer` integration tests now wait for `navigator.duckduckgo` subscription handlers, and `special-error` external link stubbing is hardened for CI.

## Testing Steps

- Run `npm run test-int-x --workspace special-pages` and verify macOS and iOS projects pass.

## Checklist

*Please tick all that apply:*

- [x] I have tested this change locally
- [ ] I have tested this change locally in all supported browsers
- [ ] This change will be visible to users
- [x] I have added automated tests that cover this change
- [ ] I have ensured the change is gated by config
- [ ] This change was covered by a ship review
- [ ] This change was covered by a tech design
- [ ] Any dependent config has been merged

---
<a href="https://cursor.com/background-agent?bcId=bc-117c7bec-5228-4e4a-a4a7-e4f8ee7896a6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-117c7bec-5228-4e4a-a4a7-e4f8ee7896a6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

