### PR TITLE
Build workflow comment strategy

### DIFF
--- a/.github/workflows/build-branch.yml
+++ b/.github/workflows/build-branch.yml
@@ -60,7 +60,7 @@ jobs:
                   echo "BUILD_BRANCH=${BUILD_BRANCH}" >> $GITHUB_ENV
                   echo "COMMIT_HASH=$(git rev-parse HEAD)" >> $GITHUB_ENV
 
-            - name: Update associated PR description and comment
+            - name: Comment on associated PR
               uses: actions/github-script@v8
               env:
                   BUILD_BRANCH: ${{ env.BUILD_BRANCH }}
@@ -81,7 +81,10 @@ jobs:
                           timeStyle: 'long'
                       });
 
-                      const integrationBlock = [
+                      const marker = '<!-- BUILD_BRANCH_COMMENT -->';
+
+                      const commentBody = [
+                          marker,
                           `### Build Branch`,
                           ``,
                           `| | |`,
@@ -139,32 +142,7 @@ jobs:
                       });
 
                       for (const pr of prs) {
-                          // --- Update PR description ---
-                          const marker = '<!-- BUILD_BRANCH_INFO -->';
-                          const markerEnd = '<!-- /BUILD_BRANCH_INFO -->';
-                          const wrappedBlock = `${marker}\n${integrationBlock}\n${markerEnd}`;
-
-                          let newBody;
-                          const currentBody = pr.body || '';
-                          if (currentBody.includes(marker)) {
-                              // Replace existing block
-                              const re = new RegExp(`${marker}[\\s\\S]*?${markerEnd}`);
-                              newBody = currentBody.replace(re, wrappedBlock);
-                          } else {
-                              // Prepend to description
-                              newBody = wrappedBlock + '\n\n---\n\n' + currentBody;
-                          }
-
-                          await github.rest.pulls.update({
-                              owner: context.repo.owner,
-                              repo: context.repo.repo,
-                              pull_number: pr.number,
-                              body: newBody,
-                          });
-
-                          console.log(`Updated PR #${pr.number} description`);
-
-                          // --- Update or create comment ---
+                          // Find existing bot comment by marker
                           const { data: comments } = await github.rest.issues.listComments({
                               owner: context.repo.owner,
                               repo: context.repo.repo,
@@ -172,7 +150,7 @@ jobs:
                           });
 
                           const botComment = comments.find(
-                              c => c.user.login === 'github-actions[bot]' && c.body.includes('Build Branch')
+                              c => c.user.login === 'github-actions[bot]' && c.body.includes(marker)
                           );
 
                           if (botComment) {
@@ -180,7 +158,7 @@ jobs:
                                   owner: context.repo.owner,
                                   repo: context.repo.repo,
                                   comment_id: botComment.id,
-                                  body: integrationBlock,
+                                  body: commentBody,
                               });
                               console.log(`Updated comment on PR #${pr.number}`);
                           } else {
@@ -188,7 +166,7 @@ jobs:
                                   owner: context.repo.owner,
                                   repo: context.repo.repo,
                                   issue_number: pr.number,
-                                  body: integrationBlock,
+                                  body: commentBody,
                               });
                               console.log(`Created comment on PR #${pr.number}`);
                           }


### PR DESCRIPTION
**Asana Task/Github Issue:**

## Description

Renames the `build-pr.yml` workflow to `build-branch.yml`. This update also modifies the workflow to stop updating the GitHub PR description. Instead, it now posts a single comment on a PR and updates that comment on subsequent pushes, using an HTML marker for reliable identification.

## Testing Steps

-   Open a new PR to trigger the `build-branch` workflow.
-   Verify that a single comment is posted by the workflow with build information.
-   Push a new commit to the PR branch.
-   Confirm that the existing workflow comment is updated in place, and no new comments are created or the PR description is modified.

## Checklist

*Please tick all that apply:*

-   [x] I have tested this change locally
-   [ ] I have tested this change locally in all supported browsers
-   [x] This change will be visible to users
-   [ ] I have added automated tests that cover this change
-   [ ] I have ensured the change is gated by config
-   [ ] This change was covered by a ship review
-   [ ] This change was covered by a tech design
-   [ ] Any dependent config has been merged

---
<p><a href="https://cursor.com/background-agent?bcId=bc-f03ba7f8-1106-4d97-9587-baad5878c9f1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f03ba7f8-1106-4d97-9587-baad5878c9f1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only change limited to PR annotation/commenting behavior; no product code or sensitive data handling changes.
> 
> **Overview**
> Stops mutating PR descriptions in the `build-branch.yml` workflow and instead posts a **single** GitHub Actions bot comment containing build branch/commit details and integration commands.
> 
> Adds an HTML marker (`<!-- BUILD_BRANCH_COMMENT -->`) to reliably find and update the existing comment on subsequent pushes, avoiding duplicate comments.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0a17956c0f4d4ec305c3c3460176fceb15dea638. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->