### PR TITLE
Content scope script states

### DIFF
--- a/injected/src/config-feature.js
+++ b/injected/src/config-feature.js
@@ -7,6 +7,7 @@ import {
     computeLimitedSiteObject,
     isSupportedVersion,
     isMaxSupportedVersion,
+    isStateEnabled,
 } from './utils.js';
 import { URLPattern } from 'urlpattern-polyfill';
 
@@ -54,7 +55,7 @@ export default class ConfigFeature {
         // If we have a bundled config, treat it as a regular config
         // This will be overriden by the remote config if it is available
         if (this.#bundledConfig && this.#args) {
-            const enabledFeatures = computeEnabledFeatures(bundledConfig, site.domain, platform.version);
+            const enabledFeatures = computeEnabledFeatures(bundledConfig, site.domain, platform);
             this.#args.featureSettings = parseFeatureSettings(bundledConfig, enabledFeatures);
         }
     }
@@ -366,18 +367,21 @@ export default class ConfigFeature {
      *   }
      * }
      * ```
+     * State values can be: 'enabled', 'disabled', 'internal', or 'preview'.
+     * 'internal' and 'preview' are enabled based on platform flags.
      * This also supports domain overrides as per `getFeatureSetting`.
      * @param {string} featureKeyName
-     * @param {'enabled' | 'disabled'} [defaultState]
+     * @param {import('./utils.js').FeatureState} [defaultState]
      * @param {string} [featureName]
      * @returns {boolean}
      */
     getFeatureSettingEnabled(featureKeyName, defaultState, featureName) {
         const result = this.getFeatureSetting(featureKeyName, featureName) || defaultState;
+        const platform = this.#args?.platform;
         if (typeof result === 'object') {
-            return result.state === 'enabled';
+            return isStateEnabled(result.state, platform);
         }
-        return result === 'enabled';
+        return isStateEnabled(result, platform);
     }
 
     /**

--- a/injected/unit-test/utils.js
+++ b/injected/unit-test/utils.js
@@ -7,6 +7,7 @@ import {
     isMaxSupportedVersion,
     getTabHostname,
     processAttr,
+    isStateEnabled,
 } from '../src/utils.js';
 import { polyfillProcessGlobals } from './helpers/polyfill-process-globals.js';
 
@@ -188,7 +189,7 @@ describe('Helpers checks', () => {
         });
     });
 
-    it('does not enable features with state "preview"', () => {
+    it('does not enable features with state "preview" when preview flag is not set', () => {
         const configIn = {
             features: {
                 testFeature: {
@@ -218,6 +219,140 @@ describe('Helpers checks', () => {
         );
         expect(processedConfig.site.enabledFeatures).toEqual(['testFeature']);
         expect(processedConfig.featureSettings).toEqual({ testFeature: {} });
+    });
+
+    it('enables features with state "preview" when platform.preview is true', () => {
+        const configIn = {
+            features: {
+                testFeature: {
+                    state: 'enabled',
+                    settings: {},
+                    exceptions: [],
+                },
+                previewFeature: {
+                    state: 'preview',
+                    settings: { foo: 'bar' },
+                    exceptions: [],
+                },
+            },
+            unprotectedTemporary: [],
+        };
+        const processedConfig = processConfig(
+            configIn,
+            [],
+            {
+                platform: {
+                    name: 'android',
+                    preview: true,
+                },
+                versionNumber: 99,
+                sessionKey: 'testSessionKey',
+            },
+            [],
+        );
+        expect(processedConfig.site.enabledFeatures).toEqual(['testFeature', 'previewFeature']);
+        expect(processedConfig.featureSettings).toEqual({ testFeature: {}, previewFeature: { foo: 'bar' } });
+    });
+
+    it('does not enable features with state "internal" when internal flag is not set', () => {
+        const configIn = {
+            features: {
+                testFeature: {
+                    state: 'enabled',
+                    settings: {},
+                    exceptions: [],
+                },
+                internalFeature: {
+                    state: 'internal',
+                    settings: {},
+                    exceptions: [],
+                },
+            },
+            unprotectedTemporary: [],
+        };
+        const processedConfig = processConfig(
+            configIn,
+            [],
+            {
+                platform: {
+                    name: 'android',
+                },
+                versionNumber: 99,
+                sessionKey: 'testSessionKey',
+            },
+            [],
+        );
+        expect(processedConfig.site.enabledFeatures).toEqual(['testFeature']);
+        expect(processedConfig.featureSettings).toEqual({ testFeature: {} });
+    });
+
+    it('enables features with state "internal" when platform.internal is true', () => {
+        const configIn = {
+            features: {
+                testFeature: {
+                    state: 'enabled',
+                    settings: {},
+                    exceptions: [],
+                },
+                internalFeature: {
+                    state: 'internal',
+                    settings: { baz: 'qux' },
+                    exceptions: [],
+                },
+            },
+            unprotectedTemporary: [],
+        };
+        const processedConfig = processConfig(
+            configIn,
+            [],
+            {
+                platform: {
+                    name: 'android',
+                    internal: true,
+                },
+                versionNumber: 99,
+                sessionKey: 'testSessionKey',
+            },
+            [],
+        );
+        expect(processedConfig.site.enabledFeatures).toEqual(['testFeature', 'internalFeature']);
+        expect(processedConfig.featureSettings).toEqual({ testFeature: {}, internalFeature: { baz: 'qux' } });
+    });
+
+    describe('utils.isStateEnabled', () => {
+        it('returns true for "enabled" state regardless of platform flags', () => {
+            expect(isStateEnabled('enabled', undefined)).toBeTrue();
+            expect(isStateEnabled('enabled', { name: 'android' })).toBeTrue();
+            expect(isStateEnabled('enabled', { name: 'android', internal: true })).toBeTrue();
+            expect(isStateEnabled('enabled', { name: 'android', preview: true })).toBeTrue();
+        });
+
+        it('returns false for "disabled" state regardless of platform flags', () => {
+            expect(isStateEnabled('disabled', undefined)).toBeFalse();
+            expect(isStateEnabled('disabled', { name: 'android' })).toBeFalse();
+            expect(isStateEnabled('disabled', { name: 'android', internal: true })).toBeFalse();
+            expect(isStateEnabled('disabled', { name: 'android', preview: true })).toBeFalse();
+        });
+
+        it('returns true for "internal" state only when platform.internal is true', () => {
+            expect(isStateEnabled('internal', undefined)).toBeFalse();
+            expect(isStateEnabled('internal', { name: 'android' })).toBeFalse();
+            expect(isStateEnabled('internal', { name: 'android', internal: false })).toBeFalse();
+            expect(isStateEnabled('internal', { name: 'android', internal: true })).toBeTrue();
+        });
+
+        it('returns true for "preview" state only when platform.preview is true', () => {
+            expect(isStateEnabled('preview', undefined)).toBeFalse();
+            expect(isStateEnabled('preview', { name: 'android' })).toBeFalse();
+            expect(isStateEnabled('preview', { name: 'android', preview: false })).toBeFalse();
+            expect(isStateEnabled('preview', { name: 'android', preview: true })).toBeTrue();
+        });
+
+        it('returns false for unknown state values', () => {
+            expect(isStateEnabled('unknown', { name: 'android' })).toBeFalse();
+            expect(isStateEnabled(undefined, { name: 'android' })).toBeFalse();
+            expect(isStateEnabled('', { name: 'android' })).toBeFalse();
+        });
     });
 
     describe('utils.satisfiesMinVersion', () => {


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1201614831475344/task/1212720272153009?focus=true

## Description

Adds support for `internal` and `preview` as valid feature states, allowing features to be conditionally enabled based on `platform.internal` and `platform.preview` flags. This extends feature gating capabilities beyond simple `enabled`/`disabled` states.

## Testing Steps

- Unit tests have been added to cover the new `isStateEnabled` logic and feature enablement for `internal` and `preview` states.
- To manually verify:
    - Create a feature with `state: 'internal'` and confirm it's enabled when `platform.internal` is true, and disabled otherwise.
    - Create a feature with `state: 'preview'` and confirm it's enabled when `platform.preview` is true, and disabled otherwise.

## Checklist

*Please tick all that apply:*

- [x] I have tested this change locally
- [ ] I have tested this change locally in all supported browsers
- [ ] This change will be visible to users
- [x] I have added automated tests that cover this change
- [ ] I have ensured the change is gated by config
- [ ] This change was covered by a ship review
- [ ] This change was covered by a tech design
- [ ] Any dependent config has been merged

---
<a href="https://cursor.com/background-agent?bcId=bc-ab9ad10f-43f9-4814-b368-608aa347a3f8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ab9ad10f-43f9-4814-b368-608aa347a3f8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces platform-gated feature states and updates enablement to depend on platform flags rather than only version.
> 
> - Adds `FeatureState` typedef and `isStateEnabled(state, platform)` to gate `enabled/disabled/internal/preview`
> - Changes `computeEnabledFeatures` to accept `platform` (not just version), use `isStateEnabled`, and still honor `minSupportedVersion` and exceptions
> - Updates `processConfig` and `ConfigFeature` constructor to pass `platform` to `computeEnabledFeatures`
> - Updates `ConfigFeature.getFeatureSettingEnabled` to use `isStateEnabled` for both string and object settings
> - Adds unit tests covering `preview`/`internal` gating and `isStateEnabled` behavior
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4cae2753e87f6fa0dc575c5f7677f3e0d9920b88. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->