### PR TITLE
fix: use pull_request_target for Dependabot workflow secrets access

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,5 +1,7 @@
 name: Dependabot auto-approve and auto-merge
-on: pull_request
+# Use pull_request_target to access secrets for Dependabot PRs
+# This is safe because this workflow does not checkout or execute PR code
+on: pull_request_target
 
 permissions:
     contents: write
@@ -12,7 +14,7 @@ jobs:
         steps:
             - name: Dependabot metadata
               id: metadata
-              uses: dependabot/fetch-metadata@08eff52bf64351f401fb50d4972fa95b9f2c2d1b
+              uses: dependabot/fetch-metadata@21025c705c08248db411dc16f3619e6b5f9ea21a # v2.5.0
               with:
                   github-token: '${{ secrets.GITHUB_TOKEN }}'
 


### PR DESCRIPTION
Changes:
- Switch from pull_request to pull_request_target trigger
- This allows access to CURSOR_PAT secret for Dependabot-triggered PRs
- Safe because this workflow doesn't checkout or execute PR code
- Also bumps dependabot/fetch-metadata from v2.4.0 to v2.5.0

**Asana Task/Github Issue:** <!-- Link to Asana Task/Github Issue -->

## Description

<!--
  Provide a terse summary of what the change is, detailed descriptions should belong in ship reviews or tech designs
-->

## Testing Steps

- <!-- Include simple steps on how to check this change is working. Write "N/A" if not applicable. -->

## Checklist

<!--
  These questions are a friendly reminder to shipping code, if you're uncertain ask the AoR owners.
  It's also totally appropriate to not check some of these boxes, if they don't apply to your change.
-->
*Please tick all that apply:*

- [ ] I have tested this change locally
- [ ] I have tested this change locally in all supported browsers
- [ ] This change will be visible to users
- [ ] I have added automated tests that cover this change
- [ ] I have ensured the change is gated by config
- [ ] This change was covered by a ship review
- [ ] This change was covered by a tech design
- [ ] Any dependent config has been merged


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Shifts the Dependabot auto-merge workflow to use `pull_request_target` for secrets access and updates the metadata action.
> 
> - Change trigger from `pull_request` to `pull_request_target`
> - Update `dependabot/fetch-metadata` action to v2.5.0 (new pinned SHA)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ecc987c4fa5324493eece583b8f1fc40fcdbab4b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->