### PR TITLE
fix(tracker-protection): keep observing under contentBlocking kill-switch

### DIFF
--- a/injected/integration-test/test-pages/tracker-protection/config/tracker-protection-blocking-disabled.json
+++ b/injected/integration-test/test-pages/tracker-protection/config/tracker-protection-blocking-disabled.json
@@ -1,0 +1,26 @@
+{
+    "readme": "Config for the legacy `contentBlocking` kill-switch path. trackerProtection stays enabled so observation continues for the privacy dashboard, but contentBlocking is disabled so emitted observations carry potentiallyBlocked=false and surrogate injection is skipped.",
+    "version": 1,
+    "features": {
+        "contentBlocking": {
+            "state": "disabled",
+            "exceptions": []
+        },
+        "clickToLoad": {
+            "state": "enabled",
+            "exceptions": []
+        },
+        "trackerAllowlist": {
+            "state": "enabled",
+            "exceptions": [],
+            "settings": {
+                "allowlistedTrackers": {}
+            }
+        },
+        "trackerProtection": {
+            "state": "enabled",
+            "exceptions": []
+        }
+    },
+    "unprotectedTemporary": []
+}

--- a/injected/integration-test/tracker-protection.spec.js
+++ b/injected/integration-test/tracker-protection.spec.js
@@ -10,6 +10,7 @@ import {
 const HTML = '/tracker-protection/pages/tracker-protection.html';
 const CONFIG = './integration-test/test-pages/tracker-protection/config/tracker-protection.json';
 const DISABLED_CONFIG = './integration-test/test-pages/tracker-protection/config/tracker-protection-disabled.json';
+const BLOCKING_DISABLED_CONFIG = './integration-test/test-pages/tracker-protection/config/tracker-protection-blocking-disabled.json';
 const CTL_DISABLED_CONFIG = './integration-test/test-pages/tracker-protection/config/tracker-protection-ctl-disabled.json';
 const CTL_ENABLED_CONFIG = './integration-test/test-pages/tracker-protection/config/tracker-protection-ctl-enabled.json';
 const UNPROTECTED_CONFIG = './integration-test/test-pages/tracker-protection/config/tracker-protection-unprotected.json';
@@ -74,7 +75,10 @@ test('tracker-protection: reports non-tracker third-party URL as resourceObserve
     expect(observation.resourceType).toBe('script');
 });
 
-test('tracker-protection: does not send messages when disabled', async ({ page }, testInfo) => {
+test('tracker-protection: does not send messages when feature state is disabled (hard kill-switch)', async ({ page }, testInfo) => {
+    // `trackerProtection.state = disabled` is the emergency hard kill-switch:
+    // C-S-S `computeEnabledFeatures` filters the feature out before `init()` is
+    // called, so no observation hooks are attached and zero messages are emitted.
     const collector = ResultsCollector.create(page, testInfo.project.use);
     await collector.load(HTML, DISABLED_CONFIG);
 
@@ -87,6 +91,29 @@ test('tracker-protection: does not send messages when disabled', async ({ page }
     const allMessages = await collector.outgoingMessages();
     const resourceObservations = trackerMessages(allMessages).filter((m) => m.payload.method === 'resourceObserved');
     expect(resourceObservations).toHaveLength(0);
+});
+
+test('tracker-protection: keeps observing under contentBlocking kill-switch with potentiallyBlocked=false', async ({ page }, testInfo) => {
+    // `contentBlocking.state = disabled` is the legacy "blocking" kill-switch:
+    // native removes WKContentRuleLists (no network blocking) but C-S-S keeps
+    // observing so the privacy dashboard can show detected-but-not-blocked
+    // entries via the native EventMapper. Surrogate injection is suppressed.
+    const collector = ResultsCollector.create(page, testInfo.project.use);
+    collector.withUserPreferences({ trackerData: makeTrackerDataBasic() });
+    await collector.load(HTML, BLOCKING_DISABLED_CONFIG);
+
+    await page.evaluate(() => {
+        /** @type {any} */ (window).addTrackerScript('https://tracker.example/scripts/analytics.js');
+    });
+
+    const observed = await collector.waitForMessage('resourceObserved', 1);
+    expect(observed[0].payload.params.url).toBe('https://tracker.example/scripts/analytics.js');
+    expect(observed[0].payload.params.potentiallyBlocked).toBe(false);
+
+    await page.waitForTimeout(200);
+    const allMessages = await collector.outgoingMessages();
+    const injected = trackerMessages(allMessages).filter((m) => m.payload.method === 'surrogateInjected');
+    expect(injected).toHaveLength(0);
 });
 
 test('tracker-protection: reports allowed tracker with potentiallyBlocked=false', async ({ page }, testInfo) => {

--- a/injected/src/features/tracker-protection.js
+++ b/injected/src/features/tracker-protection.js
@@ -66,12 +66,19 @@ export class TrackerProtection extends ContentFeature {
             return;
         }
 
+        // `contentBlocking.state` is the legacy "blocking" kill-switch: when disabled,
+        // WKContentRuleLists are removed natively (no network blocking) but we keep
+        // observing and emitting `resourceObserved` so the native EventMapper can
+        // populate the privacy dashboard with detected-but-not-blocked entries
+        // (parity with the pre-migration `ContentBlockerRulesUserScript` contract).
+        // The "hard" emergency kill-switch is `trackerProtection.state = disabled`,
+        // which gates the feature out of `enabledFeatures` upstream of `init()` —
+        // no observation, no hooks, zero JS overhead.
         this._blockingEnabled = this._isStateEnabled(
             /** @type {import('../utils.js').FeatureState | undefined} */ (this.bundledConfig?.features?.contentBlocking?.state),
         );
         if (!this._blockingEnabled) {
-            this.log.info('Tracker blocking disabled via config');
-            return;
+            this.log.info('Tracker blocking disabled via config; observing for dashboard only');
         }
 
         const surrogates = bundledSurrogates;
@@ -320,12 +327,14 @@ export class TrackerProtection extends ContentFeature {
         if (!url || !this._seenUrls || this._seenUrls.has(url)) return;
         if (!url.startsWith('http://') && !url.startsWith('https://')) return;
         this._seenUrls.add(url);
-        if (!this._blockingEnabled) return;
 
         this.notify('resourceObserved', {
             url,
             resourceType,
-            potentiallyBlocked,
+            // Force false under the `contentBlocking` kill-switch. The native side
+            // recomputes authoritatively from `contentBlockingEnabled` so this hint
+            // is non-load-bearing, but a stale `true` would mislead the mapper.
+            potentiallyBlocked: this._blockingEnabled ? potentiallyBlocked : false,
             pageUrl: this._topLevelUrl?.href || '',
         });
     }
@@ -338,7 +347,7 @@ export class TrackerProtection extends ContentFeature {
      * @param {HTMLElement | null} element
      */
     _checkAndBlock(url, resourceType, element = null) {
-        if (!url || !this._resolver || !this._seenUrls) {
+        if (!url || !this._seenUrls) {
             return false;
         }
         if (!url.startsWith('http://') && !url.startsWith('https://')) {
@@ -347,7 +356,17 @@ export class TrackerProtection extends ContentFeature {
 
         this._seenUrls.add(url);
 
-        if (!this._blockingEnabled) {
+        // Under the `contentBlocking` kill-switch we still report the observation so
+        // the dashboard stays populated, but skip the resolver / surrogate path —
+        // injecting a surrogate for a script that won't actually be blocked at the
+        // network layer would be incorrect.
+        if (!this._blockingEnabled || !this._resolver) {
+            this.notify('resourceObserved', {
+                url,
+                resourceType,
+                potentiallyBlocked: false,
+                pageUrl: this._topLevelUrl?.href || '',
+            });
             return false;
         }
 


### PR DESCRIPTION
## Summary

The Apple migration to C-S-S native-resolver tracker protection (commit
`c4b081b36a`) collapsed the legacy `contentBlocking` kill-switch and the
C-S-S `trackerProtection` feature toggle into a single `_blockingEnabled`
check that returned early from `init()`, suppressing every observation
hook. Under the kill-switch the privacy dashboard then went silent — a
regression vs. the pre-migration `ContentBlockerRulesUserScript`
contract, which kept emitting detected-but-not-blocked tracker events
so the dashboard could surface them.

This PR restores the legacy contract by separating the two semantically
distinct toggles:

| Toggle | Behavior |
|---|---|
| `contentBlocking.state = disabled` | WKContentRuleLists removed natively (no network blocking). C-S-S keeps observing and emits `resourceObserved` with `potentiallyBlocked: false`. Native `TrackerProtectionEventMapper` classifies as `.allowed(reason: .ruleException)`. **Dashboard populated, `isBlocked == false`.** |
| `trackerProtection.state = disabled` | Unchanged. C-S-S `computeEnabledFeatures` filters the feature out before `init()` runs — no hooks attached, zero JS overhead. The right surface for "fully disable the observer" in incidents. |

Surrogate injection remains gated on `_blockingEnabled && potentiallyBlocked`, since injecting a stub for a script that isn't actually being blocked at the network layer would be incorrect.

## Why this matters for Apple

Detected by an integration test in `apple-browsers` BSK (`ContentBlockerRulesUserScriptsTests.testWhenContentBlockingFeatureIsDisabledThenTrackersAreSilentlyDropped_REGRESSION`) that pins the regression vs. the legacy `ContentBlockerRulesUserScript`. After this lands and the BSK pin bumps past the next C-S-S minor, the test will flip from `XCTSkipIf(true)` to assert dashboard population.

## Changes

- `injected/src/features/tracker-protection.js`:
  - Drop the `init()` early-return on `_blockingEnabled = false`. Log line updated to reflect "observing for dashboard only".
  - `_reportResource()`: remove the `_blockingEnabled` short-circuit; force `potentiallyBlocked: false` when the kill-switch is engaged. Native side is authoritative anyway, but a stale `true` would mislead the mapper.
  - `_checkAndBlock()`: under the kill-switch (or when `_resolver` is missing), still emit `resourceObserved` with `potentiallyBlocked: false`. Skip the resolver lookup and surrogate path.
- `injected/integration-test/test-pages/tracker-protection/config/tracker-protection-blocking-disabled.json`: new config with `contentBlocking.state = "disabled"` and `trackerProtection.state = "enabled"`.
- `injected/integration-test/tracker-protection.spec.js`:
  - New test `keeps observing under contentBlocking kill-switch with potentiallyBlocked=false`.
  - Existing `does not send messages when disabled` renamed to `does not send messages when feature state is disabled (hard kill-switch)` for clarity, with explanatory comment.

## Test plan

- [x] Unit: `cd injected && npm run test-unit` — 906/906 pass.
- [x] Integration: `cd injected && npm run test-int -- tracker-protection.spec.js` — 26/26 pass on `[apple]` project, including the new test and the renamed hard-kill test.
- [x] Build: `npm run build` — dist regenerates cleanly.
- [x] Lint: `npm run lint` — no errors.
- [ ] Downstream: bump BSK `Package.swift` C-S-S pin and flip the regression test in `ContentBlockerRulesUserScriptsTests.swift` from skip to assertion.


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core tracker-protection observation/reporting behavior under the `contentBlocking` kill-switch, which could affect what events the native layer receives and how the privacy dashboard is populated. Logic is straightforward but touches a high-traffic interception path and adds a new conditional reporting mode.
> 
> **Overview**
> Restores the legacy behavior where disabling `contentBlocking` stops network blocking but **continues emitting** `trackerProtection` `resourceObserved` events for dashboard population.
> 
> `TrackerProtection.init()` no longer bails when `contentBlocking.state` is disabled; instead it keeps interception enabled, forces `potentiallyBlocked: false` in emitted observations, and suppresses resolver/surrogate injection when blocking is off (or the resolver is unavailable).
> 
> Adds a new integration-test config (`tracker-protection-blocking-disabled.json`) and a Playwright test asserting observations still fire under the `contentBlocking` kill-switch while `surrogateInjected` is not emitted; renames the existing disabled test to clarify it covers the `trackerProtection.state = disabled` hard kill-switch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 17923c9b9e842e136d2c7c6c750574526e122fe2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->