### PR TITLE
Semver label workflow trigger

### DIFF
--- a/.github/workflows/semver-label.yml
+++ b/.github/workflows/semver-label.yml
@@ -3,6 +3,9 @@ name: Semver Label
 on:
     pull_request_target:
         types: [opened, synchronize, reopened]
+    push:
+        branches-ignore:
+            - main
 
 permissions:
     contents: read
@@ -16,22 +19,45 @@ jobs:
             - name: Checkout
               uses: actions/checkout@v6
 
+            - name: Resolve PR number
+              id: pr
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              run: |
+                  if [ "${{ github.event_name }}" = "push" ]; then
+                    PR_NUMBER=$(gh pr list --head "${{ github.ref_name }}" --json number --jq '.[0].number')
+                    if [ -z "$PR_NUMBER" ]; then
+                      echo "No open PR found for branch ${{ github.ref_name }}, skipping."
+                      echo "skip=true" >> "$GITHUB_OUTPUT"
+                      exit 0
+                    fi
+                  else
+                    PR_NUMBER="${{ github.event.pull_request.number }}"
+                  fi
+                  echo "number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
+                  echo "skip=false" >> "$GITHUB_OUTPUT"
+
             - name: Get PR diff and files
+              if: steps.pr.outputs.skip != 'true'
               id: diff
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-                  PR_NUMBER: ${{ github.event.pull_request.number }}
+                  PR_NUMBER: ${{ steps.pr.outputs.number }}
               run: |
                   gh pr diff "$PR_NUMBER" > /tmp/pr_diff.txt 2>/dev/null || true
                   gh pr view "$PR_NUMBER" --json files --jq '.files[].path' > /tmp/pr_files.txt 2>/dev/null || true
 
             - name: Run semver analysis
+              if: steps.pr.outputs.skip != 'true'
               id: analyse
               env:
                   ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-                  PR_TITLE: ${{ github.event.pull_request.title }}
-                  PR_BODY: ${{ github.event.pull_request.body }}
+                  PR_NUMBER: ${{ steps.pr.outputs.number }}
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
               run: |
+                  PR_JSON=$(gh pr view "$PR_NUMBER" --json title,body)
+                  export PR_TITLE=$(echo "$PR_JSON" | jq -r '.title')
+                  export PR_BODY=$(echo "$PR_JSON" | jq -r '.body')
                   export PR_DIFF="$(cat /tmp/pr_diff.txt 2>/dev/null || echo '')"
                   export PR_FILES="$(cat /tmp/pr_files.txt 2>/dev/null || echo '')"
 
@@ -42,11 +68,11 @@ jobs:
                   echo "severity=$SEVERITY" >> "$GITHUB_OUTPUT"
 
             - name: Label PR
-              if: steps.analyse.outputs.severity != ''
+              if: steps.pr.outputs.skip != 'true' && steps.analyse.outputs.severity != ''
               uses: actions/github-script@v8
               with:
                   script: |
-                      const prNumber = context.payload.pull_request.number;
+                      const prNumber = ${{ steps.pr.outputs.number }};
                       const label = '${{ steps.analyse.outputs.severity }}';
                       const semverLabels = ['major', 'minor', 'patch'];
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**Asana Task/Github Issue:**

## Description

Enable the `semver-label.yml` workflow to run on `push` events. This change resolves the associated PR from the pushed branch, fetches PR details, and applies semver labels consistently, while gracefully handling pushes without an open PR.

## Testing Steps

- The workflow will be validated by GitHub Actions upon this commit's push.

## Checklist

*Please tick all that apply:*

- [ ] I have tested this change locally
- [ ] I have tested this change locally in all supported browsers
- [ ] This change will be visible to users
- [ ] I have added automated tests that cover this change
- [ ] I have ensured the change is gated by config
- [ ] This change was covered by a ship review
- [ ] This change was covered by a tech design
- [ ] Any dependent config has been merged

---
<p><a href="https://cursor.com/agents/bc-de5709ff-cada-4d52-9082-5de7b460f866"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-de5709ff-cada-4d52-9082-5de7b460f866"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->