### PR TITLE
Aibrahim/bugfix/overflowy browseruilock

### DIFF
--- a/injected/src/features/browser-ui-lock.js
+++ b/injected/src/features/browser-ui-lock.js
@@ -130,11 +130,18 @@ export default class BrowserUiLock extends ContentFeature {
 
     /**
      * Determine if UI should be locked based on scrollbar visibility.
-     * Lock if there's no visible vertical scrollbar on the page.
+     * Lock if the site's domain is in the `lockedDomains` list; otherwise lock if
+     * there is no visible vertical scrollbar AND `overflow-y: hidden` is explicitly
+     * set on html or body.
      * @returns {boolean}
      */
     _detectShouldLock() {
         try {
+            // Sites configured in lockedDomains bypass all other checks
+            if (this._isLockedDomain()) {
+                return true;
+            }
+
             const html = document.documentElement;
             const body = document.body;
 
@@ -146,13 +153,49 @@ export default class BrowserUiLock extends ContentFeature {
                 return false;
             }
 
-            // No visible scrollbar - lock the UI
-            return true;
+            // No visible scrollbar — additionally require overflow-y: hidden
+            // to be explicitly set on html or body before locking.
+            return Boolean((html && this._hasOverflowYHidden(html)) || (body && this._hasOverflowYHidden(body)));
         } catch (e) {
             // Fail open - return false (unlocked) on error
             this.log.warn('Failed to detect scroll state:', e);
             return false;
         }
+    }
+
+    /**
+     * Check whether the current site's URL matches any entry in the `lockedDomains`
+     * list. Each entry is matched against `host + pathname` of the site's URL:
+     *
+     * - exact host match: an entry `"example.com"` matches host `example.com` (any
+     *   path) but does NOT match `www.example.com` or `evil.example.com.attacker`.
+     * - path prefix match: an entry `"example.com/foo"` matches any URL on host
+     *   `example.com` whose path begins with `/foo` followed by `/` or end-of-path.
+     *
+     * @returns {boolean}
+     */
+    _isLockedDomain() {
+        const patterns = this.getFeatureSetting('lockedDomains');
+        if (!Array.isArray(patterns) || patterns.length === 0) {
+            return false;
+        }
+        const siteUrl = this.args?.site?.url;
+        if (typeof siteUrl !== 'string' || siteUrl.length === 0) {
+            return false;
+        }
+        let hostPath;
+        try {
+            const url = new URL(siteUrl);
+            hostPath = url.host + url.pathname;
+        } catch {
+            return false;
+        }
+        return patterns.some((p) => {
+            if (typeof p !== 'string' || p.length === 0) return false;
+            if (hostPath === p) return true;
+            if (p.endsWith('/')) return hostPath.startsWith(p);
+            return hostPath.startsWith(p + '/');
+        });
     }
 
     /**
@@ -164,8 +207,17 @@ export default class BrowserUiLock extends ContentFeature {
     _hasExplicitlyVisibleScrollbar(el) {
         const style = getComputedStyle(el);
         const overflowY = style.overflowY;
-        const overflowTypes = this.getFeatureSetting('overflowTypes') ?? ['hidden', 'clip', 'auto'];
+        const overflowTypes = this.getFeatureSetting('overflowTypes') ?? ['hidden', 'clip'];
         return el.scrollHeight > el.clientHeight && !overflowTypes.includes(overflowY);
+    }
+
+    /**
+     * Check if the element's computed `overflow-y` is `hidden`.
+     * @param {Element} el
+     * @returns {boolean}
+     */
+    _hasOverflowYHidden(el) {
+        return getComputedStyle(el).overflowY === 'hidden';
     }
 
     /**

--- a/injected/unit-test/browser-ui-lock.js
+++ b/injected/unit-test/browser-ui-lock.js
@@ -73,10 +73,10 @@ describe('BrowserUiLock', () => {
             expect(feature._hasExplicitlyVisibleScrollbar(el)).toBe(true);
         });
 
-        it('should return false when content overflows and overflow is auto (default config)', () => {
+        it('should return true when content overflows and overflow is auto (default config)', () => {
             const feature = createFeature();
             const el = createMockElement(1000, 500, 'auto');
-            expect(feature._hasExplicitlyVisibleScrollbar(el)).toBe(false);
+            expect(feature._hasExplicitlyVisibleScrollbar(el)).toBe(true);
         });
 
         it('should return true when content overflows and overflow is scroll', () => {
@@ -107,6 +107,180 @@ describe('BrowserUiLock', () => {
             const feature = createFeature();
             const el = createMockElement(300, 500, 'auto');
             expect(feature._hasExplicitlyVisibleScrollbar(el)).toBe(false);
+        });
+    });
+
+    describe('_hasOverflowYHidden', () => {
+        /** @type {typeof globalThis.getComputedStyle | undefined} */
+        let originalGetComputedStyle;
+
+        beforeEach(() => {
+            originalGetComputedStyle = globalThis.getComputedStyle;
+        });
+
+        afterEach(() => {
+            if (originalGetComputedStyle !== undefined) {
+                globalThis.getComputedStyle = originalGetComputedStyle;
+            } else {
+                // @ts-expect-error - restoring undefined
+                delete globalThis.getComputedStyle;
+            }
+        });
+
+        /**
+         * Create a mock element whose computed overflow-y is the given value.
+         * @param {string} overflowY
+         */
+        function createMockElement(overflowY) {
+            const el = /** @type {Element} */ ({});
+            globalThis.getComputedStyle = jasmine.createSpy('getComputedStyle').and.returnValue(
+                /** @type {CSSStyleDeclaration} */ ({
+                    overflowY,
+                }),
+            );
+            return el;
+        }
+
+        it('should return true when overflow-y is hidden', () => {
+            const feature = createFeature();
+            expect(feature._hasOverflowYHidden(createMockElement('hidden'))).toBe(true);
+        });
+
+        it('should return false when overflow-y is visible', () => {
+            const feature = createFeature();
+            expect(feature._hasOverflowYHidden(createMockElement('visible'))).toBe(false);
+        });
+
+        it('should return false when overflow-y is auto', () => {
+            const feature = createFeature();
+            expect(feature._hasOverflowYHidden(createMockElement('auto'))).toBe(false);
+        });
+
+        it('should return false when overflow-y is scroll', () => {
+            const feature = createFeature();
+            expect(feature._hasOverflowYHidden(createMockElement('scroll'))).toBe(false);
+        });
+
+        it('should return false when overflow-y is clip', () => {
+            const feature = createFeature();
+            expect(feature._hasOverflowYHidden(createMockElement('clip'))).toBe(false);
+        });
+    });
+
+    describe('_isLockedDomain', () => {
+        /**
+         * @param {string} siteDomain
+         * @param {object} [settings]
+         */
+        function createFeatureForDomain(siteDomain, settings = {}) {
+            return createFeature({
+                site: { domain: siteDomain, url: 'https://' + siteDomain },
+                featureSettings: {
+                    browserUiLock: settings,
+                },
+            });
+        }
+
+        it('should return false when setting is missing', () => {
+            const feature = createFeatureForDomain('example.com');
+            expect(feature._isLockedDomain()).toBe(false);
+        });
+
+        it('should return false when domain list is empty', () => {
+            const feature = createFeatureForDomain('example.com', { lockedDomains: [] });
+            expect(feature._isLockedDomain()).toBe(false);
+        });
+
+        it('should return true on exact domain match', () => {
+            const feature = createFeatureForDomain('maps.google.com', {
+                lockedDomains: ['maps.google.com'],
+            });
+            expect(feature._isLockedDomain()).toBe(true);
+        });
+
+        it('should return false on subdomain (exact-match only)', () => {
+            const feature = createFeatureForDomain('maps.google.com', {
+                lockedDomains: ['google.com'],
+            });
+            expect(feature._isLockedDomain()).toBe(false);
+        });
+
+        it('should return false on unrelated domain', () => {
+            const feature = createFeatureForDomain('example.com', {
+                lockedDomains: ['google.com'],
+            });
+            expect(feature._isLockedDomain()).toBe(false);
+        });
+
+        it('should not match domain suffix', () => {
+            const feature = createFeatureForDomain('notgoogle.com', {
+                lockedDomains: ['google.com'],
+            });
+            expect(feature._isLockedDomain()).toBe(false);
+        });
+
+        it('should ignore non-string entries in the list', () => {
+            const feature = createFeatureForDomain('google.com', {
+                // @ts-expect-error - intentionally malformed
+                lockedDomains: [null, 42, 'google.com'],
+            });
+            expect(feature._isLockedDomain()).toBe(true);
+        });
+
+        /**
+         * Build a feature with a custom site URL so we can exercise path-based matching.
+         * @param {string} url
+         * @param {object} [settings]
+         */
+        function createFeatureForUrl(url, settings = {}) {
+            return createFeature({
+                site: { domain: new URL(url).host, url },
+                featureSettings: {
+                    browserUiLock: settings,
+                },
+            });
+        }
+
+        it('should match exact host + full path', () => {
+            const feature = createFeatureForUrl('https://www.nytimes.com/games/wordle/index.html', {
+                lockedDomains: ['www.nytimes.com/games/wordle/index.html'],
+            });
+            expect(feature._isLockedDomain()).toBe(true);
+        });
+
+        it('should match a shorter path prefix at a path boundary', () => {
+            const feature = createFeatureForUrl('https://www.nytimes.com/games/wordle/index.html', {
+                lockedDomains: ['www.nytimes.com/games'],
+            });
+            expect(feature._isLockedDomain()).toBe(true);
+        });
+
+        it('should not match when prefix breaks mid-segment', () => {
+            const feature = createFeatureForUrl('https://www.nytimes.com/games/wordle/index.html', {
+                lockedDomains: ['www.nytimes.com/games/wor'],
+            });
+            expect(feature._isLockedDomain()).toBe(false);
+        });
+
+        it('should match when pattern ends with a slash', () => {
+            const feature = createFeatureForUrl('https://www.nytimes.com/games/wordle/index.html', {
+                lockedDomains: ['www.nytimes.com/games/wordle/'],
+            });
+            expect(feature._isLockedDomain()).toBe(true);
+        });
+
+        it('should not match a different host even with the same path', () => {
+            const feature = createFeatureForUrl('https://nytimes.com/games/wordle/index.html', {
+                lockedDomains: ['www.nytimes.com/games/wordle/index.html'],
+            });
+            expect(feature._isLockedDomain()).toBe(false);
+        });
+
+        it('should ignore query strings when matching the path', () => {
+            const feature = createFeatureForUrl('https://www.nytimes.com/games/wordle/index.html?ref=foo', {
+                lockedDomains: ['www.nytimes.com/games/wordle/index.html'],
+            });
+            expect(feature._isLockedDomain()).toBe(true);
         });
     });
 


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1212608036467427/task/1214187547786011?focus=true

## Description
outlook.com was getting locked incorrectly, we decided to be overly restrictive to lock by also requiriing `overflow-y:hidden`, while also adding a setting for sites that should be locked regardless. 

## Testing Steps
- sites that shouldn't lock (e.g. bbc.com, google searches, any site).
- sites that should lock (e.g. windy.com, maps.google.com, https://wafflegame.net/daily)
- SERP should always be unlocked.

## Checklist

<!--
  These questions are a friendly reminder to shipping code, if you're uncertain ask the AoR owners.
  It's also totally appropriate to not check some of these boxes, if they don't apply to your change.
-->
*Please tick all that apply:*

- [x] I have tested this change locally
- [ ] I have tested this change locally in all supported browsers
- [x] This change will be visible to users
- [ ] I have added automated tests that cover this change
- [ ] I have ensured the change is gated by config
- [ ] This change was covered by a ship review
- [ ] This change was covered by a tech design
- [ ] Any dependent config has been merged


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the heuristics that enable/disable gesture locking, which is user-visible and could cause regressions (either missed locks on apps that need it or new locks if `lockedDomains` is misconfigured). Scope is limited to one feature with added tests.
> 
> **Overview**
> Updates `BrowserUiLock`’s lock decision logic: pages now only lock when **no visible scrollbar is detected and `overflow-y: hidden` is explicitly set** on `html` or `body`, reducing accidental locks on sites with normal scrolling.
> 
> Adds a `lockedDomains` feature setting that **forces locking** for specific `host` or `host + path` prefixes (with boundary-aware matching), and adjusts scrollbar visibility defaults so `overflow-y: auto` counts as visible; unit tests are updated and expanded to cover the new matching and overflow checks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bda857114ed09622a57b809bb45f5819999037dd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->