### PR TITLE
Resolve issues with integration tests skipping

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -63,13 +63,24 @@ jobs:
             - name: 'Clean tree'
               run: 'npm run test-clean-tree'
 
+    get-playwright-version:
+        runs-on: ubuntu-latest
+        outputs:
+            version: ${{ steps.pw.outputs.version }}
+        steps:
+            - uses: actions/checkout@v6
+            - id: pw
+              run: |
+                  VERSION=$(node -e "const l=require('./package-lock.json'); console.log((l.packages['node_modules/@playwright/test']||l.packages['node_modules/playwright']).version)")
+                  echo "version=$VERSION" >> $GITHUB_OUTPUT
+
     integration-tests-special-pages:
         name: Integration tests (special-pages/${{ matrix.group }}, ubuntu-latest)
+        needs: get-playwright-version
         runs-on: ubuntu-latest
         timeout-minutes: 15
         container:
-            # Keep this pinned to the @playwright/test version in package-lock.json.
-            image: mcr.microsoft.com/playwright:v1.58.1-noble
+            image: mcr.microsoft.com/playwright:v${{ needs.get-playwright-version.outputs.version }}-noble
         env:
             HOME: /root
         strategy:
@@ -110,11 +121,11 @@ jobs:
 
     integration-tests:
         name: Integration tests (injected/${{ matrix.project }}, ubuntu-latest)
+        needs: get-playwright-version
         runs-on: ubuntu-latest
         timeout-minutes: 15
         container:
-            # Keep this pinned to the @playwright/test version in package-lock.json.
-            image: mcr.microsoft.com/playwright:v1.58.1-noble
+            image: mcr.microsoft.com/playwright:v${{ needs.get-playwright-version.outputs.version }}-noble
         env:
             HOME: /root
         strategy:


### PR DESCRIPTION
**Asana Task/Github Issue:** <!-- Link to Asana Task/Github Issue -->

## Description

Fixes integration tests timing out due to long browser installation times by narrowing which browsers are installed.

## Checklist

<!--
  These questions are a friendly reminder to shipping code, if you're uncertain ask the AoR owners.
  It's also totally appropriate to not check some of these boxes, if they don't apply to your change.
-->
*Please tick all that apply:*

- [ ] I have tested this change locally
- [ ] I have tested this change locally in all supported browsers
- [ ] This change will be visible to users
- [ ] I have added automated tests that cover this change
- [ ] I have ensured the change is gated by config
- [ ] This change was covered by a ship review
- [ ] This change was covered by a tech design
- [ ] Any dependent config has been merged


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> CI-only changes, but they alter how/where Playwright runs (containerized, different project grouping), which can cause unexpected test environment differences or missed coverage if misconfigured.
> 
> **Overview**
> **Stabilizes Playwright integration CI** by running integration tests inside the official `mcr.microsoft.com/playwright` container whose version is derived from `package-lock.json`, avoiding per-run browser installs.
> 
> Special-pages integration tests are split into `chromium` vs `webkit` groups (with separate artifact names), and the workflow now invokes `npx playwright test` directly (with `--grep-invert '@screenshots'`) instead of installing browsers via `npx playwright install --with-deps`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 896d464321c55f1eb1a0b75dc2800faf10553700. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->