### PR TITLE
strict-type: overlay-messages.js

### DIFF
--- a/injected/src/features/duckplayer/overlay-messages.js
+++ b/injected/src/features/duckplayer/overlay-messages.js
@@ -86,7 +86,9 @@ export class DuckPlayerOverlayMessages {
      * @param {(userValues: import("../duck-player.js").UserValues) => void} cb
      */
     onUserValuesChanged(cb) {
-        return this.messaging.subscribe('onUserValuesChanged', cb);
+        return this.messaging.subscribe('onUserValuesChanged', (value) => {
+            cb(/** @type {import("../duck-player.js").UserValues} */ (value));
+        });
     }
 
     /**
@@ -94,13 +96,19 @@ export class DuckPlayerOverlayMessages {
      * @param {(userValues: import("../duck-player.js").UISettings) => void} cb
      */
     onUIValuesChanged(cb) {
-        return this.messaging.subscribe('onUIValuesChanged', cb);
+        return this.messaging.subscribe('onUIValuesChanged', (value) => {
+            cb(/** @type {import("../duck-player.js").UISettings} */ (value));
+        });
     }
 
     /**
      * This allows our SERP to interact with Duck Player settings.
      */
     serpProxy() {
+        /**
+         * @param {string} kind
+         * @param {unknown} data
+         */
         function respond(kind, data) {
             window.dispatchEvent(
                 new CustomEvent(constants.MSG_NAME_PROXY_RESPONSE, {

--- a/injected/src/features/duckplayer/thumbnails.js
+++ b/injected/src/features/duckplayer/thumbnails.js
@@ -88,7 +88,7 @@ export class Thumbnails {
 
             // create the icon & append it to the page
             const icon = new IconOverlay();
-            icon.appendHoverOverlay((href) => {
+            icon.appendHoverOverlay((/** @type {string} */ href) => {
                 if (this.environment.opensVideoOverlayLinksViaMessage) {
                     this.messages.sendPixel(new Pixel({ name: 'play.use.thumbnail' }));
                 }
@@ -102,9 +102,10 @@ export class Thumbnails {
 
             // detect all click, if it's anywhere on the page
             // but in the icon overlay itself, then just hide the overlay
-            const clickHandler = (e) => {
-                const overlay = icon.getHoverOverlay();
-                if (overlay?.contains(e.target)) {
+            const clickHandler = (/** @type {MouseEvent} */ e) => {
+                const overlay = /** @type {HTMLElement | null} */ (icon.getHoverOverlay());
+                const target = e.target;
+                if (overlay && target instanceof Node && overlay.contains(target)) {
                     // do nothing here, the click will have been handled by the overlay
                 } else if (overlay) {
                     clicked = true;
@@ -119,21 +120,21 @@ export class Thumbnails {
             parentNode.addEventListener('click', clickHandler, true);
 
             const removeOverlay = () => {
-                const overlay = icon.getHoverOverlay();
+                const overlay = /** @type {HTMLElement | null} */ (icon.getHoverOverlay());
                 if (overlay) {
                     icon.hideOverlay(overlay);
                     icon.hoverOverlayVisible = false;
                 }
             };
 
-            const appendOverlay = (element) => {
+            const appendOverlay = (/** @type {HTMLElement} */ element) => {
                 if (element && element.isConnected) {
                     icon.moveHoverOverlayToVideoElement(element);
                 }
             };
 
             // detect hovers and decide to show hover icon, or not
-            const mouseOverHandler = (e) => {
+            const mouseOverHandler = (/** @type {MouseEvent} */ e) => {
                 if (clicked) return;
                 const hoverElement = findElementFromEvent(selectors.thumbLink, selectors.hoverExcluded, e);
                 const validLink = isValidLink(hoverElement, selectors.excludedRegions);
@@ -154,13 +155,14 @@ export class Thumbnails {
                 }
 
                 // if the hover target is the match, or contains the match, all good
-                if (e.target === hoverElement || hoverElement?.contains(e.target)) {
+                const target = e.target;
+                if (target === hoverElement || (target instanceof Node && hoverElement?.contains(target))) {
                     return appendOverlay(hoverElement);
                 }
 
                 // finally, check the 'allowedEventTargets' to see if the hover occurred in an element
                 // that we know to be a thumbnail overlay, like a preview
-                const matched = selectors.allowedEventTargets.find((css) => e.target.matches(css));
+                const matched = target instanceof Element && selectors.allowedEventTargets.find((css) => target.matches(css));
                 if (matched) {
                     appendOverlay(hoverElement);
                 }
@@ -200,11 +202,11 @@ export class ClickInterception {
             const { selectors } = this.settings;
             const parentNode = document.documentElement || document.body;
 
-            const clickHandler = (e) => {
+            const clickHandler = (/** @type {MouseEvent} */ e) => {
                 const elementInStack = findElementFromEvent(selectors.thumbLink, selectors.clickExcluded, e);
                 const validLink = isValidLink(elementInStack, selectors.excludedRegions);
 
-                const block = (href) => {
+                const block = (/** @type {string} */ href) => {
                     e.preventDefault();
                     e.stopImmediatePropagation();
                     this.messages.openDuckPlayer({ href });
@@ -216,13 +218,14 @@ export class ClickInterception {
                 }
 
                 // if the hover target is the match, or contains the match, all good
-                if (e.target === elementInStack || elementInStack?.contains(e.target)) {
+                const target = e.target;
+                if (target === elementInStack || (target instanceof Node && elementInStack?.contains(target))) {
                     return block(validLink);
                 }
 
                 // finally, check the 'allowedEventTargets' to see if the hover occurred in an element
                 // that we know to be a thumbnail overlay, like a preview
-                const matched = selectors.allowedEventTargets.find((css) => e.target.matches(css));
+                const matched = target instanceof Element && selectors.allowedEventTargets.find((css) => target.matches(css));
                 if (matched) {
                     block(validLink);
                 }
@@ -301,11 +304,14 @@ function isValidLink(element, excludedRegions) {
      */
     if (!('href' in element)) return null;
 
+    const href = element.href;
+    if (typeof href !== 'string') return null;
+
     /**
      * If we get here, we're trying to convert the `element.href`
      * into a valid Duck Player URL
      */
-    return VideoParams.fromHref(element.href)?.toPrivatePlayerUrl();
+    return VideoParams.fromHref(href)?.toPrivatePlayerUrl();
 }
 
 export { SideEffects, VideoParams, Environment };


### PR DESCRIPTION
**Asana Task/Github Issue:** <!-- Link to Asana Task/Github Issue -->

## Description

Adds **strict typing** (JSDoc and small runtime guards) in Duck Player **overlay messaging** and **thumbnail** code so TypeScript/checkers treat messaging payloads and DOM events safely.

In `overlay-messages.js`, subscription callbacks now cast incoming `value` to `UserValues` / `UISettings` before invoking listeners, and `serpProxy`’s `respond` helper documents `kind` and `data`.

In `thumbnails.js`, hover/click handlers annotate `MouseEvent` targets and `href` strings, use `instanceof Node` / `Element` before `contains` / `matches`, and `isValidLink` narrows `element.href` to a string before building Duck Player URLs.

## Testing Steps

- <!-- Include simple steps on how to check this change is working. Write "N/A" if not applicable. -->

## Checklist

<!--
  These questions are a friendly reminder to shipping code, if you're uncertain ask the AoR owners.
  It's also totally appropriate to not check some of these boxes, if they don't apply to your change.
-->
*Please tick all that apply:*

- [ ] I have tested this change locally
- [ ] I have tested this change locally in all supported browsers
- [ ] This change will be visible to users
- [ ] I have added automated tests that cover this change
- [ ] I have ensured the change is gated by config
- [ ] This change was covered by a ship review
- [ ] This change was covered by a tech design
- [ ] Any dependent config has been merged

---

Co-authored-by: Jonathan Kingston <jonathanKingston@users.noreply.github.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Annotation and defensive instanceof/typeof checks only; Duck Player UX logic is unchanged aside from skipping invalid non-string hrefs.
> 
> **Overview**
> Adds **strict typing** (JSDoc and small runtime guards) in Duck Player **overlay messaging** and **thumbnail** code so TypeScript/checkers treat messaging payloads and DOM events safely.
> 
> In `overlay-messages.js`, subscription callbacks now cast incoming `value` to `UserValues` / `UISettings` before invoking listeners, and `serpProxy`’s `respond` helper documents `kind` and `data`.
> 
> In `thumbnails.js`, hover/click handlers annotate `MouseEvent` targets and `href` strings, use `instanceof Node` / `Element` before `contains` / `matches`, and `isValidLink` narrows `element.href` to a string before building Duck Player URLs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 27c72765b29eb7e617c1c21fb9f984961398acf9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->