### PR TITLE
Recurring failure investigation

### DIFF
--- a/.github/workflows/auto-respond-pr.yml
+++ b/.github/workflows/auto-respond-pr.yml
@@ -2,7 +2,7 @@ name: Auto Respond to PR
 
 on:
     pull_request:
-        types: [opened, synchronize, closed, ready_for_review]
+        types: [opened, synchronize, ready_for_review]
 
 jobs:
     auto_respond:


### PR DESCRIPTION
**Asana Task/Github Issue:** N/A

## Description

Removes the `closed` event trigger from the `auto-respond-pr.yml` workflow. This prevents recurring failures where the workflow attempted to checkout the head branch of merged Dependabot PRs, which are often deleted upon closure.

## Testing Steps

- Verify that the `auto-respond-pr` workflow no longer triggers on PR `closed` events.
- Confirm that the workflow still triggers correctly on `opened`, `synchronize`, and `ready_for_review` events.

## Checklist

*Please tick all that apply:*

- [ ] I have tested this change locally
- [ ] I have tested this change locally in all supported browsers
- [ ] This change will be visible to users
- [ ] I have added automated tests that cover this change
- [ ] I have ensured the change is gated by config
- [ ] This change was covered by a ship review
- [ ] This change was covered by a tech design
- [ ] Any dependent config has been merged

---
<a href="https://cursor.com/background-agent?bcId=bc-826f0f6d-e9da-4404-9e3c-2744a06b03c8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-826f0f6d-e9da-4404-9e3c-2744a06b03c8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes the `closed` event from `pull_request` trigger types in `.github/workflows/auto-respond-pr.yml`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1beb4fda5b62f01db74d9c6848c2adceb7641040. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->