### PR TITLE
Snapshots update workflow timeout

### DIFF
--- a/.github/workflows/snapshots-update.yml
+++ b/.github/workflows/snapshots-update.yml
@@ -53,7 +53,8 @@ jobs:
 
             - name: Run Screenshot tests
               id: screenshot_tests
-              run: npm run test-int-snapshots
+              # Disable retries to fail fast - we just need to identify failing tests
+              run: npm run test-int-snapshots -- --retries=0
 
             - if: ${{ steps.screenshot_tests.conclusion == 'success' }}
               run: |
@@ -62,7 +63,8 @@ jobs:
             - name: Re-Running Playwright to update snapshots
               id: screenshot_tests_update
               if: ${{ failure() && steps.screenshot_tests.conclusion == 'failure' }}
-              run: npm run test-int-snapshots-update
+              # Disable retries since we're updating snapshots, not verifying them
+              run: npm run test-int-snapshots-update -- --retries=0
 
             - name: Commit the updated files to the PR branch
               if: ${{ failure() && steps.screenshot_tests_update.conclusion == 'success' }}


### PR DESCRIPTION
**Asana Task/Github Issue:** N/A

## Description

Disables Playwright retries (`--retries=0`) for the `test-int-snapshots` and `test-int-snapshots-update` commands within the `snapshots-update.yml` workflow.

This change addresses timeouts in the snapshot update workflow. Playwright's default CI retry logic (2 retries) was tripling the execution time for failing snapshot tests, which is counterproductive for a workflow designed to identify and update snapshots. Disabling retries allows the workflow to fail fast and proceed to the update step more efficiently.

## Testing Steps

- Observe the execution time of the `snapshots-update.yml` workflow in CI after this change.
- Verify that snapshot update workflows no longer time out due to excessive retries.

## Checklist

*Please tick all that apply:*

- [x] I have tested this change locally
- [ ] I have tested this change locally in all supported browsers
- [ ] This change will be visible to users
- [ ] I have added automated tests that cover this change
- [ ] I have ensured the change is gated by config
- [ ] This change was covered by a ship review
- [ ] This change was covered by a tech design
- [ ] Any dependent config has been merged

---
<a href="https://cursor.com/background-agent?bcId=bc-a34a3b28-5013-4284-abc5-71f5c3efe6f9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a34a3b28-5013-4284-abc5-71f5c3efe6f9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change that just alters Playwright retry behavior; it doesn’t affect production code or data paths.
> 
> **Overview**
> Disables Playwright test retries in the `snapshots-update.yml` workflow by passing `--retries=0` to both the snapshot verification (`test-int-snapshots`) and snapshot update (`test-int-snapshots-update`) runs, to reduce CI runtime/timeouts and fail fast when snapshots diverge.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8a59e4ba6047527cade4af072eadf64dcf37b5f8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->