### PR TITLE
strict-type: util.js

### DIFF
--- a/injected/src/features/duckplayer/thumbnails.js
+++ b/injected/src/features/duckplayer/thumbnails.js
@@ -299,7 +299,7 @@ function isValidLink(element, excludedRegions) {
      * We shouldn't be able to get here, but this keeps Typescript happy
      * and is a good check regardless
      */
-    if (!('href' in element)) return null;
+    if (!('href' in element) || typeof element.href !== 'string') return null;
 
     /**
      * If we get here, we're trying to convert the `element.href`

--- a/injected/src/features/duckplayer/util.js
+++ b/injected/src/features/duckplayer/util.js
@@ -204,7 +204,7 @@ export class VideoParams {
     /**
      * Convert a relative pathname into VideoParams
      *
-     * @param pathname
+     * @param {string} pathname
      * @returns {VideoParams|null}
      */
     static fromPathname(pathname) {
@@ -221,7 +221,7 @@ export class VideoParams {
      * Convert a href into valid video params. Those can then be converted into a private player
      * link when needed
      *
-     * @param href
+     * @param {string} href
      * @returns {VideoParams|null}
      */
     static fromHref(href) {
@@ -265,6 +265,7 @@ export class VideoParams {
  */
 export class DomState {
     loaded = false;
+    /** @type {Array<() => void>} */
     loadedCallbacks = [];
     constructor() {
         window.addEventListener('DOMContentLoaded', () => {
@@ -273,6 +274,9 @@ export class DomState {
         });
     }
 
+    /**
+     * @param {() => void} loadedCallback
+     */
     onLoaded(loadedCallback) {
         if (this.loaded) return loadedCallback();
         this.loadedCallbacks.push(loadedCallback);
@@ -298,22 +302,30 @@ export class Logger {
         this.id = id;
     }
 
+    /** @param {unknown[]} args */
     error(...args) {
         this.output(console.error, args);
     }
 
+    /** @param {unknown[]} args */
     info(...args) {
         this.output(console.info, args);
     }
 
+    /** @param {unknown[]} args */
     log(...args) {
         this.output(console.log, args);
     }
 
+    /** @param {unknown[]} args */
     warn(...args) {
         this.output(console.warn, args);
     }
 
+    /**
+     * @param {(...args: unknown[]) => void} handler
+     * @param {unknown[]} args
+     */
     output(handler, args) {
         if (this.shouldLog()) {
             handler(`${this.id.padEnd(20, ' ')} |`, ...args);


### PR DESCRIPTION
**Asana Task/Github Issue:** <!-- Link to Asana Task/Github Issue -->

## Description

Tightens Duck Player **strict typing** in `util.js` and one related guard in `thumbnails.js`.

**`util.js`:** Documents `VideoParams.fromPathname` / `fromHref` parameters as `{string}`, types `DomState.loadedCallbacks` and `onLoaded`, and adds JSDoc for `Logger` log methods and `output`.

**`thumbnails.js`:** `isValidLink` now rejects elements whose `href` is not a string (not only missing `href`), so `VideoParams.fromHref` is only called with a string.

## Testing Steps

- <!-- Include simple steps on how to check this change is working. Write "N/A" if not applicable. -->

## Checklist

<!--
  These questions are a friendly reminder to shipping code, if you're uncertain ask the AoR owners.
  It's also totally appropriate to not check some of these boxes, if they don't apply to your change.
-->
*Please tick all that apply:*

- [ ] I have tested this change locally
- [ ] I have tested this change locally in all supported browsers
- [ ] This change will be visible to users
- [ ] I have added automated tests that cover this change
- [ ] I have ensured the change is gated by config
- [ ] This change was covered by a ship review
- [ ] This change was covered by a tech design
- [ ] Any dependent config has been merged

---

Co-authored-by: Jonathan Kingston <jonathanKingston@users.noreply.github.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and a narrow runtime type check on thumbnail links; no change to Duck Player URL parsing logic beyond skipping non-string hrefs.
> 
> **Overview**
> Tightens Duck Player **strict typing** in `util.js` and one related guard in `thumbnails.js`.
> 
> **`util.js`:** Documents `VideoParams.fromPathname` / `fromHref` parameters as `{string}`, types `DomState.loadedCallbacks` and `onLoaded`, and adds JSDoc for `Logger` log methods and `output`.
> 
> **`thumbnails.js`:** `isValidLink` now rejects elements whose `href` is not a string (not only missing `href`), so `VideoParams.fromHref` is only called with a string.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b3642e131d4ddf35d265da860666c0d6d631a3b1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->