### PR TITLE
Auto review CI status

### DIFF
--- a/.github/workflows/cursor-review.yml
+++ b/.github/workflows/cursor-review.yml
@@ -31,14 +31,12 @@ jobs:
                               core.setOutput('is_member', 'false');
                           }
                       } catch (error) {
-                          if (error.status === 401) {
-                              core.setFailed(`DAX_PAT returned 401 — token may be expired or misconfigured`);
-                          } else if (error.status === 404) {
+                          if (error.status === 404) {
                               console.log(`⏭️ ${author} is not a member of duckduckgo/core — skipping auto-review`);
-                              core.setOutput('is_member', 'false');
                           } else {
-                              core.setFailed(`Failed to check team membership for ${author}: ${error.message} (status: ${error.status})`);
+                              console.log(`⚠️ Could not verify ${author}: ${error.message} (status: ${error.status})`);
                           }
+                          core.setOutput('is_member', 'false');
                       }
 
     cursor_auto_review:


### PR DESCRIPTION
## Description

This change prevents the `cursor-review` workflow from failing due to non-team members (e.g., dependabot PRs) or API errors during the membership check. The workflow now always completes with a green check. If the PR author is not a team member or if the membership check encounters an API issue, the `cursor_auto_review` job is simply skipped, logging a warning instead of failing the entire workflow. This reduces CI noise for non-quality-related issues.

## Testing Steps

- N/A (This is a GitHub Actions workflow change that can only be validated by CI runs on the remote. The next dependabot PR will confirm the green check.)

## Checklist

*Please tick all that apply:*

- [ ] I have tested this change locally
- [ ] I have tested this change locally in all supported browsers
- [x] This change will be visible to users
- [ ] I have added automated tests that cover this change
- [ ] I have ensured the change is gated by config
- [ ] This change was covered by a ship review
- [ ] This change was covered by a tech design
- [ ] Any dependent config has been merged

---
<p><a href="https://cursor.com/agents/bc-3b520fe4-e0bd-4023-ba55-ecf41b86e36b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3b520fe4-e0bd-4023-ba55-ecf41b86e36b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: GitHub Actions workflow-only change that gates the auto-review job and converts membership-check failures into skips. Main risk is accidentally skipping auto-reviews for valid contributors if the membership check/output is wrong or the token lacks access.
> 
> **Overview**
> The `cursor-review` workflow now runs a separate `check_membership` job that **outputs whether the PR author is an active `duckduckgo/core` member**.
> 
> `cursor_auto_review` is now **gated on that output** (`if: ... == 'true'`) and the membership check no longer fails the workflow on non-members or API errors; it logs and sets `is_member=false` so the auto-review job is skipped instead.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dff51335786b1954ae1e6788071dacfb7fd186c2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->