### PR TITLE
Semver release workflow trigger

### DIFF
--- a/.github/workflows/semver-release.yml
+++ b/.github/workflows/semver-release.yml
@@ -1,7 +1,8 @@
 name: Semver Auto-Release
 
 on:
-    push:
+    pull_request:
+        types: [closed]
         branches:
             - main
 
@@ -11,38 +12,29 @@ permissions:
 
 jobs:
     trigger_release:
+        if: github.event.pull_request.merged == true
         runs-on: ubuntu-latest
 
         steps:
-            - name: Find merged PR and check label
+            - name: Check for semver label
               id: check
               uses: actions/github-script@v8
               with:
                   script: |
-                      const { data: prs } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
-                          owner: context.repo.owner,
-                          repo: context.repo.repo,
-                          commit_sha: context.sha
-                      });
-                      const merged = prs.find(pr => pr.merged_at && pr.base.ref === 'main');
-                      if (!merged) {
-                          core.info('No merged PR found for this commit — skipping');
-                          return;
-                      }
-
+                      const pr = context.payload.pull_request;
                       const semverLabels = ['major', 'minor', 'patch'];
-                      const label = merged.labels.find(l => semverLabels.includes(l.name));
+                      const label = pr.labels.find(l => semverLabels.includes(l.name));
                       if (!label) {
-                          core.info(`PR #${merged.number} has no semver label — skipping`);
+                          core.info(`PR #${pr.number} has no semver label — skipping`);
                           return;
                       }
 
-                      core.info(`PR #${merged.number} labeled "${label.name}"`);
+                      core.info(`PR #${pr.number} labeled "${label.name}"`);
                       core.setOutput('severity', label.name);
-                      core.setOutput('pr_number', merged.number.toString());
+                      core.setOutput('pr_number', pr.number.toString());
 
             - name: Trigger Release workflow
-              if: steps.check.outputs.severity == 'major' || steps.check.outputs.severity == 'minor'
+              if: steps.check.outputs.severity
               uses: actions/github-script@v8
               env:
                   SEVERITY: ${{ steps.check.outputs.severity }}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**Asana Task/Github Issue:** <!-- Link to Asana Task/Github Issue -->

## Description

This PR fixes two issues in the `semver-release.yml` workflow that were preventing automatic releases:
1.  **Race Condition:** Changes the workflow trigger from `on: push` to `on: pull_request: types: [closed]` (gated by `merged == true`). This allows direct access to the PR payload, eliminating a race condition where the GitHub API often failed to find the associated PR immediately after a `push` event, leading to "No merged PR found" errors and missed releases.
2.  **Patch Exclusion:** Broadens the release dispatch condition from `major || minor` to `if: steps.check.outputs.severity`, ensuring `patch` releases are also correctly dispatched.

## Testing Steps

- Merge a PR with a `patch`, `minor`, or `major` semver label and verify the `semver-release` workflow runs successfully and dispatches a release.

## Checklist

*Please tick all that apply:*

- [ ] I have tested this change locally
- [ ] I have tested this change locally in all supported browsers
- [x] This change will be visible to users
- [ ] I have added automated tests that cover this change
- [ ] I have ensured the change is gated by config
- [ ] This change was covered by a ship review
- [ ] This change was covered by a tech design
- [ ] Any dependent config has been merged

---
<p><a href="https://cursor.com/agents/bc-48bc2f73-d056-4950-9e74-78235eee8d4e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-48bc2f73-d056-4950-9e74-78235eee8d4e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->