### PR TITLE
Inject feature documentation

### DIFF
--- a/injected/docs/features-guide.md
+++ b/injected/docs/features-guide.md
@@ -72,7 +72,7 @@ When editing core lifecycle code (`src/content-scope-features.js`, `src/utils.js
 ### Always-run platform-specific features (global disable bypass)
 
 - In `load()`, when `isGloballyDisabled(args)` is true (allowlisted or broken sites), we still load `platformSpecificFeatures`.
-- Current list (see `src/utils.js`): `navigatorInterface`, `windowsPermissionUsage`, `messageBridge`, `favicon`.
+- Current list is defined in `src/utils.js` under `platformSpecificFeatures`.
 - Rationale: these provide platform integration and must remain available even when protections are disabled.
 
 ### Always-init extension features (cookie)


### PR DESCRIPTION
**Asana Task/Github Issue:** N/A

## Description

Documents critical, special-case initialization and loading behaviors for injected features (e.g., `cookie`, platform-specific features) to guide developers and prevent regressions when modifying core lifecycle code.

## Testing Steps

- N/A

## Checklist

*Please tick all that apply:*

- [ ] I have tested this change locally
- [ ] I have tested this change locally in all supported browsers
- [ ] This change will be visible to users
- [ ] I have added automated tests that cover this change
- [ ] I have ensured the change is gated by config
- [ ] This change was covered by a ship review
- [ ] This change was covered by a tech design
- [ ] Any dependent config has been merged

---
<a href="https://cursor.com/background-agent?bcId=bc-c7146abf-0fee-458b-921c-7bf50d3d7268"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c7146abf-0fee-458b-921c-7bf50d3d7268"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change; no runtime behavior or configuration logic is modified.
> 
> **Overview**
> Updates `injected/docs/features-guide.md` to document **special-case feature lifecycle behaviors** that must be preserved when changing core injected feature loading/registry code.
> 
> The guide now explicitly calls out the cookie feature’s `load()`/`init()` ordering (early `Document.cookie` wrapper + later policy finalization), plus two bypass rules: always running `platformSpecificFeatures` even when globally disabled and always initializing `cookie` for `platform.name === 'extension'`, including the extension fallback to a bundled feature list before `site.enabledFeatures` exists.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9d4a422de4f75459815348176ca9e8c29fa91cdd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->