### PR TITLE
Isolate z-index in next steps list to prevent overlaying omnibox

### DIFF
--- a/special-pages/pages/new-tab/app/next-steps-list/components/NextStepsListCard.module.css
+++ b/special-pages/pages/new-tab/app/next-steps-list/components/NextStepsListCard.module.css
@@ -45,6 +45,8 @@
     min-height: calc(200 * var(--px-in-rem));
     /* Add padding at bottom to accommodate the back card peek */
     padding-bottom: calc(12 * var(--px-in-rem));
+    /* Contain child z-indices so they don't compete with the omnibar's stacking context */
+    isolation: isolate;
 }
 
 .card {


### PR DESCRIPTION
**Asana Task/Github Issue:** <!-- Link to Asana Task/Github Issue -->

## Description

<!--
  Provide a terse summary of what the change is, detailed descriptions should belong in ship reviews or tech designs
-->

## Testing Steps

### Before

![omnibox-overlay-broken](https://github.com/user-attachments/assets/dfa50177-ebd8-4374-a59c-75893bc2904e)

### After

![omnibox-overlay-fixed](https://github.com/user-attachments/assets/7ee29b46-5d24-48d6-96a6-6dca9f4ebff3)

## Checklist

<!--
  These questions are a friendly reminder to shipping code, if you're uncertain ask the AoR owners.
  It's also totally appropriate to not check some of these boxes, if they don't apply to your change.
-->
*Please tick all that apply:*

- [x] I have tested this change locally
- [ ] I have tested this change locally in all supported browsers
- [ ] This change will be visible to users
- [ ] I have added automated tests that cover this change
- [ ] I have ensured the change is gated by config
- [ ] This change was covered by a ship review
- [ ] This change was covered by a tech design
- [ ] Any dependent config has been merged


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk, CSS-only change that scopes `z-index` behavior within the Next Steps card container; main risk is unintended layering differences within the component.
> 
> **Overview**
> Prevents the Next Steps list cards from overlaying the omnibox by creating a new stacking context on `NextStepsListCard`’s `.cardContainer` via `isolation: isolate`, containing child `z-index` interactions to the component.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0cffd17ccd320b00dd655f5c11202c5e45a1a406. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->