### PR TITLE
Remove redundant steps from snapshots workflow to fix timeouts

### DIFF
--- a/.github/workflows/snapshots.yml
+++ b/.github/workflows/snapshots.yml
@@ -38,15 +38,6 @@ jobs:
             - run: npm ci
             - run: npm run build
 
-            - run: npm run lint
-              continue-on-error: true
-
-            - run: npm run stylelint
-              continue-on-error: true
-
-            - run: npm run test-unit
-              continue-on-error: true
-
             - name: 'Clean tree'
               run: 'npm run test-clean-tree'
 


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1209121419454298/task/1210713315191794?focus=true

## Description

The `snapshots.yml` workflow was [occasionally timing out](https://github.com/duckduckgo/content-scope-scripts/actions/runs/20811912435/attempts/2) (5 minute limit).

This PR removes the `lint`, `stylelint`, and `test-unit` steps from `snapshots.yml` so that there’s more time for `npm run test-int-snapshots` to run.

Both workflows have identical triggers (`push: main`, `pull_request`, `merge_group`), so these checks are redundant. Removing them saves ~2.5 minutes of runtime:
- `npm run lint`: ~55s
- `npm run stylelint`: ~4s  
- `npm run test-unit`: ~1m 26s

## Testing Steps

- Verify the snapshot workflow completes successfully on this PR
- Confirm lint/stylelint/unit-test steps still run via the Test workflow

## Checklist

- [ ] I have tested this change locally
- [ ] I have tested this change locally in all supported browsers
- [ ] This change will be visible to users
- [ ] I have added automated tests that cover this change
- [ ] I have ensured the change is gated by config
- [ ] This change was covered by a ship review
- [ ] This change was covered by a tech design
- [ ] Any dependent config has been merged

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Streamlines the `snapshots.yml` workflow by removing redundant checks to reduce runtime and avoid timeouts.
> 
> - Removes `npm run lint`, `npm run stylelint`, and `npm run test-unit` steps from `snapshots.yml`
> - Snapshot job now: install deps, build, `test-clean-tree`, install Playwright, run `test-int-snapshots`, upload artifacts
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ff44482d98f911617608b97565309e5c3076927a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->