### PR TITLE
strict-type: utils.js

### DIFF
--- a/injected/src/features/breakage-reporting/utils.js
+++ b/injected/src/features/breakage-reporting/utils.js
@@ -8,7 +8,27 @@ export function getJsPerformanceMetrics() {
 }
 
 /** @typedef {{error: string, success: false}} ErrorObject */
-/** @typedef {{success: true, metrics: any}} PerformanceMetricsResponse */
+/**
+ * @typedef {object} ExpandedPerformanceMetrics
+ * @property {number} loadComplete
+ * @property {number} domComplete
+ * @property {number} domContentLoaded
+ * @property {number} domInteractive
+ * @property {number | null} firstContentfulPaint
+ * @property {number | null} largestContentfulPaint
+ * @property {number} timeToFirstByte
+ * @property {number} responseTime
+ * @property {number} serverTime
+ * @property {number} transferSize
+ * @property {number} encodedBodySize
+ * @property {number} decodedBodySize
+ * @property {number} resourceCount
+ * @property {number} totalResourcesSize
+ * @property {string} protocol
+ * @property {number} redirectCount
+ * @property {string} navigationType
+ */
+/** @typedef {{success: true, metrics: ExpandedPerformanceMetrics}} PerformanceMetricsResponse */
 
 /**
  * Convenience function to return an error object
@@ -24,24 +44,22 @@ function returnError(errorMessage) {
  */
 function waitForLCP(timeoutMs = 500) {
     return new Promise((resolve) => {
-        // eslint-disable-next-line prefer-const
-        let timeoutId;
-        // eslint-disable-next-line prefer-const
-        let observer;
+        /** @type {{ id?: ReturnType<typeof setTimeout>, obs?: PerformanceObserver }} */
+        const refs = {};
 
         const cleanup = () => {
-            if (observer) observer.disconnect();
-            if (timeoutId) clearTimeout(timeoutId);
+            if (refs.obs) refs.obs.disconnect();
+            if (refs.id) clearTimeout(refs.id);
         };
 
         // Set timeout
-        timeoutId = setTimeout(() => {
+        refs.id = setTimeout(() => {
             cleanup();
             resolve(null); // Resolve with null instead of hanging
         }, timeoutMs);
 
         // Try to get existing LCP
-        observer = new PerformanceObserver((list) => {
+        refs.obs = new PerformanceObserver((list) => {
             const entries = list.getEntries();
             const lastEntry = entries[entries.length - 1];
             if (lastEntry) {
@@ -51,7 +69,7 @@ function waitForLCP(timeoutMs = 500) {
         });
 
         try {
-            observer.observe({ type: 'largest-contentful-paint', buffered: true });
+            refs.obs.observe({ type: 'largest-contentful-paint', buffered: true });
         } catch (error) {
             // Handle browser compatibility issues
             cleanup();
@@ -124,6 +142,7 @@ export async function getExpandedPerformanceMetrics(timeoutMs = 500) {
 
         return returnError('No navigation timing found');
     } catch (e) {
-        return returnError('JavaScript execution error: ' + e.message);
+        const message = e instanceof Error ? e.message : String(e);
+        return returnError('JavaScript execution error: ' + message);
     }
 }

--- a/injected/src/features/cookie.js
+++ b/injected/src/features/cookie.js
@@ -45,7 +45,8 @@ let cookiePolicy = {
 };
 let trackerLookup = {};
 
-let loadedPolicyResolve;
+/** @type {((value?: void) => void)} */
+let loadedPolicyResolve = () => {};
 
 /**
  * @param {'ignore' | 'block' | 'restrict'} action
@@ -118,13 +119,19 @@ export default class CookieFeature extends ContentFeature {
             let tabExempted = true;
 
             if (tabHostname != null) {
-                tabExempted = exceptions.some((exception) => {
-                    return matchHostname(tabHostname, exception.domain);
-                });
+                tabExempted = exceptions.some(
+                    /** @param {{ domain: string }} exception */
+                    (exception) => {
+                        return matchHostname(tabHostname, exception.domain);
+                    },
+                );
             }
-            const frameExempted = settings.excludedCookieDomains.some((exception) => {
-                return matchHostname(globalThis.location.hostname, exception.domain);
-            });
+            const frameExempted = settings.excludedCookieDomains.some(
+                /** @param {{ domain: string }} exception */
+                (exception) => {
+                    return matchHostname(globalThis.location.hostname, exception.domain);
+                },
+            );
             cookiePolicy.shouldBlock = !frameExempted && !tabExempted;
             cookiePolicy.policy = settings.firstPartyCookiePolicy;
             cookiePolicy.trackerPolicy = settings.firstPartyTrackerCookiePolicy;
@@ -136,10 +143,9 @@ export default class CookieFeature extends ContentFeature {
         // The cookie policy is injected into every frame immediately so that no cookie will
         // be missed.
         const document = globalThis.document;
-        // @ts-expect-error - Object is possibly 'undefined'.
-        const cookieSetter = Object.getOwnPropertyDescriptor(globalThis.Document.prototype, 'cookie').set;
-        // @ts-expect-error - Object is possibly 'undefined'.
-        const cookieGetter = Object.getOwnPropertyDescriptor(globalThis.Document.prototype, 'cookie').get;
+        const cookieDescriptor = Object.getOwnPropertyDescriptor(globalThis.Document.prototype, 'cookie');
+        const cookieSetter = cookieDescriptor?.set;
+        const cookieGetter = cookieDescriptor?.get;
 
         const loadPolicy = new Promise((resolve) => {
             loadedPolicyResolve = resolve;
@@ -214,7 +220,11 @@ export default class CookieFeature extends ContentFeature {
                     // apply cookie policy
                     if (cookie.getExpiry() > chosenPolicy.threshold) {
                         // check if the cookie still exists
-                        if (document.cookie.split(';').findIndex((kv) => kv.trim().startsWith(cookie.parts[0].trim())) !== -1) {
+                        const firstPart = cookie.parts[0];
+                        if (
+                            firstPart !== undefined &&
+                            document.cookie.split(';').findIndex((kv) => kv.trim().startsWith(firstPart.trim())) !== -1
+                        ) {
                             cookie.maxAge = chosenPolicy.maxAge;
 
                             debugHelper('restrict', 'expiry', setCookieContext);
@@ -241,6 +251,9 @@ export default class CookieFeature extends ContentFeature {
         });
     }
 
+    /**
+     * @param {import('../content-scope-features.js').LoadArgs & { cookie?: ExtensionCookiePolicy }} args
+     */
     init(args) {
         const restOfPolicy = {
             debug: this.isDebug,
@@ -259,11 +272,8 @@ export default class CookieFeature extends ContentFeature {
             };
         } else {
             // copy non-null entries from restOfPolicy to cookiePolicy
-            Object.keys(restOfPolicy).forEach((key) => {
-                if (restOfPolicy[key]) {
-                    cookiePolicy[key] = restOfPolicy[key];
-                }
-            });
+            const toCopy = Object.fromEntries(Object.entries(restOfPolicy).filter(([, v]) => v));
+            Object.assign(cookiePolicy, toCopy);
         }
 
         loadedPolicyResolve();

--- a/injected/src/features/duckplayer-native/sub-features/duck-player-native-youtube.js
+++ b/injected/src/features/duckplayer-native/sub-features/duck-player-native-youtube.js
@@ -53,6 +53,7 @@ export class DuckPlayerNativeYoutube {
 
     onLoad() {
         this.sideEffects.add('started polling current timestamp', () => {
+            /** @param {number} timestamp */
             const handler = (timestamp) => {
                 this.messages.notifyCurrentTimestamp(timestamp.toFixed(0));
             };


### PR DESCRIPTION
**Asana Task/Github Issue:** <!-- Link to Asana Task/Github Issue -->

## Description

<!--
  Provide a terse summary of what the change is, detailed descriptions should belong in ship reviews or tech designs
-->

## Testing Steps

- <!-- Include simple steps on how to check this change is working. Write "N/A" if not applicable. -->

## Checklist

<!--
  These questions are a friendly reminder to shipping code, if you're uncertain ask the AoR owners.
  It's also totally appropriate to not check some of these boxes, if they don't apply to your change.
-->
*Please tick all that apply:*

- [ ] I have tested this change locally
- [ ] I have tested this change locally in all supported browsers
- [ ] This change will be visible to users
- [ ] I have added automated tests that cover this change
- [ ] I have ensured the change is gated by config
- [ ] This change was covered by a ship review
- [ ] This change was covered by a tech design
- [ ] Any dependent config has been merged

---

Co-authored-by: Jonathan Kingston <jonathanKingston@users.noreply.github.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches injected runtime code for cookie interception and performance metric collection; while largely type/nil-safety refactors, mistakes could alter cookie blocking behavior or break metric reporting in some browsers.
> 
> **Overview**
> Improves JSDoc typing and runtime null-safety across injected features.
> 
> In `breakage-reporting/utils.js`, formalizes the expanded performance metrics shape, refactors LCP observer cleanup to avoid uninitialized refs, and hardens error message construction for non-`Error` throws.
> 
> In `cookie.js`, makes cookie getter/setter descriptor access optional, guards against missing cookie parts when checking for persistence, adds stronger inline typings for exception lists/init args, and simplifies policy merging via `Object.entries`/`Object.assign`. Also adds a small JSDoc type to the Duck Player timestamp polling handler.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6c2fe3447d3abd1534c87050eec2574be5840afa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->