### PR TITLE
fix(types): replace any with unknown for defaultValue in content-feature.js

### DIFF
--- a/injected/src/content-feature.js
+++ b/injected/src/content-feature.js
@@ -309,7 +309,7 @@ export default class ContentFeature extends ConfigFeature {
      * If the value is not an object, return the value.
      * If the value is an object, check its type property.
      * @param {string} attrName
-     * @param {any} defaultValue - The default value to use if the config setting is not set
+     * @param {unknown} defaultValue - The default value to use if the config setting is not set
      * @returns The value of the config setting or the default value
      */
     getFeatureAttr(attrName, defaultValue) {


### PR DESCRIPTION
**Asana Task/Github Issue:** <!-- Link to Asana Task/Github Issue -->

## Description

<!--
  Provide a terse summary of what the change is, detailed descriptions should belong in ship reviews or tech designs
-->

## Testing Steps

- <!-- Include simple steps on how to check this change is working. Write "N/A" if not applicable. -->

## Checklist

<!--
  These questions are a friendly reminder to shipping code, if you're uncertain ask the AoR owners.
  It's also totally appropriate to not check some of these boxes, if they don't apply to your change.
-->
*Please tick all that apply:*

- [ ] I have tested this change locally
- [ ] I have tested this change locally in all supported browsers
- [ ] This change will be visible to users
- [ ] I have added automated tests that cover this change
- [ ] I have ensured the change is gated by config
- [ ] This change was covered by a ship review
- [ ] This change was covered by a tech design
- [ ] Any dependent config has been merged

---

https://claude.ai/code/session_01QaZ2NFE7y5u8YdZhjoc79m

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> JSDoc-only type tightening from `any` to `unknown` with no runtime behavior changes; low risk aside from potentially surfacing new type-check warnings in downstream tooling.
> 
> **Overview**
> Updates `ContentFeature.getFeatureAttr` JSDoc to type `defaultValue` as `unknown` instead of `any`, tightening the public type contract without changing runtime behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f89838b9616fdab7aa5c519c69410cfad1ebb9cd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->