### PR TITLE
Remove conditional check for semver labels

### DIFF
--- a/.github/workflows/semver-label.yml
+++ b/.github/workflows/semver-label.yml
@@ -10,9 +10,6 @@ permissions:
 
 jobs:
     semver_label:
-        if: >-
-            contains(fromJSON('["release-major","release-minor","release-patch"]'),
-            github.event.pull_request.head.ref)
         runs-on: ubuntu-latest
         steps:
             - name: Checkout base branch


### PR DESCRIPTION
Removed conditional check for specific pull request labels.

**Asana Task/Github Issue:** <!-- Link to Asana Task/Github Issue -->

## Description

Removes gating for automation labeller.

## Testing Steps

- <!-- Include simple steps on how to check this change is working. Write "N/A" if not applicable. -->

## Checklist

<!--
  These questions are a friendly reminder to shipping code, if you're uncertain ask the AoR owners.
  It's also totally appropriate to not check some of these boxes, if they don't apply to your change.
-->
*Please tick all that apply:*

- [ ] I have tested this change locally
- [ ] I have tested this change locally in all supported browsers
- [ ] This change will be visible to users
- [ ] I have added automated tests that cover this change
- [ ] I have ensured the change is gated by config
- [ ] This change was covered by a ship review
- [ ] This change was covered by a tech design
- [ ] Any dependent config has been merged



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> This expands execution of a `pull_request_target` workflow (with token/secrets access and PR-branch checkout) to all PRs, increasing exposure if untrusted PR code can influence the job.
> 
> **Overview**
> The `Semver Label` GitHub Actions workflow now runs its `semver_label` job unconditionally for `pull_request_target` events, removing the prior branch-name gate that only executed on `release-major`/`release-minor`/`release-patch` PR refs.
> 
> As a result, the build/diff + semver analysis and automatic `semver-*` labeling will execute on every opened/synchronized/reopened PR instead of a limited subset.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d62051a6a25203ccf3750306a5cc5a63e694f225. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->