### PR TITLE
fix(types): replace any with unknown for onResponse param in sendmessage-transport.js

### DIFF
--- a/injected/src/sendmessage-transport.js
+++ b/injected/src/sendmessage-transport.js
@@ -62,7 +62,7 @@ export class SendMessageMessagingTransport {
     /**
      * Callback for update() handler. This connects messages sent from the Platform
      * with callback functions in the _queue.
-     * @param {any} response
+     * @param {unknown} response
      */
     onResponse(response) {
         this._queue.forEach((subscription) => subscription(response));


### PR DESCRIPTION
**Asana Task/Github Issue:** <!-- Link to Asana Task/Github Issue -->

## Description

<!--
  Provide a terse summary of what the change is, detailed descriptions should belong in ship reviews or tech designs
-->

## Testing Steps

- <!-- Include simple steps on how to check this change is working. Write "N/A" if not applicable. -->

## Checklist

<!--
  These questions are a friendly reminder to shipping code, if you're uncertain ask the AoR owners.
  It's also totally appropriate to not check some of these boxes, if they don't apply to your change.
-->
*Please tick all that apply:*

- [ ] I have tested this change locally
- [ ] I have tested this change locally in all supported browsers
- [ ] This change will be visible to users
- [ ] I have added automated tests that cover this change
- [ ] I have ensured the change is gated by config
- [ ] This change was covered by a ship review
- [ ] This change was covered by a tech design
- [ ] Any dependent config has been merged

---

https://claude.ai/code/session_01QaZ2NFE7y5u8YdZhjoc79m

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: doc/type annotation-only change with no runtime behavior impact.
> 
> **Overview**
> Updates `SendMessageMessagingTransport.onResponse` documentation to type its `response` parameter as `unknown` instead of `any`, improving type safety without changing behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 623ad6b5401dc00f0d8101aee55920def9fbe7d5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->