### PR TITLE
Html coverage reports upload

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -106,3 +106,15 @@ jobs:
                   name: coverage-merged-report
                   path: injected/coverage/
                   retention-days: 30
+            - name: Upload unit HTML coverage report
+              uses: actions/upload-artifact@v6
+              with:
+                  name: html-coverage-unit
+                  path: injected/coverage/unit/
+                  retention-days: 30
+            - name: Upload integration HTML coverage report
+              uses: actions/upload-artifact@v6
+              with:
+                  name: html-coverage-integration
+                  path: injected/coverage/integration-report/
+                  retention-days: 30

--- a/injected/scripts/merge-coverage.js
+++ b/injected/scripts/merge-coverage.js
@@ -51,7 +51,7 @@ async function generateReport({ name, inputDir, outputDir, format }) {
     const coverageReport = new CoverageReport({
         name,
         outputDir,
-        reports: ['text-summary'],
+        reports: ['text-summary', 'v8'],
     });
 
     const files = readdirSync(inputDir).filter((f) => f.endsWith('.json'));


### PR DESCRIPTION
**Asana Task/Github Issue:** N/A

## Description

Enables the generation and uploading of interactive HTML coverage reports. This change adds the `v8` reporter to the coverage merge script (`injected/scripts/merge-coverage.js`) and introduces new workflow steps to upload the generated HTML reports as dedicated artifacts (`html-coverage-unit` and `html-coverage-integration`) in `.github/workflows/coverage.yml`. This provides a more visual and detailed way to review code coverage directly from CI.

## Testing Steps

1. Trigger the `coverage` workflow.
2. After the workflow completes, navigate to the workflow run details.
3. Check the 'Artifacts' section for `html-coverage-unit` and `html-coverage-integration` artifacts.
4. Download and extract these artifacts to view the interactive HTML coverage reports.

## Checklist

*Please tick all that apply:*

- [x] I have tested this change locally
- [ ] I have tested this change locally in all supported browsers
- [ ] This change will be visible to users
- [ ] I have added automated tests that cover this change
- [ ] I have ensured the change is gated by config
- [ ] This change was covered by a ship review
- [ ] This change was covered by a tech design
- [ ] Any dependent config has been merged

---
<p><a href="https://cursor.com/background-agent?bcId=bc-f207219b-7f1f-45d0-b898-3a9f910e700e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f207219b-7f1f-45d0-b898-3a9f910e700e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only changes that affect coverage report generation and artifact uploads, with minimal risk beyond potential workflow/report-path misconfiguration.
> 
> **Overview**
> The coverage workflow now publishes *interactive HTML* coverage outputs by uploading two additional artifacts (`html-coverage-unit` and `html-coverage-integration`) alongside the existing merged report.
> 
> Coverage report generation is updated to include the `v8` reporter in `injected/scripts/merge-coverage.js`, enabling HTML output for the unit and integration coverage directories that are uploaded by CI.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7a59f86323f1e489e3cf75816dac543c811519d7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->