### PR TITLE
Skip hover initialization for iOS

### DIFF
--- a/injected/src/features/hover.js
+++ b/injected/src/features/hover.js
@@ -11,9 +11,11 @@ import { findClosestAnchor } from '../utils/dom-metadata.js';
  */
 export class Hover extends ContentFeature {
     init() {
-        // iOS doesn't need hover and has no handler so we shouldn't override
-        if (this.platform.name === 'ios') return;
-        
+        // iOS doesn't need hover, so we shouldn't override there
+        if (this.platform.name === 'ios') {
+            return;
+        }
+
         document.addEventListener(
             'mouseover',
             (event) => {


### PR DESCRIPTION
**Asana Task/Github Issue:** [<!-- Link to Asana Task/Github Issue -->](https://app.asana.com/1/137249556945/project/414709148257752/task/1213586440985421?focus=true)

## Description

We had a [very helpful and detailed report](https://github.com/duckduckgo/apple-browsers/issues/3849) filed from a nytimes engineer to flag that we're throwing errors on iOS since we don't need the feature on iOS (no mouse events) and so there's no subfeature registered there like for macOS. Solution: we should escape early instead of initializing on iOS.

## Testing Steps

N/A

## Checklist

<!--
  These questions are a friendly reminder to shipping code, if you're uncertain ask the AoR owners.
  It's also totally appropriate to not check some of these boxes, if they don't apply to your change.
-->
*Please tick all that apply:*

- [ ] I have tested this change locally
- [ ] I have tested this change locally in all supported browsers
- [ ] This change will be visible to users
- [ ] I have added automated tests that cover this change
- [ ] I have ensured the change is gated by config
- [ ] This change was covered by a ship review
- [ ] This change was covered by a tech design
- [ ] Any dependent config has been merged


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, platform-gated change that only bypasses hover event listener setup on iOS, with minimal risk outside potential missing hover behavior on misdetected platforms.
> 
> **Overview**
> Prevents the `Hover` content feature from initializing on iOS by adding an early return in `init()`, avoiding registration of `mouseover`/`mouseleave` listeners and the associated runtime errors on platforms without hover support.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 12582965cb592cdbe7fe9efc1320e22000afdaa9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->