### PR TITLE
Change Dependabot workflow trigger to pull_request

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,7 +1,5 @@
 name: Dependabot auto-approve and auto-merge
-# Use pull_request_target to access secrets for Dependabot PRs
-# This is safe because this workflow does not checkout or execute PR code
-on: pull_request_target
+on: pull_request
 
 permissions:
     contents: write


### PR DESCRIPTION
**Asana Task/Github Issue:** <!-- Link to Asana Task/Github Issue -->

## Description

<!--
  Provide a terse summary of what the change is, detailed descriptions should belong in ship reviews or tech designs
-->

## Testing Steps

- <!-- Include simple steps on how to check this change is working. Write "N/A" if not applicable. -->

## Checklist

<!--
  These questions are a friendly reminder to shipping code, if you're uncertain ask the AoR owners.
  It's also totally appropriate to not check some of these boxes, if they don't apply to your change.
-->
*Please tick all that apply:*

- [ ] I have tested this change locally
- [ ] I have tested this change locally in all supported browsers
- [ ] This change will be visible to users
- [ ] I have added automated tests that cover this change
- [ ] I have ensured the change is gated by config
- [ ] This change was covered by a ship review
- [ ] This change was covered by a tech design
- [ ] Any dependent config has been merged


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches the Dependabot workflow to run on `pull_request` events instead of `pull_request_target`.
> 
> - Updates `/.github/workflows/dependabot-auto-merge.yml` trigger to `on: pull_request`; existing permissions, job filter for `dependabot[bot]`, and auto-approve/auto-merge steps remain unchanged
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dbdb3430c51386fb2fd0bbe7b2d15919665725ca. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->