### PR TITLE
NoImplicitAny strict core files

### DIFF
--- a/tsconfig.strict-core.json
+++ b/tsconfig.strict-core.json
@@ -2,6 +2,7 @@
     "extends": "./tsconfig.json",
     "compilerOptions": {
         "strict": true,
+        "noImplicitAny": true,
         "noEmit": true
     },
     "include": [


### PR DESCRIPTION
**Asana Task/Github Issue:** N/A

## Description

Explicitly enables `noImplicitAny` for files covered by the `strict-core` TypeScript check, enhancing type safety.

## Testing Steps

- Run `npm run tsc-strict-core` to verify that all strict core files pass with `noImplicitAny` enabled.

## Checklist

*Please tick all that apply:*

- [x] I have tested this change locally
- [ ] I have tested this change locally in all supported browsers
- [ ] This change will be visible to users
- [ ] I have added automated tests that cover this change
- [ ] I have ensured the change is gated by config
- [ ] This change was covered by a ship review
- [ ] This change was covered by a tech design
- [ ] Any dependent config has been merged

---
<p><a href="https://cursor.com/background-agent?bcId=bc-f1408eee-1841-4f28-9a1a-0fa09bb6d688"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f1408eee-1841-4f28-9a1a-0fa09bb6d688"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only change that increases compile-time strictness; main risk is new/blocked builds if strict-core code still relies on implicit `any`.
> 
> **Overview**
> Tightens the `tsc-strict-core` TypeScript configuration by explicitly enabling `noImplicitAny` in `tsconfig.strict-core.json`, causing implicit-`any` usages in the strict-core file set to be reported as errors.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b5d0c3812198a296fce604daee3d845c14ec8cd9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->