### PR TITLE
Constrain background card in stack so it doesn't peek out too much

### DIFF
--- a/special-pages/pages/new-tab/app/next-steps-list/components/NextStepsListCard.module.css
+++ b/special-pages/pages/new-tab/app/next-steps-list/components/NextStepsListCard.module.css
@@ -87,6 +87,11 @@
     opacity: 0.85;
     /* Clip content when back card's translated text is taller than the front card */
     overflow: hidden;
+    /* Disable the cardFadeIn animation — its keyframes override transform/opacity,
+       hiding the stacked visual until the animation ends. After a dismiss Preact
+       reuses this DOM element so the animation never replays, which means stacking
+       only becomes visible after the first dismiss. */
+    animation: none;
 }
 
 [data-theme="dark"] .card.backCard {


### PR DESCRIPTION
**Asana Task/Github Issue:** [<!-- Link to Asana Task/Github Issue -->](https://app.asana.com/1/137249556945/task/1213263541494192)

## Description

<!--
  Provide a terse summary of what the change is, detailed descriptions should belong in ship reviews or tech designs
-->

This was an issue seen in translated text where the card height can vary significantly based on the amount of text being used.

## Testing Steps

View preview with these two cards showing in Spanish
`/new-tab/?next-steps-list=personalizeBrowser&next-steps-list=sync&locale=es`

### Before

https://content-scope-scripts.netlify.app/build/pages/new-tab/?next-steps-list=personalizeBrowser&next-steps-list=sync&locale=es

<img width="629" height="414" alt="image" src="https://github.com/user-attachments/assets/a6517166-96b7-460b-a166-a8149c48014a" />

### After

https://deploy-preview-2266--content-scope-scripts.netlify.app/build/pages/new-tab/?next-steps-list=personalizeBrowser&next-steps-list=sync&locale=es

![card-height-variance](https://github.com/user-attachments/assets/20d4ab6d-3aaf-47d6-81a9-9a9c6a42761c)

## Checklist

<!--
  These questions are a friendly reminder to shipping code, if you're uncertain ask the AoR owners.
  It's also totally appropriate to not check some of these boxes, if they don't apply to your change.
-->
*Please tick all that apply:*

- [x] I have tested this change locally
- [x] I have tested this change locally in all supported browsers
- [x] This change will be visible to users
- [ ] I have added automated tests that cover this change
- [x] I have ensured the change is gated by config
- [ ] This change was covered by a ship review
- [ ] This change was covered by a tech design
- [x] Any dependent config has been merged



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS-only changes to card stacking/animation; low risk but could cause minor visual regressions in the new-tab card transitions across browsers/themes.
> 
> **Overview**
> Improves the Next Steps stacked card UI so the background `backCard` no longer peeks out excessively when localized text increases its height.
> 
> The `backCard` is now constrained to the front card height (`bottom: 0`) and clips overflow, and its fade-in animation is disabled to avoid keyframes overriding the stacked `transform`/`opacity` when Preact reuses the DOM element after dismissals.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 80cf5a89af3d0ccbeab155994d37c2b911725ef4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->