### PR TITLE
chore(eslint): enhance configuration for pReact hooks

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,5 +1,6 @@
 import tseslint from 'typescript-eslint';
 import ddgConfig from '@duckduckgo/eslint-config';
+import reactHooks from 'eslint-plugin-react-hooks';
 import globals from 'globals';
 
 // @ts-check
@@ -80,6 +81,14 @@ export default tseslint.config(
         rules: {
             '@typescript-eslint/no-floating-promises': 'error',
             'no-void': ['error', { allowAsStatement: true }],
+        },
+    },
+    {
+        files: ['special-pages/**/*.{js,jsx,ts,tsx}'],
+        plugins: { 'react-hooks': reactHooks },
+        rules: {
+            'react-hooks/rules-of-hooks': 'error',
+            'react-hooks/exhaustive-deps': 'warn',
         },
     },
     {

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -88,7 +88,7 @@ export default tseslint.config(
         plugins: { 'react-hooks': reactHooks },
         rules: {
             'react-hooks/rules-of-hooks': 'error',
-            'react-hooks/exhaustive-deps': 'warn',
+            'react-hooks/exhaustive-deps': 'error',
         },
     },
     {

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "ajv": "^8.18.0",
         "esbuild": "^0.27.4",
         "eslint": "^10.2.0",
+        "eslint-plugin-react-hooks": "^7.1.1",
         "minimist": "^1.2.8",
         "prettier": "3.8.2",
         "stylelint": "^17.5.0",
@@ -161,6 +162,143 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@babel/compat-data": {
+      "version": "7.29.3",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.3.tgz",
+      "integrity": "sha512-LIVqM46zQWZhj17qA8wb4nW/ixr2y1Nw+r1etiAWgRM6U1IqP+LNhL1yg440jYZR72jCWcWbLWzIosH+uP1fqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
+      "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.0",
+        "@babel/generator": "^7.29.0",
+        "@babel/helper-compilation-targets": "^7.28.6",
+        "@babel/helper-module-transforms": "^7.28.6",
+        "@babel/helpers": "^7.28.6",
+        "@babel/parser": "^7.29.0",
+        "@babel/template": "^7.28.6",
+        "@babel/traverse": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "@jridgewell/remapping": "^2.3.5",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.29.1",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
+      "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
+      "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.28.6",
+        "@babel/helper-validator-option": "^7.27.1",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets/node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
+      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
+      "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
+      "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.28.6",
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/traverse": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/helper-validator-identifier": {
       "version": "7.28.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
@@ -171,11 +309,99 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
+      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.2.tgz",
+      "integrity": "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.29.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.3",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz",
+      "integrity": "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/@babel/runtime": {
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.6.tgz",
       "integrity": "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==",
       "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
+      "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.28.6",
+        "@babel/parser": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
+      "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.0",
+        "@babel/generator": "^7.29.0",
+        "@babel/helper-globals": "^7.28.0",
+        "@babel/parser": "^7.29.0",
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.29.0",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
+      },
       "engines": {
         "node": ">=6.9.0"
       }
@@ -1451,6 +1677,28 @@
       "integrity": "sha512-rM3GG4vx2H1Gp5kYCTr9aKlOEJFd43pzpiMAiy5b1+FUc2ub4e6bS6yCi/WQNDzAa5MVp9++dwcoEtcIfoEnhA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
     },
     "node_modules/@jridgewell/resolve-uri": {
       "version": "3.1.2",
@@ -2793,6 +3041,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.10.27",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.27.tgz",
+      "integrity": "sha512-zEs/ufmZoUd7WftKpKyXaT6RFxpQ5Qm9xytKRHvJfxFV9DFJkZph9RvJ1LcOUi0Z1ZVijMte65JbILeV+8QQEA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/basic-auth": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-2.0.1.tgz",
@@ -3007,6 +3268,40 @@
         "node": ">=8"
       }
     },
+    "node_modules/browserslist": {
+      "version": "4.28.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
+      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "baseline-browser-mapping": "^2.10.12",
+        "caniuse-lite": "^1.0.30001782",
+        "electron-to-chromium": "^1.5.328",
+        "node-releases": "^2.0.36",
+        "update-browserslist-db": "^1.2.3"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
     "node_modules/buffer-crc32": {
       "version": "0.2.13",
       "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
@@ -3174,6 +3469,27 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001791",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001791.tgz",
+      "integrity": "sha512-yk0l/YSrOnFZk3UROpDLQD9+kC1l4meK/wed583AXrzoarMGJcbRi2Q4RaUYbKxYAsZ8sWmaSa/DsLmdBeI1vQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
     },
     "node_modules/chalk": {
       "version": "4.1.2",
@@ -3984,6 +4300,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.349",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.349.tgz",
+      "integrity": "sha512-QsWVGyRuY07Aqb234QytTfwd5d9AJlfNIQ5wIOl1L+PZDzI9d9+Fn0FRale/QYlFxt/bUnB0/nLd1jFPGxGK1A==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
@@ -4543,6 +4866,26 @@
       "license": "MPL-2.0",
       "peerDependencies": {
         "eslint": "^9 || ^10"
+      }
+    },
+    "node_modules/eslint-plugin-react-hooks": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-7.1.1.tgz",
+      "integrity": "sha512-f2I7Gw6JbvCexzIInuSbZpfdQ44D7iqdWX01FKLvrPgqxoE7oMj8clOfto8U6vYiz4yd5oKu39rRSVOe1zRu0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.24.4",
+        "@babel/parser": "^7.24.4",
+        "hermes-parser": "^0.25.1",
+        "zod": "^3.25.0 || ^4.0.0",
+        "zod-validation-error": "^3.5.0 || ^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0 || ^10.0.0"
       }
     },
     "node_modules/eslint-scope": {
@@ -5168,6 +5511,16 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/get-caller-file": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
@@ -5629,6 +5982,23 @@
       "license": "MIT",
       "bin": {
         "he": "bin/he"
+      }
+    },
+    "node_modules/hermes-estree": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.25.1.tgz",
+      "integrity": "sha512-0wUoCcLp+5Ev5pDW2OriHC2MJCbwLwuRx+gAqMTOkGKJJiBCLjtrvy4PWUGn6MIVefecRpzoOZ/UV6iGdOr+Cw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/hermes-parser": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.25.1.tgz",
+      "integrity": "sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hermes-estree": "0.25.1"
       }
     },
     "node_modules/hookified": {
@@ -6651,6 +7021,19 @@
         "node": ">=20"
       }
     },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/json-buffer": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
@@ -7381,6 +7764,13 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.38",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.38.tgz",
+      "integrity": "sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",
@@ -10032,6 +10422,37 @@
         "yarn": "*"
       }
     },
+    "node_modules/update-browserslist-db": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
     "node_modules/update-notifier": {
       "version": "7.3.1",
       "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-7.3.1.tgz",
@@ -10791,6 +11212,13 @@
         "node": ">=10"
       }
     },
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/yaml": {
       "version": "2.8.2",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
@@ -10872,6 +11300,29 @@
       "dependencies": {
         "async": "^3.2.0",
         "jszip": "^3.2.2"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-validation-error": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/zod-validation-error/-/zod-validation-error-4.0.2.tgz",
+      "integrity": "sha512-Q6/nZLe6jxuU80qb/4uJ4t5v2VEZ44lzQjPDhYJNztRQ4wyWc6VF3D3Kb/fAuPetZQnhS3hnajCf9CsWesghLQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
       }
     },
     "special-pages": {

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "ajv": "^8.18.0",
     "esbuild": "^0.27.4",
     "eslint": "^10.2.0",
+    "eslint-plugin-react-hooks": "^7.1.1",
     "minimist": "^1.2.8",
     "prettier": "3.8.2",
     "stylelint": "^17.5.0",

--- a/special-pages/pages/duckplayer/app/components/Components.jsx
+++ b/special-pages/pages/duckplayer/app/components/Components.jsx
@@ -22,8 +22,8 @@ export function Components() {
         platform: { name: 'macos' },
         customError: { state: 'enabled' },
     });
-    let embed = /** @type {EmbedSettings} */ (EmbedSettings.fromHref('https://localhost?videoID=123'));
-    let url = embed?.toEmbedUrl();
+    const embed = /** @type {EmbedSettings} */ (EmbedSettings.fromHref('https://localhost?videoID=123'));
+    const url = embed?.toEmbedUrl();
     if (!url) throw new Error('unreachable');
     return (
         <>

--- a/special-pages/pages/duckplayer/app/components/Player.jsx
+++ b/special-pages/pages/duckplayer/app/components/Player.jsx
@@ -4,11 +4,11 @@ import styles from './Player.module.css';
 import { useEffect, useRef } from 'preact/hooks';
 import { useSettings, useOpenOnYoutubeHandler } from '../providers/SettingsProvider.jsx';
 import { createIframeFeatures } from '../features/iframe.js';
-import { Settings } from '../settings';
 import { useTypedTranslation } from '../types.js';
 
 /**
  * @import {EmbedSettings} from '../embed-settings.js';
+ * @import {Settings} from '../settings';
  */
 
 /**
@@ -56,7 +56,7 @@ export function Player({ src, layout, embed }) {
 export function PlayerError({ kind, layout }) {
     const { t } = useTypedTranslation();
     const errors = {
-        ['invalid-id']: <span dangerouslySetInnerHTML={{ __html: t('invalidIdError') }} />,
+        'invalid-id': <span dangerouslySetInnerHTML={{ __html: t('invalidIdError') }} />,
     };
     const text = errors[kind] || errors['invalid-id'];
     return (
@@ -118,7 +118,7 @@ function useIframeEffects(src, embed) {
          */
         const cleanups = [];
         const loadHandler = () => {
-            for (let feature of iframeFeatures) {
+            for (const feature of iframeFeatures) {
                 try {
                     cleanups.push(feature.iframeDidLoad(iframe));
                 } catch (e) {
@@ -134,7 +134,7 @@ function useIframeEffects(src, embed) {
         }
 
         return () => {
-            for (let cleanup of cleanups) {
+            for (const cleanup of cleanups) {
                 cleanup?.();
             }
             iframe.removeEventListener('load', loadHandler);

--- a/special-pages/pages/duckplayer/app/components/Player.jsx
+++ b/special-pages/pages/duckplayer/app/components/Player.jsx
@@ -139,7 +139,7 @@ function useIframeEffects(src, embed) {
             }
             iframe.removeEventListener('load', loadHandler);
         };
-        // eslint-disable-next-line react-hooks/exhaustive-deps -- disabled during eslint-plugin-react-hooks rollout; please remove and address deps
+        // eslint-disable-next-line react-hooks/exhaustive-deps -- workaround during eslint react rollout; consider removing and addressing deps
     }, [src, settings, embed]);
 
     return { ref, didLoad: () => (didLoad.current = true) };

--- a/special-pages/pages/duckplayer/app/components/Player.jsx
+++ b/special-pages/pages/duckplayer/app/components/Player.jsx
@@ -139,6 +139,7 @@ function useIframeEffects(src, embed) {
             }
             iframe.removeEventListener('load', loadHandler);
         };
+        // eslint-disable-next-line react-hooks/exhaustive-deps -- disabled during eslint-plugin-react-hooks rollout; please remove and address deps
     }, [src, settings, embed]);
 
     return { ref, didLoad: () => (didLoad.current = true) };

--- a/special-pages/pages/duckplayer/app/components/YouTubeError.jsx
+++ b/special-pages/pages/duckplayer/app/components/YouTubeError.jsx
@@ -1,21 +1,21 @@
 import { h } from 'preact';
 import cn from 'classnames';
-import { Settings } from '../settings';
 import { useTypedTranslation } from '../types.js';
 import { Button, OpenInIcon } from './Button.jsx';
 import { useOpenOnYoutubeHandler } from '../providers/SettingsProvider.jsx';
 
 import styles from './YouTubeError.module.css';
-import { useLocale, useYouTubeError } from '../providers/YouTubeErrorProvider';
+import { useYouTubeError } from '../providers/YouTubeErrorProvider';
 
 /**
+ * @import {Settings} from '../settings';
  * @typedef {import('../../types/duckplayer').YouTubeError} YouTubeError
  * @typedef {import('preact').ComponentChild} ComponentChild
  * @typedef {{heading: ComponentChild, messages: ComponentChild[], variant: 'list'|'inline'|'paragraphs'}} ErrorStrings
  */
 
 /**
- * @param {YouTubeError} youtubeError
+ * @param {YouTubeError | null} youtubeError
  * @returns {ErrorStrings}
  */
 function useErrorStrings(youtubeError) {
@@ -64,7 +64,7 @@ function useErrorStrings(youtubeError) {
         },
     };
 
-    return versions[version]?.[youtubeError] || versions[version]?.['unknown'] || versions['v1']['unknown'];
+    return (youtubeError && versions[version]?.[youtubeError]) || versions[version]?.unknown || versions.v1.unknown;
 }
 
 /**
@@ -74,13 +74,12 @@ function useErrorStrings(youtubeError) {
  */
 export function YouTubeError({ layout, embed }) {
     const youtubeError = useYouTubeError();
-    if (!youtubeError) {
-        return null;
-    }
-
     const { t } = useTypedTranslation();
     const openOnYoutube = useOpenOnYoutubeHandler();
     const { heading, messages, variant } = useErrorStrings(youtubeError);
+    if (!youtubeError) {
+        return null;
+    }
     const classes = cn(styles.error, {
         [styles.desktop]: layout === 'desktop',
         [styles.mobile]: layout === 'mobile',

--- a/special-pages/pages/duckplayer/app/providers/OrientationProvider.jsx
+++ b/special-pages/pages/duckplayer/app/providers/OrientationProvider.jsx
@@ -17,6 +17,7 @@ export function OrientationProvider({ onChange }) {
         };
         screen.orientation.addEventListener('change', handleOrientationChange);
         return () => screen.orientation.removeEventListener('change', handleOrientationChange);
+        // eslint-disable-next-line react-hooks/exhaustive-deps -- disabled during eslint-plugin-react-hooks rollout; please remove and address deps
     }, []);
 
     useEffect(() => {
@@ -27,6 +28,7 @@ export function OrientationProvider({ onChange }) {
         };
         window.addEventListener('resize', listener);
         return () => window.removeEventListener('resize', listener);
+        // eslint-disable-next-line react-hooks/exhaustive-deps -- disabled during eslint-plugin-react-hooks rollout; please remove and address deps
     }, []);
 
     return null;

--- a/special-pages/pages/duckplayer/app/providers/OrientationProvider.jsx
+++ b/special-pages/pages/duckplayer/app/providers/OrientationProvider.jsx
@@ -17,7 +17,7 @@ export function OrientationProvider({ onChange }) {
         };
         screen.orientation.addEventListener('change', handleOrientationChange);
         return () => screen.orientation.removeEventListener('change', handleOrientationChange);
-        // eslint-disable-next-line react-hooks/exhaustive-deps -- disabled during eslint-plugin-react-hooks rollout; please remove and address deps
+        // eslint-disable-next-line react-hooks/exhaustive-deps -- workaround during eslint react rollout; consider removing and addressing deps
     }, []);
 
     useEffect(() => {
@@ -28,7 +28,7 @@ export function OrientationProvider({ onChange }) {
         };
         window.addEventListener('resize', listener);
         return () => window.removeEventListener('resize', listener);
-        // eslint-disable-next-line react-hooks/exhaustive-deps -- disabled during eslint-plugin-react-hooks rollout; please remove and address deps
+        // eslint-disable-next-line react-hooks/exhaustive-deps -- workaround during eslint react rollout; consider removing and addressing deps
     }, []);
 
     return null;

--- a/special-pages/pages/duckplayer/app/providers/SettingsProvider.jsx
+++ b/special-pages/pages/duckplayer/app/providers/SettingsProvider.jsx
@@ -1,14 +1,13 @@
-import { h } from 'preact';
-import { createContext } from 'preact';
-import { Settings } from '../settings';
+import { h, createContext } from 'preact';
 import { useContext } from 'preact/hooks';
 import { useMessaging } from '../types.js';
 
-const SettingsContext = createContext(/** @type {{settings: Settings}} */ ({}));
-
 /**
+ * @import {Settings} from '../settings';
  * @import {EmbedSettings} from '../embed-settings.js';
  */
+
+const SettingsContext = createContext(/** @type {{settings: Settings}} */ ({}));
 
 /**
  * @param {object} params

--- a/special-pages/pages/duckplayer/app/providers/SwitchProvider.jsx
+++ b/special-pages/pages/duckplayer/app/providers/SwitchProvider.jsx
@@ -64,6 +64,7 @@ export function SwitchProvider({ children }) {
     useEffect(() => {
         const evt = 'enabled' in userValues.privatePlayerMode ? 'enabled' : 'ask';
         dispatch(evt);
+        // eslint-disable-next-line react-hooks/exhaustive-deps -- disabled during eslint-plugin-react-hooks rollout; please remove and address deps
     }, [initialState]);
 
     function onDone() {

--- a/special-pages/pages/duckplayer/app/providers/SwitchProvider.jsx
+++ b/special-pages/pages/duckplayer/app/providers/SwitchProvider.jsx
@@ -64,7 +64,7 @@ export function SwitchProvider({ children }) {
     useEffect(() => {
         const evt = 'enabled' in userValues.privatePlayerMode ? 'enabled' : 'ask';
         dispatch(evt);
-        // eslint-disable-next-line react-hooks/exhaustive-deps -- disabled during eslint-plugin-react-hooks rollout; please remove and address deps
+        // eslint-disable-next-line react-hooks/exhaustive-deps -- workaround during eslint react rollout; consider removing and addressing deps
     }, [initialState]);
 
     function onDone() {

--- a/special-pages/pages/duckplayer/app/providers/SwitchProvider.jsx
+++ b/special-pages/pages/duckplayer/app/providers/SwitchProvider.jsx
@@ -1,6 +1,5 @@
 import { createContext, h } from 'preact';
 import { useEffect, useReducer } from 'preact/hooks';
-import { useEnv } from '../../../../shared/components/EnvironmentProvider.js';
 import { useSetEnabled, useUserValues } from './UserValuesProvider.jsx';
 
 /**

--- a/special-pages/pages/duckplayer/app/providers/UserValuesProvider.jsx
+++ b/special-pages/pages/duckplayer/app/providers/UserValuesProvider.jsx
@@ -1,7 +1,6 @@
-import { useContext, useState } from 'preact/hooks';
+import { useContext, useState, useEffect } from 'preact/hooks';
 import { h, createContext } from 'preact';
 import { useMessaging } from '../types.js';
-import { useEffect } from 'preact/hooks';
 
 /**
  * @typedef {import("../../types/duckplayer.js").UserValues} UserValues
@@ -46,22 +45,20 @@ export function UserValuesProvider({ initial, children }) {
     }, [messaging]);
 
     // API for consumers
-    function setEnabled() {
+    async function setEnabled() {
         const values = {
             privatePlayerMode: { enabled: {} },
             overlayInteracted: false,
         };
-        messaging
-            .setUserValues(values)
-            .then((next) => {
-                console.log('response after setUserValues...', next);
-                console.log('will set', values);
-                setValue(values);
-            })
-            .catch((err) => {
-                console.error('could not set the enabled flag', err);
-                messaging.reportPageException({ message: 'could not set the enabled flag: ' + err.toString() });
-            });
+        try {
+            const next = await messaging.setUserValues(values);
+            console.log('response after setUserValues...', next);
+            console.log('will set', values);
+            setValue(values);
+        } catch (err) {
+            console.error('could not set the enabled flag', err);
+            messaging.reportPageException({ message: 'could not set the enabled flag: ' + err.toString() });
+        }
     }
 
     return <UserValuesContext.Provider value={{ value, setEnabled }}>{children}</UserValuesContext.Provider>;

--- a/special-pages/pages/duckplayer/app/providers/YouTubeErrorProvider.jsx
+++ b/special-pages/pages/duckplayer/app/providers/YouTubeErrorProvider.jsx
@@ -52,6 +52,7 @@ export function YouTubeErrorProvider({ initial = null, locale, children }) {
         window.addEventListener(YOUTUBE_ERROR_EVENT, errorEventHandler);
 
         return () => window.removeEventListener(YOUTUBE_ERROR_EVENT, errorEventHandler);
+        // eslint-disable-next-line react-hooks/exhaustive-deps -- disabled during eslint-plugin-react-hooks rollout; please remove and address deps
     }, []);
 
     return <YouTubeErrorContext.Provider value={{ error, locale }}>{children}</YouTubeErrorContext.Provider>;

--- a/special-pages/pages/duckplayer/app/providers/YouTubeErrorProvider.jsx
+++ b/special-pages/pages/duckplayer/app/providers/YouTubeErrorProvider.jsx
@@ -1,6 +1,5 @@
-import { useContext, useState } from 'preact/hooks';
+import { useContext, useState, useEffect } from 'preact/hooks';
 import { h, createContext } from 'preact';
-import { useEffect } from 'preact/hooks';
 import { useMessaging } from '../types';
 import { useSetFocusMode } from '../components/FocusMode';
 import { YOUTUBE_ERROR_IDS, YOUTUBE_ERROR_EVENT } from '../../../../../injected/src/features/duckplayer-native/youtube-errors.js';

--- a/special-pages/pages/duckplayer/app/providers/YouTubeErrorProvider.jsx
+++ b/special-pages/pages/duckplayer/app/providers/YouTubeErrorProvider.jsx
@@ -52,7 +52,7 @@ export function YouTubeErrorProvider({ initial = null, locale, children }) {
         window.addEventListener(YOUTUBE_ERROR_EVENT, errorEventHandler);
 
         return () => window.removeEventListener(YOUTUBE_ERROR_EVENT, errorEventHandler);
-        // eslint-disable-next-line react-hooks/exhaustive-deps -- disabled during eslint-plugin-react-hooks rollout; please remove and address deps
+        // eslint-disable-next-line react-hooks/exhaustive-deps -- workaround during eslint react rollout; consider removing and addressing deps
     }, []);
 
     return <YouTubeErrorContext.Provider value={{ error, locale }}>{children}</YouTubeErrorContext.Provider>;

--- a/special-pages/pages/history/app/components/App.jsx
+++ b/special-pages/pages/history/app/components/App.jsx
@@ -19,12 +19,10 @@ import { useRangesData } from '../global/Providers/HistoryServiceProvider.js';
 import { usePlatformName } from '../types.js';
 import { useLayoutMode } from '../global/hooks/useLayoutMode.js';
 import { useClickAnywhereElse } from '../global/hooks/useClickAnywhereElse.jsx';
-import { useTheme } from '../global/Providers/ThemeProvider.js';
 
 export function App() {
     const platformName = usePlatformName();
     const mainRef = useRef(/** @type {HTMLElement|null} */ (null));
-    const { theme, themeVariant } = useTheme();
     const ranges = useRangesData();
     const query = useQueryContext();
     const mode = useLayoutMode();

--- a/special-pages/pages/history/app/components/VirtualizedList.js
+++ b/special-pages/pages/history/app/components/VirtualizedList.js
@@ -123,7 +123,7 @@ function useVisibleRows(rows, heights, scrollerSelector, overscan = 5) {
         return () => {
             controller.abort();
         };
-        // eslint-disable-next-line react-hooks/exhaustive-deps -- disabled during eslint-plugin-react-hooks rollout; please remove and address deps
+        // eslint-disable-next-line react-hooks/exhaustive-deps -- workaround during eslint react rollout; consider removing and addressing deps
     }, [rows, heights, scrollerSelector]);
 
     useEffect(() => {
@@ -138,7 +138,7 @@ function useVisibleRows(rows, heights, scrollerSelector, overscan = 5) {
         return () => {
             return window.removeEventListener('resize', handler);
         };
-        // eslint-disable-next-line react-hooks/exhaustive-deps -- disabled during eslint-plugin-react-hooks rollout; please remove and address deps
+        // eslint-disable-next-line react-hooks/exhaustive-deps -- workaround during eslint react rollout; consider removing and addressing deps
     }, [heights, rows]);
 
     return { start, end };

--- a/special-pages/pages/history/app/components/VirtualizedList.js
+++ b/special-pages/pages/history/app/components/VirtualizedList.js
@@ -123,6 +123,7 @@ function useVisibleRows(rows, heights, scrollerSelector, overscan = 5) {
         return () => {
             controller.abort();
         };
+        // eslint-disable-next-line react-hooks/exhaustive-deps -- disabled during eslint-plugin-react-hooks rollout; please remove and address deps
     }, [rows, heights, scrollerSelector]);
 
     useEffect(() => {
@@ -137,6 +138,7 @@ function useVisibleRows(rows, heights, scrollerSelector, overscan = 5) {
         return () => {
             return window.removeEventListener('resize', handler);
         };
+        // eslint-disable-next-line react-hooks/exhaustive-deps -- disabled during eslint-plugin-react-hooks rollout; please remove and address deps
     }, [heights, rows]);
 
     return { start, end };

--- a/special-pages/pages/history/app/global/Providers/HistoryServiceProvider.js
+++ b/special-pages/pages/history/app/global/Providers/HistoryServiceProvider.js
@@ -187,7 +187,7 @@ export function HistoryServiceProvider({ service, children, initial }) {
         }
     }
 
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- disabled during eslint-plugin-react-hooks rollout; please remove and address deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- workaround during eslint react rollout; consider removing and addressing deps
     const dispatcher = useCallback(dispatch, [service]);
 
     return (

--- a/special-pages/pages/history/app/global/Providers/HistoryServiceProvider.js
+++ b/special-pages/pages/history/app/global/Providers/HistoryServiceProvider.js
@@ -187,6 +187,7 @@ export function HistoryServiceProvider({ service, children, initial }) {
         }
     }
 
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- disabled during eslint-plugin-react-hooks rollout; please remove and address deps
     const dispatcher = useCallback(dispatch, [service]);
 
     return (

--- a/special-pages/pages/history/app/global/Providers/SelectionProvider.js
+++ b/special-pages/pages/history/app/global/Providers/SelectionProvider.js
@@ -188,9 +188,9 @@ export function useRowInteractions(mainRef) {
         if (handled) event.preventDefault();
     }
 
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- disabled during eslint-plugin-react-hooks rollout; please remove and address deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- workaround during eslint react rollout; consider removing and addressing deps
     const onClick = useCallback(clickHandler, [selected, focusedIndex]);
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- disabled during eslint-plugin-react-hooks rollout; please remove and address deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- workaround during eslint react rollout; consider removing and addressing deps
     const onKeyDown = useCallback(keyHandler, [selected, focusedIndex]);
 
     return { onClick, onKeyDown };

--- a/special-pages/pages/history/app/global/Providers/SelectionProvider.js
+++ b/special-pages/pages/history/app/global/Providers/SelectionProvider.js
@@ -188,7 +188,9 @@ export function useRowInteractions(mainRef) {
         if (handled) event.preventDefault();
     }
 
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- disabled during eslint-plugin-react-hooks rollout; please remove and address deps
     const onClick = useCallback(clickHandler, [selected, focusedIndex]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- disabled during eslint-plugin-react-hooks rollout; please remove and address deps
     const onKeyDown = useCallback(keyHandler, [selected, focusedIndex]);
 
     return { onClick, onKeyDown };

--- a/special-pages/pages/history/app/global/hooks/useButtonClickHandler.js
+++ b/special-pages/pages/history/app/global/hooks/useButtonClickHandler.js
@@ -56,7 +56,7 @@ export function useButtonClickHandler() {
         return () => {
             document.removeEventListener('click', clickHandler);
         };
-        // eslint-disable-next-line react-hooks/exhaustive-deps -- disabled during eslint-plugin-react-hooks rollout; please remove and address deps
+        // eslint-disable-next-line react-hooks/exhaustive-deps -- workaround during eslint react rollout; consider removing and addressing deps
     }, []);
 }
 

--- a/special-pages/pages/history/app/global/hooks/useButtonClickHandler.js
+++ b/special-pages/pages/history/app/global/hooks/useButtonClickHandler.js
@@ -56,6 +56,7 @@ export function useButtonClickHandler() {
         return () => {
             document.removeEventListener('click', clickHandler);
         };
+        // eslint-disable-next-line react-hooks/exhaustive-deps -- disabled during eslint-plugin-react-hooks rollout; please remove and address deps
     }, []);
 }
 

--- a/special-pages/pages/history/app/global/hooks/useContextMenuForEntries.js
+++ b/special-pages/pages/history/app/global/hooks/useContextMenuForEntries.js
@@ -36,6 +36,6 @@ export function useContextMenuForEntries() {
         return () => {
             document.removeEventListener('contextmenu', contextMenu);
         };
-        // eslint-disable-next-line react-hooks/exhaustive-deps -- disabled during eslint-plugin-react-hooks rollout; please remove and address deps
+        // eslint-disable-next-line react-hooks/exhaustive-deps -- workaround during eslint react rollout; consider removing and addressing deps
     }, []);
 }

--- a/special-pages/pages/history/app/global/hooks/useContextMenuForEntries.js
+++ b/special-pages/pages/history/app/global/hooks/useContextMenuForEntries.js
@@ -36,5 +36,6 @@ export function useContextMenuForEntries() {
         return () => {
             document.removeEventListener('contextmenu', contextMenu);
         };
+        // eslint-disable-next-line react-hooks/exhaustive-deps -- disabled during eslint-plugin-react-hooks rollout; please remove and address deps
     }, []);
 }

--- a/special-pages/pages/history/app/global/hooks/useLayoutMode.js
+++ b/special-pages/pages/history/app/global/hooks/useLayoutMode.js
@@ -27,6 +27,7 @@ export function useLayoutMode() {
         return () => {
             mediaQuery.removeEventListener('change', handleChange);
         };
+        // eslint-disable-next-line react-hooks/exhaustive-deps -- disabled during eslint-plugin-react-hooks rollout; please remove and address deps
     }, []);
 
     return mode;

--- a/special-pages/pages/history/app/global/hooks/useLayoutMode.js
+++ b/special-pages/pages/history/app/global/hooks/useLayoutMode.js
@@ -27,7 +27,7 @@ export function useLayoutMode() {
         return () => {
             mediaQuery.removeEventListener('change', handleChange);
         };
-        // eslint-disable-next-line react-hooks/exhaustive-deps -- disabled during eslint-plugin-react-hooks rollout; please remove and address deps
+        // eslint-disable-next-line react-hooks/exhaustive-deps -- workaround during eslint react rollout; consider removing and addressing deps
     }, []);
 
     return mode;

--- a/special-pages/pages/history/app/global/hooks/useSelectionState.js
+++ b/special-pages/pages/history/app/global/hooks/useSelectionState.js
@@ -57,7 +57,7 @@ export function useSelectionStateApi() {
         next.lastAction = evt.kind;
         state.value = next;
     }
-    const dispatch = useCallback(dispatcher, [state, selected]);
+    const dispatch = useCallback(dispatcher, [state]);
     return { selected, dispatch, state };
 }
 

--- a/special-pages/pages/history/app/global/hooks/useSelectionState.js
+++ b/special-pages/pages/history/app/global/hooks/useSelectionState.js
@@ -57,7 +57,7 @@ export function useSelectionStateApi() {
         next.lastAction = evt.kind;
         state.value = next;
     }
-    const dispatch = useCallback(dispatcher, [state]);
+    const dispatch = useCallback(dispatcher, [state, selected]);
     return { selected, dispatch, state };
 }
 

--- a/special-pages/pages/new-tab/app/activity/NormalizeDataProvider.js
+++ b/special-pages/pages/new-tab/app/activity/NormalizeDataProvider.js
@@ -177,7 +177,7 @@ export function SignalStateProvider({ children }) {
         }
     }
 
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- disabled during eslint-plugin-react-hooks rollout; please remove and address deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- workaround during eslint react rollout; consider removing and addressing deps
     const didClick = useCallback(didClick_, [service, batched]);
     const firstUrls = state.data.activity.map((x) => x.url);
     const keys = useSignal(normalizeKeys([], firstUrls));
@@ -247,7 +247,7 @@ export function SignalStateProvider({ children }) {
         return () => {
             unsub();
         };
-        // eslint-disable-next-line react-hooks/exhaustive-deps -- disabled during eslint-plugin-react-hooks rollout; please remove and address deps
+        // eslint-disable-next-line react-hooks/exhaustive-deps -- workaround during eslint react rollout; consider removing and addressing deps
     }, [service, batched, activity, keys]);
 
     useEffect(() => {
@@ -255,7 +255,7 @@ export function SignalStateProvider({ children }) {
         return () => {
             window.removeEventListener('activity.next', showNextChunk);
         };
-        // eslint-disable-next-line react-hooks/exhaustive-deps -- disabled during eslint-plugin-react-hooks rollout; please remove and address deps
+        // eslint-disable-next-line react-hooks/exhaustive-deps -- workaround during eslint react rollout; consider removing and addressing deps
     }, []);
 
     useEffect(() => {
@@ -282,7 +282,7 @@ export function SignalStateProvider({ children }) {
         return () => {
             document.removeEventListener('visibilitychange', handler);
         };
-        // eslint-disable-next-line react-hooks/exhaustive-deps -- disabled during eslint-plugin-react-hooks rollout; please remove and address deps
+        // eslint-disable-next-line react-hooks/exhaustive-deps -- workaround during eslint react rollout; consider removing and addressing deps
     }, [batched]);
 
     return (

--- a/special-pages/pages/new-tab/app/activity/NormalizeDataProvider.js
+++ b/special-pages/pages/new-tab/app/activity/NormalizeDataProvider.js
@@ -177,6 +177,7 @@ export function SignalStateProvider({ children }) {
         }
     }
 
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- disabled during eslint-plugin-react-hooks rollout; please remove and address deps
     const didClick = useCallback(didClick_, [service, batched]);
     const firstUrls = state.data.activity.map((x) => x.url);
     const keys = useSignal(normalizeKeys([], firstUrls));
@@ -246,6 +247,7 @@ export function SignalStateProvider({ children }) {
         return () => {
             unsub();
         };
+        // eslint-disable-next-line react-hooks/exhaustive-deps -- disabled during eslint-plugin-react-hooks rollout; please remove and address deps
     }, [service, batched, activity, keys]);
 
     useEffect(() => {
@@ -253,6 +255,7 @@ export function SignalStateProvider({ children }) {
         return () => {
             window.removeEventListener('activity.next', showNextChunk);
         };
+        // eslint-disable-next-line react-hooks/exhaustive-deps -- disabled during eslint-plugin-react-hooks rollout; please remove and address deps
     }, []);
 
     useEffect(() => {
@@ -279,6 +282,7 @@ export function SignalStateProvider({ children }) {
         return () => {
             document.removeEventListener('visibilitychange', handler);
         };
+        // eslint-disable-next-line react-hooks/exhaustive-deps -- disabled during eslint-plugin-react-hooks rollout; please remove and address deps
     }, [batched]);
 
     return (

--- a/special-pages/pages/new-tab/app/activity/components/Activity.js
+++ b/special-pages/pages/new-tab/app/activity/components/Activity.js
@@ -131,13 +131,14 @@ function Loader() {
             }
         });
 
-        if (loaderRef.current) {
-            observer.observe(loaderRef.current);
+        const node = loaderRef.current;
+        if (node) {
+            observer.observe(node);
         }
 
         return () => {
-            if (loaderRef.current) {
-                observer.unobserve(loaderRef.current);
+            if (node) {
+                observer.unobserve(node);
             }
         };
     }, []);

--- a/special-pages/pages/new-tab/app/activity/components/ActivityItemAnimationWrapper.js
+++ b/special-pages/pages/new-tab/app/activity/components/ActivityItemAnimationWrapper.js
@@ -78,6 +78,7 @@ export function ActivityItemAnimationWrapper({ children, url }) {
 }
 
 function NullBurner({ url, doneBurning }) {
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- disabled during eslint-plugin-react-hooks rollout; please remove and address deps
     useEffect(() => doneBurning(url), [url]);
     return null;
 }

--- a/special-pages/pages/new-tab/app/activity/components/ActivityItemAnimationWrapper.js
+++ b/special-pages/pages/new-tab/app/activity/components/ActivityItemAnimationWrapper.js
@@ -78,7 +78,7 @@ export function ActivityItemAnimationWrapper({ children, url }) {
 }
 
 function NullBurner({ url, doneBurning }) {
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- disabled during eslint-plugin-react-hooks rollout; please remove and address deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- workaround during eslint react rollout; consider removing and addressing deps
     useEffect(() => doneBurning(url), [url]);
     return null;
 }

--- a/special-pages/pages/new-tab/app/components/Components.jsx
+++ b/special-pages/pages/new-tab/app/components/Components.jsx
@@ -74,7 +74,7 @@ function Stage({ entries }) {
                 const matchingMinus1 = matching.length === 1 ? [] : matching.slice(0, -1);
 
                 without.searchParams.delete('id');
-                for (let string of [...others, ...matchingMinus1]) {
+                for (const string of [...others, ...matchingMinus1]) {
                     without.searchParams.append('id', string);
                 }
 
@@ -218,12 +218,6 @@ export function TubeGrid({ children }) {
  * @param {Array} options.entries - The list of examples to choose from, each represented as an array with an id.
  */
 function Append({ entries }) {
-    function onReset() {
-        const url = new URL(window.location.href);
-        url.searchParams.delete('id');
-        window.location.href = url.toString();
-    }
-
     function onSubmit(event) {
         if (!event.target) return;
         event.preventDefault();

--- a/special-pages/pages/new-tab/app/components/Drawer.js
+++ b/special-pages/pages/new-tab/app/components/Drawer.js
@@ -119,6 +119,7 @@ export function useDrawer(initial) {
         return () => {
             controller.abort();
         };
+        // eslint-disable-next-line react-hooks/exhaustive-deps -- disabled during eslint-plugin-react-hooks rollout; please remove and address deps
     }, [isReducedMotion, initial]);
 
     const ntp = useMessaging();
@@ -182,6 +183,7 @@ export function useDrawerEventListeners({ onOpen, onClose, onToggle }, deps = []
             );
         }
         return () => controller.abort();
+        // eslint-disable-next-line react-hooks/exhaustive-deps -- disabled during eslint-plugin-react-hooks rollout; please remove and address deps
     }, deps);
 }
 

--- a/special-pages/pages/new-tab/app/components/Drawer.js
+++ b/special-pages/pages/new-tab/app/components/Drawer.js
@@ -119,7 +119,7 @@ export function useDrawer(initial) {
         return () => {
             controller.abort();
         };
-        // eslint-disable-next-line react-hooks/exhaustive-deps -- disabled during eslint-plugin-react-hooks rollout; please remove and address deps
+        // eslint-disable-next-line react-hooks/exhaustive-deps -- workaround during eslint react rollout; consider removing and addressing deps
     }, [isReducedMotion, initial]);
 
     const ntp = useMessaging();
@@ -183,7 +183,7 @@ export function useDrawerEventListeners({ onOpen, onClose, onToggle }, deps = []
             );
         }
         return () => controller.abort();
-        // eslint-disable-next-line react-hooks/exhaustive-deps -- disabled during eslint-plugin-react-hooks rollout; please remove and address deps
+        // eslint-disable-next-line react-hooks/exhaustive-deps -- workaround during eslint react rollout; consider removing and addressing deps
     }, deps);
 }
 

--- a/special-pages/pages/new-tab/app/dropzone.js
+++ b/special-pages/pages/new-tab/app/dropzone.js
@@ -87,11 +87,12 @@ export function useGlobalDropzone() {
 export function useDropzoneSafeArea() {
     const ref = useRef(null);
     useEffect(() => {
-        if (!ref.current) return;
-        const evt = new CustomEvent(REGISTER_EVENT, { detail: { dropzone: ref.current } });
+        const node = ref.current;
+        if (!node) return;
+        const evt = new CustomEvent(REGISTER_EVENT, { detail: { dropzone: node } });
         window.dispatchEvent(evt);
         return () => {
-            window.dispatchEvent(new CustomEvent(CLEAR_EVENT, { detail: { dropzone: ref.current } }));
+            window.dispatchEvent(new CustomEvent(CLEAR_EVENT, { detail: { dropzone: node } }));
         };
     }, []);
     return ref;

--- a/special-pages/pages/new-tab/app/favorites/components/Favorites.js
+++ b/special-pages/pages/new-tab/app/favorites/components/Favorites.js
@@ -300,7 +300,7 @@ function useVisibleRows(rows, rowHeight, safeAreaRef, expansion) {
         return () => {
             controller.abort();
         };
-        // eslint-disable-next-line react-hooks/exhaustive-deps -- disabled during eslint-plugin-react-hooks rollout; please remove and address deps
+        // eslint-disable-next-line react-hooks/exhaustive-deps -- workaround during eslint react rollout; consider removing and addressing deps
     }, [rows.length, expansion]);
 
     useEffect(() => {
@@ -315,7 +315,7 @@ function useVisibleRows(rows, rowHeight, safeAreaRef, expansion) {
         return () => {
             return window.removeEventListener('resize', handler);
         };
-        // eslint-disable-next-line react-hooks/exhaustive-deps -- disabled during eslint-plugin-react-hooks rollout; please remove and address deps
+        // eslint-disable-next-line react-hooks/exhaustive-deps -- workaround during eslint react rollout; consider removing and addressing deps
     }, [rows.length]);
 
     useEffect(() => {
@@ -340,7 +340,7 @@ function useVisibleRows(rows, rowHeight, safeAreaRef, expansion) {
             resizer.disconnect();
             clearTimeout(debounceTimer);
         };
-        // eslint-disable-next-line react-hooks/exhaustive-deps -- disabled during eslint-plugin-react-hooks rollout; please remove and address deps
+        // eslint-disable-next-line react-hooks/exhaustive-deps -- workaround during eslint react rollout; consider removing and addressing deps
     }, [rows.length]);
 
     return { start, end };

--- a/special-pages/pages/new-tab/app/favorites/components/Favorites.js
+++ b/special-pages/pages/new-tab/app/favorites/components/Favorites.js
@@ -300,6 +300,7 @@ function useVisibleRows(rows, rowHeight, safeAreaRef, expansion) {
         return () => {
             controller.abort();
         };
+        // eslint-disable-next-line react-hooks/exhaustive-deps -- disabled during eslint-plugin-react-hooks rollout; please remove and address deps
     }, [rows.length, expansion]);
 
     useEffect(() => {
@@ -314,6 +315,7 @@ function useVisibleRows(rows, rowHeight, safeAreaRef, expansion) {
         return () => {
             return window.removeEventListener('resize', handler);
         };
+        // eslint-disable-next-line react-hooks/exhaustive-deps -- disabled during eslint-plugin-react-hooks rollout; please remove and address deps
     }, [rows.length]);
 
     useEffect(() => {
@@ -338,6 +340,7 @@ function useVisibleRows(rows, rowHeight, safeAreaRef, expansion) {
             resizer.disconnect();
             clearTimeout(debounceTimer);
         };
+        // eslint-disable-next-line react-hooks/exhaustive-deps -- disabled during eslint-plugin-react-hooks rollout; please remove and address deps
     }, [rows.length]);
 
     return { start, end };

--- a/special-pages/pages/new-tab/app/favorites/components/FavoritesProvider.js
+++ b/special-pages/pages/new-tab/app/favorites/components/FavoritesProvider.js
@@ -140,7 +140,7 @@ export function FavoritesProvider({ children }) {
         return service.current.onFaviconsRefreshed(() => {
             faviconsRefreshedCount.value = faviconsRefreshedCount.value += 1;
         });
-        // eslint-disable-next-line react-hooks/exhaustive-deps -- disabled during eslint-plugin-react-hooks rollout; please remove and address deps
+        // eslint-disable-next-line react-hooks/exhaustive-deps -- workaround during eslint react rollout; consider removing and addressing deps
     }, []);
 
     return (

--- a/special-pages/pages/new-tab/app/favorites/components/FavoritesProvider.js
+++ b/special-pages/pages/new-tab/app/favorites/components/FavoritesProvider.js
@@ -140,6 +140,7 @@ export function FavoritesProvider({ children }) {
         return service.current.onFaviconsRefreshed(() => {
             faviconsRefreshedCount.value = faviconsRefreshedCount.value += 1;
         });
+        // eslint-disable-next-line react-hooks/exhaustive-deps -- disabled during eslint-plugin-react-hooks rollout; please remove and address deps
     }, []);
 
     return (

--- a/special-pages/pages/new-tab/app/favorites/components/PragmaticDND.js
+++ b/special-pages/pages/new-tab/app/favorites/components/PragmaticDND.js
@@ -142,7 +142,7 @@ function useGridState(favorites, itemsDidReOrder, instanceId) {
                 },
             }),
         );
-        // eslint-disable-next-line react-hooks/exhaustive-deps -- disabled during eslint-plugin-react-hooks rollout; please remove and address deps
+        // eslint-disable-next-line react-hooks/exhaustive-deps -- workaround during eslint react rollout; consider removing and addressing deps
     }, [instanceId, favorites]);
 }
 

--- a/special-pages/pages/new-tab/app/favorites/components/PragmaticDND.js
+++ b/special-pages/pages/new-tab/app/favorites/components/PragmaticDND.js
@@ -142,6 +142,7 @@ function useGridState(favorites, itemsDidReOrder, instanceId) {
                 },
             }),
         );
+        // eslint-disable-next-line react-hooks/exhaustive-deps -- disabled during eslint-plugin-react-hooks rollout; please remove and address deps
     }, [instanceId, favorites]);
 }
 

--- a/special-pages/pages/new-tab/app/favorites/mocks/MockFavoritesProvider.js
+++ b/special-pages/pages/new-tab/app/favorites/mocks/MockFavoritesProvider.js
@@ -47,7 +47,7 @@ export function MockFavoritesProvider({ data = favorites.many, config = DEFAULT_
 
         dispatch({ kind: 'config', config: next });
         et.dispatchEvent(new CustomEvent('state-update', { detail: next }));
-        // eslint-disable-next-line react-hooks/exhaustive-deps -- disabled during eslint-plugin-react-hooks rollout; please remove and address deps
+        // eslint-disable-next-line react-hooks/exhaustive-deps -- workaround during eslint react rollout; consider removing and addressing deps
     }, [state.status, state.config?.expansion, isReducedMotion]);
 
     /** @type {import('../components/FavoritesProvider.js').ReorderFn<Favorite>} */

--- a/special-pages/pages/new-tab/app/favorites/mocks/MockFavoritesProvider.js
+++ b/special-pages/pages/new-tab/app/favorites/mocks/MockFavoritesProvider.js
@@ -1,7 +1,6 @@
 import { h } from 'preact';
 import { FavoritesContext, FavoritesDispatchContext } from '../components/FavoritesProvider.js';
 import { useCallback, useReducer, useState } from 'preact/hooks';
-import { useEnv } from '../../../../../shared/components/EnvironmentProvider.js';
 import { favorites } from './favorites.data.js';
 import { reducer } from '../../service.hooks.js';
 
@@ -25,8 +24,6 @@ const DEFAULT_CONFIG = {
  * @param {FavoritesConfig} [props.config]
  */
 export function MockFavoritesProvider({ data = favorites.many, config = DEFAULT_CONFIG, children }) {
-    const { isReducedMotion } = useEnv();
-
     const initial = /** @type {State} */ ({
         status: 'ready',
         data,
@@ -47,8 +44,7 @@ export function MockFavoritesProvider({ data = favorites.many, config = DEFAULT_
 
         dispatch({ kind: 'config', config: next });
         et.dispatchEvent(new CustomEvent('state-update', { detail: next }));
-        // eslint-disable-next-line react-hooks/exhaustive-deps -- workaround during eslint react rollout; consider removing and addressing deps
-    }, [state.status, state.config?.expansion, isReducedMotion]);
+    }, [state.status, state.config, et]);
 
     /** @type {import('../components/FavoritesProvider.js').ReorderFn<Favorite>} */
     const favoritesDidReOrder = useCallback(({ list }) => {

--- a/special-pages/pages/new-tab/app/favorites/mocks/MockFavoritesProvider.js
+++ b/special-pages/pages/new-tab/app/favorites/mocks/MockFavoritesProvider.js
@@ -47,6 +47,7 @@ export function MockFavoritesProvider({ data = favorites.many, config = DEFAULT_
 
         dispatch({ kind: 'config', config: next });
         et.dispatchEvent(new CustomEvent('state-update', { detail: next }));
+        // eslint-disable-next-line react-hooks/exhaustive-deps -- disabled during eslint-plugin-react-hooks rollout; please remove and address deps
     }, [state.status, state.config?.expansion, isReducedMotion]);
 
     /** @type {import('../components/FavoritesProvider.js').ReorderFn<Favorite>} */

--- a/special-pages/pages/new-tab/app/next-steps/NextSteps.js
+++ b/special-pages/pages/new-tab/app/next-steps/NextSteps.js
@@ -31,10 +31,9 @@ export function NextStepsCustomized() {
  * ```
  */
 export function NextStepsConsumer() {
-    const { state, toggle } = useContext(NextStepsContext);
+    const { state, toggle, action, dismiss } = useContext(NextStepsContext);
     if (state.status === 'ready' && state.data.content) {
         const ids = state.data.content.filter((x) => x.id in nextSteps).map((x) => x.id);
-        const { action, dismiss } = useContext(NextStepsContext);
         return <NextStepsCardGroup types={ids} toggle={toggle} expansion={state.config.expansion} action={action} dismiss={dismiss} />;
     }
     return null;

--- a/special-pages/pages/new-tab/app/omnibar/components/SearchForm.js
+++ b/special-pages/pages/new-tab/app/omnibar/components/SearchForm.js
@@ -67,7 +67,7 @@ export function SearchForm({ autoFocus, onOpenSuggestion, onSubmit, onSubmitChat
         if (autoFocus && inputRef.current) {
             inputRef.current.focus();
         }
-    }, [autoFocus]);
+    }, [autoFocus, inputRef]);
 
     const acceptSuggestion = () => {
         if (selectedSuggestion) {

--- a/special-pages/pages/new-tab/app/omnibar/components/chat-tools/image-attachment/ImageAttachmentTool.js
+++ b/special-pages/pages/new-tab/app/omnibar/components/chat-tools/image-attachment/ImageAttachmentTool.js
@@ -38,7 +38,7 @@ export function ImageAttachmentContent({ state, supportsImageUpload, onVisibleIm
             prevVisibleRef.current = hasVisibleImages;
             onVisibleImagesChange(hasVisibleImages);
         }
-        // eslint-disable-next-line react-hooks/exhaustive-deps -- disabled during eslint-plugin-react-hooks rollout; please remove and address deps
+        // eslint-disable-next-line react-hooks/exhaustive-deps -- workaround during eslint react rollout; consider removing and addressing deps
     }, [hasVisibleImages]);
 
     useLayoutEffect(() => {
@@ -46,7 +46,7 @@ export function ImageAttachmentContent({ state, supportsImageUpload, onVisibleIm
             prevWarningRef.current = showImageWarning;
             onImageWarningChange(showImageWarning);
         }
-        // eslint-disable-next-line react-hooks/exhaustive-deps -- disabled during eslint-plugin-react-hooks rollout; please remove and address deps
+        // eslint-disable-next-line react-hooks/exhaustive-deps -- workaround during eslint react rollout; consider removing and addressing deps
     }, [showImageWarning]);
 
     if (!supportsImageUpload) return null;

--- a/special-pages/pages/new-tab/app/omnibar/components/chat-tools/image-attachment/ImageAttachmentTool.js
+++ b/special-pages/pages/new-tab/app/omnibar/components/chat-tools/image-attachment/ImageAttachmentTool.js
@@ -38,6 +38,7 @@ export function ImageAttachmentContent({ state, supportsImageUpload, onVisibleIm
             prevVisibleRef.current = hasVisibleImages;
             onVisibleImagesChange(hasVisibleImages);
         }
+        // eslint-disable-next-line react-hooks/exhaustive-deps -- disabled during eslint-plugin-react-hooks rollout; please remove and address deps
     }, [hasVisibleImages]);
 
     useLayoutEffect(() => {
@@ -45,6 +46,7 @@ export function ImageAttachmentContent({ state, supportsImageUpload, onVisibleIm
             prevWarningRef.current = showImageWarning;
             onImageWarningChange(showImageWarning);
         }
+        // eslint-disable-next-line react-hooks/exhaustive-deps -- disabled during eslint-plugin-react-hooks rollout; please remove and address deps
     }, [showImageWarning]);
 
     if (!supportsImageUpload) return null;

--- a/special-pages/pages/new-tab/app/privacy-stats/mocks/PrivacyStatsMockProvider.js
+++ b/special-pages/pages/new-tab/app/privacy-stats/mocks/PrivacyStatsMockProvider.js
@@ -50,7 +50,7 @@ export function PrivacyStatsMockProvider({ data = privacyStatsMocks.few, ticker 
             return () => clearTimeout(time);
         }
         return () => {};
-        // eslint-disable-next-line react-hooks/exhaustive-deps -- disabled during eslint-plugin-react-hooks rollout; please remove and address deps
+        // eslint-disable-next-line react-hooks/exhaustive-deps -- workaround during eslint react rollout; consider removing and addressing deps
     }, [ticker]);
 
     return (

--- a/special-pages/pages/new-tab/app/privacy-stats/mocks/PrivacyStatsMockProvider.js
+++ b/special-pages/pages/new-tab/app/privacy-stats/mocks/PrivacyStatsMockProvider.js
@@ -50,8 +50,7 @@ export function PrivacyStatsMockProvider({ data = privacyStatsMocks.few, ticker 
             return () => clearTimeout(time);
         }
         return () => {};
-        // eslint-disable-next-line react-hooks/exhaustive-deps -- workaround during eslint react rollout; consider removing and addressing deps
-    }, [ticker]);
+    }, [ticker, state]);
 
     return (
         <PrivacyStatsContext.Provider value={{ state }}>

--- a/special-pages/pages/new-tab/app/privacy-stats/mocks/PrivacyStatsMockProvider.js
+++ b/special-pages/pages/new-tab/app/privacy-stats/mocks/PrivacyStatsMockProvider.js
@@ -50,6 +50,7 @@ export function PrivacyStatsMockProvider({ data = privacyStatsMocks.few, ticker 
             return () => clearTimeout(time);
         }
         return () => {};
+        // eslint-disable-next-line react-hooks/exhaustive-deps -- disabled during eslint-plugin-react-hooks rollout; please remove and address deps
     }, [ticker]);
 
     return (

--- a/special-pages/pages/new-tab/app/privacy-stats/mocks/PrivacyStatsMockProvider.js
+++ b/special-pages/pages/new-tab/app/privacy-stats/mocks/PrivacyStatsMockProvider.js
@@ -50,7 +50,8 @@ export function PrivacyStatsMockProvider({ data = privacyStatsMocks.few, ticker 
             return () => clearTimeout(time);
         }
         return () => {};
-    }, [ticker, state]);
+        // eslint-disable-next-line react-hooks/exhaustive-deps -- workaround during eslint react rollout; consider removing and addressing deps
+    }, [ticker]);
 
     return (
         <PrivacyStatsContext.Provider value={{ state }}>

--- a/special-pages/pages/new-tab/app/protections/components/ProtectionsHeading.examples.js
+++ b/special-pages/pages/new-tab/app/protections/components/ProtectionsHeading.examples.js
@@ -251,8 +251,7 @@ const MockWithState = ({ children, initial = 0, feedType = 'privacy-stats', inte
         if (interval === 0) return;
         const int = setInterval(() => (signal.value += 1), interval);
         return () => clearInterval(int);
-        // eslint-disable-next-line react-hooks/exhaustive-deps -- workaround during eslint react rollout; consider removing and addressing deps
-    }, [interval]);
+    }, [interval, signal]);
     const toggle = () => {
         setExpansion((old) => (old === 'expanded' ? 'collapsed' : 'expanded'));
     };

--- a/special-pages/pages/new-tab/app/protections/components/ProtectionsHeading.examples.js
+++ b/special-pages/pages/new-tab/app/protections/components/ProtectionsHeading.examples.js
@@ -251,6 +251,7 @@ const MockWithState = ({ children, initial = 0, feedType = 'privacy-stats', inte
         if (interval === 0) return;
         const int = setInterval(() => (signal.value += 1), interval);
         return () => clearInterval(int);
+        // eslint-disable-next-line react-hooks/exhaustive-deps -- disabled during eslint-plugin-react-hooks rollout; please remove and address deps
     }, [interval]);
     const toggle = () => {
         setExpansion((old) => (old === 'expanded' ? 'collapsed' : 'expanded'));

--- a/special-pages/pages/new-tab/app/protections/components/ProtectionsHeading.examples.js
+++ b/special-pages/pages/new-tab/app/protections/components/ProtectionsHeading.examples.js
@@ -251,7 +251,7 @@ const MockWithState = ({ children, initial = 0, feedType = 'privacy-stats', inte
         if (interval === 0) return;
         const int = setInterval(() => (signal.value += 1), interval);
         return () => clearInterval(int);
-        // eslint-disable-next-line react-hooks/exhaustive-deps -- disabled during eslint-plugin-react-hooks rollout; please remove and address deps
+        // eslint-disable-next-line react-hooks/exhaustive-deps -- workaround during eslint react rollout; consider removing and addressing deps
     }, [interval]);
     const toggle = () => {
         setExpansion((old) => (old === 'expanded' ? 'collapsed' : 'expanded'));

--- a/special-pages/pages/new-tab/app/protections/utils/useAnimatedCount.js
+++ b/special-pages/pages/new-tab/app/protections/utils/useAnimatedCount.js
@@ -120,7 +120,7 @@ export function useAnimatedCount(targetValue, elementRef) {
             }
         };
         // Empty array: run once on mount. elementRef is stable, setupIntersectionObserver is memoized.
-        // eslint-disable-next-line react-hooks/exhaustive-deps -- disabled during eslint-plugin-react-hooks rollout; please remove and address deps
+        // eslint-disable-next-line react-hooks/exhaustive-deps -- workaround during eslint react rollout; consider removing and addressing deps
     }, []);
 
     // Animate count when it changes, page is visible, and element is in viewport

--- a/special-pages/pages/new-tab/app/protections/utils/useAnimatedCount.js
+++ b/special-pages/pages/new-tab/app/protections/utils/useAnimatedCount.js
@@ -119,7 +119,9 @@ export function useAnimatedCount(targetValue, elementRef) {
                 observerRef.current = null;
             }
         };
-    }, []); // Empty array: run once on mount. elementRef is stable, setupIntersectionObserver is memoized
+        // Empty array: run once on mount. elementRef is stable, setupIntersectionObserver is memoized.
+        // eslint-disable-next-line react-hooks/exhaustive-deps -- disabled during eslint-plugin-react-hooks rollout; please remove and address deps
+    }, []);
 
     // Animate count when it changes, page is visible, and element is in viewport
     useEffect(() => {

--- a/special-pages/pages/new-tab/app/service.hooks.js
+++ b/special-pages/pages/new-tab/app/service.hooks.js
@@ -117,6 +117,7 @@ export function useInitialDataAndConfig({ dispatch, service }) {
         return () => {
             currentService.destroy();
         };
+        // eslint-disable-next-line react-hooks/exhaustive-deps -- disabled during eslint-plugin-react-hooks rollout; please remove and address deps
     }, [messaging]);
 }
 
@@ -156,6 +157,7 @@ export function useInitialData({ dispatch, service }) {
         return () => {
             currentService.destroy();
         };
+        // eslint-disable-next-line react-hooks/exhaustive-deps -- disabled during eslint-plugin-react-hooks rollout; please remove and address deps
     }, []);
 }
 
@@ -199,5 +201,6 @@ export function useConfigSubscription({ dispatch, service }) {
         return () => {
             unsub2();
         };
+        // eslint-disable-next-line react-hooks/exhaustive-deps -- disabled during eslint-plugin-react-hooks rollout; please remove and address deps
     }, [service]);
 }

--- a/special-pages/pages/new-tab/app/service.hooks.js
+++ b/special-pages/pages/new-tab/app/service.hooks.js
@@ -117,7 +117,7 @@ export function useInitialDataAndConfig({ dispatch, service }) {
         return () => {
             currentService.destroy();
         };
-        // eslint-disable-next-line react-hooks/exhaustive-deps -- disabled during eslint-plugin-react-hooks rollout; please remove and address deps
+        // eslint-disable-next-line react-hooks/exhaustive-deps -- workaround during eslint react rollout; consider removing and addressing deps
     }, [messaging]);
 }
 
@@ -157,7 +157,7 @@ export function useInitialData({ dispatch, service }) {
         return () => {
             currentService.destroy();
         };
-        // eslint-disable-next-line react-hooks/exhaustive-deps -- disabled during eslint-plugin-react-hooks rollout; please remove and address deps
+        // eslint-disable-next-line react-hooks/exhaustive-deps -- workaround during eslint react rollout; consider removing and addressing deps
     }, []);
 }
 
@@ -201,6 +201,6 @@ export function useConfigSubscription({ dispatch, service }) {
         return () => {
             unsub2();
         };
-        // eslint-disable-next-line react-hooks/exhaustive-deps -- disabled during eslint-plugin-react-hooks rollout; please remove and address deps
+        // eslint-disable-next-line react-hooks/exhaustive-deps -- workaround during eslint react rollout; consider removing and addressing deps
     }, [service]);
 }

--- a/special-pages/pages/onboarding/app/global.js
+++ b/special-pages/pages/onboarding/app/global.js
@@ -271,6 +271,7 @@ export function GlobalProvider({ order, children, stepDefinitions, messaging, fi
         if (state.status.kind !== 'fatal') return;
         const { error } = state.status.action;
         messaging.reportPageException(error);
+        // eslint-disable-next-line react-hooks/exhaustive-deps -- disabled during eslint-plugin-react-hooks rollout; please remove and address deps
     }, [state.status.kind, messaging]);
 
     // handle 'update-system-value' messages from the UI
@@ -305,6 +306,7 @@ export function GlobalProvider({ order, children, stepDefinitions, messaging, fi
                 const message = e?.message || 'unknown error';
                 dispatch({ kind: 'exec-error', id: action.id, message });
             });
+        // eslint-disable-next-line react-hooks/exhaustive-deps -- disabled during eslint-plugin-react-hooks rollout; please remove and address deps
     }, [state.status.kind, messaging]);
 
     return (

--- a/special-pages/pages/onboarding/app/global.js
+++ b/special-pages/pages/onboarding/app/global.js
@@ -271,7 +271,7 @@ export function GlobalProvider({ order, children, stepDefinitions, messaging, fi
         if (state.status.kind !== 'fatal') return;
         const { error } = state.status.action;
         messaging.reportPageException(error);
-        // eslint-disable-next-line react-hooks/exhaustive-deps -- disabled during eslint-plugin-react-hooks rollout; please remove and address deps
+        // eslint-disable-next-line react-hooks/exhaustive-deps -- workaround during eslint react rollout; consider removing and addressing deps
     }, [state.status.kind, messaging]);
 
     // handle 'update-system-value' messages from the UI
@@ -306,7 +306,7 @@ export function GlobalProvider({ order, children, stepDefinitions, messaging, fi
                 const message = e?.message || 'unknown error';
                 dispatch({ kind: 'exec-error', id: action.id, message });
             });
-        // eslint-disable-next-line react-hooks/exhaustive-deps -- disabled during eslint-plugin-react-hooks rollout; please remove and address deps
+        // eslint-disable-next-line react-hooks/exhaustive-deps -- workaround during eslint react rollout; consider removing and addressing deps
     }, [state.status.kind, messaging]);
 
     return (

--- a/special-pages/pages/onboarding/app/shared/components/RiveAnimation.js
+++ b/special-pages/pages/onboarding/app/shared/components/RiveAnimation.js
@@ -32,6 +32,7 @@ export function RiveAnimation({ animation, state, stateMachine, artboard, inputN
         return () => {
             rive.current?.cleanup();
         };
+        // eslint-disable-next-line react-hooks/exhaustive-deps -- disabled during eslint-plugin-react-hooks rollout; please remove and address deps
     }, [stateMachine, inputName, artboard, autoplay]);
 
     // handle a before/after value
@@ -45,6 +46,7 @@ export function RiveAnimation({ animation, state, stateMachine, artboard, inputN
         if (!toggle) return console.warn('could not find input');
         if (state === 'after') toggle.value = true;
         if (state === 'before') toggle.value = false;
+        // eslint-disable-next-line react-hooks/exhaustive-deps -- disabled during eslint-plugin-react-hooks rollout; please remove and address deps
     }, [state]);
 
     // handle light/dark mode
@@ -62,6 +64,7 @@ export function RiveAnimation({ animation, state, stateMachine, artboard, inputN
         return () => {
             rive.current?.off(/** @type {any} */ ('load'), handle);
         };
+        // eslint-disable-next-line react-hooks/exhaustive-deps -- disabled during eslint-plugin-react-hooks rollout; please remove and address deps
     }, [isDarkMode]);
 
     return <canvas width="432" height="208" ref={ref} style="border-radius: 12px; overflow: hidden"></canvas>;

--- a/special-pages/pages/onboarding/app/shared/components/RiveAnimation.js
+++ b/special-pages/pages/onboarding/app/shared/components/RiveAnimation.js
@@ -32,7 +32,7 @@ export function RiveAnimation({ animation, state, stateMachine, artboard, inputN
         return () => {
             rive.current?.cleanup();
         };
-        // eslint-disable-next-line react-hooks/exhaustive-deps -- disabled during eslint-plugin-react-hooks rollout; please remove and address deps
+        // eslint-disable-next-line react-hooks/exhaustive-deps -- workaround during eslint react rollout; consider removing and addressing deps
     }, [stateMachine, inputName, artboard, autoplay]);
 
     // handle a before/after value
@@ -46,7 +46,7 @@ export function RiveAnimation({ animation, state, stateMachine, artboard, inputN
         if (!toggle) return console.warn('could not find input');
         if (state === 'after') toggle.value = true;
         if (state === 'before') toggle.value = false;
-        // eslint-disable-next-line react-hooks/exhaustive-deps -- disabled during eslint-plugin-react-hooks rollout; please remove and address deps
+        // eslint-disable-next-line react-hooks/exhaustive-deps -- workaround during eslint react rollout; consider removing and addressing deps
     }, [state]);
 
     // handle light/dark mode
@@ -64,7 +64,7 @@ export function RiveAnimation({ animation, state, stateMachine, artboard, inputN
         return () => {
             rive.current?.off(/** @type {any} */ ('load'), handle);
         };
-        // eslint-disable-next-line react-hooks/exhaustive-deps -- disabled during eslint-plugin-react-hooks rollout; please remove and address deps
+        // eslint-disable-next-line react-hooks/exhaustive-deps -- workaround during eslint react rollout; consider removing and addressing deps
     }, [isDarkMode]);
 
     return <canvas width="432" height="208" ref={ref} style="border-radius: 12px; overflow: hidden"></canvas>;

--- a/special-pages/pages/onboarding/app/v3/components/Animation.js
+++ b/special-pages/pages/onboarding/app/v3/components/Animation.js
@@ -28,7 +28,7 @@ export function SlideIn({ children, onAnimationEnd }) {
     useEffect(() => {
         setAnimationState(activeStepVisible ? 'animating' : 'idle');
         if (isReducedMotion) animationEnd();
-        // eslint-disable-next-line react-hooks/exhaustive-deps -- disabled during eslint-plugin-react-hooks rollout; please remove and address deps
+        // eslint-disable-next-line react-hooks/exhaustive-deps -- workaround during eslint react rollout; consider removing and addressing deps
     }, [activeStep, activeStepVisible, isReducedMotion]);
 
     const animationDidEnd = (e) => {

--- a/special-pages/pages/onboarding/app/v3/components/Animation.js
+++ b/special-pages/pages/onboarding/app/v3/components/Animation.js
@@ -28,6 +28,7 @@ export function SlideIn({ children, onAnimationEnd }) {
     useEffect(() => {
         setAnimationState(activeStepVisible ? 'animating' : 'idle');
         if (isReducedMotion) animationEnd();
+        // eslint-disable-next-line react-hooks/exhaustive-deps -- disabled during eslint-plugin-react-hooks rollout; please remove and address deps
     }, [activeStep, activeStepVisible, isReducedMotion]);
 
     const animationDidEnd = (e) => {

--- a/special-pages/pages/onboarding/app/v3/components/DuckPlayerStep.js
+++ b/special-pages/pages/onboarding/app/v3/components/DuckPlayerStep.js
@@ -33,7 +33,7 @@ export function DuckPlayerStep({ defaultState = 'before' }) {
         return () => {
             if (timer.current) clearTimeout(timer.current);
         };
-        // eslint-disable-next-line react-hooks/exhaustive-deps -- disabled during eslint-plugin-react-hooks rollout; please remove and address deps
+        // eslint-disable-next-line react-hooks/exhaustive-deps -- workaround during eslint react rollout; consider removing and addressing deps
     }, [canPlay, isReducedMotion]);
 
     const animationDidEnd = () => {

--- a/special-pages/pages/onboarding/app/v3/components/DuckPlayerStep.js
+++ b/special-pages/pages/onboarding/app/v3/components/DuckPlayerStep.js
@@ -33,6 +33,7 @@ export function DuckPlayerStep({ defaultState = 'before' }) {
         return () => {
             if (timer.current) clearTimeout(timer.current);
         };
+        // eslint-disable-next-line react-hooks/exhaustive-deps -- disabled during eslint-plugin-react-hooks rollout; please remove and address deps
     }, [canPlay, isReducedMotion]);
 
     const animationDidEnd = () => {

--- a/special-pages/pages/onboarding/app/v3/components/Heading.js
+++ b/special-pages/pages/onboarding/app/v3/components/Heading.js
@@ -107,6 +107,7 @@ function SpeechBubble({ title, subtitle, onComplete, children }) {
                 setDimensions({ width, height });
             }
         }
+        // eslint-disable-next-line react-hooks/exhaustive-deps -- disabled during eslint-plugin-react-hooks rollout; please remove and address deps
     }, [bubbleContents, title, subtitle, children]);
 
     useEffect(() => {
@@ -129,6 +130,7 @@ function SpeechBubble({ title, subtitle, onComplete, children }) {
             clearTimeout(debounce);
             window.removeEventListener('resize', handleResize);
         };
+        // eslint-disable-next-line react-hooks/exhaustive-deps -- disabled during eslint-plugin-react-hooks rollout; please remove and address deps
     }, []);
 
     const onTransitionEnd = () => {

--- a/special-pages/pages/onboarding/app/v3/components/Heading.js
+++ b/special-pages/pages/onboarding/app/v3/components/Heading.js
@@ -107,7 +107,7 @@ function SpeechBubble({ title, subtitle, onComplete, children }) {
                 setDimensions({ width, height });
             }
         }
-        // eslint-disable-next-line react-hooks/exhaustive-deps -- disabled during eslint-plugin-react-hooks rollout; please remove and address deps
+        // eslint-disable-next-line react-hooks/exhaustive-deps -- workaround during eslint react rollout; consider removing and addressing deps
     }, [bubbleContents, title, subtitle, children]);
 
     useEffect(() => {
@@ -130,7 +130,7 @@ function SpeechBubble({ title, subtitle, onComplete, children }) {
             clearTimeout(debounce);
             window.removeEventListener('resize', handleResize);
         };
-        // eslint-disable-next-line react-hooks/exhaustive-deps -- disabled during eslint-plugin-react-hooks rollout; please remove and address deps
+        // eslint-disable-next-line react-hooks/exhaustive-deps -- workaround during eslint react rollout; consider removing and addressing deps
     }, []);
 
     const onTransitionEnd = () => {

--- a/special-pages/pages/onboarding/app/v3/components/Typed.js
+++ b/special-pages/pages/onboarding/app/v3/components/Typed.js
@@ -26,6 +26,7 @@ export function Typed({ text, children = null, onComplete = null, paused = false
             }
         }
         pre.current = text;
+        // eslint-disable-next-line react-hooks/exhaustive-deps -- disabled during eslint-plugin-react-hooks rollout; please remove and address deps
     }, [activeStep, text]);
     return (
         <TypedInner key={text} text={text} onComplete={onComplete} paused={paused} delay={delay} {...rest}>
@@ -56,6 +57,7 @@ function TypedInner({ text, onComplete, paused, delay, children, ...rest }) {
             setCurrentText(text);
             setCurrentIndex(text.length);
         }
+        // eslint-disable-next-line react-hooks/exhaustive-deps -- disabled during eslint-plugin-react-hooks rollout; please remove and address deps
     }, [isReducedMotion, localOnComplete]);
 
     useEffect(() => {
@@ -115,6 +117,7 @@ function TypedInner({ text, onComplete, paused, delay, children, ...rest }) {
             localOnComplete();
             return () => controller.abort();
         }
+        // eslint-disable-next-line react-hooks/exhaustive-deps -- disabled during eslint-plugin-react-hooks rollout; please remove and address deps
     }, [currentIndex, delay, text, paused]);
 
     function updatePlacement() {

--- a/special-pages/pages/onboarding/app/v3/components/Typed.js
+++ b/special-pages/pages/onboarding/app/v3/components/Typed.js
@@ -26,7 +26,7 @@ export function Typed({ text, children = null, onComplete = null, paused = false
             }
         }
         pre.current = text;
-        // eslint-disable-next-line react-hooks/exhaustive-deps -- disabled during eslint-plugin-react-hooks rollout; please remove and address deps
+        // eslint-disable-next-line react-hooks/exhaustive-deps -- workaround during eslint react rollout; consider removing and addressing deps
     }, [activeStep, text]);
     return (
         <TypedInner key={text} text={text} onComplete={onComplete} paused={paused} delay={delay} {...rest}>
@@ -57,7 +57,7 @@ function TypedInner({ text, onComplete, paused, delay, children, ...rest }) {
             setCurrentText(text);
             setCurrentIndex(text.length);
         }
-        // eslint-disable-next-line react-hooks/exhaustive-deps -- disabled during eslint-plugin-react-hooks rollout; please remove and address deps
+        // eslint-disable-next-line react-hooks/exhaustive-deps -- workaround during eslint react rollout; consider removing and addressing deps
     }, [isReducedMotion, localOnComplete]);
 
     useEffect(() => {
@@ -117,7 +117,7 @@ function TypedInner({ text, onComplete, paused, delay, children, ...rest }) {
             localOnComplete();
             return () => controller.abort();
         }
-        // eslint-disable-next-line react-hooks/exhaustive-deps -- disabled during eslint-plugin-react-hooks rollout; please remove and address deps
+        // eslint-disable-next-line react-hooks/exhaustive-deps -- workaround during eslint react rollout; consider removing and addressing deps
     }, [currentIndex, delay, text, paused]);
 
     function updatePlacement() {

--- a/special-pages/pages/onboarding/app/v3/pages/AddressBarMode/AddressBarMode.js
+++ b/special-pages/pages/onboarding/app/v3/pages/AddressBarMode/AddressBarMode.js
@@ -29,6 +29,7 @@ export function AddressBarMode() {
 
     useEffect(() => {
         dispatchPreference(selectedOption);
+        // eslint-disable-next-line react-hooks/exhaustive-deps -- disabled during eslint-plugin-react-hooks rollout; please remove and address deps
     }, []);
 
     const handleSelection = (option) => {

--- a/special-pages/pages/onboarding/app/v3/pages/AddressBarMode/AddressBarMode.js
+++ b/special-pages/pages/onboarding/app/v3/pages/AddressBarMode/AddressBarMode.js
@@ -29,7 +29,7 @@ export function AddressBarMode() {
 
     useEffect(() => {
         dispatchPreference(selectedOption);
-        // eslint-disable-next-line react-hooks/exhaustive-deps -- disabled during eslint-plugin-react-hooks rollout; please remove and address deps
+        // eslint-disable-next-line react-hooks/exhaustive-deps -- workaround during eslint react rollout; consider removing and addressing deps
     }, []);
 
     const handleSelection = (option) => {

--- a/special-pages/pages/onboarding/app/v4/components/Bubble.js
+++ b/special-pages/pages/onboarding/app/v4/components/Bubble.js
@@ -81,7 +81,7 @@ export function Bubble({
         });
         observer.observe(content);
         return () => observer.disconnect();
-    }, [onHeight]);
+    }, [onHeight, frameRef]);
 
     useEffect(() => {
         if (prevBounceKey.current === bounceKey) return;
@@ -115,7 +115,7 @@ export function Bubble({
                 delay: bounceDelay,
             },
         );
-    }, [bounceKey, animateFrame, animateProgressBadge, bounceDelay]);
+    }, [bounceKey, animateFrame, animateProgressBadge, bounceDelay, frameRef, contentRef, prevBounceKey]);
 
     /** @param {import('preact').JSX.TargetedAnimationEvent<HTMLDivElement>} e */
     const complete = (e) => {

--- a/special-pages/pages/onboarding/app/v4/components/DuckPlayerContent.js
+++ b/special-pages/pages/onboarding/app/v4/components/DuckPlayerContent.js
@@ -118,7 +118,7 @@ function DuckPlayerDefault({ advance }) {
             isReducedMotion ? 0 : 917,
         );
         return () => clearTimeout(id);
-        // eslint-disable-next-line react-hooks/exhaustive-deps -- disabled during eslint-plugin-react-hooks rollout; please remove and address deps
+        // eslint-disable-next-line react-hooks/exhaustive-deps -- workaround during eslint react rollout; consider removing and addressing deps
     }, []); // exclude isReducedMotion from deps — must not re-fire if reduced motion changes after mount
 
     const toggle = async () => {

--- a/special-pages/pages/onboarding/app/v4/components/DuckPlayerContent.js
+++ b/special-pages/pages/onboarding/app/v4/components/DuckPlayerContent.js
@@ -118,6 +118,7 @@ function DuckPlayerDefault({ advance }) {
             isReducedMotion ? 0 : 917,
         );
         return () => clearTimeout(id);
+        // eslint-disable-next-line react-hooks/exhaustive-deps -- disabled during eslint-plugin-react-hooks rollout; please remove and address deps
     }, []); // exclude isReducedMotion from deps — must not re-fire if reduced motion changes after mount
 
     const toggle = async () => {

--- a/special-pages/pages/onboarding/app/v4/components/LottieAnimation.js
+++ b/special-pages/pages/onboarding/app/v4/components/LottieAnimation.js
@@ -77,7 +77,7 @@ export function LottieAnimation({
             if (animationRef) animationRef.current = null;
             animation.destroy();
         };
-    }, [resolvedSrc, loop, onComplete, isReducedMotion]);
+    }, [resolvedSrc, loop, onComplete, isReducedMotion, autoplay, animationRef]);
 
     return (
         <div

--- a/special-pages/pages/onboarding/app/v4/components/Typed.js
+++ b/special-pages/pages/onboarding/app/v4/components/Typed.js
@@ -25,6 +25,7 @@ export function Typed({ text, onComplete = null, delay = 20, startDelay = 0, ...
             }
         }
         pre.current = text;
+        // eslint-disable-next-line react-hooks/exhaustive-deps -- disabled during eslint-plugin-react-hooks rollout; please remove and address deps
     }, [activeStep, text]);
     return <TypedInner key={text} text={text} onComplete={onComplete} delay={delay} startDelay={startDelay} {...rest} />;
 }
@@ -89,6 +90,7 @@ function TypedInner({ text, onComplete, delay, startDelay, ...rest }) {
             onComplete?.();
             return () => controller.abort();
         }
+        // eslint-disable-next-line react-hooks/exhaustive-deps -- disabled during eslint-plugin-react-hooks rollout; please remove and address deps
     }, [currentIndex, delay, text, waiting]);
 
     const currentText = text.slice(0, currentIndex);

--- a/special-pages/pages/onboarding/app/v4/components/Typed.js
+++ b/special-pages/pages/onboarding/app/v4/components/Typed.js
@@ -25,7 +25,7 @@ export function Typed({ text, onComplete = null, delay = 20, startDelay = 0, ...
             }
         }
         pre.current = text;
-        // eslint-disable-next-line react-hooks/exhaustive-deps -- disabled during eslint-plugin-react-hooks rollout; please remove and address deps
+        // eslint-disable-next-line react-hooks/exhaustive-deps -- workaround during eslint react rollout; consider removing and addressing deps
     }, [activeStep, text]);
     return <TypedInner key={text} text={text} onComplete={onComplete} delay={delay} startDelay={startDelay} {...rest} />;
 }
@@ -90,7 +90,7 @@ function TypedInner({ text, onComplete, delay, startDelay, ...rest }) {
             onComplete?.();
             return () => controller.abort();
         }
-        // eslint-disable-next-line react-hooks/exhaustive-deps -- disabled during eslint-plugin-react-hooks rollout; please remove and address deps
+        // eslint-disable-next-line react-hooks/exhaustive-deps -- workaround during eslint react rollout; consider removing and addressing deps
     }, [currentIndex, delay, text, waiting]);
 
     const currentText = text.slice(0, currentIndex);

--- a/special-pages/pages/onboarding/app/v4/components/WelcomeContent.js
+++ b/special-pages/pages/onboarding/app/v4/components/WelcomeContent.js
@@ -28,7 +28,7 @@ export function WelcomeContent({ onComplete }) {
         if (!isReducedMotion) return;
         const timer = setTimeout(complete, WELCOME_ANIMATION_MS);
         return () => clearTimeout(timer);
-        // eslint-disable-next-line react-hooks/exhaustive-deps -- disabled during eslint-plugin-react-hooks rollout; please remove and address deps
+        // eslint-disable-next-line react-hooks/exhaustive-deps -- workaround during eslint react rollout; consider removing and addressing deps
     }, [isReducedMotion]);
 
     return (

--- a/special-pages/pages/onboarding/app/v4/components/WelcomeContent.js
+++ b/special-pages/pages/onboarding/app/v4/components/WelcomeContent.js
@@ -28,6 +28,7 @@ export function WelcomeContent({ onComplete }) {
         if (!isReducedMotion) return;
         const timer = setTimeout(complete, WELCOME_ANIMATION_MS);
         return () => clearTimeout(timer);
+        // eslint-disable-next-line react-hooks/exhaustive-deps -- disabled during eslint-plugin-react-hooks rollout; please remove and address deps
     }, [isReducedMotion]);
 
     return (

--- a/special-pages/pages/release-notes/app/components/App.js
+++ b/special-pages/pages/release-notes/app/components/App.js
@@ -27,6 +27,7 @@ export function App({ children }) {
             console.log('DATA RECEIVED', data);
             setReleaseData(data);
         });
+        // eslint-disable-next-line react-hooks/exhaustive-deps -- disabled during eslint-plugin-react-hooks rollout; please remove and address deps
     }, []);
 
     /**

--- a/special-pages/pages/release-notes/app/components/App.js
+++ b/special-pages/pages/release-notes/app/components/App.js
@@ -27,7 +27,7 @@ export function App({ children }) {
             console.log('DATA RECEIVED', data);
             setReleaseData(data);
         });
-        // eslint-disable-next-line react-hooks/exhaustive-deps -- disabled during eslint-plugin-react-hooks rollout; please remove and address deps
+        // eslint-disable-next-line react-hooks/exhaustive-deps -- workaround during eslint react rollout; consider removing and addressing deps
     }, []);
 
     /**

--- a/special-pages/pages/special-error/app/components/AdvancedInfo.jsx
+++ b/special-pages/pages/special-error/app/components/AdvancedInfo.jsx
@@ -1,6 +1,7 @@
 import { h } from 'preact';
 import { useRef } from 'preact/hooks';
 import { useTypedTranslation } from '../types';
+// eslint-disable-next-line no-redeclare -- shadows DOM global `Text` intentionally
 import { Text } from '../../../../shared/components/Text/Text';
 import { useMessaging } from '../providers/MessagingProvider';
 import { useAdvancedInfoHeading, useAdvancedInfoContent } from '../hooks/ErrorStrings';

--- a/special-pages/pages/special-error/app/components/Warning.jsx
+++ b/special-pages/pages/special-error/app/components/Warning.jsx
@@ -5,6 +5,7 @@ import { useMessaging } from '../providers/MessagingProvider';
 import { useErrorData } from '../providers/SpecialErrorProvider';
 import { usePlatformName, useIsMobile } from '../providers/SettingsProvider';
 import { useWarningHeading, useWarningContent } from '../hooks/ErrorStrings';
+// eslint-disable-next-line no-redeclare -- shadows DOM global `Text` intentionally
 import { Text } from '../../../../shared/components/Text/Text';
 import { Button } from '../../../../shared/components/Button/Button';
 
@@ -54,11 +55,10 @@ export function LeaveSiteButton() {
 
 export function WarningHeading() {
     const heading = useWarningHeading();
-    if (!heading) return null;
-
     const { kind } = useErrorData();
     const platformName = usePlatformName();
     const isMobile = useIsMobile();
+    if (!heading) return null;
 
     /** @type {'title-2'|'title-2-emphasis'|'custom-title-1'} */
     let textVariant;

--- a/special-pages/pages/special-error/app/hooks/ErrorStrings.jsx
+++ b/special-pages/pages/special-error/app/hooks/ErrorStrings.jsx
@@ -65,9 +65,10 @@ export function useWarningHeading() {
             return t('sslPageHeading');
         case 'malware':
         case 'phishing':
-        case 'scam':
+        case 'scam': {
             const translationKey = /** @type {const} */ (`${kind}PageHeading`);
             return t(translationKey).replace('{newline}', '\n');
+        }
         default:
     }
 
@@ -118,11 +119,12 @@ export function useAdvancedInfoHeading() {
             return t('sslAdvancedInfoHeading');
         case 'malware':
         case 'phishing':
-        case 'scam':
+        case 'scam': {
             const { url } = /** @type {MaliciousSite} */ (errorData);
             const anchorTagParams = reportSiteAnchorTagParams(url);
             const translationKey = /** @type {const} */ (`${kind}AdvancedInfoHeading`);
             return <Trans str={t(translationKey)} values={{ a: anchorTagParams }} />;
+        }
         default:
     }
 
@@ -150,9 +152,10 @@ export function useAdvancedInfoContent() {
                 return [<Trans str={t('sslInvalidAdvancedInfoText', { domain })} values="" />];
             case 'selfSigned':
                 return [<Trans str={t('sslSelfSignedAdvancedInfoText', { domain })} values="" />];
-            case 'wrongHost':
+            case 'wrongHost': {
                 const { eTldPlus1 } = /** @type {SSLWrongHost} */ (errorData);
                 return [<Trans str={t('sslWrongHostAdvancedInfoText', { domain, eTldPlus1 })} values="" />];
+            }
             default:
                 throw new Error(`Unhandled SSL error type ${errorType}`);
         }

--- a/special-pages/pages/special-error/app/providers/SettingsProvider.jsx
+++ b/special-pages/pages/special-error/app/providers/SettingsProvider.jsx
@@ -1,7 +1,7 @@
-import { h } from 'preact';
-import { createContext } from 'preact';
-import { Settings } from '../settings';
+import { h, createContext } from 'preact';
 import { useContext } from 'preact/hooks';
+
+/** @import {Settings} from '../settings' */
 
 const SettingsContext = createContext(/** @type {{settings: Settings}} */ ({}));
 


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/72649045549333/task/1214509830706139?focus=true

## Description
Enables `eslint-plugin-react-hooks` (`rules-of-hooks` + `exhaustive-deps`) for `special-pages/**` and clears the resulting errors so the rule can ship as `error`.

## Changes
Turns on `react-hooks/rules-of-hooks` and `react-hooks/exhaustive-deps` (as errors) for `special-pages/**` and makes the workspace pass.

- Adds `eslint-plugin-react-hooks` and a scoped flat-config block in `eslint.config.js` limiting the rules to `special-pages/**`. 
- Fixes a handful of real rules-of-hooks violations where hooks ran after an early return or inside a branch
- Where exhaustive-deps flagged genuinely missing deps, addressed them
- Everywhere else, suppresses `exhaustive-deps` with a uniform `workaround during eslint react rollout; consider removing and addressing deps` comment. This is the bulk of the diff and is intentionally deferred — no behavior change at those sites.


## Checklist

<!--
  These questions are a friendly reminder to shipping code, if you're uncertain ask the AoR owners.
  It's also totally appropriate to not check some of these boxes, if they don't apply to your change.
-->
*Please tick all that apply:*

- [x] I have tested this change locally
- [ ] I have tested this change locally in all supported browsers
- [x] This change will be visible to users
- [ ] I have added automated tests that cover this change
- [ ] I have ensured the change is gated by config
- [ ] This change was covered by a ship review
- [ ] This change was covered by a tech design
- [x] Any dependent config has been merged


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Mostly linting/config changes, but it touches many Preact components and adjusts hook usage and some effect dependency arrays, which could subtly change when effects run or handlers are recreated.
> 
> **Overview**
> Enables `eslint-plugin-react-hooks` for `special-pages/**/*.{js,jsx,ts,tsx}` and adds it to dev dependencies, making `rules-of-hooks` and `exhaustive-deps` enforced as errors.
> 
> Updates numerous `special-pages` components/providers to comply: fixes a few real hooks issues (e.g., moving early returns after hooks), adds/adjusts some dependency arrays, and adds consistent `// eslint-disable-next-line react-hooks/exhaustive-deps` suppressions where deps are intentionally deferred during rollout. Minor refactors accompany this (e.g., `let`→`const`, cleanup of unused imports, and converting a promise chain to `async/await`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ea5805b2aadb3c4fe240e27b1ca3dbff1d9c18ed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->