### PR TITLE
fix(types): replace  with  in PerformanceMetricsResponse typedef

### DIFF
--- a/injected/src/features/breakage-reporting/utils.js
+++ b/injected/src/features/breakage-reporting/utils.js
@@ -8,7 +8,27 @@ export function getJsPerformanceMetrics() {
 }
 
 /** @typedef {{error: string, success: false}} ErrorObject */
-/** @typedef {{success: true, metrics: any}} PerformanceMetricsResponse */
+/**
+ * @typedef {object} ExpandedPerformanceMetrics
+ * @property {number} loadComplete
+ * @property {number} domComplete
+ * @property {number} domContentLoaded
+ * @property {number} domInteractive
+ * @property {number | null} firstContentfulPaint
+ * @property {number | null} largestContentfulPaint
+ * @property {number} timeToFirstByte
+ * @property {number} responseTime
+ * @property {number} serverTime
+ * @property {number} transferSize
+ * @property {number} encodedBodySize
+ * @property {number} decodedBodySize
+ * @property {number} resourceCount
+ * @property {number} totalResourcesSize
+ * @property {string} protocol
+ * @property {number} redirectCount
+ * @property {string} navigationType
+ */
+/** @typedef {{success: true, metrics: ExpandedPerformanceMetrics}} PerformanceMetricsResponse */
 
 /**
  * Convenience function to return an error object


### PR DESCRIPTION
**Asana Task/Github Issue:** <!-- Link to Asana Task/Github Issue -->

## Description

<!--
  Provide a terse summary of what the change is, detailed descriptions should belong in ship reviews or tech designs
-->

## Testing Steps

- <!-- Include simple steps on how to check this change is working. Write "N/A" if not applicable. -->

## Checklist

<!--
  These questions are a friendly reminder to shipping code, if you're uncertain ask the AoR owners.
  It's also totally appropriate to not check some of these boxes, if they don't apply to your change.
-->
*Please tick all that apply:*

- [ ] I have tested this change locally
- [ ] I have tested this change locally in all supported browsers
- [ ] This change will be visible to users
- [ ] I have added automated tests that cover this change
- [ ] I have ensured the change is gated by config
- [ ] This change was covered by a ship review
- [ ] This change was covered by a tech design
- [ ] Any dependent config has been merged

---

Replace the `any` type annotation for the `metrics` property in
`PerformanceMetricsResponse` with a proper `ExpandedPerformanceMetrics`
typedef that captures the exact shape of the metrics object returned by
`getExpandedPerformanceMetrics()`.

https://claude.ai/code/session_01GV4igA7C3xVvuP2aA4CuaH

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because this PR only tightens JSDoc typedefs for performance metrics and does not change runtime behavior.
> 
> **Overview**
> Tightens the JSDoc typing for `PerformanceMetricsResponse` by replacing the `metrics: any` annotation with a new `ExpandedPerformanceMetrics` typedef that enumerates the expected timing/network/size fields returned from `getExpandedPerformanceMetrics()`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 43f45ee5900325d1e12c1c942d403debe9e285ea. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->