### PR TITLE
Enable favicon feature for iOS

### DIFF
--- a/injected/src/features/favicon.js
+++ b/injected/src/features/favicon.js
@@ -3,8 +3,6 @@ import { isBeingFramed } from '../utils.js';
 
 export class Favicon extends ContentFeature {
     init() {
-        if (this.platform.name === 'ios') return;
-
         /**
          * This feature never operates in a frame
          */
@@ -98,6 +96,7 @@ export function getFaviconList() {
     return Array.from(elements).map((/** @type {HTMLLinkElement} */ link) => {
         const href = link.href || '';
         const rel = link.getAttribute('rel') || '';
-        return { href, rel };
+        const type = link.getAttribute('type') || '';
+        return { href, rel, type };
     });
 }

--- a/injected/src/messages/favicon/faviconFound.notify.json
+++ b/injected/src/messages/favicon/faviconFound.notify.json
@@ -16,6 +16,10 @@
           },
           "rel": {
             "type": "string"
+          },
+          "type": {
+            "type": "string",
+            "description": "The MIME type from the link element's type attribute (e.g., image/svg+xml)"
           }
         }
       }

--- a/injected/src/types/favicon.ts
+++ b/injected/src/types/favicon.ts
@@ -26,6 +26,10 @@ export interface FaviconFound {
 export interface FaviconAttrs {
   href: string;
   rel: string;
+  /**
+   * The MIME type from the link element's type attribute (e.g., image/svg+xml)
+   */
+  type?: string;
 }
 
 declare module "../features/favicon.js" {


### PR DESCRIPTION
## Summary
- Remove the iOS platform guard in the favicon feature to enable it on iOS
- This is part of migrating iOS webkit handlers to C-S-S to avoid breakage when websites think they can access `window.webkit`

## Context
iOS currently uses an inline JavaScript `UserScript` that calls `webkit.messageHandlers.faviconFound`. This change enables the existing C-S-S favicon feature for iOS, which was previously disabled via a platform guard.

The corresponding iOS native changes (converting `FaviconUserScript` to a C-S-S Subfeature) will be in a separate apple-browsers PR that depends on this change.

## Test plan
- [ ] Verify favicon feature works on macOS (no regression)
- [ ] Once iOS native changes land, verify favicons load correctly on iOS

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it turns on messaging from injected code on iOS and changes the shape of the `faviconFound` payload, which may impact native/consumer integrations if not updated together.
> 
> **Overview**
> Enables the injected `Favicon` content feature on iOS by removing the iOS-only early return, so it now emits `faviconFound` notifications on that platform.
> 
> Extends the favicon payload to include the `<link>` element’s `type` attribute (MIME type) by updating `getFaviconList`, the `faviconFound` JSON schema, and the generated `FaviconAttrs` TypeScript type.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3609dd178879ac102c7fecd5aa26b35644d73897. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->