### PR TITLE
Add customizer drawer open/close telemetry

### DIFF
--- a/special-pages/pages/new-tab/app/customizer/CustomizerProvider.js
+++ b/special-pages/pages/new-tab/app/customizer/CustomizerProvider.js
@@ -4,6 +4,7 @@ import { signal, useComputed, useSignal, useSignalEffect } from '@preact/signals
 import { useThemes } from './themes.js';
 import { applyDefaultStyles } from './utils.js';
 import { useDrawerEventListeners } from '../components/Drawer.js';
+import { useMessaging } from '../types.js';
 
 /**
  * @typedef {import('../../types/new-tab.js').CustomizerData} CustomizerData
@@ -77,6 +78,7 @@ export const CustomizerContext = createContext({
 export function CustomizerProvider({ service, initialData, children }) {
     // const [state, dispatch] = useReducer(withLog('RMFProvider', reducer), initial)
     const data = useSignal(initialData);
+    const ntp = useMessaging();
     const { main, browser, variant } = useThemes(data);
 
     useSignalEffect(() => {
@@ -163,13 +165,18 @@ export function CustomizerProvider({ service, initialData, children }) {
             onOpen: () => {
                 drawerOpenCount.value++;
                 service.dismissThemeVariantPopover();
+                ntp.telemetryEvent({ attributes: { name: 'customizer_drawer', value: 'opened' } });
             },
-            onToggle: () => {
+            onClose: () => {
+                ntp.telemetryEvent({ attributes: { name: 'customizer_drawer', value: 'closed' } });
+            },
+            onToggle: (state) => {
                 drawerOpenCount.value++;
                 service.dismissThemeVariantPopover();
+                ntp.telemetryEvent({ attributes: { name: 'customizer_drawer', value: state === 'visible' ? 'opened' : 'closed' } });
             },
         },
-        [service],
+        [service, ntp],
     );
 
     return (

--- a/special-pages/pages/new-tab/messages/telemetryEvent.notify.json
+++ b/special-pages/pages/new-tab/messages/telemetryEvent.notify.json
@@ -29,6 +29,20 @@
               "const": "ntp_example"
             }
           }
+        },
+        {
+          "type": "object",
+          "title": "Customizer Drawer State",
+          "required": ["name", "value"],
+          "properties": {
+            "name": {
+              "const": "customizer_drawer"
+            },
+            "value": {
+              "type": "string",
+              "enum": ["opened", "closed"]
+            }
+          }
         }
       ]
     }

--- a/special-pages/pages/new-tab/types/new-tab.ts
+++ b/special-pages/pages/new-tab/types/new-tab.ts
@@ -679,7 +679,7 @@ export interface TelemetryEventNotification {
   params: NTPTelemetryEvent;
 }
 export interface NTPTelemetryEvent {
-  attributes: StatsShowMore | ExampleTelemetryEvent;
+  attributes: StatsShowMore | ExampleTelemetryEvent | CustomizerDrawerState;
 }
 export interface StatsShowMore {
   name: "stats_toggle";
@@ -687,6 +687,10 @@ export interface StatsShowMore {
 }
 export interface ExampleTelemetryEvent {
   name: "ntp_example";
+}
+export interface CustomizerDrawerState {
+  name: "customizer_drawer";
+  value: "opened" | "closed";
 }
 /**
  * Generated from @see "../messages/updateNotification_dismiss.notify.json"


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/72649045549333/task/1212677805201383?focus=true

## Description

Add telemetry events for when the customizer drawer opens or closes. Sends `telemetryEvent` notifications with `{ name: "customizer_drawer", value: "opened" | "closed" }`.

## Testing Steps

- Open https://deploy-preview-2167--aspect-content-scope-scripts.netlify.app/new-tab/index.html?platform=macos
- Click "Customize" button → verify `opened` telemetry event is sent (check console for "unhandled notification")
- Click "Close" button → verify `closed` telemetry event is sent
- Open https://deploy-preview-2167--aspect-content-scope-scripts.netlify.app/new-tab/index.html?platform=macos&autoOpen=true → verify `opened` telemetry event is sent on auto-open

## Checklist

*Please tick all that apply:*

- [x] I have tested this change locally
- [ ] I have tested this change locally in all supported browsers
- [ ] This change will be visible to users
- [x] I have added automated tests that cover this change
- [ ] I have ensured the change is gated by config
- [ ] This change was covered by a ship review
- [ ] This change was covered by a tech design
- [ ] Any dependent config has been merged

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds instrumentation for customizer drawer visibility and aligns events, schema, and types.
> 
> - Emits `toggle-drawer-complete` with `{ state: 'visible'|'hidden' }` from `Drawer.js`; `useDrawerEventListeners` now uses `useLayoutEffect` and listens to `toggle-drawer-complete`, passing the new state to `onToggle`
> - Sends `telemetryEvent` from `CustomizerProvider` on drawer `opened`/`closed`, including auto-open; adds `useMessaging` and updates hook deps
> - Extends `telemetryEvent.notify.json` and generated `types/new-tab.ts` with `CustomizerDrawerState` (`{ name: 'customizer_drawer', value: 'opened'|'closed' }`)
> - Adds integration tests asserting telemetry on open/close and auto-open
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b8509e86bcf7ee198ba81ad9289743bf7844c015. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->