### PR TITLE
strict-type: cookie.js

### DIFF
--- a/injected/src/features/cookie.js
+++ b/injected/src/features/cookie.js
@@ -45,7 +45,8 @@ let cookiePolicy = {
 };
 let trackerLookup = {};
 
-let loadedPolicyResolve;
+/** @type {((value?: void) => void)} */
+let loadedPolicyResolve = () => {};
 
 /**
  * @param {'ignore' | 'block' | 'restrict'} action
@@ -118,13 +119,19 @@ export default class CookieFeature extends ContentFeature {
             let tabExempted = true;
 
             if (tabHostname != null) {
-                tabExempted = exceptions.some((exception) => {
-                    return matchHostname(tabHostname, exception.domain);
-                });
+                tabExempted = exceptions.some(
+                    /** @param {{ domain: string }} exception */
+                    (exception) => {
+                        return matchHostname(tabHostname, exception.domain);
+                    },
+                );
             }
-            const frameExempted = settings.excludedCookieDomains.some((exception) => {
-                return matchHostname(globalThis.location.hostname, exception.domain);
-            });
+            const frameExempted = settings.excludedCookieDomains.some(
+                /** @param {{ domain: string }} exception */
+                (exception) => {
+                    return matchHostname(globalThis.location.hostname, exception.domain);
+                },
+            );
             cookiePolicy.shouldBlock = !frameExempted && !tabExempted;
             cookiePolicy.policy = settings.firstPartyCookiePolicy;
             cookiePolicy.trackerPolicy = settings.firstPartyTrackerCookiePolicy;
@@ -136,10 +143,9 @@ export default class CookieFeature extends ContentFeature {
         // The cookie policy is injected into every frame immediately so that no cookie will
         // be missed.
         const document = globalThis.document;
-        // @ts-expect-error - Object is possibly 'undefined'.
-        const cookieSetter = Object.getOwnPropertyDescriptor(globalThis.Document.prototype, 'cookie').set;
-        // @ts-expect-error - Object is possibly 'undefined'.
-        const cookieGetter = Object.getOwnPropertyDescriptor(globalThis.Document.prototype, 'cookie').get;
+        const cookieDescriptor = Object.getOwnPropertyDescriptor(globalThis.Document.prototype, 'cookie');
+        const cookieSetter = cookieDescriptor?.set;
+        const cookieGetter = cookieDescriptor?.get;
 
         const loadPolicy = new Promise((resolve) => {
             loadedPolicyResolve = resolve;
@@ -214,7 +220,11 @@ export default class CookieFeature extends ContentFeature {
                     // apply cookie policy
                     if (cookie.getExpiry() > chosenPolicy.threshold) {
                         // check if the cookie still exists
-                        if (document.cookie.split(';').findIndex((kv) => kv.trim().startsWith(cookie.parts[0].trim())) !== -1) {
+                        const firstPart = cookie.parts[0];
+                        if (
+                            firstPart !== undefined &&
+                            document.cookie.split(';').findIndex((kv) => kv.trim().startsWith(firstPart.trim())) !== -1
+                        ) {
                             cookie.maxAge = chosenPolicy.maxAge;
 
                             debugHelper('restrict', 'expiry', setCookieContext);
@@ -241,6 +251,9 @@ export default class CookieFeature extends ContentFeature {
         });
     }
 
+    /**
+     * @param {import('../content-scope-features.js').LoadArgs & { cookie?: ExtensionCookiePolicy }} args
+     */
     init(args) {
         const restOfPolicy = {
             debug: this.isDebug,
@@ -259,11 +272,8 @@ export default class CookieFeature extends ContentFeature {
             };
         } else {
             // copy non-null entries from restOfPolicy to cookiePolicy
-            Object.keys(restOfPolicy).forEach((key) => {
-                if (restOfPolicy[key]) {
-                    cookiePolicy[key] = restOfPolicy[key];
-                }
-            });
+            const toCopy = Object.fromEntries(Object.entries(restOfPolicy).filter(([, v]) => v));
+            Object.assign(cookiePolicy, toCopy);
         }
 
         loadedPolicyResolve();

--- a/injected/src/features/duckplayer-native/sub-features/duck-player-native-youtube.js
+++ b/injected/src/features/duckplayer-native/sub-features/duck-player-native-youtube.js
@@ -53,6 +53,7 @@ export class DuckPlayerNativeYoutube {
 
     onLoad() {
         this.sideEffects.add('started polling current timestamp', () => {
+            /** @param {number} timestamp */
             const handler = (timestamp) => {
                 this.messages.notifyCurrentTimestamp(timestamp.toFixed(0));
             };


### PR DESCRIPTION
**Asana Task/Github Issue:** <!-- Link to Asana Task/Github Issue -->

## Description

<!--
  Provide a terse summary of what the change is, detailed descriptions should belong in ship reviews or tech designs
-->

## Testing Steps

- <!-- Include simple steps on how to check this change is working. Write "N/A" if not applicable. -->

## Checklist

<!--
  These questions are a friendly reminder to shipping code, if you're uncertain ask the AoR owners.
  It's also totally appropriate to not check some of these boxes, if they don't apply to your change.
-->
*Please tick all that apply:*

- [ ] I have tested this change locally
- [ ] I have tested this change locally in all supported browsers
- [ ] This change will be visible to users
- [ ] I have added automated tests that cover this change
- [ ] I have ensured the change is gated by config
- [ ] This change was covered by a ship review
- [ ] This change was covered by a tech design
- [ ] Any dependent config has been merged

---

Co-authored-by: Jonathan Kingston <jonathanKingston@users.noreply.github.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly JSDoc/type-safety and null-check refactors in injected features with minimal functional change; main risk is subtle behavior differences around cookie descriptor/cookie parsing edge cases.
> 
> **Overview**
> Tightens type-safety and null handling in injected features, primarily `cookie.js`, to reduce TS/JS runtime edge cases.
> 
> `cookie.js` now initializes `loadedPolicyResolve` to a no-op, adds JSDoc typing for callbacks/`init` args, safely reads the `Document.prototype.cookie` descriptor with optional chaining, and guards cookie-part access before trimming/restricting expiry. It also simplifies merging of default policy values using `Object.fromEntries` + `Object.assign`.
> 
> Adds a small JSDoc annotation for the YouTube Duck Player timestamp poll handler parameter.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d3d7455517a729a91a10100789fb426c200d79de. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->