### PR TITLE
strict-type: environment.js

### DIFF
--- a/injected/src/features/duckplayer/environment.js
+++ b/injected/src/features/duckplayer/environment.js
@@ -50,11 +50,18 @@ export class Environment {
         return window.location.href;
     }
 
+    /**
+     * @param {string} videoId
+     * @returns {string}
+     */
     getLargeThumbnailSrc(videoId) {
         const url = new URL(`/vi/${videoId}/maxresdefault.jpg`, 'https://i.ytimg.com');
         return url.href;
     }
 
+    /**
+     * @param {string} href
+     */
     setHref(href) {
         window.location.href = href;
     }

--- a/injected/src/features/duckplayer/video-overlay.js
+++ b/injected/src/features/duckplayer/video-overlay.js
@@ -374,9 +374,9 @@ export class VideoOverlay {
      */
     appendThumbnail(overlayElement) {
         const params = VideoParams.forWatchPage(this.environment.getPlayerPageHref());
-        const videoId = params?.id;
+        if (!params) return;
 
-        const imageUrl = this.environment.getLargeThumbnailSrc(videoId);
+        const imageUrl = this.environment.getLargeThumbnailSrc(params.id);
         appendImageAsBackground(overlayElement, '.ddg-vpo-bg', imageUrl);
     }
 


### PR DESCRIPTION
**Asana Task/Github Issue:** <!-- Link to Asana Task/Github Issue -->

## Description

Adds **JSDoc** on `Environment.getLargeThumbnailSrc` and `Environment.setHref` so strict typing treats `videoId` and `href` as strings.

In **`appendThumbnail`**, bails out when `VideoParams.forWatchPage` returns nothing instead of passing a possibly undefined id into `getLargeThumbnailSrc`; thumbnail URL uses `params.id` only after that guard.

## Testing Steps

- <!-- Include simple steps on how to check this change is working. Write "N/A" if not applicable. -->

## Checklist

<!--
  These questions are a friendly reminder to shipping code, if you're uncertain ask the AoR owners.
  It's also totally appropriate to not check some of these boxes, if they don't apply to your change.
-->
*Please tick all that apply:*

- [ ] I have tested this change locally
- [ ] I have tested this change locally in all supported browsers
- [ ] This change will be visible to users
- [ ] I have added automated tests that cover this change
- [ ] I have ensured the change is gated by config
- [ ] This change was covered by a ship review
- [ ] This change was covered by a tech design
- [ ] Any dependent config has been merged

---

Co-authored-by: Jonathan Kingston <jonathanKingston@users.noreply.github.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and a defensive early return in overlay thumbnail logic; no auth or data-path changes.
> 
> **Overview**
> Adds **JSDoc** on `Environment.getLargeThumbnailSrc` and `Environment.setHref` so strict typing treats `videoId` and `href` as strings.
> 
> In **`appendThumbnail`**, bails out when `VideoParams.forWatchPage` returns nothing instead of passing a possibly undefined id into `getLargeThumbnailSrc`; thumbnail URL uses `params.id` only after that guard.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e9ea4afbfa7a5bef64f4ff17481105c8d5aa5d93. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->