### PR TITLE
Prevent button wrapping on older Safari

### DIFF
--- a/special-pages/pages/new-tab/app/next-steps-list/components/NextStepsListCard.module.css
+++ b/special-pages/pages/new-tab/app/next-steps-list/components/NextStepsListCard.module.css
@@ -237,4 +237,6 @@
     margin-top: var(--sp-1);
 }
 
-
+.buttonRow button {
+    white-space: nowrap;
+}


### PR DESCRIPTION
**Asana Task/Github Issue:** <!-- Link to Asana Task/Github Issue -->

## Description

Button text wraps on older Safari for next steps list card. This fixes it by preventing button text from wrapping.

### Safari 16 (⚠️  Issue)
<img width="1823" height="815" alt="Screenshot 2026-05-04 at 18 42 12" src="https://github.com/user-attachments/assets/2bd21081-6a40-4a7e-a788-d44a7fdacb4e" />

### Safari 18 (✅ No issue)
<img width="1825" height="815" alt="Screenshot 2026-05-04 at 18 29 12" src="https://github.com/user-attachments/assets/74e51ccd-8f52-4533-8176-2bb91408cec0" />


<!--
  Provide a terse summary of what the change is, detailed descriptions should belong in ship reviews or tech designs
-->

## Testing Steps

- <!-- Include simple steps on how to check this change is working. Write "N/A" if not applicable. -->

## Checklist

<!--
  These questions are a friendly reminder to shipping code, if you're uncertain ask the AoR owners.
  It's also totally appropriate to not check some of these boxes, if they don't apply to your change.
-->
*Please tick all that apply:*

- [ ] I have tested this change locally
- [ ] I have tested this change locally in all supported browsers
- [ ] This change will be visible to users
- [ ] I have added automated tests that cover this change
- [ ] I have ensured the change is gated by config
- [ ] This change was covered by a ship review
- [ ] This change was covered by a tech design
- [ ] Any dependent config has been merged


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CSS-only change scoped to `NextStepsListCard` button styling; primary risk is minor layout/overflow differences in narrow widths.
> 
> **Overview**
> Prevents button labels in the New Tab `NextStepsListCard` from wrapping (notably affecting older Safari) by applying `white-space: nowrap` to buttons within `.buttonRow`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 557760a9cf99c6616344fa0ff77711f675ff10ad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->