### PR TITLE
fix(types): replace  with  in ExposeMethods generic parameter

### DIFF
--- a/injected/src/content-feature.js
+++ b/injected/src/content-feature.js
@@ -104,7 +104,7 @@ export default class ContentFeature extends ConfigFeature {
      *
      * Use `this._declareExposeMethods([...names])` to declare which methods are exposed.
      *
-     * @type {ExposeMethods<any> | undefined}
+     * @type {ExposeMethods<string> | undefined}
      */
     _exposedMethods;
 


### PR DESCRIPTION
**Asana Task/Github Issue:** <!-- Link to Asana Task/Github Issue -->

## Description

<!--
  Provide a terse summary of what the change is, detailed descriptions should belong in ship reviews or tech designs
-->

## Testing Steps

- <!-- Include simple steps on how to check this change is working. Write "N/A" if not applicable. -->

## Checklist

<!--
  These questions are a friendly reminder to shipping code, if you're uncertain ask the AoR owners.
  It's also totally appropriate to not check some of these boxes, if they don't apply to your change.
-->
*Please tick all that apply:*

- [ ] I have tested this change locally
- [ ] I have tested this change locally in all supported browsers
- [ ] This change will be visible to users
- [ ] I have added automated tests that cover this change
- [ ] I have ensured the change is gated by config
- [ ] This change was covered by a ship review
- [ ] This change was covered by a tech design
- [ ] Any dependent config has been merged

---

The `_exposedMethods` field in ContentFeature used `ExposeMethods<any>` which
bypasses type safety. Since `ExposeMethods<K>` requires `K extends string` and
the field holds method name strings, the correct generic parameter is `string`.

https://claude.ai/code/session_01GV4igA7C3xVvuP2aA4CuaH

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: JSDoc-only type tightening with no runtime behavior changes; impact is limited to TS/type-checking of inter-feature method exposure.
> 
> **Overview**
> Updates `ContentFeature`’s `_exposedMethods` JSDoc from `ExposeMethods<any>` to `ExposeMethods<string>`, preventing `any` from bypassing type checks when declaring/calling exposed inter-feature methods.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8cd47c503d77d09b2ee6bf6921d18549c9d51952. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->