### PR TITLE
Add themeVariantPopoverWasOpen to drawer telemetry

### DIFF
--- a/special-pages/pages/new-tab/app/customizer/CustomizerProvider.js
+++ b/special-pages/pages/new-tab/app/customizer/CustomizerProvider.js
@@ -164,16 +164,46 @@ export function CustomizerProvider({ service, initialData, children }) {
         {
             onOpen: () => {
                 drawerOpenCount.value++;
+                ntp.telemetryEvent({
+                    attributes: {
+                        name: 'customizer_drawer',
+                        value: {
+                            state: 'opened',
+                            themeVariantPopoverWasOpen: data.value.showThemeVariantPopover ?? false,
+                        },
+                    },
+                });
                 service.dismissThemeVariantPopover();
-                ntp.telemetryEvent({ attributes: { name: 'customizer_drawer', value: 'opened' } });
             },
             onClose: () => {
-                ntp.telemetryEvent({ attributes: { name: 'customizer_drawer', value: 'closed' } });
+                ntp.telemetryEvent({
+                    attributes: {
+                        name: 'customizer_drawer',
+                        value: { state: 'closed' },
+                    },
+                });
             },
             onToggle: (state) => {
                 drawerOpenCount.value++;
+                if (state === 'visible') {
+                    ntp.telemetryEvent({
+                        attributes: {
+                            name: 'customizer_drawer',
+                            value: {
+                                state: 'opened',
+                                themeVariantPopoverWasOpen: data.value.showThemeVariantPopover ?? false,
+                            },
+                        },
+                    });
+                } else {
+                    ntp.telemetryEvent({
+                        attributes: {
+                            name: 'customizer_drawer',
+                            value: { state: 'closed' },
+                        },
+                    });
+                }
                 service.dismissThemeVariantPopover();
-                ntp.telemetryEvent({ attributes: { name: 'customizer_drawer', value: state === 'visible' ? 'opened' : 'closed' } });
             },
         },
         [service, ntp],

--- a/special-pages/pages/new-tab/app/customizer/integration-tests/customizer.spec.js
+++ b/special-pages/pages/new-tab/app/customizer/integration-tests/customizer.spec.js
@@ -458,7 +458,7 @@ test.describe('newtab customizer', () => {
             featureName: 'newTabPage',
             method: 'telemetryEvent',
             params: {
-                attributes: { name: 'customizer_drawer', value: 'opened' },
+                attributes: { name: 'customizer_drawer', value: { state: 'opened', themeVariantPopoverWasOpen: false } },
             },
         });
 
@@ -470,7 +470,7 @@ test.describe('newtab customizer', () => {
             featureName: 'newTabPage',
             method: 'telemetryEvent',
             params: {
-                attributes: { name: 'customizer_drawer', value: 'closed' },
+                attributes: { name: 'customizer_drawer', value: { state: 'closed' } },
             },
         });
     });
@@ -486,7 +486,28 @@ test.describe('newtab customizer', () => {
             featureName: 'newTabPage',
             method: 'telemetryEvent',
             params: {
-                attributes: { name: 'customizer_drawer', value: 'opened' },
+                attributes: { name: 'customizer_drawer', value: { state: 'opened', themeVariantPopoverWasOpen: false } },
+            },
+        });
+    });
+
+    test('sends telemetryEvent with themeVariantPopoverWasOpen when drawer opens while popover is visible', async ({
+        page,
+    }, workerInfo) => {
+        const ntp = NewtabPage.create(page, workerInfo);
+        await ntp.reducedMotion();
+        await ntp.openPage({ additional: { 'customizer.showThemeVariantPopover': true, themeVariant: 'default' } });
+
+        const cp = new CustomizerPage(ntp);
+        await cp.opensCustomizer();
+
+        const calls = await ntp.mocks.waitForCallCount({ method: 'telemetryEvent', count: 1 });
+        expect(calls[0].payload).toStrictEqual({
+            context: 'specialPages',
+            featureName: 'newTabPage',
+            method: 'telemetryEvent',
+            params: {
+                attributes: { name: 'customizer_drawer', value: { state: 'opened', themeVariantPopoverWasOpen: true } },
             },
         });
     });

--- a/special-pages/pages/new-tab/messages/telemetryEvent.notify.json
+++ b/special-pages/pages/new-tab/messages/telemetryEvent.notify.json
@@ -39,8 +39,18 @@
               "const": "customizer_drawer"
             },
             "value": {
-              "type": "string",
-              "enum": ["opened", "closed"]
+              "type": "object",
+              "required": ["state"],
+              "properties": {
+                "state": {
+                  "type": "string",
+                  "enum": ["opened", "closed"]
+                },
+                "themeVariantPopoverWasOpen": {
+                  "type": "boolean",
+                  "description": "True if the theme variant popover was visible when the drawer was opened"
+                }
+              }
             }
           }
         }

--- a/special-pages/pages/new-tab/types/new-tab.ts
+++ b/special-pages/pages/new-tab/types/new-tab.ts
@@ -690,7 +690,13 @@ export interface ExampleTelemetryEvent {
 }
 export interface CustomizerDrawerState {
   name: "customizer_drawer";
-  value: "opened" | "closed";
+  value: {
+    state: "opened" | "closed";
+    /**
+     * True if the theme variant popover was visible when the drawer was opened
+     */
+    themeVariantPopoverWasOpen?: boolean;
+  };
 }
 /**
  * Generated from @see "../messages/updateNotification_dismiss.notify.json"


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/72649045549333/task/1212677805201383?focus=true

## Description

Updates the `customizer_drawer` telemetry event to include richer information. The `value` field is now an object with:
- `state`: `"opened"` | `"closed"`
- `themeVariantPopoverWasOpen`: boolean (only included in `opened` events) - indicates if the theme variant popover was visible when the drawer was opened

## Testing Steps

- Open https://deploy-preview-2172--aspect-content-scope-scripts.netlify.app/new-tab/index.html?platform=macos
- Click "Customize" button → verify `opened` telemetry event is sent with `{ state: "opened", themeVariantPopoverWasOpen: false }`
- Click "Close" button → verify `closed` telemetry event is sent with `{ state: "closed" }`
- Open https://deploy-preview-2172--aspect-content-scope-scripts.netlify.app/new-tab/index.html?platform=macos&customizer.showThemeVariantPopover=true&themeVariant=default
- Click "Customize" button → verify `opened` telemetry event is sent with `{ state: "opened", themeVariantPopoverWasOpen: true }`

## Checklist

*Please tick all that apply:*

- [x] I have tested this change locally
- [ ] I have tested this change locally in all supported browsers
- [ ] This change will be visible to users
- [x] I have added automated tests that cover this change
- [ ] I have ensured the change is gated by config
- [ ] This change was covered by a ship review
- [ ] This change was covered by a tech design
- [ ] Any dependent config has been merged

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds richer telemetry for the Customizer drawer.
> 
> - `CustomizerProvider.js`: emits structured `telemetryEvent` on drawer open/close/toggle with `{ state: 'opened'|'closed', themeVariantPopoverWasOpen?: boolean }`; includes popover visibility on open and continues dismissing the popover
> - `messages/telemetryEvent.notify.json` and `types/new-tab.ts`: change `customizer_drawer.value` from string to object; add optional `themeVariantPopoverWasOpen`
> - Integration tests: update expectations for structured payloads and add case when opening while the theme variant popover is visible
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1df4d922be4fb8c3e61bf89273a6b99f579b30d6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->