### PR TITLE
NTP: fix two selected items bug

### DIFF
--- a/special-pages/pages/new-tab/app/omnibar/components/AiChatsList.module.css
+++ b/special-pages/pages/new-tab/app/omnibar/components/AiChatsList.module.css
@@ -23,13 +23,11 @@
     }
 
     &[aria-selected="true"],
-    &:hover,
     &:active {
         color: var(--ds-color-theme-accent-content-primary);
     }
 
-    &[aria-selected="true"],
-    &:hover {
+    &[aria-selected="true"] {
         background: var(--ds-color-theme-accent-primary);
     }
 

--- a/special-pages/pages/new-tab/app/omnibar/components/AiChatsListFooter.js
+++ b/special-pages/pages/new-tab/app/omnibar/components/AiChatsListFooter.js
@@ -16,7 +16,7 @@ export function AiChatsListFooter() {
     const { viewAllAiChats } = useContext(OmnibarContext);
     const platformName = usePlatformName();
     const { t } = useTypedTranslationWith(/** @type {Strings} */ ({}));
-    const { viewAllChatsSelected } = useAiChatsContext();
+    const { viewAllChatsSelected, selectViewAllChats, clearSelectedChat } = useAiChatsContext();
 
     return (
         <div class={styles.footer}>
@@ -26,6 +26,8 @@ export function AiChatsListFooter() {
                 class={styles.item}
                 tabIndex={viewAllChatsSelected ? 0 : -1}
                 aria-selected={viewAllChatsSelected}
+                onMouseOver={() => selectViewAllChats()}
+                onMouseLeave={() => clearSelectedChat()}
                 onClick={(event) => {
                     event.preventDefault();
                     viewAllAiChats({

--- a/special-pages/pages/new-tab/app/omnibar/components/AiChatsListFooter.module.css
+++ b/special-pages/pages/new-tab/app/omnibar/components/AiChatsListFooter.module.css
@@ -22,8 +22,7 @@
         margin: var(--sp-2);
     }
 
-    &[aria-selected="true"],
-    &:hover {
+    &[aria-selected="true"] {
         background: var(--ds-color-theme-accent-primary);
         color: var(--ds-color-theme-accent-content-primary);
 

--- a/special-pages/pages/new-tab/app/omnibar/components/useAiChats.js
+++ b/special-pages/pages/new-tab/app/omnibar/components/useAiChats.js
@@ -28,7 +28,7 @@ export function getAiChatElementId(chatId) {
  *   | { type: 'showChats' }
  *   | { type: 'setSelectedChat', payload: AiChat }
  *   | { type: 'clearSelectedChat' }
- *   | { type: 'selectViewAllChats' }
+ *   | { type: 'selectViewAllChats', targetIndex: number }
  *   | { type: 'previousChat', itemCount: number }
  *   | { type: 'nextChat', itemCount: number }
  * )} Action
@@ -71,7 +71,7 @@ function reducer(state, action) {
         case 'selectViewAllChats':
             return {
                 ...state,
-                selectedIndex: state.chats.length,
+                selectedIndex: action.targetIndex,
             };
         case 'previousChat': {
             const nextIndex = state.selectedIndex === null ? action.itemCount - 1 : state.selectedIndex - 1;
@@ -160,7 +160,7 @@ export function useAiChats({ query, initiallyVisible, enableRecentAiChats, showV
 
     const selectViewAllChats = () => {
         if (!showViewAllAiChats || itemCount === 0) return;
-        dispatch({ type: 'selectViewAllChats' });
+        dispatch({ type: 'selectViewAllChats', targetIndex: itemCount - 1 });
     };
 
     const hideChats = () => {

--- a/special-pages/pages/new-tab/app/omnibar/components/useAiChats.js
+++ b/special-pages/pages/new-tab/app/omnibar/components/useAiChats.js
@@ -28,6 +28,7 @@ export function getAiChatElementId(chatId) {
  *   | { type: 'showChats' }
  *   | { type: 'setSelectedChat', payload: AiChat }
  *   | { type: 'clearSelectedChat' }
+ *   | { type: 'selectViewAllChats' }
  *   | { type: 'previousChat', itemCount: number }
  *   | { type: 'nextChat', itemCount: number }
  * )} Action
@@ -66,6 +67,11 @@ function reducer(state, action) {
             return {
                 ...state,
                 selectedIndex: null,
+            };
+        case 'selectViewAllChats':
+            return {
+                ...state,
+                selectedIndex: state.chats.length,
             };
         case 'previousChat': {
             const nextIndex = state.selectedIndex === null ? action.itemCount - 1 : state.selectedIndex - 1;
@@ -152,6 +158,11 @@ export function useAiChats({ query, initiallyVisible, enableRecentAiChats, showV
         dispatch({ type: 'clearSelectedChat' });
     };
 
+    const selectViewAllChats = () => {
+        if (!showViewAllAiChats || itemCount === 0) return;
+        dispatch({ type: 'selectViewAllChats' });
+    };
+
     const hideChats = () => {
         dispatch({ type: 'hideChats' });
     };
@@ -168,6 +179,7 @@ export function useAiChats({ query, initiallyVisible, enableRecentAiChats, showV
         selectNextChat,
         setSelectedChat,
         clearSelectedChat,
+        selectViewAllChats,
         hideChats,
         showChats,
     };


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1213881875984009/task/1213995046612866?focus=true

## Description
Replace CSS :hover styles with programmatic selection via aria-selected so that hovering over AI chat items and the "View All" footer updates the selection state, keeping at most one item visually highlighted at a time.

- Removed CSS `:hover` pseudo-class styling from chat list items and footer — selection highlight is now driven entirely by aria-selected
- Added `onMouseOver` / `onMouseLeave` handlers to the "View All Chats" footer link so hovering selects it and leaving clears the selection
- Added `selectViewAllChats` action and dispatcher to set the selected index to the footer position

## Testing Steps

1. Open http://localhost:8000/?omnibar=true&omnibar.enableAi=true&omnibar.enableRecentAiChats=true&omnibar.mode=ai&omnibar.showViewAllAiChats=true NTP
2. Type a query, ensure there are at least 2 suggestions
2. Place the mouse cursor over one suggestion (A)
3. Hit keyboard arrows to select a different suggestion (B)
4. Only B selection should be selected

## Checklist

<!--
  These questions are a friendly reminder to shipping code, if you're uncertain ask the AoR owners.
  It's also totally appropriate to not check some of these boxes, if they don't apply to your change.
-->
*Please tick all that apply:*

- [ ] I have tested this change locally
- [ ] I have tested this change locally in all supported browsers
- [ ] This change will be visible to users
- [ ] I have added automated tests that cover this change
- [ ] I have ensured the change is gated by config
- [ ] This change was covered by a ship review
- [ ] This change was covered by a tech design
- [ ] Any dependent config has been merged



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI/interaction change that shifts highlight behavior from CSS hover to state-driven `aria-selected`, with minimal impact outside omnibar selection UX.
> 
> **Overview**
> Fixes a bug where hovering could visually highlight an AI chat item while keyboard selection highlighted a different one, resulting in two “selected” rows.
> 
> Removes `:hover`-based highlight styling from AI chat rows and the “View all chats” footer so highlighting is driven solely by `aria-selected`. Adds hover handlers for the footer and a new `selectViewAllChats` action in `useAiChats` to programmatically move selection to the footer and clear it on mouse leave.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 13a0dcb9127c797b9c8760a5fb5a6bd158781622. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->