### PR TITLE
fix(types): replace any with unknown for _args in content-feature.js init

### DIFF
--- a/injected/src/content-feature.js
+++ b/injected/src/content-feature.js
@@ -318,7 +318,7 @@ export default class ContentFeature extends ConfigFeature {
     }
 
     /**
-     * @param {any} [_args]
+     * @param {unknown} [_args]
      */
     init(_args) {}
 


### PR DESCRIPTION
**Asana Task/Github Issue:** <!-- Link to Asana Task/Github Issue -->

## Description

<!--
  Provide a terse summary of what the change is, detailed descriptions should belong in ship reviews or tech designs
-->

## Testing Steps

- <!-- Include simple steps on how to check this change is working. Write "N/A" if not applicable. -->

## Checklist

<!--
  These questions are a friendly reminder to shipping code, if you're uncertain ask the AoR owners.
  It's also totally appropriate to not check some of these boxes, if they don't apply to your change.
-->
*Please tick all that apply:*

- [ ] I have tested this change locally
- [ ] I have tested this change locally in all supported browsers
- [ ] This change will be visible to users
- [ ] I have added automated tests that cover this change
- [ ] I have ensured the change is gated by config
- [ ] This change was covered by a ship review
- [ ] This change was covered by a tech design
- [ ] Any dependent config has been merged

---

https://claude.ai/code/session_01QaZ2NFE7y5u8YdZhjoc79m

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk JSDoc typing-only change; no runtime logic is modified.
> 
> **Overview**
> Tightens the JSDoc type for `ContentFeature.init`’s optional `_args` parameter from `any` to `unknown` to improve type safety without changing behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5b9285af902e2f5b9fda49716cc7ceaf3eb03f73. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->