### PR TITLE
strict-type: duck-player-native-no-cookie.js

### DIFF
--- a/injected/src/features/duckplayer-native/sub-features/duck-player-native-no-cookie.js
+++ b/injected/src/features/duckplayer-native/sub-features/duck-player-native-no-cookie.js
@@ -40,6 +40,7 @@ export class DuckPlayerNativeNoCookie {
 
     onLoad() {
         this.sideEffects.add('started polling current timestamp', () => {
+            /** @param {number} timestamp */
             const handler = (timestamp) => {
                 this.messages.notifyCurrentTimestamp(timestamp.toFixed(0));
             };

--- a/scripts/check-strict-core.js
+++ b/scripts/check-strict-core.js
@@ -73,6 +73,7 @@ const CORE_FILES = new Set([
     'injected/src/features/duckplayer-native/get-current-timestamp.js',
     'injected/src/features/duckplayer-native/mute-audio.js',
     'injected/src/features/duckplayer-native/pause-video.js',
+    'injected/src/features/duckplayer-native/sub-features/duck-player-native-no-cookie.js',
     'injected/src/features/duckplayer-native/sub-features/duck-player-native-serp.js',
     'injected/src/features/duckplayer/components/ddg-video-overlay-mobile.js',
     'injected/src/features/duckplayer/components/ddg-video-thumbnail-overlay-mobile.js',


### PR DESCRIPTION
**Asana Task/Github Issue:** <!-- Link to Asana Task/Github Issue -->

## Description

Brings **`duck-player-native-no-cookie.js`** under the injected **strict TypeScript** gate used by `check-strict-core.js`.

The only source change in that file is a JSDoc **`@param {number} timestamp`** on the `pollTimestamp` callback handler so strict checking can type the value passed to `notifyCurrentTimestamp`. **`scripts/check-strict-core.js`** adds this path to **`CORE_FILES`**, so CI will fail if new strict-mode errors appear there.

## Testing Steps

- <!-- Include simple steps on how to check this change is working. Write "N/A" if not applicable. -->

## Checklist

<!--
  These questions are a friendly reminder to shipping code, if you're uncertain ask the AoR owners.
  It's also totally appropriate to not check some of these boxes, if they don't apply to your change.
-->
*Please tick all that apply:*

- [ ] I have tested this change locally
- [ ] I have tested this change locally in all supported browsers
- [ ] This change will be visible to users
- [ ] I have added automated tests that cover this change
- [ ] I have ensured the change is gated by config
- [ ] This change was covered by a ship review
- [ ] This change was covered by a tech design
- [ ] Any dependent config has been merged

---

Co-authored-by: Jonathan Kingston <jonathanKingston@users.noreply.github.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and CI allowlist only; no runtime or user-visible behavior changes.
> 
> **Overview**
> Brings **`duck-player-native-no-cookie.js`** under the injected **strict TypeScript** gate used by `check-strict-core.js`.
> 
> The only source change in that file is a JSDoc **`@param {number} timestamp`** on the `pollTimestamp` callback handler so strict checking can type the value passed to `notifyCurrentTimestamp`. **`scripts/check-strict-core.js`** adds this path to **`CORE_FILES`**, so CI will fail if new strict-mode errors appear there.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fb75402ce5bb287d7769cbaa37df838e07e1ae19. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->