### PR TITLE
strict-type: youtube-errors.js

### DIFF
--- a/injected/src/features/duckplayer-native/youtube-errors.js
+++ b/injected/src/features/duckplayer-native/youtube-errors.js
@@ -6,7 +6,7 @@
 
 export const YOUTUBE_ERROR_EVENT = 'ddg-duckplayer-youtube-error';
 
-/** @type {Record<string,YouTubeError>} */
+/** @type {{ readonly ageRestricted: YouTubeError; readonly signInRequired: YouTubeError; readonly noEmbed: YouTubeError; readonly unknown: YouTubeError }} */
 export const YOUTUBE_ERRORS = {
     ageRestricted: 'age-restricted',
     signInRequired: 'sign-in-required',
@@ -42,7 +42,7 @@ export function checkForError(errorSelector, node) {
  * @returns {YouTubeError}
  */
 export function getErrorType(windowObject, signInRequiredSelector, logger) {
-    const currentWindow = /** @type {Window & typeof globalThis & { ytcfg: object }} */ (windowObject);
+    const currentWindow = /** @type {Window & typeof globalThis & { ytcfg?: { get: (key: string) => unknown } }} */ (windowObject);
     const currentDocument = currentWindow.document;
 
     if (!currentWindow || !currentDocument) {
@@ -59,10 +59,17 @@ export function getErrorType(windowObject, signInRequiredSelector, logger) {
     }
 
     try {
-        const playerResponseJSON = currentWindow.ytcfg?.get('PLAYER_VARS')?.embedded_player_response;
+        const playVars = currentWindow.ytcfg?.get('PLAYER_VARS');
+        const raw =
+            typeof playVars === 'object' && playVars !== null && 'embedded_player_response' in playVars
+                ? playVars.embedded_player_response
+                : undefined;
+        const playerResponseJSON = typeof raw === 'string' ? raw : undefined;
         logger?.log('Player response', playerResponseJSON);
 
-        playerResponse = JSON.parse(playerResponseJSON);
+        if (playerResponseJSON) {
+            playerResponse = JSON.parse(playerResponseJSON);
+        }
     } catch (e) {
         logger?.log('Could not parse player response', e);
     }


### PR DESCRIPTION
**Asana Task/Github Issue:** <!-- Link to Asana Task/Github Issue -->

## Description

Tightens **JSDoc / strict typing** in Duck Player’s YouTube embed error helper without changing the public error IDs or detection flow.

`YOUTUBE_ERRORS` is annotated with explicit readonly keys mapped to `YouTubeError`, and `getErrorType` now types `ytcfg` as an optional `get(key) => unknown` instead of a loose object. **Player response parsing** is guarded: `PLAYER_VARS` and `embedded_player_response` are validated as an object property and a string before `JSON.parse`, so missing or malformed YouTube config is less likely to throw and more often falls through to **unknown** (or existing DOM/sign-in checks) as before.

## Testing Steps

- <!-- Include simple steps on how to check this change is working. Write "N/A" if not applicable. -->

## Checklist

<!--
  These questions are a friendly reminder to shipping code, if you're uncertain ask the AoR owners.
  It's also totally appropriate to not check some of these boxes, if they don't apply to your change.
-->
*Please tick all that apply:*

- [ ] I have tested this change locally
- [ ] I have tested this change locally in all supported browsers
- [ ] This change will be visible to users
- [ ] I have added automated tests that cover this change
- [ ] I have ensured the change is gated by config
- [ ] This change was covered by a ship review
- [ ] This change was covered by a tech design
- [ ] Any dependent config has been merged

---

Co-authored-by: Jonathan Kingston <jonathanKingston@users.noreply.github.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Type-only and defensive parsing changes in embed error detection; behavior should match prior logic when valid YouTube data is present.
> 
> **Overview**
> Tightens **JSDoc / strict typing** in Duck Player’s YouTube embed error helper without changing the public error IDs or detection flow.
> 
> `YOUTUBE_ERRORS` is annotated with explicit readonly keys mapped to `YouTubeError`, and `getErrorType` now types `ytcfg` as an optional `get(key) => unknown` instead of a loose object. **Player response parsing** is guarded: `PLAYER_VARS` and `embedded_player_response` are validated as an object property and a string before `JSON.parse`, so missing or malformed YouTube config is less likely to throw and more often falls through to **unknown** (or existing DOM/sign-in checks) as before.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cbab83b84dc613d998a1eaebdf0c1f29b28af08c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->