### PR TITLE
Skip privileged PR workflows on forks

### DIFF
--- a/.github/workflows/asana.yml
+++ b/.github/workflows/asana.yml
@@ -13,6 +13,7 @@ on:
 jobs:
     sync:
         if: >-
+            !github.event.pull_request.head.repo.fork &&
             !startsWith(github.event.pull_request.head.ref, 'cursor/') &&
             !startsWith(github.event.pull_request.head.ref, 'claude/')
         runs-on: ubuntu-latest

--- a/.github/workflows/assign-reviewer.yml
+++ b/.github/workflows/assign-reviewer.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
     request-review:
+        if: ${{ !github.event.pull_request.head.repo.fork }}
         runs-on: ubuntu-latest
         steps:
             - name: Request review from assignee

--- a/.github/workflows/cursor-review.yml
+++ b/.github/workflows/cursor-review.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
     check_membership:
+        if: ${{ !github.event.pull_request.head.repo.fork }}
         runs-on: ubuntu-latest
         outputs:
             is_member: ${{ steps.membership.outputs.is_member }}

--- a/.github/workflows/semver-label.yml
+++ b/.github/workflows/semver-label.yml
@@ -10,6 +10,7 @@ permissions:
 
 jobs:
     semver_label:
+        if: ${{ !github.event.pull_request.head.repo.fork }}
         runs-on: ubuntu-latest
         steps:
             - name: Checkout base branch


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1204023833050360/task/1214178616039048?focus=true

## Description

<!--
  Provide a terse summary of what the change is, detailed descriptions should belong in ship reviews or tech designs
-->

## Testing Steps

- <!-- Include simple steps on how to check this change is working. Write "N/A" if not applicable. -->

## Checklist

<!--
  These questions are a friendly reminder to shipping code, if you're uncertain ask the AoR owners.
  It's also totally appropriate to not check some of these boxes, if they don't apply to your change.
-->
*Please tick all that apply:*

- [ ] I have tested this change locally
- [ ] I have tested this change locally in all supported browsers
- [ ] This change will be visible to users
- [ ] I have added automated tests that cover this change
- [ ] I have ensured the change is gated by config
- [ ] This change was covered by a ship review
- [ ] This change was covered by a tech design
- [ ] Any dependent config has been merged


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only gating change that reduces secret exposure risk; primary risk is reduced automation for forked PRs.
> 
> **Overview**
> Updates several GitHub Actions workflows to **skip execution for fork-based PRs** by adding `if: !github.event.pull_request.head.repo.fork` guards.
> 
> This prevents privileged `pull_request_target`/sync jobs (Asana sync, reviewer assignment, Cursor auto-review, and semver labeling) from running on forks while preserving existing branch-name exclusions where applicable.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ee2d018f5e200104ecffb483c5086c4e39c56b15. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->