### PR TITLE
fix(types): replace  with  in matchConditionalFeatureSetting

### DIFF
--- a/injected/src/config-feature.js
+++ b/injected/src/config-feature.js
@@ -35,6 +35,15 @@ import { URLPattern } from 'urlpattern-polyfill';
  */
 
 /**
+ * An entry from a conditional feature setting list.
+ * Each entry has optional condition/domain fields for matching,
+ * plus optional patchSettings for config patching.
+ * Features may add additional properties specific to their config.
+ *
+ * @typedef {{condition?: ConditionBlockOrArray, domain?: string | string[], patchSettings?: import('immutable-json-patch').JSONPatchDocument} & Record<string, unknown>} ConditionalSettingEntry
+ */
+
+/**
  * This class is extended by each feature to implement remote config handling:
  * - Parsing the remote config, with conditional logic applied,
  * - Providing API for features to check if they are enabled,
@@ -117,7 +126,7 @@ export default class ConfigFeature {
      * Given a config key, interpret the value as a list of conditionals objects, and return the elements that match the current page
      * Consider in your feature using patchSettings instead as per `getFeatureSetting`.
      * @param {string} featureKeyName
-     * @return {any[]}
+     * @return {ConditionalSettingEntry[]}
      * @protected
      */
     matchConditionalFeatureSetting(featureKeyName) {

--- a/injected/src/features/element-hiding.js
+++ b/injected/src/features/element-hiding.js
@@ -381,7 +381,9 @@ export default class ElementHiding extends ContentFeature {
         }
 
         // collect all matching rules for domain
-        const activeDomainRules = this.matchConditionalFeatureSetting('domains').flatMap((item) => item.rules);
+        const activeDomainRules = this.matchConditionalFeatureSetting('domains').flatMap((item) => {
+            return /** @type {ElementHidingRule[]} */ (item.rules) || [];
+        });
 
         const overrideRules = activeDomainRules.filter((rule) => {
             return rule.type === 'override';
@@ -401,8 +403,8 @@ export default class ElementHiding extends ContentFeature {
         }
 
         // remove overrides and rules that match overrides from array of rules to be applied to page
-        overrideRules.forEach((override) => {
-            activeRules = activeRules.filter((rule) => {
+        overrideRules.forEach((/** @type {ElementHidingRuleHide} */ override) => {
+            activeRules = activeRules.filter((/** @type {ElementHidingRuleHide} */ rule) => {
                 return rule.selector !== override.selector;
             });
         });


### PR DESCRIPTION
**Asana Task/Github Issue:** <!-- Link to Asana Task/Github Issue -->

## Description

<!--
  Provide a terse summary of what the change is, detailed descriptions should belong in ship reviews or tech designs
-->

## Testing Steps

- <!-- Include simple steps on how to check this change is working. Write "N/A" if not applicable. -->

## Checklist

<!--
  These questions are a friendly reminder to shipping code, if you're uncertain ask the AoR owners.
  It's also totally appropriate to not check some of these boxes, if they don't apply to your change.
-->
*Please tick all that apply:*

- [ ] I have tested this change locally
- [ ] I have tested this change locally in all supported browsers
- [ ] This change will be visible to users
- [ ] I have added automated tests that cover this change
- [ ] I have ensured the change is gated by config
- [ ] This change was covered by a ship review
- [ ] This change was covered by a tech design
- [ ] Any dependent config has been merged

---

Replace the `any[]` return type annotation on `matchConditionalFeatureSetting` in
`config-feature.js` with a proper `ConditionalSettingEntry` type that captures the
known properties (condition, domain, patchSettings) while allowing feature-specific
additional properties via `Record<string, unknown>`. Update element-hiding.js call
site with appropriate type annotations to maintain type safety.

https://claude.ai/code/session_01GV4igA7C3xVvuP2aA4CuaH

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are JSDoc type annotations and minor defensive handling around optional `rules` arrays, with no change to matching or patching logic.
> 
> **Overview**
> Improves type-safety for conditional feature settings by introducing a `ConditionalSettingEntry` typedef and updating `ConfigFeature.matchConditionalFeatureSetting` to return `ConditionalSettingEntry[]` instead of `any[]`.
> 
> Updates the element hiding feature to be more type-safe/defensive when reading domain-specific rules by treating `item.rules` as optional (defaulting to an empty array) and adding explicit rule/override JSDoc casts during override filtering.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9619454f7b4767fbcc6aaf59ad52b125aa77fbe4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->