### PR TITLE
Changed copy for Onboarding -> YouTube Ad block

### DIFF
--- a/special-pages/pages/onboarding/integration-tests/onboarding.v3.spec.js
+++ b/special-pages/pages/onboarding/integration-tests/onboarding.v3.spec.js
@@ -506,7 +506,7 @@ test.describe('onboarding v3', () => {
 
             // Ad-free title and subtitle are shown
             await expect(page.getByRole('heading', { name: 'Watch YouTube ad-free!', level: 1 })).toBeVisible();
-            await expect(page.getByRole('heading', { name: /No need for a premium subscription/, level: 2 })).toBeVisible();
+            await expect(page.getByRole('heading', { name: /No need for extensions or third-party plugins/, level: 2 })).toBeVisible();
 
             // Toggle button is hidden
             await expect(page.getByLabel('See Without Duck Player')).not.toBeVisible();

--- a/special-pages/pages/onboarding/integration-tests/onboarding.v4.spec.js
+++ b/special-pages/pages/onboarding/integration-tests/onboarding.v4.spec.js
@@ -185,7 +185,7 @@ test.describe('onboarding v4', () => {
 
             // Ad-free title and subtitle are shown
             await expect(page.getByRole('heading', { name: 'Watch YouTube ad-free!', level: 2 })).toBeVisible();
-            await expect(page.getByText(/No need for a premium subscription/)).toBeVisible();
+            await expect(page.getByText(/No need for extensions or third-party plugins/)).toBeVisible();
 
             // Toggle button is hidden
             await expect(page.getByRole('button', { name: 'See Without Duck Player' })).not.toBeVisible();

--- a/special-pages/pages/onboarding/public/locales/en/onboarding.json
+++ b/special-pages/pages/onboarding/public/locales/en/onboarding.json
@@ -298,7 +298,7 @@
     "note": "Title for the Duck Player step variant that emphasizes ad-free YouTube viewing."
   },
   "duckPlayer_adFree_subtitle": {
-    "title": "No need for a premium subscription or third-party plugins.{newline}Just your video, without the ads.",
+    "title": "No need for extensions or third-party plugins.{newline}Just your videos, without the ads.",
     "note": "Subtitle for the Duck Player step variant that emphasizes ad-free YouTube viewing."
   },
   "addressBarMode_title": {


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/38424471409662/task/1213765049459900

## Description

Changed copy for Duck player subtitles.

## Testing Steps

N/A

## Checklist

<!--
  These questions are a friendly reminder to shipping code, if you're uncertain ask the AoR owners.
  It's also totally appropriate to not check some of these boxes, if they don't apply to your change.
-->
*Please tick all that apply:*

- [x] I have tested this change locally
- [x] I have tested this change locally in all supported browsers
- [x] This change will be visible to users
- [ ] I have added automated tests that cover this change
- [ ] I have ensured the change is gated by config
- [x] This change was covered by a ship review
- [x] This change was covered by a tech design
- [ ] Any dependent config has been merged


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: copy-only localization update plus matching Playwright assertion updates; no logic or config behavior changes.
> 
> **Overview**
> Updates the Duck Player *ad-free* onboarding subtitle copy in `onboarding.json` (switching from “premium subscription” messaging to “extensions” messaging, and tweaking “video” → “videos”).
> 
> Adjusts v3/v4 Playwright onboarding tests to assert the new subtitle text for the ad-free Duck Player variant.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b609b908b0975dd05a886ef543a28b0ece46030d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->