### PR TITLE
Ci merge queue workflow

### DIFF
--- a/.github/workflows/review-check.yml
+++ b/.github/workflows/review-check.yml
@@ -5,6 +5,7 @@ on:
         types: [submitted, dismissed]
     pull_request_target:
         types: [opened, synchronize, reopened]
+    merge_group:
 
 permissions:
     checks: write
@@ -12,7 +13,15 @@ permissions:
     pull-requests: read
 
 jobs:
+    # In the merge queue, review validation already passed on the PR — just succeed.
+    review_validation:
+        if: ${{ github.event_name == 'merge_group' }}
+        runs-on: ubuntu-latest
+        steps:
+            - run: echo "Review already validated before entering merge queue"
+
     validate_review:
+        if: ${{ github.event_name != 'merge_group' }}
         runs-on: ubuntu-latest
 
         steps:


### PR DESCRIPTION
**Asana Task/Github Issue:**

## Description

Fixes an issue where the `review_validation` check would hang indefinitely in the merge queue. The `review-check.yml` workflow now triggers on `merge_group` events, providing an auto-passing `review_validation` status for merge queue contexts, as review validation is completed prior to entering the queue. The original `validate_review` job is now gated to prevent it from running on `merge_group` events.

## Testing Steps

- Verify that PRs can successfully enter and exit the merge queue without the `review_validation` check hanging.

## Checklist

*Please tick all that apply:*

- [x] I have tested this change locally
- [ ] I have tested this change locally in all supported browsers
- [x] This change will be visible to users
- [ ] I have added automated tests that cover this change
- [ ] I have ensured the change is gated by config
- [ ] This change was covered by a ship review
- [ ] This change was covered by a tech design
- [ ] Any dependent config has been merged

---
<p><a href="https://cursor.com/agents/bc-97af0b42-5118-4598-bc78-61f3f20bdeac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-97af0b42-5118-4598-bc78-61f3f20bdeac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk workflow-only change: adds explicit handling for `merge_group` events to avoid a stuck check, without changing review validation logic for normal PR events.
> 
> **Overview**
> Updates the `Review Validation` GitHub Actions workflow to also trigger on `merge_group` events and immediately succeed via a lightweight `review_validation` job.
> 
> Gates the existing `validate_review` job to *not* run for merge-queue executions, preventing the `review_validation` check from hanging when PRs enter the merge queue.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fe11041dfead1649beb40943fa289cb0d49f7868. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->