### PR TITLE
fix(types): replace any with unknown for bridge callback param in create-page-world-bridge.js

### DIFF
--- a/injected/src/features/message-bridge/create-page-world-bridge.js
+++ b/injected/src/features/message-bridge/create-page-world-bridge.js
@@ -167,7 +167,7 @@ function createMessagingInterface(featureName, send, appendToken, context) {
 
         /**
          * @param {string} name
-         * @param {(d: any) => void} callback
+         * @param {(d: unknown) => void} callback
          * @returns {() => void}
          */
         subscribe(name, callback) {


### PR DESCRIPTION
**Asana Task/Github Issue:** <!-- Link to Asana Task/Github Issue -->

## Description

<!--
  Provide a terse summary of what the change is, detailed descriptions should belong in ship reviews or tech designs
-->

## Testing Steps

- <!-- Include simple steps on how to check this change is working. Write "N/A" if not applicable. -->

## Checklist

<!--
  These questions are a friendly reminder to shipping code, if you're uncertain ask the AoR owners.
  It's also totally appropriate to not check some of these boxes, if they don't apply to your change.
-->
*Please tick all that apply:*

- [ ] I have tested this change locally
- [ ] I have tested this change locally in all supported browsers
- [ ] This change will be visible to users
- [ ] I have added automated tests that cover this change
- [ ] I have ensured the change is gated by config
- [ ] This change was covered by a ship review
- [ ] This change was covered by a tech design
- [ ] Any dependent config has been merged

---

https://claude.ai/code/session_01QaZ2NFE7y5u8YdZhjoc79m

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this is a JSDoc type tightening from `any` to `unknown` on the `subscribe` callback parameter with no runtime behavior changes.
> 
> **Overview**
> Tightens the JSDoc typing for `createPageWorldBridge`’s `subscribe` callback by replacing `any` with `unknown`, encouraging explicit type narrowing for subscription payloads without changing runtime behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b440f50022919bdd337fd774a8a2b0a77b6befdd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->