### PR TITLE
feat(ntp): update localization for omnibar features

### DIFF
--- a/special-pages/pages/new-tab/public/locales/de/new-tab.json
+++ b/special-pages/pages/new-tab/public/locales/de/new-tab.json
@@ -166,7 +166,7 @@
     "description": "Title of the omnibar widget in the customizer panel."
   },
   "omnibar_aiChatFormPlaceholder": {
-    "title": "Privat fragen",
+    "title": "Alles privat fragen",
     "description": "Placeholder text for the AI chat input field."
   },
   "omnibar_aiChatFormSubmitButtonLabel": {
@@ -228,6 +228,98 @@
   "omnibar_customizePopoverDescription": {
     "title": "Deine Daten bleiben auf jeden Fall privat.<br />Du möchtest das nicht? <button>Anpassen</button>",
     "description": "Description message in the popover including privacy statement and customize option."
+  },
+  "omnibar_attachImageLabel": {
+    "title": "Bild anhängen",
+    "description": "Accessible label for the attach image button in the AI chat toolbar."
+  },
+  "omnibar_removeImageLabel": {
+    "title": "Bild entfernen",
+    "description": "Accessible label for the button to remove an attached image thumbnail."
+  },
+  "omnibar_modelSelectorLabel": {
+    "title": "Modell auswählen",
+    "description": "Accessible label for the AI model selector dropdown."
+  },
+  "omnibar_imageAttachmentLimitWarning": {
+    "title": "Du kannst jeweils nur {limit} Bilder anhängen",
+    "description": "Warning shown when user attaches more images than the allowed maximum."
+  },
+  "omnibar_imageTooLargeError": {
+    "title": "Das Bild ist zu groß. Bitte verwende ein Bild, das kleiner als 10000×10000 Pixel ist.",
+    "description": "Error shown when a user tries to attach an image that exceeds the maximum pixel dimensions."
+  },
+  "omnibar_imageProcessingError": {
+    "title": "Bild wurde nicht verarbeitet. Bitte versuche es mit einer anderen Datei.",
+    "description": "Error shown when an attached image cannot be processed."
+  },
+  "omnibar_advancedModelsSectionHeader": {
+    "title": "Erweiterte Modelle – DuckDuckGo-Abo",
+    "description": "Section header in the model picker for premium models that require a subscription."
+  },
+  "omnibar_viewAllChats": {
+    "title": "Alle Chats anzeigen",
+    "description": "Link text to view all AI chat history."
+  },
+  "omnibar_openDuckAi": {
+    "title": "Duck.ai öffnen",
+    "description": "Link text to open the Duck.ai chat interface."
+  },
+  "omnibar_createImageLabel": {
+    "title": "Bild erstellen",
+    "description": "Label for the toggle button to enable image generation mode in the AI chat toolbar."
+  },
+  "omnibar_imageGenerationPlaceholder": {
+    "title": "Beschreibe das Bild, das du erstellen möchtest",
+    "description": "Placeholder text for the AI chat input when image generation mode is active."
+  },
+  "omnibar_toolsMenuLabel": {
+    "title": "Werkzeuge",
+    "description": "Accessible label for the tools menu button in the AI chat toolbar."
+  },
+  "omnibar_createImageDescription": {
+    "title": "Text in Bilder umwandeln",
+    "description": "Description for the Create Image tool shown in the tools menu dropdown."
+  },
+  "omnibar_webSearchLabel": {
+    "title": "Websuche",
+    "description": "Label for the Web Search tool shown in the tools menu dropdown."
+  },
+  "omnibar_webSearchDescription": {
+    "title": "Antworten aus dem Web beziehen",
+    "description": "Description for the Web Search tool shown in the tools menu dropdown."
+  },
+  "omnibar_imageGenerationWithAttachmentPlaceholder": {
+    "title": "Beschreibe die Änderungen basierend auf dem Bild",
+    "description": "Placeholder text for the AI chat input when image generation mode is active and an image is attached."
+  },
+  "omnibar_reasoningPickerLabel": {
+    "title": "Begründung",
+    "description": "Accessible label (and chip text) for the reasoning-effort picker in the AI chat toolbar."
+  },
+  "omnibar_reasoningEffortFastLabel": {
+    "title": "Schnell",
+    "description": "Label for the 'fast' reasoning-effort option (answers right away, no deliberate reasoning)."
+  },
+  "omnibar_reasoningEffortFastDescription": {
+    "title": "Sofortige Antworten",
+    "description": "Subtitle for the 'fast' reasoning-effort option in the reasoning picker dropdown."
+  },
+  "omnibar_reasoningEffortReasoningLabel": {
+    "title": "Begründung",
+    "description": "Label for the 'reasoning' reasoning-effort option (model spends a moment reasoning)."
+  },
+  "omnibar_reasoningEffortReasoningDescription": {
+    "title": "Nimmt sich einen Moment Zeit zum Antworten",
+    "description": "Subtitle for the 'reasoning' reasoning-effort option in the reasoning picker dropdown."
+  },
+  "omnibar_reasoningEffortExtendedReasoningLabel": {
+    "title": "Erweiterte Begründung",
+    "description": "Label for the 'extended reasoning' reasoning-effort option (model researches before responding)."
+  },
+  "omnibar_reasoningEffortExtendedReasoningDescription": {
+    "title": "Recherchiert, bevor du antwortest",
+    "description": "Subtitle for the 'extended reasoning' reasoning-effort option in the reasoning picker dropdown."
   },
   "nextStepsList_sectionTitle": {
     "title": "Nächste Schritte",
@@ -652,41 +744,5 @@
   "activity_show_less_history": {
     "title": "Zusätzliches ausblenden",
     "note": "Button label that hides the expanded browsing history items."
-  },
-  "omnibar_attachImageLabel": {
-    "title": "Bild anhängen",
-    "description": "Accessible label for the attach image button in the AI chat toolbar."
-  },
-  "omnibar_removeImageLabel": {
-    "title": "Bild entfernen",
-    "description": "Accessible label for the button to remove an attached image thumbnail."
-  },
-  "omnibar_modelSelectorLabel": {
-    "title": "Modell auswählen",
-    "description": "Accessible label for the AI model selector dropdown."
-  },
-  "omnibar_imageAttachmentLimitWarning": {
-    "title": "Du kannst jeweils nur {limit} Bilder gleichzeitig anhängen",
-    "description": "Warning shown when user attaches more images than the allowed maximum."
-  },
-  "omnibar_imageTooLargeError": {
-    "title": "Das Bild ist zu groß. Bitte verwende ein Bild, das kleiner als 10000×10000 Pixel ist.",
-    "description": "Error shown when a user tries to attach an image that exceeds the maximum pixel dimensions."
-  },
-  "omnibar_imageProcessingError": {
-    "title": "Bild wurde nicht verarbeitet. Bitte versuche es mit einer anderen Datei.",
-    "description": "Error shown when an attached image cannot be processed."
-  },
-  "omnibar_advancedModelsSectionHeader": {
-    "title": "Erweiterte Modelle – DuckDuckGo-Abo",
-    "description": "Section header in the model picker for premium models that require a subscription."
-  },
-  "omnibar_viewAllChats": {
-    "title": "Alle Chats anzeigen",
-    "description": "Link text to view all AI chat history."
-  },
-  "omnibar_openDuckAi": {
-    "title": "Duck.ai öffnen",
-    "description": "Link text to open the Duck.ai chat interface."
   }
 }

--- a/special-pages/pages/new-tab/public/locales/es/new-tab.json
+++ b/special-pages/pages/new-tab/public/locales/es/new-tab.json
@@ -166,7 +166,7 @@
     "description": "Title of the omnibar widget in the customizer panel."
   },
   "omnibar_aiChatFormPlaceholder": {
-    "title": "Pregunta en privado",
+    "title": "Pregunta cualquier cosa en privado",
     "description": "Placeholder text for the AI chat input field."
   },
   "omnibar_aiChatFormSubmitButtonLabel": {
@@ -228,6 +228,98 @@
   "omnibar_customizePopoverDescription": {
     "title": "De cualquier manera, tu información sigue siendo privada.¿No es lo que querías? <button>Personalizar</button>",
     "description": "Description message in the popover including privacy statement and customize option."
+  },
+  "omnibar_attachImageLabel": {
+    "title": "Adjuntar imagen",
+    "description": "Accessible label for the attach image button in the AI chat toolbar."
+  },
+  "omnibar_removeImageLabel": {
+    "title": "Eliminar imagen",
+    "description": "Accessible label for the button to remove an attached image thumbnail."
+  },
+  "omnibar_modelSelectorLabel": {
+    "title": "Seleccionar modelo",
+    "description": "Accessible label for the AI model selector dropdown."
+  },
+  "omnibar_imageAttachmentLimitWarning": {
+    "title": "Solo puedes adjuntar {limit} imágenes a la vez.",
+    "description": "Warning shown when user attaches more images than the allowed maximum."
+  },
+  "omnibar_imageTooLargeError": {
+    "title": "La imagen es demasiado grande. Utiliza una imagen de menos de 10 000×10 000 píxeles.",
+    "description": "Error shown when a user tries to attach an image that exceeds the maximum pixel dimensions."
+  },
+  "omnibar_imageProcessingError": {
+    "title": "No se ha podido procesar la imagen. Prueba con otro archivo.",
+    "description": "Error shown when an attached image cannot be processed."
+  },
+  "omnibar_advancedModelsSectionHeader": {
+    "title": "Modelos avanzados - suscripción a DuckDuckGo",
+    "description": "Section header in the model picker for premium models that require a subscription."
+  },
+  "omnibar_viewAllChats": {
+    "title": "Ver todos los chats",
+    "description": "Link text to view all AI chat history."
+  },
+  "omnibar_openDuckAi": {
+    "title": "Abrir Duck.ai",
+    "description": "Link text to open the Duck.ai chat interface."
+  },
+  "omnibar_createImageLabel": {
+    "title": "Crear imagen",
+    "description": "Label for the toggle button to enable image generation mode in the AI chat toolbar."
+  },
+  "omnibar_imageGenerationPlaceholder": {
+    "title": "Describe la imagen que quieres crear",
+    "description": "Placeholder text for the AI chat input when image generation mode is active."
+  },
+  "omnibar_toolsMenuLabel": {
+    "title": "Herramientas",
+    "description": "Accessible label for the tools menu button in the AI chat toolbar."
+  },
+  "omnibar_createImageDescription": {
+    "title": "Convierte texto en imágenes",
+    "description": "Description for the Create Image tool shown in the tools menu dropdown."
+  },
+  "omnibar_webSearchLabel": {
+    "title": "Búsqueda en la web",
+    "description": "Label for the Web Search tool shown in the tools menu dropdown."
+  },
+  "omnibar_webSearchDescription": {
+    "title": "Obtener respuestas de la web",
+    "description": "Description for the Web Search tool shown in the tools menu dropdown."
+  },
+  "omnibar_imageGenerationWithAttachmentPlaceholder": {
+    "title": "Describir cambios basados en la imagen",
+    "description": "Placeholder text for the AI chat input when image generation mode is active and an image is attached."
+  },
+  "omnibar_reasoningPickerLabel": {
+    "title": "Razonamiento",
+    "description": "Accessible label (and chip text) for the reasoning-effort picker in the AI chat toolbar."
+  },
+  "omnibar_reasoningEffortFastLabel": {
+    "title": "Rápido",
+    "description": "Label for the 'fast' reasoning-effort option (answers right away, no deliberate reasoning)."
+  },
+  "omnibar_reasoningEffortFastDescription": {
+    "title": "Responde de inmediato",
+    "description": "Subtitle for the 'fast' reasoning-effort option in the reasoning picker dropdown."
+  },
+  "omnibar_reasoningEffortReasoningLabel": {
+    "title": "Razonamiento",
+    "description": "Label for the 'reasoning' reasoning-effort option (model spends a moment reasoning)."
+  },
+  "omnibar_reasoningEffortReasoningDescription": {
+    "title": "Tarda un momento en responder",
+    "description": "Subtitle for the 'reasoning' reasoning-effort option in the reasoning picker dropdown."
+  },
+  "omnibar_reasoningEffortExtendedReasoningLabel": {
+    "title": "Razonamiento ampliado",
+    "description": "Label for the 'extended reasoning' reasoning-effort option (model researches before responding)."
+  },
+  "omnibar_reasoningEffortExtendedReasoningDescription": {
+    "title": "Investiga antes de responder",
+    "description": "Subtitle for the 'extended reasoning' reasoning-effort option in the reasoning picker dropdown."
   },
   "nextStepsList_sectionTitle": {
     "title": "Próximos pasos",
@@ -652,41 +744,5 @@
   "activity_show_less_history": {
     "title": "Ocultar adicional",
     "note": "Button label that hides the expanded browsing history items."
-  },
-  "omnibar_attachImageLabel": {
-    "title": "Adjuntar imagen",
-    "description": "Accessible label for the attach image button in the AI chat toolbar."
-  },
-  "omnibar_removeImageLabel": {
-    "title": "Eliminar imagen",
-    "description": "Accessible label for the button to remove an attached image thumbnail."
-  },
-  "omnibar_modelSelectorLabel": {
-    "title": "Seleccionar modelo",
-    "description": "Accessible label for the AI model selector dropdown."
-  },
-  "omnibar_imageAttachmentLimitWarning": {
-    "title": "Solo puedes adjuntar {limit} imágenes a la vez",
-    "description": "Warning shown when user attaches more images than the allowed maximum."
-  },
-  "omnibar_imageTooLargeError": {
-    "title": "La imagen es demasiado grande. Utiliza una imagen de menos de 10 000×10 000 píxeles.",
-    "description": "Error shown when a user tries to attach an image that exceeds the maximum pixel dimensions."
-  },
-  "omnibar_imageProcessingError": {
-    "title": "No se ha podido procesar la imagen. Prueba con otro archivo.",
-    "description": "Error shown when an attached image cannot be processed."
-  },
-  "omnibar_advancedModelsSectionHeader": {
-    "title": "Modelos avanzados - suscripción a DuckDuckGo",
-    "description": "Section header in the model picker for premium models that require a subscription."
-  },
-  "omnibar_viewAllChats": {
-    "title": "Ver todos los chats",
-    "description": "Link text to view all AI chat history."
-  },
-  "omnibar_openDuckAi": {
-    "title": "Abrir Duck.ai",
-    "description": "Link text to open the Duck.ai chat interface."
   }
 }

--- a/special-pages/pages/new-tab/public/locales/fr/new-tab.json
+++ b/special-pages/pages/new-tab/public/locales/fr/new-tab.json
@@ -166,7 +166,7 @@
     "description": "Title of the omnibar widget in the customizer panel."
   },
   "omnibar_aiChatFormPlaceholder": {
-    "title": "Demander en privé",
+    "title": "Posez toutes vos questions en privé",
     "description": "Placeholder text for the AI chat input field."
   },
   "omnibar_aiChatFormSubmitButtonLabel": {
@@ -228,6 +228,98 @@
   "omnibar_customizePopoverDescription": {
     "title": "Dans tous les cas, vos informations restent privées.<br />Ce n'est pas ce que vous souhaitez&nbsp;? <button>Personnaliser</button>",
     "description": "Description message in the popover including privacy statement and customize option."
+  },
+  "omnibar_attachImageLabel": {
+    "title": "Joindre une image",
+    "description": "Accessible label for the attach image button in the AI chat toolbar."
+  },
+  "omnibar_removeImageLabel": {
+    "title": "Supprimer l’image",
+    "description": "Accessible label for the button to remove an attached image thumbnail."
+  },
+  "omnibar_modelSelectorLabel": {
+    "title": "Sélectionner le modèle",
+    "description": "Accessible label for the AI model selector dropdown."
+  },
+  "omnibar_imageAttachmentLimitWarning": {
+    "title": "Vous ne pouvez joindre que {limit} images à la fois.",
+    "description": "Warning shown when user attaches more images than the allowed maximum."
+  },
+  "omnibar_imageTooLargeError": {
+    "title": "L'image est trop grande. Veuillez en utiliser une inférieure à 10 000 × 10 000 pixels.",
+    "description": "Error shown when a user tries to attach an image that exceeds the maximum pixel dimensions."
+  },
+  "omnibar_imageProcessingError": {
+    "title": "Échec du traitement de l'image. Veuillez essayer un autre fichier.",
+    "description": "Error shown when an attached image cannot be processed."
+  },
+  "omnibar_advancedModelsSectionHeader": {
+    "title": "Modèles avancés - Abonnement DuckDuckGo",
+    "description": "Section header in the model picker for premium models that require a subscription."
+  },
+  "omnibar_viewAllChats": {
+    "title": "Voir toutes les discussions",
+    "description": "Link text to view all AI chat history."
+  },
+  "omnibar_openDuckAi": {
+    "title": "Ouvrir Duck.ai",
+    "description": "Link text to open the Duck.ai chat interface."
+  },
+  "omnibar_createImageLabel": {
+    "title": "Créer une image",
+    "description": "Label for the toggle button to enable image generation mode in the AI chat toolbar."
+  },
+  "omnibar_imageGenerationPlaceholder": {
+    "title": "Décrivez l’image que vous souhaitez créer",
+    "description": "Placeholder text for the AI chat input when image generation mode is active."
+  },
+  "omnibar_toolsMenuLabel": {
+    "title": "Outils",
+    "description": "Accessible label for the tools menu button in the AI chat toolbar."
+  },
+  "omnibar_createImageDescription": {
+    "title": "Transformer le texte en images",
+    "description": "Description for the Create Image tool shown in the tools menu dropdown."
+  },
+  "omnibar_webSearchLabel": {
+    "title": "Recherche sur le Web",
+    "description": "Label for the Web Search tool shown in the tools menu dropdown."
+  },
+  "omnibar_webSearchDescription": {
+    "title": "Trouver des réponses sur le Web",
+    "description": "Description for the Web Search tool shown in the tools menu dropdown."
+  },
+  "omnibar_imageGenerationWithAttachmentPlaceholder": {
+    "title": "Décrivez les modifications en fonction de l'image",
+    "description": "Placeholder text for the AI chat input when image generation mode is active and an image is attached."
+  },
+  "omnibar_reasoningPickerLabel": {
+    "title": "Raisonnement",
+    "description": "Accessible label (and chip text) for the reasoning-effort picker in the AI chat toolbar."
+  },
+  "omnibar_reasoningEffortFastLabel": {
+    "title": "Rapide",
+    "description": "Label for the 'fast' reasoning-effort option (answers right away, no deliberate reasoning)."
+  },
+  "omnibar_reasoningEffortFastDescription": {
+    "title": "Réponses immédiates",
+    "description": "Subtitle for the 'fast' reasoning-effort option in the reasoning picker dropdown."
+  },
+  "omnibar_reasoningEffortReasoningLabel": {
+    "title": "Raisonnement",
+    "description": "Label for the 'reasoning' reasoning-effort option (model spends a moment reasoning)."
+  },
+  "omnibar_reasoningEffortReasoningDescription": {
+    "title": "Prend un moment pour répondre",
+    "description": "Subtitle for the 'reasoning' reasoning-effort option in the reasoning picker dropdown."
+  },
+  "omnibar_reasoningEffortExtendedReasoningLabel": {
+    "title": "Raisonnement étendu",
+    "description": "Label for the 'extended reasoning' reasoning-effort option (model researches before responding)."
+  },
+  "omnibar_reasoningEffortExtendedReasoningDescription": {
+    "title": "Effectue des recherches avant de répondre",
+    "description": "Subtitle for the 'extended reasoning' reasoning-effort option in the reasoning picker dropdown."
   },
   "nextStepsList_sectionTitle": {
     "title": "Étapes suivantes",
@@ -652,41 +744,5 @@
   "activity_show_less_history": {
     "title": "Masquer les éléments supplémentaires",
     "note": "Button label that hides the expanded browsing history items."
-  },
-  "omnibar_attachImageLabel": {
-    "title": "Joindre une image",
-    "description": "Accessible label for the attach image button in the AI chat toolbar."
-  },
-  "omnibar_removeImageLabel": {
-    "title": "Supprimer l’image",
-    "description": "Accessible label for the button to remove an attached image thumbnail."
-  },
-  "omnibar_modelSelectorLabel": {
-    "title": "Sélectionner le modèle",
-    "description": "Accessible label for the AI model selector dropdown."
-  },
-  "omnibar_imageAttachmentLimitWarning": {
-    "title": "Vous ne pouvez joindre que {limit} images à la fois",
-    "description": "Warning shown when user attaches more images than the allowed maximum."
-  },
-  "omnibar_imageTooLargeError": {
-    "title": "L'image est trop grande. Veuillez en utiliser une inférieure à 10 000 × 10 000 pixels.",
-    "description": "Error shown when a user tries to attach an image that exceeds the maximum pixel dimensions."
-  },
-  "omnibar_imageProcessingError": {
-    "title": "Échec du traitement de l'image. Veuillez essayer un autre fichier.",
-    "description": "Error shown when an attached image cannot be processed."
-  },
-  "omnibar_advancedModelsSectionHeader": {
-    "title": "Modèles avancés - Abonnement DuckDuckGo",
-    "description": "Section header in the model picker for premium models that require a subscription."
-  },
-  "omnibar_viewAllChats": {
-    "title": "Voir toutes les discussions",
-    "description": "Link text to view all AI chat history."
-  },
-  "omnibar_openDuckAi": {
-    "title": "Ouvrir Duck.ai",
-    "description": "Link text to open the Duck.ai chat interface."
   }
 }

--- a/special-pages/pages/new-tab/public/locales/it/new-tab.json
+++ b/special-pages/pages/new-tab/public/locales/it/new-tab.json
@@ -166,7 +166,7 @@
     "description": "Title of the omnibar widget in the customizer panel."
   },
   "omnibar_aiChatFormPlaceholder": {
-    "title": "Chiedi in privato",
+    "title": "Chiedi qualsiasi cosa in privato",
     "description": "Placeholder text for the AI chat input field."
   },
   "omnibar_aiChatFormSubmitButtonLabel": {
@@ -228,6 +228,98 @@
   "omnibar_customizePopoverDescription": {
     "title": "In ogni caso, le tue informazioni rimangono private.Non lo vuoi? <button>Personalizza</button>",
     "description": "Description message in the popover including privacy statement and customize option."
+  },
+  "omnibar_attachImageLabel": {
+    "title": "Allega immagine",
+    "description": "Accessible label for the attach image button in the AI chat toolbar."
+  },
+  "omnibar_removeImageLabel": {
+    "title": "Rimuovi immagine",
+    "description": "Accessible label for the button to remove an attached image thumbnail."
+  },
+  "omnibar_modelSelectorLabel": {
+    "title": "Seleziona modello",
+    "description": "Accessible label for the AI model selector dropdown."
+  },
+  "omnibar_imageAttachmentLimitWarning": {
+    "title": "Puoi allegare solo {limit} immagini alla volta.",
+    "description": "Warning shown when user attaches more images than the allowed maximum."
+  },
+  "omnibar_imageTooLargeError": {
+    "title": "L'immagine è troppo grande. Utilizza un'immagine di dimensioni inferiori a 10.000×10.000 pixel.",
+    "description": "Error shown when a user tries to attach an image that exceeds the maximum pixel dimensions."
+  },
+  "omnibar_imageProcessingError": {
+    "title": "Impossibile elaborare l'immagine. Prova con un file diverso.",
+    "description": "Error shown when an attached image cannot be processed."
+  },
+  "omnibar_advancedModelsSectionHeader": {
+    "title": "Modelli avanzati - Abbonamento DuckDuckGo",
+    "description": "Section header in the model picker for premium models that require a subscription."
+  },
+  "omnibar_viewAllChats": {
+    "title": "Visualizza tutte le chat",
+    "description": "Link text to view all AI chat history."
+  },
+  "omnibar_openDuckAi": {
+    "title": "Apri Duck.ai",
+    "description": "Link text to open the Duck.ai chat interface."
+  },
+  "omnibar_createImageLabel": {
+    "title": "Crea immagine",
+    "description": "Label for the toggle button to enable image generation mode in the AI chat toolbar."
+  },
+  "omnibar_imageGenerationPlaceholder": {
+    "title": "Descrivi l'immagine che vuoi creare",
+    "description": "Placeholder text for the AI chat input when image generation mode is active."
+  },
+  "omnibar_toolsMenuLabel": {
+    "title": "Strumenti",
+    "description": "Accessible label for the tools menu button in the AI chat toolbar."
+  },
+  "omnibar_createImageDescription": {
+    "title": "Trasforma il testo in immagini",
+    "description": "Description for the Create Image tool shown in the tools menu dropdown."
+  },
+  "omnibar_webSearchLabel": {
+    "title": "Ricerca nel web",
+    "description": "Label for the Web Search tool shown in the tools menu dropdown."
+  },
+  "omnibar_webSearchDescription": {
+    "title": "Reperisci risposte dal web",
+    "description": "Description for the Web Search tool shown in the tools menu dropdown."
+  },
+  "omnibar_imageGenerationWithAttachmentPlaceholder": {
+    "title": "Descrivi i cambiamenti in base all'immagine",
+    "description": "Placeholder text for the AI chat input when image generation mode is active and an image is attached."
+  },
+  "omnibar_reasoningPickerLabel": {
+    "title": "Ragionamento",
+    "description": "Accessible label (and chip text) for the reasoning-effort picker in the AI chat toolbar."
+  },
+  "omnibar_reasoningEffortFastLabel": {
+    "title": "Veloce",
+    "description": "Label for the 'fast' reasoning-effort option (answers right away, no deliberate reasoning)."
+  },
+  "omnibar_reasoningEffortFastDescription": {
+    "title": "Risposte immediate",
+    "description": "Subtitle for the 'fast' reasoning-effort option in the reasoning picker dropdown."
+  },
+  "omnibar_reasoningEffortReasoningLabel": {
+    "title": "Ragionamento",
+    "description": "Label for the 'reasoning' reasoning-effort option (model spends a moment reasoning)."
+  },
+  "omnibar_reasoningEffortReasoningDescription": {
+    "title": "Richiede un momento per rispondere",
+    "description": "Subtitle for the 'reasoning' reasoning-effort option in the reasoning picker dropdown."
+  },
+  "omnibar_reasoningEffortExtendedReasoningLabel": {
+    "title": "Ragionamento Esteso",
+    "description": "Label for the 'extended reasoning' reasoning-effort option (model researches before responding)."
+  },
+  "omnibar_reasoningEffortExtendedReasoningDescription": {
+    "title": "Cerca prima di rispondere",
+    "description": "Subtitle for the 'extended reasoning' reasoning-effort option in the reasoning picker dropdown."
   },
   "nextStepsList_sectionTitle": {
     "title": "Passaggi successivi",
@@ -652,41 +744,5 @@
   "activity_show_less_history": {
     "title": "Nascondi altro",
     "note": "Button label that hides the expanded browsing history items."
-  },
-  "omnibar_attachImageLabel": {
-    "title": "Allega immagine",
-    "description": "Accessible label for the attach image button in the AI chat toolbar."
-  },
-  "omnibar_removeImageLabel": {
-    "title": "Rimuovi immagine",
-    "description": "Accessible label for the button to remove an attached image thumbnail."
-  },
-  "omnibar_modelSelectorLabel": {
-    "title": "Seleziona modello",
-    "description": "Accessible label for the AI model selector dropdown."
-  },
-  "omnibar_imageAttachmentLimitWarning": {
-    "title": "Puoi allegare solo {limit} immagini alla volta",
-    "description": "Warning shown when user attaches more images than the allowed maximum."
-  },
-  "omnibar_imageTooLargeError": {
-    "title": "L'immagine è troppo grande. Utilizza un'immagine di dimensioni inferiori a 10.000×10.000 pixel.",
-    "description": "Error shown when a user tries to attach an image that exceeds the maximum pixel dimensions."
-  },
-  "omnibar_imageProcessingError": {
-    "title": "Impossibile elaborare l'immagine. Prova con un file diverso.",
-    "description": "Error shown when an attached image cannot be processed."
-  },
-  "omnibar_advancedModelsSectionHeader": {
-    "title": "Modelli avanzati - Abbonamento DuckDuckGo",
-    "description": "Section header in the model picker for premium models that require a subscription."
-  },
-  "omnibar_viewAllChats": {
-    "title": "Visualizza tutte le chat",
-    "description": "Link text to view all AI chat history."
-  },
-  "omnibar_openDuckAi": {
-    "title": "Apri Duck.ai",
-    "description": "Link text to open the Duck.ai chat interface."
   }
 }

--- a/special-pages/pages/new-tab/public/locales/nl/new-tab.json
+++ b/special-pages/pages/new-tab/public/locales/nl/new-tab.json
@@ -166,7 +166,7 @@
     "description": "Title of the omnibar widget in the customizer panel."
   },
   "omnibar_aiChatFormPlaceholder": {
-    "title": "Vraag privé",
+    "title": "Vraag iets privé",
     "description": "Placeholder text for the AI chat input field."
   },
   "omnibar_aiChatFormSubmitButtonLabel": {
@@ -228,6 +228,98 @@
   "omnibar_customizePopoverDescription": {
     "title": "Hoe dan ook, je gegevens blijven privé.Wil je dit niet? <button>Aanpassen</button>",
     "description": "Description message in the popover including privacy statement and customize option."
+  },
+  "omnibar_attachImageLabel": {
+    "title": "Afbeelding bijvoegen",
+    "description": "Accessible label for the attach image button in the AI chat toolbar."
+  },
+  "omnibar_removeImageLabel": {
+    "title": "Afbeelding verwijderen",
+    "description": "Accessible label for the button to remove an attached image thumbnail."
+  },
+  "omnibar_modelSelectorLabel": {
+    "title": "Model kiezen",
+    "description": "Accessible label for the AI model selector dropdown."
+  },
+  "omnibar_imageAttachmentLimitWarning": {
+    "title": "Je kunt slechts {limit} afbeeldingen tegelijk bijvoegen.",
+    "description": "Warning shown when user attaches more images than the allowed maximum."
+  },
+  "omnibar_imageTooLargeError": {
+    "title": "De afbeelding is te groot. Gebruik een afbeelding kleiner dan 10.000×10.000 pixels.",
+    "description": "Error shown when a user tries to attach an image that exceeds the maximum pixel dimensions."
+  },
+  "omnibar_imageProcessingError": {
+    "title": "Het verwerken van de afbeelding is mislukt. Probeer een ander bestand.",
+    "description": "Error shown when an attached image cannot be processed."
+  },
+  "omnibar_advancedModelsSectionHeader": {
+    "title": "Geavanceerde modellen - DuckDuckGo-abonnement",
+    "description": "Section header in the model picker for premium models that require a subscription."
+  },
+  "omnibar_viewAllChats": {
+    "title": "Bekijk alle chats",
+    "description": "Link text to view all AI chat history."
+  },
+  "omnibar_openDuckAi": {
+    "title": "Duck.ai openen",
+    "description": "Link text to open the Duck.ai chat interface."
+  },
+  "omnibar_createImageLabel": {
+    "title": "Afbeelding maken",
+    "description": "Label for the toggle button to enable image generation mode in the AI chat toolbar."
+  },
+  "omnibar_imageGenerationPlaceholder": {
+    "title": "Beschrijf de afbeelding die je wilt maken",
+    "description": "Placeholder text for the AI chat input when image generation mode is active."
+  },
+  "omnibar_toolsMenuLabel": {
+    "title": "Hulpmiddelen",
+    "description": "Accessible label for the tools menu button in the AI chat toolbar."
+  },
+  "omnibar_createImageDescription": {
+    "title": "Zet tekst om in afbeeldingen",
+    "description": "Description for the Create Image tool shown in the tools menu dropdown."
+  },
+  "omnibar_webSearchLabel": {
+    "title": "Zoeken op het web",
+    "description": "Label for the Web Search tool shown in the tools menu dropdown."
+  },
+  "omnibar_webSearchDescription": {
+    "title": "Antwoorden van internet",
+    "description": "Description for the Web Search tool shown in the tools menu dropdown."
+  },
+  "omnibar_imageGenerationWithAttachmentPlaceholder": {
+    "title": "Beschrijf veranderingen op basis van de afbeelding",
+    "description": "Placeholder text for the AI chat input when image generation mode is active and an image is attached."
+  },
+  "omnibar_reasoningPickerLabel": {
+    "title": "Redenering",
+    "description": "Accessible label (and chip text) for the reasoning-effort picker in the AI chat toolbar."
+  },
+  "omnibar_reasoningEffortFastLabel": {
+    "title": "Snel",
+    "description": "Label for the 'fast' reasoning-effort option (answers right away, no deliberate reasoning)."
+  },
+  "omnibar_reasoningEffortFastDescription": {
+    "title": "Geeft meteen antwoord",
+    "description": "Subtitle for the 'fast' reasoning-effort option in the reasoning picker dropdown."
+  },
+  "omnibar_reasoningEffortReasoningLabel": {
+    "title": "Redenering",
+    "description": "Label for the 'reasoning' reasoning-effort option (model spends a moment reasoning)."
+  },
+  "omnibar_reasoningEffortReasoningDescription": {
+    "title": "Het duurt even om te reageren",
+    "description": "Subtitle for the 'reasoning' reasoning-effort option in the reasoning picker dropdown."
+  },
+  "omnibar_reasoningEffortExtendedReasoningLabel": {
+    "title": "Uitgebreide redenering",
+    "description": "Label for the 'extended reasoning' reasoning-effort option (model researches before responding)."
+  },
+  "omnibar_reasoningEffortExtendedReasoningDescription": {
+    "title": "Onderzoekt voordat wordt gereageerd",
+    "description": "Subtitle for the 'extended reasoning' reasoning-effort option in the reasoning picker dropdown."
   },
   "nextStepsList_sectionTitle": {
     "title": "Volgende stappen",
@@ -652,41 +744,5 @@
   "activity_show_less_history": {
     "title": "Aanvullende gegevens verbergen",
     "note": "Button label that hides the expanded browsing history items."
-  },
-  "omnibar_attachImageLabel": {
-    "title": "Afbeelding bijvoegen",
-    "description": "Accessible label for the attach image button in the AI chat toolbar."
-  },
-  "omnibar_removeImageLabel": {
-    "title": "Afbeelding verwijderen",
-    "description": "Accessible label for the button to remove an attached image thumbnail."
-  },
-  "omnibar_modelSelectorLabel": {
-    "title": "Model kiezen",
-    "description": "Accessible label for the AI model selector dropdown."
-  },
-  "omnibar_imageAttachmentLimitWarning": {
-    "title": "Je kunt slechts {limit} afbeeldingen tegelijk bijvoegen",
-    "description": "Warning shown when user attaches more images than the allowed maximum."
-  },
-  "omnibar_imageTooLargeError": {
-    "title": "De afbeelding is te groot. Gebruik een afbeelding kleiner dan 10.000×10.000 pixels.",
-    "description": "Error shown when a user tries to attach an image that exceeds the maximum pixel dimensions."
-  },
-  "omnibar_imageProcessingError": {
-    "title": "Het verwerken van de afbeelding is mislukt. Probeer een ander bestand.",
-    "description": "Error shown when an attached image cannot be processed."
-  },
-  "omnibar_advancedModelsSectionHeader": {
-    "title": "Geavanceerde modellen - DuckDuckGo-abonnement",
-    "description": "Section header in the model picker for premium models that require a subscription."
-  },
-  "omnibar_viewAllChats": {
-    "title": "Bekijk alle chats",
-    "description": "Link text to view all AI chat history."
-  },
-  "omnibar_openDuckAi": {
-    "title": "Duck.ai openen",
-    "description": "Link text to open the Duck.ai chat interface."
   }
 }

--- a/special-pages/pages/new-tab/public/locales/pl/new-tab.json
+++ b/special-pages/pages/new-tab/public/locales/pl/new-tab.json
@@ -166,7 +166,7 @@
     "description": "Title of the omnibar widget in the customizer panel."
   },
   "omnibar_aiChatFormPlaceholder": {
-    "title": "Zapytaj prywatnie",
+    "title": "Zapytaj o cokolwiek prywatnie",
     "description": "Placeholder text for the AI chat input field."
   },
   "omnibar_aiChatFormSubmitButtonLabel": {
@@ -228,6 +228,98 @@
   "omnibar_customizePopoverDescription": {
     "title": "W każdym przypadku Twoje dane pozostaną prywatne.<br />Nie chcesz tego? <button>Dostosuj</button>",
     "description": "Description message in the popover including privacy statement and customize option."
+  },
+  "omnibar_attachImageLabel": {
+    "title": "Załącz obraz",
+    "description": "Accessible label for the attach image button in the AI chat toolbar."
+  },
+  "omnibar_removeImageLabel": {
+    "title": "Usuń obraz",
+    "description": "Accessible label for the button to remove an attached image thumbnail."
+  },
+  "omnibar_modelSelectorLabel": {
+    "title": "Wybierz model",
+    "description": "Accessible label for the AI model selector dropdown."
+  },
+  "omnibar_imageAttachmentLimitWarning": {
+    "title": "Jednocześnie możesz załączyć tylko {limit} obrazy.",
+    "description": "Warning shown when user attaches more images than the allowed maximum."
+  },
+  "omnibar_imageTooLargeError": {
+    "title": "Obraz jest zbyt duży. Użyj obrazu mniejszego niż 10000×10000 pikseli.",
+    "description": "Error shown when a user tries to attach an image that exceeds the maximum pixel dimensions."
+  },
+  "omnibar_imageProcessingError": {
+    "title": "Nie udało się przetworzyć obrazu. Wybierz inny plik.",
+    "description": "Error shown when an attached image cannot be processed."
+  },
+  "omnibar_advancedModelsSectionHeader": {
+    "title": "Zaawansowane modele – subskrypcja DuckDuckGo",
+    "description": "Section header in the model picker for premium models that require a subscription."
+  },
+  "omnibar_viewAllChats": {
+    "title": "Zobacz wszystkie czaty",
+    "description": "Link text to view all AI chat history."
+  },
+  "omnibar_openDuckAi": {
+    "title": "Otwórz Duck.ai",
+    "description": "Link text to open the Duck.ai chat interface."
+  },
+  "omnibar_createImageLabel": {
+    "title": "Utwórz obraz",
+    "description": "Label for the toggle button to enable image generation mode in the AI chat toolbar."
+  },
+  "omnibar_imageGenerationPlaceholder": {
+    "title": "Opisz obraz, który chcesz utworzyć",
+    "description": "Placeholder text for the AI chat input when image generation mode is active."
+  },
+  "omnibar_toolsMenuLabel": {
+    "title": "Narzędzia",
+    "description": "Accessible label for the tools menu button in the AI chat toolbar."
+  },
+  "omnibar_createImageDescription": {
+    "title": "Przekształć tekst w obrazy",
+    "description": "Description for the Create Image tool shown in the tools menu dropdown."
+  },
+  "omnibar_webSearchLabel": {
+    "title": "Wyszukiwanie w sieci",
+    "description": "Label for the Web Search tool shown in the tools menu dropdown."
+  },
+  "omnibar_webSearchDescription": {
+    "title": "Pobieraj odpowiedzi z internetu",
+    "description": "Description for the Web Search tool shown in the tools menu dropdown."
+  },
+  "omnibar_imageGenerationWithAttachmentPlaceholder": {
+    "title": "Opisz zmiany na podstawie obrazu",
+    "description": "Placeholder text for the AI chat input when image generation mode is active and an image is attached."
+  },
+  "omnibar_reasoningPickerLabel": {
+    "title": "Rozumowanie",
+    "description": "Accessible label (and chip text) for the reasoning-effort picker in the AI chat toolbar."
+  },
+  "omnibar_reasoningEffortFastLabel": {
+    "title": "Szybko",
+    "description": "Label for the 'fast' reasoning-effort option (answers right away, no deliberate reasoning)."
+  },
+  "omnibar_reasoningEffortFastDescription": {
+    "title": "Odpowiedzi od razu",
+    "description": "Subtitle for the 'fast' reasoning-effort option in the reasoning picker dropdown."
+  },
+  "omnibar_reasoningEffortReasoningLabel": {
+    "title": "Rozumowanie",
+    "description": "Label for the 'reasoning' reasoning-effort option (model spends a moment reasoning)."
+  },
+  "omnibar_reasoningEffortReasoningDescription": {
+    "title": "Potrzebuje chwili, by odpowiedzieć",
+    "description": "Subtitle for the 'reasoning' reasoning-effort option in the reasoning picker dropdown."
+  },
+  "omnibar_reasoningEffortExtendedReasoningLabel": {
+    "title": "Rozszerzone rozumowanie",
+    "description": "Label for the 'extended reasoning' reasoning-effort option (model researches before responding)."
+  },
+  "omnibar_reasoningEffortExtendedReasoningDescription": {
+    "title": "Przeprowadź badania przed odpowiedzią",
+    "description": "Subtitle for the 'extended reasoning' reasoning-effort option in the reasoning picker dropdown."
   },
   "nextStepsList_sectionTitle": {
     "title": "Dalsze kroki",
@@ -652,41 +744,5 @@
   "activity_show_less_history": {
     "title": "Ukryj dodatkowe",
     "note": "Button label that hides the expanded browsing history items."
-  },
-  "omnibar_attachImageLabel": {
-    "title": "Załącz obraz",
-    "description": "Accessible label for the attach image button in the AI chat toolbar."
-  },
-  "omnibar_removeImageLabel": {
-    "title": "Usuń obraz",
-    "description": "Accessible label for the button to remove an attached image thumbnail."
-  },
-  "omnibar_modelSelectorLabel": {
-    "title": "Wybierz model",
-    "description": "Accessible label for the AI model selector dropdown."
-  },
-  "omnibar_imageAttachmentLimitWarning": {
-    "title": "Jednocześnie możesz załączyć tylko {limit} obrazów",
-    "description": "Warning shown when user attaches more images than the allowed maximum."
-  },
-  "omnibar_imageTooLargeError": {
-    "title": "Obraz jest zbyt duży. Użyj obrazu mniejszego niż 10000×10000 pikseli.",
-    "description": "Error shown when a user tries to attach an image that exceeds the maximum pixel dimensions."
-  },
-  "omnibar_imageProcessingError": {
-    "title": "Nie udało się przetworzyć obrazu. Wybierz inny plik.",
-    "description": "Error shown when an attached image cannot be processed."
-  },
-  "omnibar_advancedModelsSectionHeader": {
-    "title": "Zaawansowane modele – subskrypcja DuckDuckGo",
-    "description": "Section header in the model picker for premium models that require a subscription."
-  },
-  "omnibar_viewAllChats": {
-    "title": "Zobacz wszystkie czaty",
-    "description": "Link text to view all AI chat history."
-  },
-  "omnibar_openDuckAi": {
-    "title": "Otwórz Duck.ai",
-    "description": "Link text to open the Duck.ai chat interface."
   }
 }

--- a/special-pages/pages/new-tab/public/locales/pt/new-tab.json
+++ b/special-pages/pages/new-tab/public/locales/pt/new-tab.json
@@ -166,7 +166,7 @@
     "description": "Title of the omnibar widget in the customizer panel."
   },
   "omnibar_aiChatFormPlaceholder": {
-    "title": "Perguntar em privado",
+    "title": "Pergunta o que quiseres em privado",
     "description": "Placeholder text for the AI chat input field."
   },
   "omnibar_aiChatFormSubmitButtonLabel": {
@@ -228,6 +228,98 @@
   "omnibar_customizePopoverDescription": {
     "title": "De qualquer forma, as tuas informações permanecem privadas.<br />Não queres isto? <button>Personalizar</button>",
     "description": "Description message in the popover including privacy statement and customize option."
+  },
+  "omnibar_attachImageLabel": {
+    "title": "Anexar imagem",
+    "description": "Accessible label for the attach image button in the AI chat toolbar."
+  },
+  "omnibar_removeImageLabel": {
+    "title": "Remover imagem",
+    "description": "Accessible label for the button to remove an attached image thumbnail."
+  },
+  "omnibar_modelSelectorLabel": {
+    "title": "Selecionar modelo",
+    "description": "Accessible label for the AI model selector dropdown."
+  },
+  "omnibar_imageAttachmentLimitWarning": {
+    "title": "Só podes anexar {limit} imagens de cada vez.",
+    "description": "Warning shown when user attaches more images than the allowed maximum."
+  },
+  "omnibar_imageTooLargeError": {
+    "title": "A imagem é demasiado grande. Usa uma imagem menor que 10 000 × 10 000 píxeis.",
+    "description": "Error shown when a user tries to attach an image that exceeds the maximum pixel dimensions."
+  },
+  "omnibar_imageProcessingError": {
+    "title": "Falha ao processar a imagem. Experimenta com um ficheiro diferente.",
+    "description": "Error shown when an attached image cannot be processed."
+  },
+  "omnibar_advancedModelsSectionHeader": {
+    "title": "Modelos Avançados - subscrição da DuckDuckGo",
+    "description": "Section header in the model picker for premium models that require a subscription."
+  },
+  "omnibar_viewAllChats": {
+    "title": "Ver todos os chats",
+    "description": "Link text to view all AI chat history."
+  },
+  "omnibar_openDuckAi": {
+    "title": "Abrir Duck.ai",
+    "description": "Link text to open the Duck.ai chat interface."
+  },
+  "omnibar_createImageLabel": {
+    "title": "Criar imagem",
+    "description": "Label for the toggle button to enable image generation mode in the AI chat toolbar."
+  },
+  "omnibar_imageGenerationPlaceholder": {
+    "title": "Descreve a imagem que queres criar",
+    "description": "Placeholder text for the AI chat input when image generation mode is active."
+  },
+  "omnibar_toolsMenuLabel": {
+    "title": "Ferramentas",
+    "description": "Accessible label for the tools menu button in the AI chat toolbar."
+  },
+  "omnibar_createImageDescription": {
+    "title": "Transformar texto em imagens",
+    "description": "Description for the Create Image tool shown in the tools menu dropdown."
+  },
+  "omnibar_webSearchLabel": {
+    "title": "Pesquisa na Web",
+    "description": "Label for the Web Search tool shown in the tools menu dropdown."
+  },
+  "omnibar_webSearchDescription": {
+    "title": "Respostas da web",
+    "description": "Description for the Web Search tool shown in the tools menu dropdown."
+  },
+  "omnibar_imageGenerationWithAttachmentPlaceholder": {
+    "title": "Descreve as alterações com base na imagem",
+    "description": "Placeholder text for the AI chat input when image generation mode is active and an image is attached."
+  },
+  "omnibar_reasoningPickerLabel": {
+    "title": "Raciocínio",
+    "description": "Accessible label (and chip text) for the reasoning-effort picker in the AI chat toolbar."
+  },
+  "omnibar_reasoningEffortFastLabel": {
+    "title": "Rápido",
+    "description": "Label for the 'fast' reasoning-effort option (answers right away, no deliberate reasoning)."
+  },
+  "omnibar_reasoningEffortFastDescription": {
+    "title": "Responder de imediato",
+    "description": "Subtitle for the 'fast' reasoning-effort option in the reasoning picker dropdown."
+  },
+  "omnibar_reasoningEffortReasoningLabel": {
+    "title": "Raciocínio",
+    "description": "Label for the 'reasoning' reasoning-effort option (model spends a moment reasoning)."
+  },
+  "omnibar_reasoningEffortReasoningDescription": {
+    "title": "Demora um momento a responder",
+    "description": "Subtitle for the 'reasoning' reasoning-effort option in the reasoning picker dropdown."
+  },
+  "omnibar_reasoningEffortExtendedReasoningLabel": {
+    "title": "Raciocínio Estendido",
+    "description": "Label for the 'extended reasoning' reasoning-effort option (model researches before responding)."
+  },
+  "omnibar_reasoningEffortExtendedReasoningDescription": {
+    "title": "Pesquisa antes de responder",
+    "description": "Subtitle for the 'extended reasoning' reasoning-effort option in the reasoning picker dropdown."
   },
   "nextStepsList_sectionTitle": {
     "title": "Passos seguintes",
@@ -652,41 +744,5 @@
   "activity_show_less_history": {
     "title": "Ocultar itens adicionais",
     "note": "Button label that hides the expanded browsing history items."
-  },
-  "omnibar_attachImageLabel": {
-    "title": "Anexar imagem",
-    "description": "Accessible label for the attach image button in the AI chat toolbar."
-  },
-  "omnibar_removeImageLabel": {
-    "title": "Remover imagem",
-    "description": "Accessible label for the button to remove an attached image thumbnail."
-  },
-  "omnibar_modelSelectorLabel": {
-    "title": "Selecionar modelo",
-    "description": "Accessible label for the AI model selector dropdown."
-  },
-  "omnibar_imageAttachmentLimitWarning": {
-    "title": "Só podes anexar {limit} imagens de cada vez",
-    "description": "Warning shown when user attaches more images than the allowed maximum."
-  },
-  "omnibar_imageTooLargeError": {
-    "title": "A imagem é demasiado grande. Usa uma imagem menor que 10 000 × 10 000 píxeis.",
-    "description": "Error shown when a user tries to attach an image that exceeds the maximum pixel dimensions."
-  },
-  "omnibar_imageProcessingError": {
-    "title": "Falha ao processar a imagem. Experimenta com um ficheiro diferente.",
-    "description": "Error shown when an attached image cannot be processed."
-  },
-  "omnibar_advancedModelsSectionHeader": {
-    "title": "Modelos Avançados - subscrição da DuckDuckGo",
-    "description": "Section header in the model picker for premium models that require a subscription."
-  },
-  "omnibar_viewAllChats": {
-    "title": "Ver todos os chats",
-    "description": "Link text to view all AI chat history."
-  },
-  "omnibar_openDuckAi": {
-    "title": "Abrir Duck.ai",
-    "description": "Link text to open the Duck.ai chat interface."
   }
 }

--- a/special-pages/pages/new-tab/public/locales/ru/new-tab.json
+++ b/special-pages/pages/new-tab/public/locales/ru/new-tab.json
@@ -166,7 +166,7 @@
     "description": "Title of the omnibar widget in the customizer panel."
   },
   "omnibar_aiChatFormPlaceholder": {
-    "title": "Задать вопрос (конфиденциально)",
+    "title": "Задавайте любые вопросы, сохраняя конфиденциальность",
     "description": "Placeholder text for the AI chat input field."
   },
   "omnibar_aiChatFormSubmitButtonLabel": {
@@ -228,6 +228,98 @@
   "omnibar_customizePopoverDescription": {
     "title": "Ваши данные в любом случае остаются в тайне.<br />Не устраивает такой вариант? <button>Настройте свой!</button>",
     "description": "Description message in the popover including privacy statement and customize option."
+  },
+  "omnibar_attachImageLabel": {
+    "title": "Прикрепить изображение",
+    "description": "Accessible label for the attach image button in the AI chat toolbar."
+  },
+  "omnibar_removeImageLabel": {
+    "title": "Удалить изображение",
+    "description": "Accessible label for the button to remove an attached image thumbnail."
+  },
+  "omnibar_modelSelectorLabel": {
+    "title": "Выбрать модель",
+    "description": "Accessible label for the AI model selector dropdown."
+  },
+  "omnibar_imageAttachmentLimitWarning": {
+    "title": "Число изображений, прикрепляемых за один раз, ограничено: максимум {limit}.",
+    "description": "Warning shown when user attaches more images than the allowed maximum."
+  },
+  "omnibar_imageTooLargeError": {
+    "title": "Слишком большой файл. Выберите изображение размером до 10 000 × 10 000 пикселей.",
+    "description": "Error shown when a user tries to attach an image that exceeds the maximum pixel dimensions."
+  },
+  "omnibar_imageProcessingError": {
+    "title": "Не удалось обработать изображение. Пожалуйста, попробуйте другой файл.",
+    "description": "Error shown when an attached image cannot be processed."
+  },
+  "omnibar_advancedModelsSectionHeader": {
+    "title": "Расширенные модели — подписка на DuckDuckGo",
+    "description": "Section header in the model picker for premium models that require a subscription."
+  },
+  "omnibar_viewAllChats": {
+    "title": "Просмотреть все чаты",
+    "description": "Link text to view all AI chat history."
+  },
+  "omnibar_openDuckAi": {
+    "title": "Открыть Duck.ai",
+    "description": "Link text to open the Duck.ai chat interface."
+  },
+  "omnibar_createImageLabel": {
+    "title": "Создать изображение",
+    "description": "Label for the toggle button to enable image generation mode in the AI chat toolbar."
+  },
+  "omnibar_imageGenerationPlaceholder": {
+    "title": "Опишите нужное вам изображение",
+    "description": "Placeholder text for the AI chat input when image generation mode is active."
+  },
+  "omnibar_toolsMenuLabel": {
+    "title": "Инструменты",
+    "description": "Accessible label for the tools menu button in the AI chat toolbar."
+  },
+  "omnibar_createImageDescription": {
+    "title": "Преобразуй текст в изображения",
+    "description": "Description for the Create Image tool shown in the tools menu dropdown."
+  },
+  "omnibar_webSearchLabel": {
+    "title": "Веб-поиск",
+    "description": "Label for the Web Search tool shown in the tools menu dropdown."
+  },
+  "omnibar_webSearchDescription": {
+    "title": "Получать ответы из интернета",
+    "description": "Description for the Web Search tool shown in the tools menu dropdown."
+  },
+  "omnibar_imageGenerationWithAttachmentPlaceholder": {
+    "title": "Опиши изменения на основе изображения",
+    "description": "Placeholder text for the AI chat input when image generation mode is active and an image is attached."
+  },
+  "omnibar_reasoningPickerLabel": {
+    "title": "Рассуждения",
+    "description": "Accessible label (and chip text) for the reasoning-effort picker in the AI chat toolbar."
+  },
+  "omnibar_reasoningEffortFastLabel": {
+    "title": "Быстрый",
+    "description": "Label for the 'fast' reasoning-effort option (answers right away, no deliberate reasoning)."
+  },
+  "omnibar_reasoningEffortFastDescription": {
+    "title": "Моментальные ответы.",
+    "description": "Subtitle for the 'fast' reasoning-effort option in the reasoning picker dropdown."
+  },
+  "omnibar_reasoningEffortReasoningLabel": {
+    "title": "Рассуждения",
+    "description": "Label for the 'reasoning' reasoning-effort option (model spends a moment reasoning)."
+  },
+  "omnibar_reasoningEffortReasoningDescription": {
+    "title": "Ответ занимает чуть больше времени.",
+    "description": "Subtitle for the 'reasoning' reasoning-effort option in the reasoning picker dropdown."
+  },
+  "omnibar_reasoningEffortExtendedReasoningLabel": {
+    "title": "Углубленные рассуждения",
+    "description": "Label for the 'extended reasoning' reasoning-effort option (model researches before responding)."
+  },
+  "omnibar_reasoningEffortExtendedReasoningDescription": {
+    "title": "ИИ собирает и изучает данные, прежде чем дать ответ.",
+    "description": "Subtitle for the 'extended reasoning' reasoning-effort option in the reasoning picker dropdown."
   },
   "nextStepsList_sectionTitle": {
     "title": "Дальнейшие шаги",
@@ -652,41 +744,5 @@
   "activity_show_less_history": {
     "title": "Свернуть",
     "note": "Button label that hides the expanded browsing history items."
-  },
-  "omnibar_attachImageLabel": {
-    "title": "Прикрепить изображение",
-    "description": "Accessible label for the attach image button in the AI chat toolbar."
-  },
-  "omnibar_removeImageLabel": {
-    "title": "Удалить изображение",
-    "description": "Accessible label for the button to remove an attached image thumbnail."
-  },
-  "omnibar_modelSelectorLabel": {
-    "title": "Выбрать модель",
-    "description": "Accessible label for the AI model selector dropdown."
-  },
-  "omnibar_imageAttachmentLimitWarning": {
-    "title": "Число изображений, прикрепляемых за один раз, ограничено: максимум {limit}.",
-    "description": "Warning shown when user attaches more images than the allowed maximum."
-  },
-  "omnibar_imageTooLargeError": {
-    "title": "Слишком большой файл. Выберите изображение размером до 10 000 × 10 000 пикселей.",
-    "description": "Error shown when a user tries to attach an image that exceeds the maximum pixel dimensions."
-  },
-  "omnibar_imageProcessingError": {
-    "title": "Не удалось обработать изображение. Пожалуйста, попробуйте другой файл.",
-    "description": "Error shown when an attached image cannot be processed."
-  },
-  "omnibar_advancedModelsSectionHeader": {
-    "title": "Расширенные модели — подписка на DuckDuckGo",
-    "description": "Section header in the model picker for premium models that require a subscription."
-  },
-  "omnibar_viewAllChats": {
-    "title": "Просмотреть все чаты",
-    "description": "Link text to view all AI chat history."
-  },
-  "omnibar_openDuckAi": {
-    "title": "Открыть Duck.ai",
-    "description": "Link text to open the Duck.ai chat interface."
   }
 }


### PR DESCRIPTION
## Description

Adds translations for the omnibar's image-generation, web-search, and reasoning-effort UI across 8 non-English locales.

Changes

- Translates 14 new omnibar keys (Create Image / Tools menu, Web Search, and the Reasoning effort picker with Fast / Reasoning / Extended Reasoning variants) into German, Spanish, French, Italian, Dutch, Polish, Portuguese, and Russian.
- Re-translates `omnibar_aiChatFormPlaceholder` to match the updated English source ("Ask anything privately")


## Checklist

<!--
  These questions are a friendly reminder to shipping code, if you're uncertain ask the AoR owners.
  It's also totally appropriate to not check some of these boxes, if they don't apply to your change.
-->
*Please tick all that apply:*

- [x] I have tested this change locally
- [ ] I have tested this change locally in all supported browsers
- [x] This change will be visible to users
- [ ] I have added automated tests that cover this change
- [x] I have ensured the change is gated by config
- [x] This change was covered by a ship review
- [x] This change was covered by a tech design
- [x] Any dependent config has been merged


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only updates static localization strings for the New Tab omnibar across several locales; no logic, data handling, or security-sensitive code changes.
> 
> **Overview**
> Updates `new-tab.json` locale strings (de/es/fr/it/nl/pl/pt/ru) to localize newly added omnibar AI-chat UI, including image attachment controls, the *Tools* menu (Create Image + Web Search), and the reasoning-effort picker options.
> 
> Also refreshes `omnibar_aiChatFormPlaceholder` translations to match the updated English source and reorders some omnibar translation blocks within the JSON files (no functional behavior changes).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8ba1db1aef422f2e57cdf6d97d74ddb4fff7136f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->