### PR TITLE
First message auto capture gate

### DIFF
--- a/injected/src/features/page-context.js
+++ b/injected/src/features/page-context.js
@@ -398,6 +398,9 @@ export default class PageContext extends ContentFeature {
 
                 this.scheduleDelayedRecheck();
             });
+            // Start observing immediately if we already have cached content
+            // (e.g., when activeCaptureOnFirstMessage is enabled and content was collected before observer creation)
+            this.startObserving();
         }
     }
 


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1199237043598868/task/1212683187147170?focus=true

## Description

Adds feature gating for the behaviours that push content to native.
Additionally adds another mode that doesn't speak until it's spoken to. This is currently for use on mobile where native will send a message and from there on out ContentScopeScripts will push updates about the content changing.

## Testing Steps

- <!-- Include simple steps on how to check this change is working. Write "N/A" if not applicable. -->

## Checklist

<!--
  These questions are a friendly reminder to shipping code, if you're uncertain ask the AoR owners.
  It's also totally appropriate to not check some of these boxes, if they don't apply to your change.
-->
*Please tick all that apply:*

- [ ] I have tested this change locally
- [ ] I have tested this change locally in all supported browsers
- [ ] This change will be visible to users
- [ ] I have added automated tests that cover this change
- [ ] I have ensured the change is gated by config
- [ ] This change was covered by a ship review
- [ ] This change was covered by a tech design
- [ ] Any dependent config has been merged



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces gated active capture so page content is only pushed after the first native `collect` message, with clear separation of `setupListeners` and `setupActiveCaptureListeners`.
> 
> - New gating via `activeCaptureOnFirstMessage`; activates on first `collect` and conditionally wires listeners
> - Adds `shouldListenForUrlChanges` getter and updates `init`/`urlChanged` to respect gating and `shouldActivate`
> - Event listeners now behind feature flags: `subscribeToLoad`, `subscribeToHashChange`, `subscribeToPageShow`, `subscribeToVisibilityChange`, `subscribeToUrlChange`; initial collection via `collectOnInit`
> - Mutation observing is controlled by `observeMutations` and begins immediately when cached content exists
> - Refactors `shouldActivate` into a getter; removes `listenForUrlChanges`; minor setup/cache/observer flow adjustments
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 03ff0d3fd19da5b7a2ff512124e86aa1568e4d82. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->