### PR TITLE
strict-type: parse.js

### DIFF
--- a/injected/src/features/web-detection/parse.js
+++ b/injected/src/features/web-detection/parse.js
@@ -1,5 +1,3 @@
-import { withDefaults } from '../../utils.js';
-
 /**
  * @typedef {import('../../utils.js').FeatureState} FeatureState
  */
@@ -44,25 +42,31 @@ import { withDefaults } from '../../utils.js';
  */
 
 /**
- * Base properties supported by all actions.
- *
- * @typedef {object} ActionBase
- * @property {FeatureState} state - whether the action is enabled
+ * @typedef {object} FireEventAction
+ * @property {FeatureState} state - whether this action is enabled
+ * @property {string} type
  */
 
 /**
  * Actions to take when a detector matches.
+ * breakageReportData is always present (defaults to enabled).
+ * fireEvent is opt-in by presence; when present, sub-fields are fully resolved.
  *
+ * @typedef {object} ActionState
+ * @property {FeatureState} state - whether the action is enabled
+ */
+
+/**
  * @typedef {object} DetectorActions
- * @property {ActionBase} breakageReportData - Whether to include in breakage report data
+ * @property {ActionState} breakageReportData - Whether to include in breakage report data
+ * @property {FireEventAction} [fireEvent] - fire a detection event to the client via webEvents
  */
 
 /**
  * Normalized detector configuration.
  *
- * The user-facing configuration has optional attributes that are required
- * under-the-hood. This type represents the normalized configuration once
- * default values have been applied.
+ * Every optional field from the raw config is resolved to a concrete value.
+ * Consumers never need fallback defaults.
  *
  * @typedef {object} DetectorConfig
  * @property {FeatureState} state - Whether the detector is enabled
@@ -72,46 +76,18 @@ import { withDefaults } from '../../utils.js';
  */
 
 /**
- * Default runConditions - applied only when config doesn't provide runConditions.
- *
- * NOTE: We make this an array so that specifying custom runConditions overrides rather than merges.
- *
- * By default, detectors will only trigger in the top frame.
+ * Default runConditions — by default, detectors only trigger in the top frame.
+ * Specifying custom runConditions in config replaces (not merges) these defaults.
  */
-const DEFAULT_RUN_CONDITIONS = /** @type {import('../../config-feature.js').ConditionBlock[]} */ ([
+const DEFAULT_RUN_CONDITIONS = /** @type {import('../../config-feature.js').ConditionBlockOrArray} */ ([
     {
         context: { top: true },
     },
 ]);
 
 /**
- * Default configuration values for detectors.
- *
- * This is merged deeply with the config such that any time the config provides
- * a scalar or nested value, the default value is overridden.
- */
-const DEFAULTS = {
-    state: /** @type {FeatureState} */ ('enabled'),
-    triggers: {
-        breakageReport: {
-            state: /** @type {FeatureState} */ ('enabled'),
-            runConditions: DEFAULT_RUN_CONDITIONS,
-        },
-        auto: {
-            state: /** @type {FeatureState} */ ('disabled'),
-            runConditions: DEFAULT_RUN_CONDITIONS,
-        },
-    },
-    actions: {
-        breakageReportData: {
-            state: /** @type {FeatureState} */ ('enabled'),
-        },
-    },
-};
-
-/**
  * Validate that a name matches the required format.
- * Names must start with a lowercase letter and contain only alphanumeric characters and underscores.
+ * Names must start with a letter and contain only alphanumeric characters and underscores.
  *
  * @param {string} name
  * @returns {boolean}
@@ -121,13 +97,58 @@ function isValidName(name) {
 }
 
 /**
- * Normalize a raw detector configuration by applying defaults.
+ * Normalize a raw detector configuration by resolving all optional fields to concrete values.
+ * After normalization, consumers never need fallback defaults.
+ *
+ * Default behavior (when fields are omitted from config):
+ * - Detector is enabled
+ * - breakageReport trigger is enabled, restricted to top frame
+ * - auto trigger is disabled (opt-in only), restricted to top frame, no intervals
+ * - breakageReportData action is enabled (results included in breakage reports)
+ * - other actions are enabled by default if present, but can be explicitly disabled. If omitted they are not enabled
  *
  * @param {import('@duckduckgo/privacy-configuration/schema/features/web-detection').DetectorConfig} config
  * @returns {DetectorConfig}
  */
 function normalizeDetector(config) {
-    return withDefaults(DEFAULTS, config);
+    const fireEvent = config.actions?.fireEvent;
+
+    const breakageRunConditions = /** @type {import('../../config-feature.js').ConditionBlockOrArray} */ (
+        config.triggers?.breakageReport?.runConditions ?? DEFAULT_RUN_CONDITIONS
+    );
+    const autoRunConditions = /** @type {import('../../config-feature.js').ConditionBlockOrArray} */ (
+        config.triggers?.auto?.runConditions ?? DEFAULT_RUN_CONDITIONS
+    );
+
+    return {
+        // Detectors are enabled by default
+        state: config.state ?? 'enabled',
+        match: config.match,
+        triggers: {
+            // breakageReport: enabled by default - detectors participate in breakage report flow
+            breakageReport: {
+                state: config.triggers?.breakageReport?.state ?? 'enabled',
+                runConditions: breakageRunConditions,
+            },
+            // auto: disabled by default - detectors must opt in to automatic execution
+            auto: {
+                state: config.triggers?.auto?.state ?? 'disabled',
+                runConditions: autoRunConditions,
+                when: config.triggers?.auto?.when ?? { intervalMs: [] },
+            },
+        },
+        actions: {
+            // breakageReportData: enabled by default - detection results included in breakage reports
+            breakageReportData: { state: config.actions?.breakageReportData?.state ?? 'enabled' },
+            // fireEvent: only present when configured - opt-in action that sends events to the client via webEvents
+            ...(fireEvent && {
+                fireEvent: {
+                    state: fireEvent.state ?? 'enabled',
+                    type: fireEvent.type,
+                },
+            }),
+        },
+    };
 }
 
 /**

--- a/injected/src/features/web-detection/parse.js
+++ b/injected/src/features/web-detection/parse.js
@@ -111,8 +111,6 @@ function isValidName(name) {
  * @returns {DetectorConfig}
  */
 function normalizeDetector(config) {
-    const fireEvent = config.actions?.fireEvent;
-
     const breakageRunConditions = /** @type {import('../../config-feature.js').ConditionBlockOrArray} */ (
         config.triggers?.breakageReport?.runConditions ?? DEFAULT_RUN_CONDITIONS
     );
@@ -120,34 +118,65 @@ function normalizeDetector(config) {
         config.triggers?.auto?.runConditions ?? DEFAULT_RUN_CONDITIONS
     );
 
+    /** @type {DetectorActions} */
+    const actions = {
+        breakageReportData: { state: defaultState(config.actions?.breakageReportData?.state, 'enabled') },
+    };
+
+    const rawActions = /** @type {Record<string, unknown> | undefined} */ (config.actions);
+    // eslint-disable-next-line dot-notation -- fireEvent not in upstream schema yet
+    const fireEvent = normalizeFireEvent(rawActions?.['fireEvent']);
+    if (fireEvent) {
+        actions.fireEvent = fireEvent;
+    }
+
     return {
-        // Detectors are enabled by default
-        state: config.state ?? 'enabled',
+        state: defaultState(config.state, 'enabled'),
         match: config.match,
         triggers: {
-            // breakageReport: enabled by default - detectors participate in breakage report flow
             breakageReport: {
-                state: config.triggers?.breakageReport?.state ?? 'enabled',
+                state: defaultState(config.triggers?.breakageReport?.state, 'enabled'),
                 runConditions: breakageRunConditions,
             },
-            // auto: disabled by default - detectors must opt in to automatic execution
             auto: {
-                state: config.triggers?.auto?.state ?? 'disabled',
+                state: defaultState(config.triggers?.auto?.state, 'disabled'),
                 runConditions: autoRunConditions,
                 when: config.triggers?.auto?.when ?? { intervalMs: [] },
             },
         },
-        actions: {
-            // breakageReportData: enabled by default - detection results included in breakage reports
-            breakageReportData: { state: config.actions?.breakageReportData?.state ?? 'enabled' },
-            // fireEvent: only present when configured - opt-in action that sends events to the client via webEvents
-            ...(fireEvent && {
-                fireEvent: {
-                    state: fireEvent.state ?? 'enabled',
-                    type: fireEvent.type,
-                },
-            }),
-        },
+        actions,
+    };
+}
+
+/**
+ * Default a state field only when it is `undefined`.
+ * Explicit `null` or other non-string values pass through unchanged so that
+ * `isStateEnabled` treats them as disabled (fail-closed).
+ *
+ * @param {import('../../utils.js').FeatureState | null | undefined} value
+ * @param {import('../../utils.js').FeatureState} fallback
+ * @returns {import('../../utils.js').FeatureState}
+ */
+function defaultState(value, fallback) {
+    // @ts-expect-error - null is intentionally handled for defensive config parsing
+    return value === undefined ? fallback : value;
+}
+
+/**
+ * Normalize an optional `fireEvent` action from config.
+ * Returns the normalized action only when the config provides a valid shape
+ * (object with a non-empty string `type`). Invalid shapes are dropped.
+ *
+ * @param {unknown} raw
+ * @returns {FireEventAction | null}
+ */
+function normalizeFireEvent(raw) {
+    if (!raw || typeof raw !== 'object') return null;
+    const obj = /** @type {Record<string, unknown>} */ (raw);
+    if (typeof obj.type !== 'string' || obj.type.length === 0) return null;
+    return {
+        state: defaultState(/** @type {import('../../utils.js').FeatureState | undefined} */ (obj.state), 'enabled'),
+        type: obj.type,
     };
 }
 

--- a/injected/unit-test/web-detection.js
+++ b/injected/unit-test/web-detection.js
@@ -188,6 +188,160 @@ describe('WebDetection', () => {
             expect(result.actions.breakageReportData.state).toBe('disabled');
         });
 
+        describe('null state handling (fail-closed)', () => {
+            it('should pass through null detector state (treated as disabled by isStateEnabled)', () => {
+                const result = oneDetectorConfigParsed({
+                    // @ts-expect-error - null is not a valid state but may arrive via malformed config
+                    state: null,
+                    match: { text: { pattern: 'test' } },
+                });
+                // @ts-expect-error - null passes through for fail-closed handling
+                expect(result.state).toBe(null);
+            });
+
+            it('should pass through null trigger state', () => {
+                const result = oneDetectorConfigParsed({
+                    match: { text: { pattern: 'test' } },
+                    triggers: {
+                        // @ts-expect-error - null is not a valid state
+                        breakageReport: { state: null },
+                    },
+                });
+                // @ts-expect-error - null passes through for fail-closed handling
+                expect(result.triggers.breakageReport.state).toBe(null);
+            });
+
+            it('should pass through null breakageReportData state', () => {
+                const result = oneDetectorConfigParsed({
+                    match: { text: { pattern: 'test' } },
+                    actions: {
+                        // @ts-expect-error - null is not a valid state
+                        breakageReportData: { state: null },
+                    },
+                });
+                // @ts-expect-error - null passes through for fail-closed handling
+                expect(result.actions.breakageReportData.state).toBe(null);
+            });
+
+            it('should pass through null auto trigger state', () => {
+                const result = oneDetectorConfigParsed({
+                    match: { text: { pattern: 'test' } },
+                    triggers: {
+                        auto: {
+                            // @ts-expect-error - null is not a valid state
+                            state: null,
+                            when: { intervalMs: [100] },
+                        },
+                    },
+                });
+                // @ts-expect-error - null passes through for fail-closed handling
+                expect(result.triggers.auto.state).toBe(null);
+            });
+        });
+
+        describe('fireEvent action validation', () => {
+            it('should include fireEvent when type is a valid non-empty string', () => {
+                const result = oneDetectorConfigParsed({
+                    match: { text: { pattern: 'test' } },
+                    actions: {
+                        // @ts-expect-error - fireEvent not in upstream schema yet
+                        fireEvent: { type: 'adwall_detected' },
+                    },
+                });
+                expect(result.actions.fireEvent).toEqual({ state: 'enabled', type: 'adwall_detected' });
+            });
+
+            it('should allow disabling fireEvent state', () => {
+                const result = oneDetectorConfigParsed({
+                    match: { text: { pattern: 'test' } },
+                    actions: {
+                        // @ts-expect-error - fireEvent not in upstream schema yet
+                        fireEvent: { state: 'disabled', type: 'adwall_detected' },
+                    },
+                });
+                expect(result.actions.fireEvent).toEqual({ state: 'disabled', type: 'adwall_detected' });
+            });
+
+            it('should omit fireEvent when type is missing', () => {
+                const result = oneDetectorConfigParsed({
+                    match: { text: { pattern: 'test' } },
+                    actions: {
+                        // @ts-expect-error - fireEvent not in upstream schema yet
+                        fireEvent: {},
+                    },
+                });
+                expect(result.actions.fireEvent).toBeUndefined();
+            });
+
+            it('should omit fireEvent when type is empty string', () => {
+                const result = oneDetectorConfigParsed({
+                    match: { text: { pattern: 'test' } },
+                    actions: {
+                        // @ts-expect-error - fireEvent not in upstream schema yet
+                        fireEvent: { type: '' },
+                    },
+                });
+                expect(result.actions.fireEvent).toBeUndefined();
+            });
+
+            it('should omit fireEvent when type is not a string', () => {
+                const result = oneDetectorConfigParsed({
+                    match: { text: { pattern: 'test' } },
+                    actions: {
+                        // @ts-expect-error - fireEvent not in upstream schema yet
+                        fireEvent: { type: 123 },
+                    },
+                });
+                expect(result.actions.fireEvent).toBeUndefined();
+            });
+
+            it('should omit fireEvent when value is not an object', () => {
+                const result = oneDetectorConfigParsed({
+                    match: { text: { pattern: 'test' } },
+                    actions: {
+                        // @ts-expect-error - fireEvent not in upstream schema yet
+                        fireEvent: true,
+                    },
+                });
+                expect(result.actions.fireEvent).toBeUndefined();
+            });
+
+            it('should pass through null fireEvent state (fail-closed)', () => {
+                const result = oneDetectorConfigParsed({
+                    match: { text: { pattern: 'test' } },
+                    actions: {
+                        // @ts-expect-error - fireEvent not in upstream schema yet
+                        fireEvent: { state: null, type: 'adwall_detected' },
+                    },
+                });
+                // @ts-expect-error - null passes through for fail-closed handling
+                expect(result.actions.fireEvent?.state).toBe(null);
+                expect(result.actions.fireEvent?.type).toBe('adwall_detected');
+            });
+
+            it('should not include fireEvent when actions.fireEvent is absent', () => {
+                const result = oneDetectorConfigParsed({
+                    match: { text: { pattern: 'test' } },
+                });
+                expect(result.actions.fireEvent).toBeUndefined();
+            });
+        });
+
+        describe('unknown action keys', () => {
+            it('should drop unknown action keys during normalization', () => {
+                const result = oneDetectorConfigParsed({
+                    match: { text: { pattern: 'test' } },
+                    actions: {
+                        // @ts-expect-error - unknown action key
+                        unknownAction: { state: 'enabled' },
+                    },
+                });
+                expect(Object.keys(result.actions)).toEqual(['breakageReportData']);
+                // @ts-expect-error - checking unknown key was dropped
+                expect(result.actions.unknownAction).toBeUndefined();
+            });
+        });
+
         /**
          *
          * @template T


### PR DESCRIPTION
**Asana Task/Github Issue:** <!-- Link to Asana Task/Github Issue -->

## Description

<!--
  Provide a terse summary of what the change is, detailed descriptions should belong in ship reviews or tech designs
-->

## Testing Steps

- <!-- Include simple steps on how to check this change is working. Write "N/A" if not applicable. -->

## Checklist

<!--
  These questions are a friendly reminder to shipping code, if you're uncertain ask the AoR owners.
  It's also totally appropriate to not check some of these boxes, if they don't apply to your change.
-->
*Please tick all that apply:*

- [ ] I have tested this change locally
- [ ] I have tested this change locally in all supported browsers
- [ ] This change will be visible to users
- [ ] I have added automated tests that cover this change
- [ ] I have ensured the change is gated by config
- [ ] This change was covered by a ship review
- [ ] This change was covered by a tech design
- [ ] Any dependent config has been merged

---

Co-authored-by: Jonathan Kingston <jonathanKingston@users.noreply.github.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how web-detection detector configs are normalized (replacing deep default-merging with explicit field resolution) and adds new action parsing, which could affect runtime behavior for malformed or previously-tolerated configs.
> 
> **Overview**
> Updates `web-detection/parse.js` to stop using deep `withDefaults` merging and instead explicitly normalize detector config fields, including **fail-closed** handling where `state: null` is preserved (and therefore treated as disabled by `isStateEnabled`).
> 
> Adds an opt-in `actions.fireEvent` action that is only included when it has a valid non-empty string `type`, drops unknown action keys during normalization, and loosens valid detector/group name validation to allow names starting with any letter (not just lowercase). Unit tests are expanded to cover null-state passthrough, `fireEvent` validation, and unknown action key dropping.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1a64520078d544aa93017c7e8b29ca144747da3d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->