### PR TITLE
fix(types): replace  with proper type in web-compat.js

### DIFF
--- a/injected/src/features/web-compat.js
+++ b/injected/src/features/web-compat.js
@@ -109,10 +109,10 @@ function cleanShareData(data) {
 }
 
 export class WebCompat extends ContentFeature {
-    /** @type {Promise<any> | null} */
+    /** @type {Promise<{failure?: {name: string, message: string}}> | null} */
     #activeShareRequest = null;
 
-    /** @type {Promise<any> | null} */
+    /** @type {Promise<{failure?: {name: string, message: string}}> | null} */
     #activeScreenLockRequest = null;
 
     /** @type {Map<string, object>} */


### PR DESCRIPTION
**Asana Task/Github Issue:** <!-- Link to Asana Task/Github Issue -->

## Description

<!--
  Provide a terse summary of what the change is, detailed descriptions should belong in ship reviews or tech designs
-->

## Testing Steps

- <!-- Include simple steps on how to check this change is working. Write "N/A" if not applicable. -->

## Checklist

<!--
  These questions are a friendly reminder to shipping code, if you're uncertain ask the AoR owners.
  It's also totally appropriate to not check some of these boxes, if they don't apply to your change.
-->
*Please tick all that apply:*

- [ ] I have tested this change locally
- [ ] I have tested this change locally in all supported browsers
- [ ] This change will be visible to users
- [ ] I have added automated tests that cover this change
- [ ] I have ensured the change is gated by config
- [ ] This change was covered by a ship review
- [ ] This change was covered by a tech design
- [ ] Any dependent config has been merged

---

Replace `Promise<any>` type annotations for `#activeShareRequest` and
`#activeScreenLockRequest` with `Promise<{failure?: {name: string, message: string}}>`,
matching the actual response shape used after awaiting these promises.

https://claude.ai/code/session_01GV4igA7C3xVvuP2aA4CuaH

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only updates JSDoc type annotations for in-flight web share and screen lock requests, with no runtime logic changes. Low risk aside from potential downstream type-checking assumptions.
> 
> **Overview**
> Updates `WebCompat`’s JSDoc types for `#activeShareRequest` and `#activeScreenLockRequest` from `Promise<any>` to `Promise<{failure?: {name: string, message: string}}>` to reflect the actual awaited response shape used by the error-handling code paths.
> 
> No runtime behavior changes are included.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 142fe10d248c07b7bd9a029c82b542c222bf27ad. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->