### PR TITLE
Add playwright-cli config for isolated browsing

### DIFF
--- a/.playwright/cli.config.json
+++ b/.playwright/cli.config.json
@@ -1,0 +1,13 @@
+{
+  "browser": {
+    "isolated": true
+  },
+  "network": {
+    "allowedOrigins": [
+      "https://localhost:*",
+      "http://localhost:*",
+      "https://127.0.0.1:*",
+      "http://127.0.0.1:*"
+    ]
+  }
+}


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1209741563761102/task/1213557739400766

## Description

Adds `.playwright/cli.config.json` per the agentic browsing policy:
- **Isolated mode** — uses a fresh browser profile each session, preventing credential leakage
- **Allowed origins** — restricted to `localhost` and `127.0.0.1` only, matching the test servers used in this project (ports 3220, 3210, 8000)

## Testing Steps

- Run `npm run serve` to start the dev server
- Run `playwright-cli open http://localhost:3220` and confirm it loads successfully
- Run `playwright-cli open https://example.com` and confirm it is blocked

## Checklist

- [x] I have tested this change locally
- [ ] I have tested this change locally in all supported browsers
- [ ] This change will be visible to users
- [ ] I have added automated tests that cover this change
- [ ] I have ensured the change is gated by config
- [ ] This change was covered by a ship review
- [ ] This change was covered by a tech design
- [ ] Any dependent config has been merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily adds documentation/config and a dev-only dependency; main behavior change is restricting `playwright-cli` network origins and slightly adjusting the formatting hook’s payload parsing.
> 
> **Overview**
> Adds two new agent skills: `implement-design` (Figma MCP workflow) and `playwright-cli` (browser automation) including reference docs, and wires them into Claude via `.claude/skills/*` plus a new `skills-lock.json`.
> 
> Introduces `@playwright/cli` as a dev dependency and adds `.playwright/cli.config.json` to run the CLI in isolated mode with navigation restricted to `localhost`/`127.0.0.1` origins.
> 
> Tweaks Claude/Cursor integration by refining `.gitignore` rules for `.claude/*`, adding `.claude/settings.json` hook config, and updating `.cursor/hooks/format.sh` to read `file_path` from either the top-level or `.tool_input` payload format.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7d2389be0c6c781d79f9470c75ac1748bd1aae00. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->