### PR TITLE
fix(types): replace  with  in GetInstalledRelatedAppsConfigMixin

### DIFF
--- a/injected/src/features/harmful-apis.js
+++ b/injected/src/features/harmful-apis.js
@@ -411,7 +411,7 @@ export default class HarmfulApis extends ContentFeature {
 @typedef {{ blockSensorStart: boolean }} GenericSensorConfigMixin
 @typedef {{ highEntropyValues: { trimBrands: boolean, model: string, trimPlatformVersion: number, trimUaFullVersion: number, trimFullVersionList: number, architecture: string, bitness: string, mobile: boolean, platform: string } }} UaClientHintsConfigMixin
 @typedef {{ }} NetworkInformationConfigMixin
-@typedef {{ returnValue: any }} GetInstalledRelatedAppsConfigMixin
+@typedef {{ returnValue: string[] }} GetInstalledRelatedAppsConfigMixin
 @typedef {{ disableOpenFilePicker: boolean, disableSaveFilePicker: boolean, disableDirectoryPicker: boolean, disableGetAsFileSystemHandle: boolean }} FileSystemAccessConfigMixin
 @typedef {{ screenIsExtended?: boolean }} WindowPlacementConfigMixin
 @typedef {{ blockGetAvailability: boolean, blockRequestDevice: boolean }} WebBluetoothConfigMixin


### PR DESCRIPTION
**Asana Task/Github Issue:** <!-- Link to Asana Task/Github Issue -->

## Description

<!--
  Provide a terse summary of what the change is, detailed descriptions should belong in ship reviews or tech designs
-->

## Testing Steps

- <!-- Include simple steps on how to check this change is working. Write "N/A" if not applicable. -->

## Checklist

<!--
  These questions are a friendly reminder to shipping code, if you're uncertain ask the AoR owners.
  It's also totally appropriate to not check some of these boxes, if they don't apply to your change.
-->
*Please tick all that apply:*

- [ ] I have tested this change locally
- [ ] I have tested this change locally in all supported browsers
- [ ] This change will be visible to users
- [ ] I have added automated tests that cover this change
- [ ] I have ensured the change is gated by config
- [ ] This change was covered by a ship review
- [ ] This change was covered by a tech design
- [ ] Any dependent config has been merged

---

The returnValue field in GetInstalledRelatedAppsConfigMixin is used as the
return value for navigator.getInstalledRelatedApps(), with a fallback of [].
The config provides an array of strings, so string[] is the correct type.

https://claude.ai/code/session_01GV4igA7C3xVvuP2aA4CuaH

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only updates a JSDoc typedef used for type checking/documentation; no runtime logic changes.
> 
> **Overview**
> Tightens the `GetInstalledRelatedAppsConfigMixin` JSDoc type in `harmful-apis.js` by changing `returnValue` from `any` to `string[]`, matching the expected shape for the `navigator.getInstalledRelatedApps()` override.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2a880961a01daa73970f39fbb8027ebdf9b60fde. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->