### PR TITLE
Mdc submodule change reporting

### DIFF
--- a/.cursor/rules/submodule-change-reporting.mdc
+++ b/.cursor/rules/submodule-change-reporting.mdc
@@ -1,0 +1,35 @@
+---
+description: Change reporting shortcut for single-workspace diffs
+# Apply across the monorepo workspaces
+# (injected/, special-pages/, messaging/, types-generator/)
+globs: "**/*"
+---
+
+# Single-workspace change reporting
+
+When summarizing work or reporting what changed, first determine whether the diff touches **only one** top-level workspace directory:
+
+- `injected/`
+- `special-pages/`
+- `messaging/`
+- `types-generator/`
+
+## Rule
+
+- If **all changed files** are under exactly one of the directories above, **do not** produce a multi-file or cross-workspace change report.
+- Instead, report **only**:
+  - the **current branch name**, and
+  - a **link to the branch** on GitHub.
+
+Use this branch URL shape:
+
+- `https://github.com/duckduckgo/content-scope-scripts/tree/<branch>`
+
+## Output template
+
+- **Branch**: `<branch>`
+- **Link**: `https://github.com/duckduckgo/content-scope-scripts/tree/<branch>`
+
+## Notes
+
+- If changes span **multiple** workspace directories (or touch files outside these directories), produce the normal detailed report.


### PR DESCRIPTION
**Asana Task/Github Issue:** N/A

## Description

Adds a new Cursor `.mdc` rule (`submodule-change-reporting.mdc`) to simplify change reporting. If a diff is confined to a single top-level workspace directory (e.g., `injected/`, `special-pages/`, `messaging/`, `types-generator/`), Cursor will now report only the current branch name and a link to the branch on GitHub, instead of a detailed multi-file report.

## Testing Steps

- Make a change within a single workspace directory (e.g., `injected/`). Ask Cursor to "summarize changes" and observe that it reports only the branch name and GitHub link.
- Make a change spanning multiple workspace directories or outside them. Ask Cursor to "summarize changes" and observe that it provides a normal detailed report.

## Checklist

*Please tick all that apply:*

- [x] I have tested this change locally
- [ ] I have tested this change locally in all supported browsers
- [x] This change will be visible to users
- [ ] I have added automated tests that cover this change
- [ ] I have ensured the change is gated by config
- [ ] This change was covered by a ship review
- [ ] This change was covered by a tech design
- [ ] Any dependent config has been merged

---
<a href="https://cursor.com/background-agent?bcId=bc-b3ab6cf4-3328-4150-9ca4-4d16aa174e0a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b3ab6cf4-3328-4150-9ca4-4d16aa174e0a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

