### PR TITLE
Development environment setup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -93,3 +93,11 @@ See [`guides/debugging.md`](guides/debugging.md) for debugging resources includi
 
 - When running Playwright commands, use `--reporter list` to prevent the Shell tool from hanging
 - Use `.github/pull_request_template.md` when creating a pull request.
+
+## Cursor Cloud specific instructions
+
+- Node 22 and npm are pre-installed. Playwright browsers + system deps are pre-installed. Just run `npm ci` to refresh dependencies.
+- `npm run serve-special-pages` actually serves on **port 3210** (not 3221 as the Commands table above states). The injected test pages serve on port 3220 as documented.
+- Integration tests for injected workspace may show 2 flaky iOS mobile drawer timeouts (`duckplayer-mobile-drawer.spec.js`); these are pre-existing timing issues, not environment problems.
+- No Docker, databases, or external services are needed. All tests are self-contained with local HTTP servers and mocked native messaging.
+- On headless Linux, `xvfb` is pre-installed. The injected workspace provides `npm run test-int-x` which wraps Playwright with `xvfb-run`, but standard `npm run test-int` also works in this environment.


### PR DESCRIPTION
**Asana Task/Github Issue:** N/A

## Description

Updates `AGENTS.md` with Cursor Cloud-specific development environment instructions, including a correction for the `special-pages` server port (3210) and notes on known flaky integration test failures.

## Testing Steps

- Verify the updated `AGENTS.md` content locally.
- Run `npm run serve-special-pages` and confirm the server starts on port 3210.
- Run `npm run test-int -w injected` and `npm run test-int -w special-pages` to observe the noted flaky test failures.

## Checklist

*Please tick all that apply:*

- [x] I have tested this change locally
- [ ] I have tested this change locally in all supported browsers
- [x] This change will be visible to users
- [ ] I have added automated tests that cover this change
- [ ] I have ensured the change is gated by config
- [ ] This change was covered by a ship review
- [ ] This change was covered by a tech design
- [ ] Any dependent config has been merged

---
<p><a href="https://cursor.com/agents/bc-349ec5de-fbc3-4e87-8bdf-6ac17cd6928c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-349ec5de-fbc3-4e87-8bdf-6ac17cd6928c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change; no runtime code, build, or test behavior is modified.
> 
> **Overview**
> Adds a **Cursor Cloud-specific** section to `AGENTS.md` documenting the preinstalled Node/Playwright setup, headless `xvfb` usage, and that no external services are required.
> 
> Clarifies that `npm run serve-special-pages` listens on **port 3210** in Cursor Cloud (not the previously documented 3221) and notes a known flaky `duckplayer-mobile-drawer.spec.js` timeout in injected integration tests.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bf4538d43dae2512538e7c5f299c1c1200aff73a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->