### PR TITLE
make overflow-y required to lock, and add a setting for locked sites

### DIFF
--- a/injected/src/features/browser-ui-lock.js
+++ b/injected/src/features/browser-ui-lock.js
@@ -130,11 +130,18 @@ export default class BrowserUiLock extends ContentFeature {
 
     /**
      * Determine if UI should be locked based on scrollbar visibility or content type.
-     * Lock if the page is a direct image display or has no visible vertical scrollbar.
+     * Lock if the site's domain is in the `lockedDomains` list; otherwise lock if
+     * the page is a direct image display, or if there is no visible vertical
+     * scrollbar AND `overflow-y: hidden` is explicitly set on html or body.
      * @returns {boolean}
      */
     _detectShouldLock() {
         try {
+            // Sites configured in lockedDomains bypass all other checks
+            if (this._isLockedDomain()) {
+                return true;
+            }
+
             // Image display pages (navigating directly to an image URL) should lock
             if (this.getFeatureSettingEnabled('lockImagePages', 'enabled') && this._isImageDisplayPage()) {
                 return true;
@@ -151,8 +158,9 @@ export default class BrowserUiLock extends ContentFeature {
                 return false;
             }
 
-            // No visible scrollbar - lock the UI
-            return true;
+            // No visible scrollbar — additionally require overflow-y: hidden
+            // to be explicitly set on html or body before locking.
+            return Boolean((html && this._hasOverflowYHidden(html)) || (body && this._hasOverflowYHidden(body)));
         } catch (e) {
             // Fail open - return false (unlocked) on error
             this.log.warn('Failed to detect scroll state:', e);
@@ -171,6 +179,41 @@ export default class BrowserUiLock extends ContentFeature {
     }
 
     /**
+     * Check whether the current site's URL matches any entry in the `lockedDomains`
+     * list. Each entry is matched against `host + pathname` of the site's URL:
+     *
+     * - exact host match: an entry `"example.com"` matches host `example.com` (any
+     *   path) but does NOT match `www.example.com` or `evil.example.com.attacker`.
+     * - path prefix match: an entry `"example.com/foo"` matches any URL on host
+     *   `example.com` whose path begins with `/foo` followed by `/` or end-of-path.
+     *
+     * @returns {boolean}
+     */
+    _isLockedDomain() {
+        const patterns = this.getFeatureSetting('lockedDomains');
+        if (!Array.isArray(patterns) || patterns.length === 0) {
+            return false;
+        }
+        const siteUrl = this.args?.site?.url;
+        if (typeof siteUrl !== 'string' || siteUrl.length === 0) {
+            return false;
+        }
+        let hostPath;
+        try {
+            const url = new URL(siteUrl);
+            hostPath = url.host + url.pathname;
+        } catch {
+            return false;
+        }
+        return patterns.some((p) => {
+            if (typeof p !== 'string' || p.length === 0) return false;
+            if (hostPath === p) return true;
+            if (p.endsWith('/')) return hostPath.startsWith(p);
+            return hostPath.startsWith(p + '/');
+        });
+    }
+
+    /**
      * Check if an element has a visible vertical scrollbar.
      * A scrollbar is visible when content overflows AND overflow isn't hidden/clip.
      * @param {Element} el
@@ -179,8 +222,17 @@ export default class BrowserUiLock extends ContentFeature {
     _hasExplicitlyVisibleScrollbar(el) {
         const style = getComputedStyle(el);
         const overflowY = style.overflowY;
-        const overflowTypes = this.getFeatureSetting('overflowTypes') ?? ['hidden', 'clip', 'auto'];
+        const overflowTypes = this.getFeatureSetting('overflowTypes') ?? ['hidden', 'clip'];
         return el.scrollHeight > el.clientHeight && !overflowTypes.includes(overflowY);
+    }
+
+    /**
+     * Check if the element's computed `overflow-y` is `hidden`.
+     * @param {Element} el
+     * @returns {boolean}
+     */
+    _hasOverflowYHidden(el) {
+        return getComputedStyle(el).overflowY === 'hidden';
     }
 
     /**

--- a/injected/src/features/browser-ui-lock.js
+++ b/injected/src/features/browser-ui-lock.js
@@ -130,15 +130,18 @@ export default class BrowserUiLock extends ContentFeature {
 
     /**
      * Determine if UI should be locked based on scrollbar visibility or content type.
-     * Lock if the site's domain is in the `lockedDomains` list; otherwise lock if
-     * the page is a direct image display, or if there is no visible vertical
-     * scrollbar AND `overflow-y: hidden` is explicitly set on html or body.
+     * Lock if the `isLockedPage` feature setting is enabled for the current page
+     * (configured via privacy-config `conditionalChanges` / `patchSettings`);
+     * otherwise lock if the page is a direct image display, or if there is no
+     * visible vertical scrollbar AND a locking `overflow-y` value is explicitly
+     * set on html or body. The set of locking overflow values is controlled by
+     * the `overflowTypes` setting (default: `['hidden', 'clip']`).
      * @returns {boolean}
      */
     _detectShouldLock() {
         try {
-            // Sites configured in lockedDomains bypass all other checks
-            if (this._isLockedDomain()) {
+            // Pages configured via privacy-config bypass all other checks
+            if (this.getFeatureSettingEnabled('isLockedPage')) {
                 return true;
             }
 
@@ -158,14 +161,23 @@ export default class BrowserUiLock extends ContentFeature {
                 return false;
             }
 
-            // No visible scrollbar — additionally require overflow-y: hidden
-            // to be explicitly set on html or body before locking.
-            return Boolean((html && this._hasOverflowYHidden(html)) || (body && this._hasOverflowYHidden(body)));
+            // No visible scrollbar — additionally require a locking overflow-y
+            // value to be explicitly set on html or body before locking.
+            return Boolean((html && this._hasLockingOverflowY(html)) || (body && this._hasLockingOverflowY(body)));
         } catch (e) {
             // Fail open - return false (unlocked) on error
             this.log.warn('Failed to detect scroll state:', e);
             return false;
         }
+    }
+
+    /**
+     * Get the list of `overflow-y` values that indicate the page is in lock mode
+     * (no usable scrollbar). Configurable via the `overflowTypes` feature setting.
+     * @returns {string[]}
+     */
+    _getOverflowTypes() {
+        return this.getFeatureSetting('overflowTypes') ?? ['hidden', 'clip'];
     }
 
     /**
@@ -179,60 +191,25 @@ export default class BrowserUiLock extends ContentFeature {
     }
 
     /**
-     * Check whether the current site's URL matches any entry in the `lockedDomains`
-     * list. Each entry is matched against `host + pathname` of the site's URL:
-     *
-     * - exact host match: an entry `"example.com"` matches host `example.com` (any
-     *   path) but does NOT match `www.example.com` or `evil.example.com.attacker`.
-     * - path prefix match: an entry `"example.com/foo"` matches any URL on host
-     *   `example.com` whose path begins with `/foo` followed by `/` or end-of-path.
-     *
-     * @returns {boolean}
-     */
-    _isLockedDomain() {
-        const patterns = this.getFeatureSetting('lockedDomains');
-        if (!Array.isArray(patterns) || patterns.length === 0) {
-            return false;
-        }
-        const siteUrl = this.args?.site?.url;
-        if (typeof siteUrl !== 'string' || siteUrl.length === 0) {
-            return false;
-        }
-        let hostPath;
-        try {
-            const url = new URL(siteUrl);
-            hostPath = url.host + url.pathname;
-        } catch {
-            return false;
-        }
-        return patterns.some((p) => {
-            if (typeof p !== 'string' || p.length === 0) return false;
-            if (hostPath === p) return true;
-            if (p.endsWith('/')) return hostPath.startsWith(p);
-            return hostPath.startsWith(p + '/');
-        });
-    }
-
-    /**
      * Check if an element has a visible vertical scrollbar.
-     * A scrollbar is visible when content overflows AND overflow isn't hidden/clip.
+     * A scrollbar is visible when content overflows AND `overflow-y` is not in
+     * the configured `overflowTypes` list.
      * @param {Element} el
      * @returns {boolean}
      */
     _hasExplicitlyVisibleScrollbar(el) {
-        const style = getComputedStyle(el);
-        const overflowY = style.overflowY;
-        const overflowTypes = this.getFeatureSetting('overflowTypes') ?? ['hidden', 'clip'];
-        return el.scrollHeight > el.clientHeight && !overflowTypes.includes(overflowY);
+        const overflowY = getComputedStyle(el).overflowY;
+        return el.scrollHeight > el.clientHeight && !this._getOverflowTypes().includes(overflowY);
     }
 
     /**
-     * Check if the element's computed `overflow-y` is `hidden`.
+     * Check if the element's computed `overflow-y` matches a configured locking
+     * value (default: `hidden`, `clip`).
      * @param {Element} el
      * @returns {boolean}
      */
-    _hasOverflowYHidden(el) {
-        return getComputedStyle(el).overflowY === 'hidden';
+    _hasLockingOverflowY(el) {
+        return this._getOverflowTypes().includes(getComputedStyle(el).overflowY);
     }
 
     /**

--- a/injected/unit-test/browser-ui-lock.js
+++ b/injected/unit-test/browser-ui-lock.js
@@ -91,10 +91,18 @@ describe('BrowserUiLock', () => {
             expect(feature._hasExplicitlyVisibleScrollbar(el)).toBe(false);
         });
 
-        it('should return false when content overflows but overflow is clip', () => {
+        it('should return false when content overflows but overflow is clip (default config)', () => {
             const feature = createFeature();
             const el = createMockElement(1000, 500, 'clip');
             expect(feature._hasExplicitlyVisibleScrollbar(el)).toBe(false);
+        });
+
+        it('should return true when content overflows and overflow is clip with overflowTypes excluding clip', () => {
+            const feature = createFeature({
+                featureSettings: { browserUiLock: { overflowTypes: ['hidden'] } },
+            });
+            const el = createMockElement(1000, 500, 'clip');
+            expect(feature._hasExplicitlyVisibleScrollbar(el)).toBe(true);
         });
 
         it('should return false when content fits (no overflow)', () => {
@@ -110,7 +118,7 @@ describe('BrowserUiLock', () => {
         });
     });
 
-    describe('_hasOverflowYHidden', () => {
+    describe('_hasLockingOverflowY', () => {
         /** @type {typeof globalThis.getComputedStyle | undefined} */
         let originalGetComputedStyle;
 
@@ -141,145 +149,77 @@ describe('BrowserUiLock', () => {
             return el;
         }
 
-        it('should return true when overflow-y is hidden', () => {
+        it('should return true when overflow-y is hidden (default config)', () => {
             const feature = createFeature();
-            expect(feature._hasOverflowYHidden(createMockElement('hidden'))).toBe(true);
+            expect(feature._hasLockingOverflowY(createMockElement('hidden'))).toBe(true);
         });
 
         it('should return false when overflow-y is visible', () => {
             const feature = createFeature();
-            expect(feature._hasOverflowYHidden(createMockElement('visible'))).toBe(false);
+            expect(feature._hasLockingOverflowY(createMockElement('visible'))).toBe(false);
         });
 
         it('should return false when overflow-y is auto', () => {
             const feature = createFeature();
-            expect(feature._hasOverflowYHidden(createMockElement('auto'))).toBe(false);
+            expect(feature._hasLockingOverflowY(createMockElement('auto'))).toBe(false);
         });
 
         it('should return false when overflow-y is scroll', () => {
             const feature = createFeature();
-            expect(feature._hasOverflowYHidden(createMockElement('scroll'))).toBe(false);
+            expect(feature._hasLockingOverflowY(createMockElement('scroll'))).toBe(false);
         });
 
-        it('should return false when overflow-y is clip', () => {
+        it('should return true when overflow-y is clip (default config)', () => {
             const feature = createFeature();
-            expect(feature._hasOverflowYHidden(createMockElement('clip'))).toBe(false);
+            expect(feature._hasLockingOverflowY(createMockElement('clip'))).toBe(true);
+        });
+
+        it('should return false when overflow-y is clip and overflowTypes excludes clip', () => {
+            const feature = createFeature({
+                featureSettings: { browserUiLock: { overflowTypes: ['hidden'] } },
+            });
+            expect(feature._hasLockingOverflowY(createMockElement('clip'))).toBe(false);
+        });
+
+        it('should respect a custom overflowTypes list (e.g. only "clip")', () => {
+            const feature = createFeature({
+                featureSettings: { browserUiLock: { overflowTypes: ['clip'] } },
+            });
+            expect(feature._hasLockingOverflowY(createMockElement('hidden'))).toBe(false);
+            expect(feature._hasLockingOverflowY(createMockElement('clip'))).toBe(true);
         });
     });
 
-    describe('_isLockedDomain', () => {
+    describe('isLockedPage setting', () => {
         /**
-         * @param {string} siteDomain
          * @param {object} [settings]
          */
-        function createFeatureForDomain(siteDomain, settings = {}) {
+        function createFeatureWithSettings(settings = {}) {
             return createFeature({
-                site: { domain: siteDomain, url: 'https://' + siteDomain },
                 featureSettings: {
                     browserUiLock: settings,
                 },
             });
         }
 
-        it('should return false when setting is missing', () => {
-            const feature = createFeatureForDomain('example.com');
-            expect(feature._isLockedDomain()).toBe(false);
+        it('returns false when setting is missing', () => {
+            const feature = createFeatureWithSettings();
+            expect(feature.getFeatureSettingEnabled('isLockedPage')).toBeFalsy();
         });
 
-        it('should return false when domain list is empty', () => {
-            const feature = createFeatureForDomain('example.com', { lockedDomains: [] });
-            expect(feature._isLockedDomain()).toBe(false);
+        it('returns true when setting is "enabled"', () => {
+            const feature = createFeatureWithSettings({ isLockedPage: 'enabled' });
+            expect(feature.getFeatureSettingEnabled('isLockedPage')).toBe(true);
         });
 
-        it('should return true on exact domain match', () => {
-            const feature = createFeatureForDomain('maps.google.com', {
-                lockedDomains: ['maps.google.com'],
-            });
-            expect(feature._isLockedDomain()).toBe(true);
+        it('returns false when setting is "disabled"', () => {
+            const feature = createFeatureWithSettings({ isLockedPage: 'disabled' });
+            expect(feature.getFeatureSettingEnabled('isLockedPage')).toBe(false);
         });
 
-        it('should return false on subdomain (exact-match only)', () => {
-            const feature = createFeatureForDomain('maps.google.com', {
-                lockedDomains: ['google.com'],
-            });
-            expect(feature._isLockedDomain()).toBe(false);
-        });
-
-        it('should return false on unrelated domain', () => {
-            const feature = createFeatureForDomain('example.com', {
-                lockedDomains: ['google.com'],
-            });
-            expect(feature._isLockedDomain()).toBe(false);
-        });
-
-        it('should not match domain suffix', () => {
-            const feature = createFeatureForDomain('notgoogle.com', {
-                lockedDomains: ['google.com'],
-            });
-            expect(feature._isLockedDomain()).toBe(false);
-        });
-
-        it('should ignore non-string entries in the list', () => {
-            const feature = createFeatureForDomain('google.com', {
-                lockedDomains: [null, 42, 'google.com'],
-            });
-            expect(feature._isLockedDomain()).toBe(true);
-        });
-
-        /**
-         * Build a feature with a custom site URL so we can exercise path-based matching.
-         * @param {string} url
-         * @param {object} [settings]
-         */
-        function createFeatureForUrl(url, settings = {}) {
-            return createFeature({
-                site: { domain: new URL(url).host, url },
-                featureSettings: {
-                    browserUiLock: settings,
-                },
-            });
-        }
-
-        it('should match exact host + full path', () => {
-            const feature = createFeatureForUrl('https://www.nytimes.com/games/wordle/index.html', {
-                lockedDomains: ['www.nytimes.com/games/wordle/index.html'],
-            });
-            expect(feature._isLockedDomain()).toBe(true);
-        });
-
-        it('should match a shorter path prefix at a path boundary', () => {
-            const feature = createFeatureForUrl('https://www.nytimes.com/games/wordle/index.html', {
-                lockedDomains: ['www.nytimes.com/games'],
-            });
-            expect(feature._isLockedDomain()).toBe(true);
-        });
-
-        it('should not match when prefix breaks mid-segment', () => {
-            const feature = createFeatureForUrl('https://www.nytimes.com/games/wordle/index.html', {
-                lockedDomains: ['www.nytimes.com/games/wor'],
-            });
-            expect(feature._isLockedDomain()).toBe(false);
-        });
-
-        it('should match when pattern ends with a slash', () => {
-            const feature = createFeatureForUrl('https://www.nytimes.com/games/wordle/index.html', {
-                lockedDomains: ['www.nytimes.com/games/wordle/'],
-            });
-            expect(feature._isLockedDomain()).toBe(true);
-        });
-
-        it('should not match a different host even with the same path', () => {
-            const feature = createFeatureForUrl('https://nytimes.com/games/wordle/index.html', {
-                lockedDomains: ['www.nytimes.com/games/wordle/index.html'],
-            });
-            expect(feature._isLockedDomain()).toBe(false);
-        });
-
-        it('should ignore query strings when matching the path', () => {
-            const feature = createFeatureForUrl('https://www.nytimes.com/games/wordle/index.html?ref=foo', {
-                lockedDomains: ['www.nytimes.com/games/wordle/index.html'],
-            });
-            expect(feature._isLockedDomain()).toBe(true);
+        it('causes _detectShouldLock to return true regardless of scrollbar state', () => {
+            const feature = createFeatureWithSettings({ isLockedPage: 'enabled' });
+            expect(feature._detectShouldLock()).toBe(true);
         });
     });
 

--- a/injected/unit-test/browser-ui-lock.js
+++ b/injected/unit-test/browser-ui-lock.js
@@ -73,10 +73,10 @@ describe('BrowserUiLock', () => {
             expect(feature._hasExplicitlyVisibleScrollbar(el)).toBe(true);
         });
 
-        it('should return false when content overflows and overflow is auto (default config)', () => {
+        it('should return true when content overflows and overflow is auto (default config)', () => {
             const feature = createFeature();
             const el = createMockElement(1000, 500, 'auto');
-            expect(feature._hasExplicitlyVisibleScrollbar(el)).toBe(false);
+            expect(feature._hasExplicitlyVisibleScrollbar(el)).toBe(true);
         });
 
         it('should return true when content overflows and overflow is scroll', () => {
@@ -107,6 +107,179 @@ describe('BrowserUiLock', () => {
             const feature = createFeature();
             const el = createMockElement(300, 500, 'auto');
             expect(feature._hasExplicitlyVisibleScrollbar(el)).toBe(false);
+        });
+    });
+
+    describe('_hasOverflowYHidden', () => {
+        /** @type {typeof globalThis.getComputedStyle | undefined} */
+        let originalGetComputedStyle;
+
+        beforeEach(() => {
+            originalGetComputedStyle = globalThis.getComputedStyle;
+        });
+
+        afterEach(() => {
+            if (originalGetComputedStyle !== undefined) {
+                globalThis.getComputedStyle = originalGetComputedStyle;
+            } else {
+                // @ts-expect-error - restoring undefined
+                delete globalThis.getComputedStyle;
+            }
+        });
+
+        /**
+         * Create a mock element whose computed overflow-y is the given value.
+         * @param {string} overflowY
+         */
+        function createMockElement(overflowY) {
+            const el = /** @type {Element} */ ({});
+            globalThis.getComputedStyle = jasmine.createSpy('getComputedStyle').and.returnValue(
+                /** @type {CSSStyleDeclaration} */ ({
+                    overflowY,
+                }),
+            );
+            return el;
+        }
+
+        it('should return true when overflow-y is hidden', () => {
+            const feature = createFeature();
+            expect(feature._hasOverflowYHidden(createMockElement('hidden'))).toBe(true);
+        });
+
+        it('should return false when overflow-y is visible', () => {
+            const feature = createFeature();
+            expect(feature._hasOverflowYHidden(createMockElement('visible'))).toBe(false);
+        });
+
+        it('should return false when overflow-y is auto', () => {
+            const feature = createFeature();
+            expect(feature._hasOverflowYHidden(createMockElement('auto'))).toBe(false);
+        });
+
+        it('should return false when overflow-y is scroll', () => {
+            const feature = createFeature();
+            expect(feature._hasOverflowYHidden(createMockElement('scroll'))).toBe(false);
+        });
+
+        it('should return false when overflow-y is clip', () => {
+            const feature = createFeature();
+            expect(feature._hasOverflowYHidden(createMockElement('clip'))).toBe(false);
+        });
+    });
+
+    describe('_isLockedDomain', () => {
+        /**
+         * @param {string} siteDomain
+         * @param {object} [settings]
+         */
+        function createFeatureForDomain(siteDomain, settings = {}) {
+            return createFeature({
+                site: { domain: siteDomain, url: 'https://' + siteDomain },
+                featureSettings: {
+                    browserUiLock: settings,
+                },
+            });
+        }
+
+        it('should return false when setting is missing', () => {
+            const feature = createFeatureForDomain('example.com');
+            expect(feature._isLockedDomain()).toBe(false);
+        });
+
+        it('should return false when domain list is empty', () => {
+            const feature = createFeatureForDomain('example.com', { lockedDomains: [] });
+            expect(feature._isLockedDomain()).toBe(false);
+        });
+
+        it('should return true on exact domain match', () => {
+            const feature = createFeatureForDomain('maps.google.com', {
+                lockedDomains: ['maps.google.com'],
+            });
+            expect(feature._isLockedDomain()).toBe(true);
+        });
+
+        it('should return false on subdomain (exact-match only)', () => {
+            const feature = createFeatureForDomain('maps.google.com', {
+                lockedDomains: ['google.com'],
+            });
+            expect(feature._isLockedDomain()).toBe(false);
+        });
+
+        it('should return false on unrelated domain', () => {
+            const feature = createFeatureForDomain('example.com', {
+                lockedDomains: ['google.com'],
+            });
+            expect(feature._isLockedDomain()).toBe(false);
+        });
+
+        it('should not match domain suffix', () => {
+            const feature = createFeatureForDomain('notgoogle.com', {
+                lockedDomains: ['google.com'],
+            });
+            expect(feature._isLockedDomain()).toBe(false);
+        });
+
+        it('should ignore non-string entries in the list', () => {
+            const feature = createFeatureForDomain('google.com', {
+                lockedDomains: [null, 42, 'google.com'],
+            });
+            expect(feature._isLockedDomain()).toBe(true);
+        });
+
+        /**
+         * Build a feature with a custom site URL so we can exercise path-based matching.
+         * @param {string} url
+         * @param {object} [settings]
+         */
+        function createFeatureForUrl(url, settings = {}) {
+            return createFeature({
+                site: { domain: new URL(url).host, url },
+                featureSettings: {
+                    browserUiLock: settings,
+                },
+            });
+        }
+
+        it('should match exact host + full path', () => {
+            const feature = createFeatureForUrl('https://www.nytimes.com/games/wordle/index.html', {
+                lockedDomains: ['www.nytimes.com/games/wordle/index.html'],
+            });
+            expect(feature._isLockedDomain()).toBe(true);
+        });
+
+        it('should match a shorter path prefix at a path boundary', () => {
+            const feature = createFeatureForUrl('https://www.nytimes.com/games/wordle/index.html', {
+                lockedDomains: ['www.nytimes.com/games'],
+            });
+            expect(feature._isLockedDomain()).toBe(true);
+        });
+
+        it('should not match when prefix breaks mid-segment', () => {
+            const feature = createFeatureForUrl('https://www.nytimes.com/games/wordle/index.html', {
+                lockedDomains: ['www.nytimes.com/games/wor'],
+            });
+            expect(feature._isLockedDomain()).toBe(false);
+        });
+
+        it('should match when pattern ends with a slash', () => {
+            const feature = createFeatureForUrl('https://www.nytimes.com/games/wordle/index.html', {
+                lockedDomains: ['www.nytimes.com/games/wordle/'],
+            });
+            expect(feature._isLockedDomain()).toBe(true);
+        });
+
+        it('should not match a different host even with the same path', () => {
+            const feature = createFeatureForUrl('https://nytimes.com/games/wordle/index.html', {
+                lockedDomains: ['www.nytimes.com/games/wordle/index.html'],
+            });
+            expect(feature._isLockedDomain()).toBe(false);
+        });
+
+        it('should ignore query strings when matching the path', () => {
+            const feature = createFeatureForUrl('https://www.nytimes.com/games/wordle/index.html?ref=foo', {
+                lockedDomains: ['www.nytimes.com/games/wordle/index.html'],
+            });
+            expect(feature._isLockedDomain()).toBe(true);
         });
     });
 


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1212608036467427/task/1214187547786011?focus=true

## Description
outlook.com was getting locked incorrectly, we decided to be overly restrictive to lock by also requiriing `overflow-y:hidden`, while also adding a setting for sites that should be locked regardless. 

## Testing Steps
- sites that shouldn't lock (e.g. bbc.com, google searches, any site).
- sites that should lock (e.g. windy.com, maps.google.com, https://wafflegame.net/daily)
- SERP should always be unlocked.

## Checklist

<!--
  These questions are a friendly reminder to shipping code, if you're uncertain ask the AoR owners.
  It's also totally appropriate to not check some of these boxes, if they don't apply to your change.
-->
*Please tick all that apply:*

- [x] I have tested this change locally
- [ ] I have tested this change locally in all supported browsers
- [x] This change will be visible to users
- [ ] I have added automated tests that cover this change
- [ ] I have ensured the change is gated by config
- [ ] This change was covered by a ship review
- [ ] This change was covered by a tech design
- [ ] Any dependent config has been merged


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes a user-visible heuristic that controls when browser gestures are disabled, which can regress locking/unlocking behavior across many sites. Risk is mitigated by conservative defaults and a config override to force-lock known cases.
> 
> **Overview**
> Tightens `BrowserUiLock` detection so pages only lock when **no visible scrollbar exists** *and* `html` or `body` explicitly sets a locking `overflow-y` value (configurable via `overflowTypes`, defaulting to `['hidden','clip']`), reducing false-positive locks.
> 
> Adds an `isLockedPage` feature setting that **forces lock** for configured sites/pages (via privacy-config), bypassing all other heuristics, and updates unit tests to reflect the new default `overflowTypes` behavior plus coverage for the new override and `_hasLockingOverflowY`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a024c960b58fa75631d9b0041e37f550d6af2c9e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->