### PR TITLE
strict-type: web-interference-detection.js

### DIFF
--- a/injected/src/detectors/detections/youtube-ad-detection.js
+++ b/injected/src/detectors/detections/youtube-ad-detection.js
@@ -28,10 +28,12 @@ class YouTubeAdDetector {
     /**
      * @param {YouTubeDetectorConfig} config - Configuration from privacy-config (required)
      * @param {{info: Function, warn: Function, error: Function}} [logger] - Optional logger from ContentFeature
+     * @param {((type: string) => Promise<void>)} [fireEvent] - Optional callback to fire web events on detection
      */
-    constructor(config, logger) {
+    constructor(config, logger, fireEvent) {
         // Logger for debug output (only logs when debug mode is enabled)
         this.log = logger || noopLogger;
+        this.fireEvent = fireEvent || null;
 
         // All config comes from privacy-config
         this.config = {
@@ -119,6 +121,10 @@ class YouTubeAdDetector {
         }
 
         this.log.info(`Detection: ${type}`, details.message || '');
+
+        if (this.fireEvent) {
+            this.fireEvent(type);
+        }
 
         typeState.showing = true;
         typeState.count++;
@@ -716,13 +722,11 @@ let detectorInstance = null;
 /**
  * Run YouTube ad detection
  * @param {YouTubeDetectorConfig} [config] - Configuration from privacy-config
+ * @param {{info: Function, warn: Function, error: Function}} [logger] - Optional logger from ContentFeature
+ * @param {((type: string) => Promise<void>)} [fireEvent] - Optional callback to fire web events on detection
  * @returns {Object} Detection results in standard format
  */
-/**
- * @param {YouTubeDetectorConfig} [config] - Configuration from privacy-config
- * @param {{info: Function, warn: Function, error: Function}} [logger] - Optional logger from ContentFeature
- */
-export function runYoutubeAdDetection(config, logger) {
+export function runYoutubeAdDetection(config, logger, fireEvent) {
     // Only run if explicitly enabled or internal
     if (config?.state !== 'enabled' && config?.state !== 'internal') {
         return { detected: false, type: 'youtubeAds', results: [] };
@@ -741,7 +745,7 @@ export function runYoutubeAdDetection(config, logger) {
     // Auto-initialize on first call if on YouTube
     const hostname = window.location.hostname;
     if (hostname === 'youtube.com' || hostname.endsWith('.youtube.com')) {
-        detectorInstance = new YouTubeAdDetector(config, logger);
+        detectorInstance = new YouTubeAdDetector(config, logger, fireEvent);
         detectorInstance.start();
         return detectorInstance.getResults();
     }

--- a/injected/src/features/web-interference-detection.js
+++ b/injected/src/features/web-interference-detection.js
@@ -25,6 +25,7 @@ export default class WebInterferenceDetection extends ContentFeature {
          */
         const fireEvent = async (type) => {
             try {
+                // @ts-expect-error — webEvents will be added to FeatureMap when the feature lands
                 const result = await this.callFeatureMethod('webEvents', 'fireEvent', { type });
                 if (result instanceof CallFeatureMethodError && this.isDebug) {
                     this.log.warn('webEvents.fireEvent failed:', result.message);

--- a/injected/src/features/web-interference-detection.js
+++ b/injected/src/features/web-interference-detection.js
@@ -1,4 +1,4 @@
-import ContentFeature from '../content-feature.js';
+import ContentFeature, { CallFeatureMethodError } from '../content-feature.js';
 import { runBotDetection } from '../detectors/detections/bot-detection.js';
 import { runFraudDetection } from '../detectors/detections/fraud-detection.js';
 import { runAdwallDetection } from '../detectors/detections/adwall-detection.js';
@@ -9,16 +9,32 @@ import { runYoutubeAdDetection } from '../detectors/detections/youtube-ad-detect
  * @property {string[]} [types]
  */
 
+/**
+ * Note: breakageReporting also runs these detectors directly by reading this
+ * feature's `interferenceTypes` settings via getFeatureSetting. Those calls
+ * execute in breakageReporting's world (apple-isolated), independent of which
+ * world this feature is bundled into.
+ */
 export default class WebInterferenceDetection extends ContentFeature {
     init() {
         // Get settings with conditionalChanges already applied by framework
         const settings = this.getFeatureSetting('interferenceTypes');
 
-        // Initialize YouTube detector early on YouTube pages to capture video load times
-        const hostname = window.location.hostname;
-        if (hostname === 'youtube.com' || hostname.endsWith('.youtube.com')) {
-            runYoutubeAdDetection(settings?.youtubeAds, this.log);
-        }
+        /**
+         * @param {string} type - Event type to fire
+         */
+        const fireEvent = async (type) => {
+            try {
+                const result = await this.callFeatureMethod('webEvents', 'fireEvent', { type });
+                if (result instanceof CallFeatureMethodError && this.isDebug) {
+                    this.log.warn('webEvents.fireEvent failed:', result.message);
+                }
+            } catch {
+                // webEvents may not be loaded on this platform — silently ignore
+            }
+        };
+
+        runYoutubeAdDetection(settings?.youtubeAds, this.log, fireEvent);
 
         // Register messaging handler for PIR/native requests
         this.messaging.subscribe('detectInterference', (params) => {


### PR DESCRIPTION
**Asana Task/Github Issue:** <!-- Link to Asana Task/Github Issue -->

## Description

<!--
  Provide a terse summary of what the change is, detailed descriptions should belong in ship reviews or tech designs
-->

## Testing Steps

- <!-- Include simple steps on how to check this change is working. Write "N/A" if not applicable. -->

## Checklist

<!--
  These questions are a friendly reminder to shipping code, if you're uncertain ask the AoR owners.
  It's also totally appropriate to not check some of these boxes, if they don't apply to your change.
-->
*Please tick all that apply:*

- [ ] I have tested this change locally
- [ ] I have tested this change locally in all supported browsers
- [ ] This change will be visible to users
- [ ] I have added automated tests that cover this change
- [ ] I have ensured the change is gated by config
- [ ] This change was covered by a ship review
- [ ] This change was covered by a tech design
- [ ] Any dependent config has been merged

---

Co-authored-by: Jonathan Kingston <jonathanKingston@users.noreply.github.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it adds new cross-feature async calls (`callFeatureMethod` to `webEvents`) triggered by YouTube detection events, which could introduce unexpected side effects or performance/telemetry changes if misconfigured.
> 
> **Overview**
> Adds an optional `fireEvent(type)` callback to `YouTubeAdDetector`/`runYoutubeAdDetection` and invokes it whenever a new YouTube detection is reported.
> 
> Updates `web-interference-detection` to always initialize YouTube detection via a `fireEvent` wrapper that calls `webEvents.fireEvent` (with debug-only warnings and silent fallback when `webEvents` is unavailable), replacing the prior YouTube-only early-init block.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e6750615e97339cf867adac9211585b31bde2f50. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->