### PR TITLE
feat(ntp): add YouTube ad blocking next steps card

### DIFF
--- a/special-pages/pages/new-tab/app/next-steps-list/next-steps-list.data.js
+++ b/special-pages/pages/new-tab/app/next-steps-list/next-steps-list.data.js
@@ -36,6 +36,14 @@ export const variants = {
         actionText: t('nextStepsList_duckplayer_actionText'),
     }),
     /** @param {(translationId: keyof enStrings) => string} t */
+    youtubeAdBlocking: (t) => ({
+        id: 'youtubeAdBlocking',
+        icon: 'duck-player',
+        title: t('nextStepsList_youtubeAdBlocking_title'),
+        summary: t('nextStepsList_youtubeAdBlocking_summary'),
+        actionText: t('nextStepsList_youtubeAdBlocking_actionText'),
+    }),
+    /** @param {(translationId: keyof enStrings) => string} t */
     emailProtection: (t) => ({
         id: 'emailProtection',
         icon: 'email-protection',

--- a/special-pages/pages/new-tab/app/next-steps-list/strings.json
+++ b/special-pages/pages/new-tab/app/next-steps-list/strings.json
@@ -55,6 +55,18 @@
     "title": "Try Duck Player",
     "note": "Button text of the Next Steps List card for Duck Player"
   },
+  "nextStepsList_youtubeAdBlocking_title": {
+    "title": "Watch YouTube Without Ads",
+    "note": "Title of the Next Steps List card for YouTube ad blocking"
+  },
+  "nextStepsList_youtubeAdBlocking_summary": {
+    "title": "Enjoy a clean viewing experience without creepy, personalized ads.",
+    "note": "Summary of the Next Steps List card for YouTube ad blocking"
+  },
+  "nextStepsList_youtubeAdBlocking_actionText": {
+    "title": "Open YouTube",
+    "note": "Button text of the Next Steps List card for YouTube ad blocking"
+  },
   "nextStepsList_emailProtection_title": {
     "title": "Protect Your Email Address and Block Trackers",
     "note": "Title of the Next Steps List card for email protection"

--- a/special-pages/pages/new-tab/app/next-steps/components/NextSteps.examples.js
+++ b/special-pages/pages/new-tab/app/next-steps/components/NextSteps.examples.js
@@ -16,6 +16,7 @@ export const nextStepsExamples = {
                     'blockCookies',
                     'emailProtection',
                     'duckplayer',
+                    'youtubeAdBlocking',
                     'addAppToDockMac',
                     'pinAppToTaskbarWindows',
                 ]}
@@ -35,6 +36,7 @@ export const nextStepsExamples = {
                     'blockCookies',
                     'emailProtection',
                     'duckplayer',
+                    'youtubeAdBlocking',
                     'addAppToDockMac',
                     'pinAppToTaskbarWindows',
                 ]}
@@ -75,6 +77,9 @@ export const otherNextStepsExamples = {
     },
     'next-steps.duckplayer': {
         factory: () => <NextStepsCard type="duckplayer" dismiss={noop('dismiss')} action={noop('action')} />,
+    },
+    'next-steps.youtubeAdBlocking': {
+        factory: () => <NextStepsCard type="youtubeAdBlocking" dismiss={noop('dismiss')} action={noop('action')} />,
     },
     'next-steps.defaultApp': {
         factory: () => <NextStepsCard type="defaultApp" dismiss={noop('dismiss')} action={noop('action')} />,

--- a/special-pages/pages/new-tab/app/next-steps/nextsteps.data.js
+++ b/special-pages/pages/new-tab/app/next-steps/nextsteps.data.js
@@ -44,6 +44,14 @@ export const variants = {
         actionText: t('nextSteps_duckPlayer_actionText'),
     }),
     /** @param {(translationId: keyof enStrings) => string} t */
+    youtubeAdBlocking: (t) => ({
+        id: 'youtubeAdBlocking',
+        icon: 'Tube-Clean',
+        title: t('nextSteps_youtubeAdBlocking_title'),
+        summary: t('nextSteps_youtubeAdBlocking_summary'),
+        actionText: t('nextSteps_youtubeAdBlocking_actionText'),
+    }),
+    /** @param {(translationId: keyof enStrings) => string} t */
     addAppToDockMac: (t) => ({
         id: 'addAppToDockMac',
         icon: 'Dock-Add-Mac',

--- a/special-pages/pages/new-tab/app/next-steps/strings.json
+++ b/special-pages/pages/new-tab/app/next-steps/strings.json
@@ -63,6 +63,18 @@
     "title": "Try Duck Player",
     "note": "Button text of the Next Steps card for adopting DuckPlayer"
   },
+  "nextSteps_youtubeAdBlocking_title": {
+    "title": "Watch YouTube Without Ads",
+    "note": "Title of the Next Steps card for YouTube ad blocking"
+  },
+  "nextSteps_youtubeAdBlocking_summary": {
+    "title": "Enjoy a clean viewing experience without creepy, personalized ads.",
+    "note": "Summary of the Next Steps card for YouTube ad blocking"
+  },
+  "nextSteps_youtubeAdBlocking_actionText": {
+    "title": "Open YouTube",
+    "note": "Button text of the Next Steps card for YouTube ad blocking"
+  },
   "nextSteps_addAppDockMac_title": {
     "title": "Add App to the Dock",
     "note": "Title of the Next Steps card for adding DDG app to OS dock"

--- a/special-pages/pages/new-tab/messages/types/next-steps.json
+++ b/special-pages/pages/new-tab/messages/types/next-steps.json
@@ -31,7 +31,8 @@
                                     "duckplayer",
                                     "addAppToDockMac",
                                     "pinAppToTaskbarWindows",
-                                    "subscription"
+                                    "subscription",
+                                    "youtubeAdBlocking"
                                 ]
                             }
                         }

--- a/special-pages/pages/new-tab/public/locales/de/new-tab.json
+++ b/special-pages/pages/new-tab/public/locales/de/new-tab.json
@@ -377,6 +377,18 @@
     "title": "Duck Player testen",
     "note": "Button text of the Next Steps List card for Duck Player"
   },
+  "nextStepsList_youtubeAdBlocking_title": {
+    "title": "YouTube ohne Werbung ansehen",
+    "note": "Title of the Next Steps List card for YouTube ad blocking"
+  },
+  "nextStepsList_youtubeAdBlocking_summary": {
+    "title": "Genieße ein sauberes Seherlebnis ohne aufdringliche, personalisierte Werbung.",
+    "note": "Summary of the Next Steps List card for YouTube ad blocking"
+  },
+  "nextStepsList_youtubeAdBlocking_actionText": {
+    "title": "YouTube öffnen",
+    "note": "Button text of the Next Steps List card for YouTube ad blocking"
+  },
   "nextStepsList_emailProtection_title": {
     "title": "Schütze deine E-Mail-Adresse und blockiere Tracker",
     "note": "Title of the Next Steps List card for email protection"
@@ -500,6 +512,18 @@
   "nextSteps_duckPlayer_actionText": {
     "title": "Duck Player testen",
     "note": "Button text of the Next Steps card for adopting DuckPlayer"
+  },
+  "nextSteps_youtubeAdBlocking_title": {
+    "title": "YouTube ohne Werbung ansehen",
+    "note": "Title of the Next Steps card for YouTube ad blocking"
+  },
+  "nextSteps_youtubeAdBlocking_summary": {
+    "title": "Genieße ein sauberes Seherlebnis ohne aufdringliche, personalisierte Werbung.",
+    "note": "Summary of the Next Steps card for YouTube ad blocking"
+  },
+  "nextSteps_youtubeAdBlocking_actionText": {
+    "title": "YouTube öffnen",
+    "note": "Button text of the Next Steps card for YouTube ad blocking"
   },
   "nextSteps_addAppDockMac_title": {
     "title": "App zum Dock hinzufügen",

--- a/special-pages/pages/new-tab/public/locales/en/new-tab.json
+++ b/special-pages/pages/new-tab/public/locales/en/new-tab.json
@@ -381,6 +381,18 @@
     "title": "Try Duck Player",
     "note": "Button text of the Next Steps List card for Duck Player"
   },
+  "nextStepsList_youtubeAdBlocking_title": {
+    "title": "Watch YouTube Without Ads",
+    "note": "Title of the Next Steps List card for YouTube ad blocking"
+  },
+  "nextStepsList_youtubeAdBlocking_summary": {
+    "title": "Enjoy a clean viewing experience without creepy, personalized ads.",
+    "note": "Summary of the Next Steps List card for YouTube ad blocking"
+  },
+  "nextStepsList_youtubeAdBlocking_actionText": {
+    "title": "Open YouTube",
+    "note": "Button text of the Next Steps List card for YouTube ad blocking"
+  },
   "nextStepsList_emailProtection_title": {
     "title": "Protect Your Email Address and Block Trackers",
     "note": "Title of the Next Steps List card for email protection"
@@ -504,6 +516,18 @@
   "nextSteps_duckPlayer_actionText": {
     "title": "Try Duck Player",
     "note": "Button text of the Next Steps card for adopting DuckPlayer"
+  },
+  "nextSteps_youtubeAdBlocking_title": {
+    "title": "Watch YouTube Without Ads",
+    "note": "Title of the Next Steps card for YouTube ad blocking"
+  },
+  "nextSteps_youtubeAdBlocking_summary": {
+    "title": "Enjoy a clean viewing experience without creepy, personalized ads.",
+    "note": "Summary of the Next Steps card for YouTube ad blocking"
+  },
+  "nextSteps_youtubeAdBlocking_actionText": {
+    "title": "Open YouTube",
+    "note": "Button text of the Next Steps card for YouTube ad blocking"
   },
   "nextSteps_addAppDockMac_title": {
     "title": "Add App to the Dock",

--- a/special-pages/pages/new-tab/public/locales/es/new-tab.json
+++ b/special-pages/pages/new-tab/public/locales/es/new-tab.json
@@ -377,6 +377,18 @@
     "title": "Prueba Duck Player",
     "note": "Button text of the Next Steps List card for Duck Player"
   },
+  "nextStepsList_youtubeAdBlocking_title": {
+    "title": "Ver YouTube sin anuncios",
+    "note": "Title of the Next Steps List card for YouTube ad blocking"
+  },
+  "nextStepsList_youtubeAdBlocking_summary": {
+    "title": "Disfruta de una experiencia de visualización limpia sin anuncios escalofriantes personalizados.",
+    "note": "Summary of the Next Steps List card for YouTube ad blocking"
+  },
+  "nextStepsList_youtubeAdBlocking_actionText": {
+    "title": "Abre YouTube",
+    "note": "Button text of the Next Steps List card for YouTube ad blocking"
+  },
   "nextStepsList_emailProtection_title": {
     "title": "Protege tu dirección de correo electrónico y bloquea los rastreadores",
     "note": "Title of the Next Steps List card for email protection"
@@ -500,6 +512,18 @@
   "nextSteps_duckPlayer_actionText": {
     "title": "Prueba Duck Player",
     "note": "Button text of the Next Steps card for adopting DuckPlayer"
+  },
+  "nextSteps_youtubeAdBlocking_title": {
+    "title": "Ver YouTube sin anuncios",
+    "note": "Title of the Next Steps card for YouTube ad blocking"
+  },
+  "nextSteps_youtubeAdBlocking_summary": {
+    "title": "Disfruta de una experiencia de visualización limpia sin anuncios escalofriantes personalizados.",
+    "note": "Summary of the Next Steps card for YouTube ad blocking"
+  },
+  "nextSteps_youtubeAdBlocking_actionText": {
+    "title": "Abre YouTube",
+    "note": "Button text of the Next Steps card for YouTube ad blocking"
   },
   "nextSteps_addAppDockMac_title": {
     "title": "Añade la aplicación al Dock",

--- a/special-pages/pages/new-tab/public/locales/fr/new-tab.json
+++ b/special-pages/pages/new-tab/public/locales/fr/new-tab.json
@@ -377,6 +377,18 @@
     "title": "Essayer Duck Player",
     "note": "Button text of the Next Steps List card for Duck Player"
   },
+  "nextStepsList_youtubeAdBlocking_title": {
+    "title": "Regardez YouTube sans publicités",
+    "note": "Title of the Next Steps List card for YouTube ad blocking"
+  },
+  "nextStepsList_youtubeAdBlocking_summary": {
+    "title": "Profitez d'une expérience de visionnage épurée, sans publicités personnalisées intrusives et douteuses.",
+    "note": "Summary of the Next Steps List card for YouTube ad blocking"
+  },
+  "nextStepsList_youtubeAdBlocking_actionText": {
+    "title": "Ouvrir YouTube",
+    "note": "Button text of the Next Steps List card for YouTube ad blocking"
+  },
   "nextStepsList_emailProtection_title": {
     "title": "Protégez votre adresse e-mail et bloquez les traqueurs",
     "note": "Title of the Next Steps List card for email protection"
@@ -500,6 +512,18 @@
   "nextSteps_duckPlayer_actionText": {
     "title": "Essayer Duck Player",
     "note": "Button text of the Next Steps card for adopting DuckPlayer"
+  },
+  "nextSteps_youtubeAdBlocking_title": {
+    "title": "Regardez YouTube sans publicités",
+    "note": "Title of the Next Steps card for YouTube ad blocking"
+  },
+  "nextSteps_youtubeAdBlocking_summary": {
+    "title": "Profitez d'une expérience de visionnage épurée, sans publicités personnalisées intrusives et douteuses.",
+    "note": "Summary of the Next Steps card for YouTube ad blocking"
+  },
+  "nextSteps_youtubeAdBlocking_actionText": {
+    "title": "Ouvrir YouTube",
+    "note": "Button text of the Next Steps card for YouTube ad blocking"
   },
   "nextSteps_addAppDockMac_title": {
     "title": "Ajouter l'application au Dock",

--- a/special-pages/pages/new-tab/public/locales/it/new-tab.json
+++ b/special-pages/pages/new-tab/public/locales/it/new-tab.json
@@ -377,6 +377,18 @@
     "title": "Prova Duck Player",
     "note": "Button text of the Next Steps List card for Duck Player"
   },
+  "nextStepsList_youtubeAdBlocking_title": {
+    "title": "Guarda YouTube senza annunci",
+    "note": "Title of the Next Steps List card for YouTube ad blocking"
+  },
+  "nextStepsList_youtubeAdBlocking_summary": {
+    "title": "Usufruisci di un'esperienza di visione lineare, senza annunci personalizzati e inquietanti.",
+    "note": "Summary of the Next Steps List card for YouTube ad blocking"
+  },
+  "nextStepsList_youtubeAdBlocking_actionText": {
+    "title": "Apri YouTube",
+    "note": "Button text of the Next Steps List card for YouTube ad blocking"
+  },
   "nextStepsList_emailProtection_title": {
     "title": "Proteggi il tuo indirizzo email e blocca i sistemi di tracciamento",
     "note": "Title of the Next Steps List card for email protection"
@@ -500,6 +512,18 @@
   "nextSteps_duckPlayer_actionText": {
     "title": "Prova Duck Player",
     "note": "Button text of the Next Steps card for adopting DuckPlayer"
+  },
+  "nextSteps_youtubeAdBlocking_title": {
+    "title": "Guarda YouTube senza annunci",
+    "note": "Title of the Next Steps card for YouTube ad blocking"
+  },
+  "nextSteps_youtubeAdBlocking_summary": {
+    "title": "Usufruisci di un'esperienza di visione lineare, senza annunci personalizzati e inquietanti.",
+    "note": "Summary of the Next Steps card for YouTube ad blocking"
+  },
+  "nextSteps_youtubeAdBlocking_actionText": {
+    "title": "Apri YouTube",
+    "note": "Button text of the Next Steps card for YouTube ad blocking"
   },
   "nextSteps_addAppDockMac_title": {
     "title": "Aggiungi app al Dock",

--- a/special-pages/pages/new-tab/public/locales/nl/new-tab.json
+++ b/special-pages/pages/new-tab/public/locales/nl/new-tab.json
@@ -377,6 +377,18 @@
     "title": "Probeer Duck Player",
     "note": "Button text of the Next Steps List card for Duck Player"
   },
+  "nextStepsList_youtubeAdBlocking_title": {
+    "title": "Bekijk YouTube zonder advertenties",
+    "note": "Title of the Next Steps List card for YouTube ad blocking"
+  },
+  "nextStepsList_youtubeAdBlocking_summary": {
+    "title": "Beleef ongeëvenaard kijkplezier zonder enge, gepersonaliseerde advertenties.",
+    "note": "Summary of the Next Steps List card for YouTube ad blocking"
+  },
+  "nextStepsList_youtubeAdBlocking_actionText": {
+    "title": "YouTube openen",
+    "note": "Button text of the Next Steps List card for YouTube ad blocking"
+  },
   "nextStepsList_emailProtection_title": {
     "title": "Bescherm je e-mailadres en blokkeer trackers",
     "note": "Title of the Next Steps List card for email protection"
@@ -500,6 +512,18 @@
   "nextSteps_duckPlayer_actionText": {
     "title": "Probeer Duck Player",
     "note": "Button text of the Next Steps card for adopting DuckPlayer"
+  },
+  "nextSteps_youtubeAdBlocking_title": {
+    "title": "Bekijk YouTube zonder advertenties",
+    "note": "Title of the Next Steps card for YouTube ad blocking"
+  },
+  "nextSteps_youtubeAdBlocking_summary": {
+    "title": "Beleef ongeëvenaard kijkplezier zonder enge, gepersonaliseerde advertenties.",
+    "note": "Summary of the Next Steps card for YouTube ad blocking"
+  },
+  "nextSteps_youtubeAdBlocking_actionText": {
+    "title": "YouTube openen",
+    "note": "Button text of the Next Steps card for YouTube ad blocking"
   },
   "nextSteps_addAppDockMac_title": {
     "title": "Voeg de App toe aan je Dock",

--- a/special-pages/pages/new-tab/public/locales/pl/new-tab.json
+++ b/special-pages/pages/new-tab/public/locales/pl/new-tab.json
@@ -377,6 +377,18 @@
     "title": "Wypróbuj Duck Player",
     "note": "Button text of the Next Steps List card for Duck Player"
   },
+  "nextStepsList_youtubeAdBlocking_title": {
+    "title": "Oglądaj YouTube bez reklam",
+    "note": "Title of the Next Steps List card for YouTube ad blocking"
+  },
+  "nextStepsList_youtubeAdBlocking_summary": {
+    "title": "Korzystaj z czystego środowiska oglądania bez wstrętnych, spersonalizowanych reklam.",
+    "note": "Summary of the Next Steps List card for YouTube ad blocking"
+  },
+  "nextStepsList_youtubeAdBlocking_actionText": {
+    "title": "Otwórz YouTube",
+    "note": "Button text of the Next Steps List card for YouTube ad blocking"
+  },
   "nextStepsList_emailProtection_title": {
     "title": "Chroń swój adres e-mail i blokuj skrypty śledzące",
     "note": "Title of the Next Steps List card for email protection"
@@ -500,6 +512,18 @@
   "nextSteps_duckPlayer_actionText": {
     "title": "Wypróbuj Duck Player",
     "note": "Button text of the Next Steps card for adopting DuckPlayer"
+  },
+  "nextSteps_youtubeAdBlocking_title": {
+    "title": "Oglądaj YouTube bez reklam",
+    "note": "Title of the Next Steps card for YouTube ad blocking"
+  },
+  "nextSteps_youtubeAdBlocking_summary": {
+    "title": "Korzystaj z czystego środowiska oglądania bez wstrętnych, spersonalizowanych reklam.",
+    "note": "Summary of the Next Steps card for YouTube ad blocking"
+  },
+  "nextSteps_youtubeAdBlocking_actionText": {
+    "title": "Otwórz YouTube",
+    "note": "Button text of the Next Steps card for YouTube ad blocking"
   },
   "nextSteps_addAppDockMac_title": {
     "title": "Dodaj aplikację do Docka",

--- a/special-pages/pages/new-tab/public/locales/pt/new-tab.json
+++ b/special-pages/pages/new-tab/public/locales/pt/new-tab.json
@@ -377,6 +377,18 @@
     "title": "Experimente o Duck Player",
     "note": "Button text of the Next Steps List card for Duck Player"
   },
+  "nextStepsList_youtubeAdBlocking_title": {
+    "title": "Vê vídeos do YouTube sem anúncios",
+    "note": "Title of the Next Steps List card for YouTube ad blocking"
+  },
+  "nextStepsList_youtubeAdBlocking_summary": {
+    "title": "Desfruta de uma experiência de visualização limpa, sem anúncios personalizados e assustadores.",
+    "note": "Summary of the Next Steps List card for YouTube ad blocking"
+  },
+  "nextStepsList_youtubeAdBlocking_actionText": {
+    "title": "Abrir o YouTube",
+    "note": "Button text of the Next Steps List card for YouTube ad blocking"
+  },
   "nextStepsList_emailProtection_title": {
     "title": "Protege o teu endereço de e-mail e bloqueia rastreadores",
     "note": "Title of the Next Steps List card for email protection"
@@ -500,6 +512,18 @@
   "nextSteps_duckPlayer_actionText": {
     "title": "Experimente o Duck Player",
     "note": "Button text of the Next Steps card for adopting DuckPlayer"
+  },
+  "nextSteps_youtubeAdBlocking_title": {
+    "title": "Vê vídeos do YouTube sem anúncios",
+    "note": "Title of the Next Steps card for YouTube ad blocking"
+  },
+  "nextSteps_youtubeAdBlocking_summary": {
+    "title": "Desfruta de uma experiência de visualização limpa, sem anúncios personalizados e assustadores.",
+    "note": "Summary of the Next Steps card for YouTube ad blocking"
+  },
+  "nextSteps_youtubeAdBlocking_actionText": {
+    "title": "Abrir o YouTube",
+    "note": "Button text of the Next Steps card for YouTube ad blocking"
   },
   "nextSteps_addAppDockMac_title": {
     "title": "Adicionar aplicação à Dock",

--- a/special-pages/pages/new-tab/public/locales/ru/new-tab.json
+++ b/special-pages/pages/new-tab/public/locales/ru/new-tab.json
@@ -377,6 +377,18 @@
     "title": "Попробовать Duck Player",
     "note": "Button text of the Next Steps List card for Duck Player"
   },
+  "nextStepsList_youtubeAdBlocking_title": {
+    "title": "Смотри YouTube без рекламы",
+    "note": "Title of the Next Steps List card for YouTube ad blocking"
+  },
+  "nextStepsList_youtubeAdBlocking_summary": {
+    "title": "Пользуйтесь «чистым» просмотром без персонализированной рекламы.",
+    "note": "Summary of the Next Steps List card for YouTube ad blocking"
+  },
+  "nextStepsList_youtubeAdBlocking_actionText": {
+    "title": "Открыть YouTube",
+    "note": "Button text of the Next Steps List card for YouTube ad blocking"
+  },
   "nextStepsList_emailProtection_title": {
     "title": "Остановить спам и трекеры",
     "note": "Title of the Next Steps List card for email protection"
@@ -500,6 +512,18 @@
   "nextSteps_duckPlayer_actionText": {
     "title": "Попробовать Duck Player",
     "note": "Button text of the Next Steps card for adopting DuckPlayer"
+  },
+  "nextSteps_youtubeAdBlocking_title": {
+    "title": "Смотрите YouTube без рекламы",
+    "note": "Title of the Next Steps card for YouTube ad blocking"
+  },
+  "nextSteps_youtubeAdBlocking_summary": {
+    "title": "Пользуйтесь «чистым» просмотром без персонализированной рекламы.",
+    "note": "Summary of the Next Steps card for YouTube ad blocking"
+  },
+  "nextSteps_youtubeAdBlocking_actionText": {
+    "title": "Открыть YouTube",
+    "note": "Button text of the Next Steps card for YouTube ad blocking"
   },
   "nextSteps_addAppDockMac_title": {
     "title": "DuckDuckGo на док-панели",

--- a/special-pages/pages/new-tab/types/new-tab.ts
+++ b/special-pages/pages/new-tab/types/new-tab.ts
@@ -139,7 +139,8 @@ export type NextStepsCardTypes =
   | "duckplayer"
   | "addAppToDockMac"
   | "pinAppToTaskbarWindows"
-  | "subscription";
+  | "subscription"
+  | "youtubeAdBlocking";
 export type NextStepsCards = {
   id: NextStepsCardTypes;
 }[];


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1203936086921904/task/1214259973392242

## Description
Add support for a new next step card for "YouTube Ad Blocking".

<img width="510" height="243" alt="Screenshot 2026-05-06 at 18 20 17" src="https://github.com/user-attachments/assets/50ba1fdd-5ec2-4fa9-ad86-8bebbc07c10d" />


## Testing Steps
n/a

## Checklist

<!--
  These questions are a friendly reminder to shipping code, if you're uncertain ask the AoR owners.
  It's also totally appropriate to not check some of these boxes, if they don't apply to your change.
-->
*Please tick all that apply:*

- [ ] I have tested this change locally
- [ ] I have tested this change locally in all supported browsers
- [ ] This change will be visible to users
- [ ] I have added automated tests that cover this change
- [ ] I have ensured the change is gated by config
- [ ] This change was covered by a ship review
- [ ] This change was covered by a tech design
- [ ] Any dependent config has been merged



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this is mainly additive UI copy/data and type/schema enum updates for a new card, with no changes to security-sensitive logic. Primary risk is mismatched IDs/translation keys causing missing/incorrect rendering in the Next Steps UI.
> 
> **Overview**
> Adds a new `youtubeAdBlocking` option to the New Tab Page **Next Steps** and **Next Steps List** card sets, including variant metadata (id/icon/title/summary/action text) and example rendering.
> 
> Extends the allowed card-type enums in both the `next-steps` message schema and the `NextStepsCardTypes` TypeScript union, and ships new localized strings (including `en`, `de`, `es`, `fr`, `it`, `nl`, `pl`, `pt`, `ru`) for the new card’s labels.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 08c90033b0aa35d67c441a3598daeb4686c34394. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->