### PR TITLE
strict-type: schema.js

### DIFF
--- a/injected/src/features/message-bridge/schema.js
+++ b/injected/src/features/message-bridge/schema.js
@@ -6,6 +6,20 @@ import { isObject, isString } from '../../type-utils.js';
  */
 
 /**
+ * Validates an optional object field on a validated parent object.
+ * Returns the field value if it's a valid object, `undefined` if absent or null, or `null` if invalid (present but not an object).
+ * @param {object} obj
+ * @param {string} key
+ * @returns {object | undefined | null}
+ */
+function optionalObject(obj, key) {
+    if (!(key in obj)) return undefined;
+    const val = /** @type {Record<string, unknown>} */ (obj)[key];
+    if (val == null) return undefined;
+    return isObject(val) ? val : null;
+}
+
+/**
  * Sending this event
  */
 export class InstallProxy {
@@ -84,8 +98,8 @@ export class ProxyRequest {
         if (!('featureName' in params) || !isString(params.featureName)) return null;
         if (!('method' in params) || !isString(params.method)) return null;
         if (!('id' in params) || !isString(params.id)) return null;
-        if ('params' in params && params.params != null && !isObject(params.params)) return null;
-        const requestParams = 'params' in params && params.params != null && isObject(params.params) ? params.params : undefined;
+        const requestParams = optionalObject(params, 'params');
+        if (requestParams === null) return null;
         return new ProxyRequest({
             featureName: params.featureName,
             method: params.method,
@@ -123,10 +137,10 @@ export class ProxyResponse {
         if (!('featureName' in params) || !isString(params.featureName)) return null;
         if (!('method' in params) || !isString(params.method)) return null;
         if (!('id' in params) || !isString(params.id)) return null;
-        if ('result' in params && params.result != null && !isObject(params.result)) return null;
-        if ('error' in params && params.error != null && !isObject(params.error)) return null;
-        const responseResult = 'result' in params && params.result != null && isObject(params.result) ? params.result : undefined;
-        const responseError = 'error' in params && params.error != null && isObject(params.error) ? params.error : undefined;
+        const responseResult = optionalObject(params, 'result');
+        if (responseResult === null) return null;
+        const responseError = optionalObject(params, 'error');
+        if (responseError === null) return null;
         return new ProxyResponse({
             featureName: params.featureName,
             method: params.method,
@@ -163,8 +177,8 @@ export class ProxyNotification {
         if (!isObject(params)) return null;
         if (!('featureName' in params) || !isString(params.featureName)) return null;
         if (!('method' in params) || !isString(params.method)) return null;
-        if ('params' in params && params.params != null && !isObject(params.params)) return null;
-        const notificationParams = 'params' in params && params.params != null && isObject(params.params) ? params.params : undefined;
+        const notificationParams = optionalObject(params, 'params');
+        if (notificationParams === null) return null;
         return new ProxyNotification({
             featureName: params.featureName,
             method: params.method,
@@ -231,8 +245,8 @@ export class SubscriptionResponse {
         if (!('featureName' in params) || !isString(params.featureName)) return null;
         if (!('subscriptionName' in params) || !isString(params.subscriptionName)) return null;
         if (!('id' in params) || !isString(params.id)) return null;
-        if ('params' in params && params.params != null && !isObject(params.params)) return null;
-        const responseParams = 'params' in params && params.params != null && isObject(params.params) ? params.params : undefined;
+        const responseParams = optionalObject(params, 'params');
+        if (responseParams === null) return null;
         return new SubscriptionResponse({
             featureName: params.featureName,
             subscriptionName: params.subscriptionName,

--- a/injected/src/features/message-bridge/schema.js
+++ b/injected/src/features/message-bridge/schema.js
@@ -29,8 +29,8 @@ export class InstallProxy {
      */
     static create(params) {
         if (!isObject(params)) return null;
-        if (!isString(params.featureName)) return null;
-        if (!isString(params.id)) return null;
+        if (!('featureName' in params) || !isString(params.featureName)) return null;
+        if (!('id' in params) || !isString(params.id)) return null;
         return new InstallProxy({ featureName: params.featureName, id: params.id });
     }
 }
@@ -53,7 +53,7 @@ export class DidInstall {
      */
     static create(params) {
         if (!isObject(params)) return null;
-        if (!isString(params.id)) return null;
+        if (!('id' in params) || !isString(params.id)) return null;
         return new DidInstall({ id: params.id });
     }
 }
@@ -68,7 +68,7 @@ export class ProxyRequest {
      * @param {string} params.featureName
      * @param {string} params.method
      * @param {string} params.id
-     * @param {Record<string, any>} [params.params]
+     * @param {object} [params.params]
      */
     constructor(params) {
         this.featureName = params.featureName;
@@ -81,14 +81,15 @@ export class ProxyRequest {
      */
     static create(params) {
         if (!isObject(params)) return null;
-        if (!isString(params.featureName)) return null;
-        if (!isString(params.method)) return null;
-        if (!isString(params.id)) return null;
-        if (params.params && !isObject(params.params)) return null;
+        if (!('featureName' in params) || !isString(params.featureName)) return null;
+        if (!('method' in params) || !isString(params.method)) return null;
+        if (!('id' in params) || !isString(params.id)) return null;
+        if ('params' in params && params.params != null && !isObject(params.params)) return null;
+        const requestParams = 'params' in params && params.params != null && isObject(params.params) ? params.params : undefined;
         return new ProxyRequest({
             featureName: params.featureName,
             method: params.method,
-            params: params.params,
+            params: requestParams,
             id: params.id,
         });
     }
@@ -104,8 +105,8 @@ export class ProxyResponse {
      * @param {string} params.featureName
      * @param {string} params.method
      * @param {string} params.id
-     * @param {Record<string, any>} [params.result]
-     * @param {import("@duckduckgo/messaging").MessageError} [params.error]
+     * @param {object} [params.result]
+     * @param {object} [params.error]
      */
     constructor(params) {
         this.featureName = params.featureName;
@@ -119,16 +120,18 @@ export class ProxyResponse {
      */
     static create(params) {
         if (!isObject(params)) return null;
-        if (!isString(params.featureName)) return null;
-        if (!isString(params.method)) return null;
-        if (!isString(params.id)) return null;
-        if (params.result && !isObject(params.result)) return null;
-        if (params.error && !isObject(params.error)) return null;
+        if (!('featureName' in params) || !isString(params.featureName)) return null;
+        if (!('method' in params) || !isString(params.method)) return null;
+        if (!('id' in params) || !isString(params.id)) return null;
+        if ('result' in params && params.result != null && !isObject(params.result)) return null;
+        if ('error' in params && params.error != null && !isObject(params.error)) return null;
+        const responseResult = 'result' in params && params.result != null && isObject(params.result) ? params.result : undefined;
+        const responseError = 'error' in params && params.error != null && isObject(params.error) ? params.error : undefined;
         return new ProxyResponse({
             featureName: params.featureName,
             method: params.method,
-            result: params.result,
-            error: params.error,
+            result: responseResult,
+            error: responseError,
             id: params.id,
         });
     }
@@ -145,7 +148,7 @@ export class ProxyNotification {
      * @param {object} params
      * @param {string} params.featureName
      * @param {string} params.method
-     * @param {Record<string, any>} [params.params]
+     * @param {object} [params.params]
      */
     constructor(params) {
         this.featureName = params.featureName;
@@ -158,13 +161,14 @@ export class ProxyNotification {
      */
     static create(params) {
         if (!isObject(params)) return null;
-        if (!isString(params.featureName)) return null;
-        if (!isString(params.method)) return null;
-        if (params.params && !isObject(params.params)) return null;
+        if (!('featureName' in params) || !isString(params.featureName)) return null;
+        if (!('method' in params) || !isString(params.method)) return null;
+        if ('params' in params && params.params != null && !isObject(params.params)) return null;
+        const notificationParams = 'params' in params && params.params != null && isObject(params.params) ? params.params : undefined;
         return new ProxyNotification({
             featureName: params.featureName,
             method: params.method,
-            params: params.params,
+            params: notificationParams,
         });
     }
 }
@@ -190,9 +194,9 @@ export class SubscriptionRequest {
      */
     static create(params) {
         if (!isObject(params)) return null;
-        if (!isString(params.featureName)) return null;
-        if (!isString(params.subscriptionName)) return null;
-        if (!isString(params.id)) return null;
+        if (!('featureName' in params) || !isString(params.featureName)) return null;
+        if (!('subscriptionName' in params) || !isString(params.subscriptionName)) return null;
+        if (!('id' in params) || !isString(params.id)) return null;
         return new SubscriptionRequest({
             featureName: params.featureName,
             subscriptionName: params.subscriptionName,
@@ -211,7 +215,7 @@ export class SubscriptionResponse {
      * @param {string} params.featureName
      * @param {string} params.subscriptionName
      * @param {string} params.id
-     * @param {Record<string, any>} [params.params]
+     * @param {object} [params.params]
      */
     constructor(params) {
         this.featureName = params.featureName;
@@ -224,14 +228,15 @@ export class SubscriptionResponse {
      */
     static create(params) {
         if (!isObject(params)) return null;
-        if (!isString(params.featureName)) return null;
-        if (!isString(params.subscriptionName)) return null;
-        if (!isString(params.id)) return null;
-        if (params.params && !isObject(params.params)) return null;
+        if (!('featureName' in params) || !isString(params.featureName)) return null;
+        if (!('subscriptionName' in params) || !isString(params.subscriptionName)) return null;
+        if (!('id' in params) || !isString(params.id)) return null;
+        if ('params' in params && params.params != null && !isObject(params.params)) return null;
+        const responseParams = 'params' in params && params.params != null && isObject(params.params) ? params.params : undefined;
         return new SubscriptionResponse({
             featureName: params.featureName,
             subscriptionName: params.subscriptionName,
-            params: params.params,
+            params: responseParams,
             id: params.id,
         });
     }
@@ -254,7 +259,7 @@ export class SubscriptionUnsubscribe {
      */
     static create(params) {
         if (!isObject(params)) return null;
-        if (!isString(params.id)) return null;
+        if (!('id' in params) || !isString(params.id)) return null;
         return new SubscriptionUnsubscribe({
             id: params.id,
         });

--- a/injected/unit-test/message-bridge-schema.js
+++ b/injected/unit-test/message-bridge-schema.js
@@ -1,0 +1,205 @@
+import {
+    InstallProxy,
+    DidInstall,
+    ProxyRequest,
+    ProxyResponse,
+    ProxyNotification,
+    SubscriptionRequest,
+    SubscriptionResponse,
+    SubscriptionUnsubscribe,
+} from '../src/features/message-bridge/schema.js';
+
+describe('InstallProxy.create', () => {
+    it('accepts valid input', () => {
+        const result = InstallProxy.create({ featureName: 'test', id: '123' });
+        expect(result).not.toBeNull();
+        expect(result?.featureName).toBe('test');
+        expect(result?.id).toBe('123');
+    });
+    it('rejects non-object', () => {
+        expect(InstallProxy.create(null)).toBeNull();
+        expect(InstallProxy.create(undefined)).toBeNull();
+        expect(InstallProxy.create('string')).toBeNull();
+        expect(InstallProxy.create(42)).toBeNull();
+    });
+    it('rejects missing required fields', () => {
+        expect(InstallProxy.create({})).toBeNull();
+        expect(InstallProxy.create({ featureName: 'test' })).toBeNull();
+        expect(InstallProxy.create({ id: '123' })).toBeNull();
+    });
+    it('rejects non-string required fields', () => {
+        expect(InstallProxy.create({ featureName: 123, id: '123' })).toBeNull();
+        expect(InstallProxy.create({ featureName: 'test', id: 123 })).toBeNull();
+    });
+});
+
+describe('DidInstall.create', () => {
+    it('accepts valid input', () => {
+        const result = DidInstall.create({ id: '123' });
+        expect(result).not.toBeNull();
+        expect(result?.id).toBe('123');
+    });
+    it('rejects missing id', () => {
+        expect(DidInstall.create({})).toBeNull();
+    });
+    it('rejects non-string id', () => {
+        expect(DidInstall.create({ id: 123 })).toBeNull();
+    });
+});
+
+describe('ProxyRequest.create', () => {
+    const valid = { featureName: 'test', method: 'doThing', id: '123' };
+
+    it('accepts valid input without params', () => {
+        const result = ProxyRequest.create(valid);
+        expect(result).not.toBeNull();
+        expect(result?.params).toBeUndefined();
+    });
+    it('accepts valid input with object params', () => {
+        const result = ProxyRequest.create({ ...valid, params: { key: 'val' } });
+        expect(result).not.toBeNull();
+        expect(result?.params).toEqual({ key: 'val' });
+    });
+    it('normalizes null params to undefined', () => {
+        const result = ProxyRequest.create({ ...valid, params: null });
+        expect(result).not.toBeNull();
+        expect(result?.params).toBeUndefined();
+    });
+    it('normalizes undefined params to undefined', () => {
+        const result = ProxyRequest.create({ ...valid, params: undefined });
+        expect(result).not.toBeNull();
+        expect(result?.params).toBeUndefined();
+    });
+    it('rejects primitive params', () => {
+        expect(ProxyRequest.create({ ...valid, params: 'string' })).toBeNull();
+        expect(ProxyRequest.create({ ...valid, params: 42 })).toBeNull();
+        expect(ProxyRequest.create({ ...valid, params: true })).toBeNull();
+    });
+    it('rejects missing required fields', () => {
+        expect(ProxyRequest.create({ method: 'doThing', id: '123' })).toBeNull();
+        expect(ProxyRequest.create({ featureName: 'test', id: '123' })).toBeNull();
+        expect(ProxyRequest.create({ featureName: 'test', method: 'doThing' })).toBeNull();
+    });
+});
+
+describe('ProxyResponse.create', () => {
+    const valid = { featureName: 'test', method: 'doThing', id: '123' };
+
+    it('accepts valid input without result or error', () => {
+        const result = ProxyResponse.create(valid);
+        expect(result).not.toBeNull();
+        expect(result?.result).toBeUndefined();
+        expect(result?.error).toBeUndefined();
+    });
+    it('accepts valid input with result object', () => {
+        const result = ProxyResponse.create({ ...valid, result: { data: 1 } });
+        expect(result).not.toBeNull();
+        expect(result?.result).toEqual({ data: 1 });
+    });
+    it('accepts valid input with error object', () => {
+        const result = ProxyResponse.create({ ...valid, error: { message: 'fail' } });
+        expect(result).not.toBeNull();
+        expect(result?.error).toEqual({ message: 'fail' });
+    });
+    it('normalizes null result to undefined', () => {
+        const result = ProxyResponse.create({ ...valid, result: null });
+        expect(result).not.toBeNull();
+        expect(result?.result).toBeUndefined();
+    });
+    it('normalizes null error to undefined', () => {
+        const result = ProxyResponse.create({ ...valid, error: null });
+        expect(result).not.toBeNull();
+        expect(result?.error).toBeUndefined();
+    });
+    it('rejects primitive result', () => {
+        expect(ProxyResponse.create({ ...valid, result: 'string' })).toBeNull();
+        expect(ProxyResponse.create({ ...valid, result: 42 })).toBeNull();
+    });
+    it('rejects primitive error', () => {
+        expect(ProxyResponse.create({ ...valid, error: 'string' })).toBeNull();
+        expect(ProxyResponse.create({ ...valid, error: 42 })).toBeNull();
+    });
+    it('rejects missing required fields', () => {
+        expect(ProxyResponse.create({ method: 'doThing', id: '123' })).toBeNull();
+        expect(ProxyResponse.create({ featureName: 'test', id: '123' })).toBeNull();
+        expect(ProxyResponse.create({ featureName: 'test', method: 'doThing' })).toBeNull();
+    });
+});
+
+describe('ProxyNotification.create', () => {
+    const valid = { featureName: 'test', method: 'doThing' };
+
+    it('accepts valid input without params', () => {
+        const result = ProxyNotification.create(valid);
+        expect(result).not.toBeNull();
+        expect(result?.params).toBeUndefined();
+    });
+    it('accepts valid input with object params', () => {
+        const result = ProxyNotification.create({ ...valid, params: { key: 'val' } });
+        expect(result).not.toBeNull();
+        expect(result?.params).toEqual({ key: 'val' });
+    });
+    it('normalizes null params to undefined', () => {
+        const result = ProxyNotification.create({ ...valid, params: null });
+        expect(result).not.toBeNull();
+        expect(result?.params).toBeUndefined();
+    });
+    it('rejects primitive params', () => {
+        expect(ProxyNotification.create({ ...valid, params: 'string' })).toBeNull();
+        expect(ProxyNotification.create({ ...valid, params: 42 })).toBeNull();
+    });
+});
+
+describe('SubscriptionRequest.create', () => {
+    const valid = { featureName: 'test', subscriptionName: 'onUpdate', id: '123' };
+
+    it('accepts valid input', () => {
+        const result = SubscriptionRequest.create(valid);
+        expect(result).not.toBeNull();
+        expect(result?.featureName).toBe('test');
+        expect(result?.subscriptionName).toBe('onUpdate');
+        expect(result?.id).toBe('123');
+    });
+    it('rejects missing required fields', () => {
+        expect(SubscriptionRequest.create({ subscriptionName: 'onUpdate', id: '123' })).toBeNull();
+        expect(SubscriptionRequest.create({ featureName: 'test', id: '123' })).toBeNull();
+        expect(SubscriptionRequest.create({ featureName: 'test', subscriptionName: 'onUpdate' })).toBeNull();
+    });
+});
+
+describe('SubscriptionResponse.create', () => {
+    const valid = { featureName: 'test', subscriptionName: 'onUpdate', id: '123' };
+
+    it('accepts valid input without params', () => {
+        const result = SubscriptionResponse.create(valid);
+        expect(result).not.toBeNull();
+        expect(result?.params).toBeUndefined();
+    });
+    it('accepts valid input with object params', () => {
+        const result = SubscriptionResponse.create({ ...valid, params: { key: 'val' } });
+        expect(result).not.toBeNull();
+        expect(result?.params).toEqual({ key: 'val' });
+    });
+    it('normalizes null params to undefined', () => {
+        const result = SubscriptionResponse.create({ ...valid, params: null });
+        expect(result).not.toBeNull();
+        expect(result?.params).toBeUndefined();
+    });
+    it('rejects primitive params', () => {
+        expect(SubscriptionResponse.create({ ...valid, params: 'string' })).toBeNull();
+    });
+});
+
+describe('SubscriptionUnsubscribe.create', () => {
+    it('accepts valid input', () => {
+        const result = SubscriptionUnsubscribe.create({ id: '123' });
+        expect(result).not.toBeNull();
+        expect(result?.id).toBe('123');
+    });
+    it('rejects missing id', () => {
+        expect(SubscriptionUnsubscribe.create({})).toBeNull();
+    });
+    it('rejects non-string id', () => {
+        expect(SubscriptionUnsubscribe.create({ id: 123 })).toBeNull();
+    });
+});

--- a/scripts/check-strict-core.js
+++ b/scripts/check-strict-core.js
@@ -89,6 +89,7 @@ const CORE_FILES = new Set([
     'injected/src/features/duckplayer/text.js',
     'injected/src/features/fingerprinting-hardware.js',
     'injected/src/features/google-rejected.js',
+    'injected/src/features/message-bridge/schema.js',
     'injected/src/features/page-observer.js',
     'injected/src/features/print.js',
     'injected/src/features/referrer.js',


### PR DESCRIPTION
**Asana Task/Github Issue:** <!-- Link to Asana Task/Github Issue -->

## Description

Hardens **message-bridge** payload parsing in `schema.js` for strict TypeScript and clearer runtime validation.

Adds **`optionalObject`** for optional nested fields (`params`, `result`, `error`): missing keys stay absent, **`null` is normalized to `undefined`**, and non-objects are rejected. Required string fields now use **`'key' in params`** before `isString`, so inherited or accidental properties are not accepted. JSDoc drops **`Record<string, any>`** / **`MessageError`** in favor of plain **`object`**.

Adds **`injected/unit-test/message-bridge-schema.js`** covering all `*.create` factories (valid input, missing fields, primitives, null normalization). Registers **`message-bridge/schema.js`** in **`scripts/check-strict-core.js`** so it must pass strict `tsc`.

## Testing Steps

- <!-- Include simple steps on how to check this change is working. Write "N/A" if not applicable. -->

## Checklist

<!--
  These questions are a friendly reminder to shipping code, if you're uncertain ask the AoR owners.
  It's also totally appropriate to not check some of these boxes, if they don't apply to your change.
-->
*Please tick all that apply:*

- [ ] I have tested this change locally
- [ ] I have tested this change locally in all supported browsers
- [ ] This change will be visible to users
- [ ] I have added automated tests that cover this change
- [ ] I have ensured the change is gated by config
- [ ] This change was covered by a ship review
- [ ] This change was covered by a tech design
- [ ] Any dependent config has been merged

---

Co-authored-by: Jonathan Kingston <jonathanKingston@users.noreply.github.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Stricter parsing at the page/native messaging boundary may drop payloads that previously passed (e.g. inherited properties); null optional fields are now accepted where they might have failed before.
> 
> **Overview**
> Tightens **message-bridge** inbound payload parsing in `schema.js` so `*.create` factories align with strict typing and stricter runtime rules.
> 
> Introduces **`optionalObject`** for optional nested fields (`params`, `result`, `error`): absent keys stay absent, **`null` becomes `undefined`**, and primitives are rejected. Required strings now require an **own property** via **`'key' in params`** before `isString`, avoiding values picked up from the prototype chain. JSDoc replaces **`Record<string, any>`** / **`MessageError`** with plain **`object`**.
> 
> Adds **`injected/unit-test/message-bridge-schema.js`** with coverage for every message type’s `create` path, and lists **`message-bridge/schema.js`** in **`scripts/check-strict-core.js`** so it must pass strict `tsc`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b139e096fe357c04f9c3cef8868a4338b3d20b1c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->