### PR TITLE
fix(types): replace any with object for wrapProperty getter param in wrapper-utils.js

### DIFF
--- a/injected/src/wrapper-utils.js
+++ b/injected/src/wrapper-utils.js
@@ -113,7 +113,7 @@ export function wrapFunction(functionValue, realTarget) {
 
 /**
  * Wrap a `get`/`set` or `value` property descriptor. Only for data properties. For methods, use wrapMethod(). For constructors, use wrapConstructor().
- * @param {any} object - object whose property we are wrapping (most commonly a prototype, e.g. globalThis.Screen.prototype)
+ * @param {object} object - object whose property we are wrapping (most commonly a prototype, e.g. globalThis.Screen.prototype)
  * @param {string} propertyName
  * @param {Partial<PropertyDescriptor>} descriptor
  * @param {DefinePropertyFn} definePropertyFn - function to use for defining the property


### PR DESCRIPTION
**Asana Task/Github Issue:** <!-- Link to Asana Task/Github Issue -->

## Description

<!--
  Provide a terse summary of what the change is, detailed descriptions should belong in ship reviews or tech designs
-->

## Testing Steps

- <!-- Include simple steps on how to check this change is working. Write "N/A" if not applicable. -->

## Checklist

<!--
  These questions are a friendly reminder to shipping code, if you're uncertain ask the AoR owners.
  It's also totally appropriate to not check some of these boxes, if they don't apply to your change.
-->
*Please tick all that apply:*

- [ ] I have tested this change locally
- [ ] I have tested this change locally in all supported browsers
- [ ] This change will be visible to users
- [ ] I have added automated tests that cover this change
- [ ] I have ensured the change is gated by config
- [ ] This change was covered by a ship review
- [ ] This change was covered by a tech design
- [ ] Any dependent config has been merged

---

https://claude.ai/code/session_01QaZ2NFE7y5u8YdZhjoc79m

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Doc/JSDoc type annotation tweak only; no runtime behavior changes and minimal risk beyond potential type-checking impacts.
> 
> **Overview**
> Updates `wrapProperty` documentation in `wrapper-utils.js` to narrow the `object` parameter type from `any` to `object`, improving type clarity for callers without changing runtime behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 907875758b0252000ae7ef2f3769852a475d444d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->