### PR TITLE
Pass login state with youtube detection event

### DIFF
--- a/injected/integration-test/web-interference-detection-events.spec.js
+++ b/injected/integration-test/web-interference-detection-events.spec.js
@@ -27,7 +27,7 @@ test.describe('YouTube detection events via webInterferenceDetection', () => {
             (webEventMessages[0].payload).params;
         expect(params).toEqual({
             type: 'youtube_adBlocker',
-            data: {},
+            data: { loginState: 'unknown' },
         });
     });
 

--- a/injected/src/detectors/detections/youtube-ad-detection.js
+++ b/injected/src/detectors/detections/youtube-ad-detection.js
@@ -29,12 +29,12 @@ export class YouTubeAdDetector {
     /**
      * @param {YouTubeDetectorConfig} config - Configuration from privacy-config (required)
      * @param {{info: Function, warn: Function, error: Function}} [logger] - Optional logger from ContentFeature
-     * @param {(type: string) => void} [onEvent] - Callback fired when a new detection occurs (may be async)
+     * @param {(type: string, data?: Record<string, unknown>) => void} [onEvent] - Callback fired when a new detection occurs (may be async)
      */
     constructor(config, logger, onEvent) {
         // Logger for debug output (only logs when debug mode is enabled)
         this.log = logger || noopLogger;
-        /** @type {(type: string) => void} */
+        /** @type {(type: string, data?: Record<string, unknown>) => void} */
         this.onEvent = onEvent || (() => {});
 
         // All config comes from privacy-config
@@ -134,7 +134,11 @@ export class YouTubeAdDetector {
 
         if (this.config.fireDetectionEvents?.[type]) {
             try {
-                const result = /** @type {any} */ (this.onEvent(`youtube_${type}`));
+                const result = /** @type {any} */ (
+                    this.onEvent(`youtube_${type}`, {
+                        loginState: this.state.loginState?.state || 'unknown',
+                    })
+                );
                 if (result && typeof result.catch === 'function') {
                     // eslint-disable-next-line promise/prefer-await-to-then
                     result.catch(() => {});

--- a/injected/src/features/web-interference-detection.js
+++ b/injected/src/features/web-interference-detection.js
@@ -20,9 +20,9 @@ export default class WebInterferenceDetection extends ContentFeature {
         // Get settings with conditionalChanges already applied by framework
         const settings = this.getFeatureSetting('interferenceTypes');
 
-        const fireEvent = async (type) => {
+        const fireEvent = async (type, data) => {
             try {
-                const result = await this.callFeatureMethod('webEvents', 'fireEvent', { type });
+                const result = await this.callFeatureMethod('webEvents', 'fireEvent', { type, data });
                 if (result instanceof CallFeatureMethodError && this.isDebug) {
                     this.log.warn('webEvents.fireEvent failed:', result.message);
                 }

--- a/injected/unit-test/youtube-ad-detection.js
+++ b/injected/unit-test/youtube-ad-detection.js
@@ -26,25 +26,31 @@ const configWithAllEvents = {
 
 describe('YouTubeAdDetector', () => {
     describe('onEvent callback', () => {
-        it('calls onEvent with youtube_ prefix when a new detection occurs', () => {
+        it('calls onEvent with youtube_ prefix and loginState when a new detection occurs', () => {
             const events = [];
-            const detector = new YouTubeAdDetector(configWithAllEvents, undefined, (type) => events.push(type));
+            const detector = new YouTubeAdDetector(configWithAllEvents, undefined, (type, data) => events.push({ type, data }));
 
             detector.reportDetection('adBlocker');
 
-            expect(events).toEqual(['youtube_adBlocker']);
+            expect(events).toEqual([{ type: 'youtube_adBlocker', data: { loginState: 'unknown' } }]);
         });
 
-        it('fires for each detection type', () => {
+        it('fires for each detection type with loginState', () => {
             const events = [];
-            const detector = new YouTubeAdDetector(configWithAllEvents, undefined, (type) => events.push(type));
+            const detector = new YouTubeAdDetector(configWithAllEvents, undefined, (type, data) => events.push({ type, data }));
 
             detector.reportDetection('videoAd');
             detector.reportDetection('playabilityError', { message: 'error' });
             detector.reportDetection('adBlocker');
             detector.reportDetection('staticAd');
 
-            expect(events).toEqual(['youtube_videoAd', 'youtube_playabilityError', 'youtube_adBlocker', 'youtube_staticAd']);
+            expect(events.map((e) => e.type)).toEqual([
+                'youtube_videoAd',
+                'youtube_playabilityError',
+                'youtube_adBlocker',
+                'youtube_staticAd',
+            ]);
+            events.forEach((e) => expect(e.data).toEqual({ loginState: 'unknown' }));
         });
 
         it('does not fire for duplicate detections', () => {


### PR DESCRIPTION
**Asana Task/Github Issue:** <!-- Link to Asana Task/Github Issue -->
https://app.asana.com/1/137249556945/project/72649045549333/task/1214157598747980

## Description

<!--
  Provide a terse summary of what the change is, detailed descriptions should belong in ship reviews or tech designs
-->
Adding login state to the youtube detection events

## Testing Steps

- <!-- Include simple steps on how to check this change is working. Write "N/A" if not applicable. -->
cd injected && npm run test-unit
cd injected && npx playwright test web-interference-detection-events --reporter list

## Checklist

<!--
  These questions are a friendly reminder to shipping code, if you're uncertain ask the AoR owners.
  It's also totally appropriate to not check some of these boxes, if they don't apply to your change.
-->
*Please tick all that apply:*

- [ ] I have tested this change locally
- [ ] I have tested this change locally in all supported browsers
- [ ] This change will be visible to users
- [ ] I have added automated tests that cover this change
- [ ] I have ensured the change is gated by config
- [ ] This change was covered by a ship review
- [ ] This change was covered by a tech design
- [ ] Any dependent config has been merged


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the runtime payload shape for `webEvent` notifications (adds `data.loginState`), which may affect downstream consumers expecting an empty object; logic is otherwise small and covered by tests.
> 
> **Overview**
> YouTube interference detection events now include a `data` payload with the detector’s current `loginState` (defaulting to `'unknown'`) when firing `youtube_*` web events.
> 
> This threads an optional `data` argument through `YouTubeAdDetector`’s `onEvent` callback and `WebInterferenceDetection`’s `webEvents.fireEvent` call, and updates unit/integration tests to assert the new event shape.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fe9afc7315b06e9822e9e8bfc839a35777f65e4f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->