### PR TITLE
Workflow skip condition

### DIFF
--- a/.github/workflows/review-check.yml
+++ b/.github/workflows/review-check.yml
@@ -13,19 +13,16 @@ permissions:
     pull-requests: read
 
 jobs:
-    # In the merge queue, review validation already passed on the PR — just succeed.
     review_validation:
-        if: ${{ github.event_name == 'merge_group' }}
-        runs-on: ubuntu-latest
-        steps:
-            - run: echo "Review already validated before entering merge queue"
-
-    validate_review:
-        if: ${{ github.event_name != 'merge_group' }}
         runs-on: ubuntu-latest
 
         steps:
+            - name: Merge queue pass-through
+              if: ${{ github.event_name == 'merge_group' }}
+              run: echo "Review already validated before entering merge queue"
+
             - name: Checkout base branch
+              if: ${{ github.event_name != 'merge_group' }}
               uses: actions/checkout@v6
               with:
                   ref: ${{ github.event.pull_request.base.ref }}
@@ -35,6 +32,7 @@ jobs:
                   sparse-checkout-cone-mode: false
 
             - name: Validate approved review from authorized reviewer
+              if: ${{ github.event_name != 'merge_group' }}
               uses: actions/github-script@v8
               env:
                   ORG_TOKEN: ${{ secrets.DAX_PAT }}


### PR DESCRIPTION
**Asana Task/Github Issue:** https://github.com/duckduckgo/content-scope-scripts/pull/2382

## Description

Consolidates the `review-check.yml` workflow into a single job with step-level conditions. This resolves an issue where the workflow was incorrectly reported as "skipped" on PR events, blocking merges due to conflicting check statuses.

## Testing Steps

- This is a CI workflow change; validation will occur upon the next PR event trigger on GitHub.
- YAML lint and workflow structure verified locally.

## Checklist

*Please tick all that apply:*

- [x] I have tested this change locally
- [ ] I have tested this change locally in all supported browsers
- [x] This change will be visible to users
- [ ] I have added automated tests that cover this change
- [ ] I have ensured the change is gated by config
- [ ] This change was covered by a ship review
- [ ] This change was covered by a tech design
- [ ] Any dependent config has been merged

---
<p><a href="https://cursor.com/agents/bc-23d53c49-8c4e-4096-867b-26d1310ad8c0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-23d53c49-8c4e-4096-867b-26d1310ad8c0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the required `review_validation` GitHub check behavior and event handling, which can affect merge gating if the workflow logic is incorrect. Scope is limited to workflow YAML with no product/runtime code changes.
> 
> **Overview**
> Consolidates the `review-check.yml` workflow into a single `review_validation` job so the check is created consistently instead of being reported as *skipped* on some events.
> 
> For `merge_group` events, the job now runs a simple pass-through step, while checkout and review-authorization validation steps are conditionally skipped for merge queue runs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7569426a33837b25e92002700f66c363c9f140a5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->