### PR TITLE
Add support for webDetection conditionals

### DIFF
--- a/injected/package.json
+++ b/injected/package.json
@@ -35,7 +35,7 @@
   },
   "type": "module",
   "dependencies": {
-    "@duckduckgo/privacy-configuration": "github:duckduckgo/privacy-configuration#1779290401870",
+    "@duckduckgo/privacy-configuration": "github:duckduckgo/privacy-configuration#1782146788039",
     "@duckduckgo/tracker-surrogates": "github:duckduckgo/tracker-surrogates#0528e3226df15b1a3e319ad68ef76612a8f26623",
     "esbuild": "^0.27.4",
     "minimist": "^1.2.8",

--- a/injected/src/features/web-detection/matching.js
+++ b/injected/src/features/web-detection/matching.js
@@ -1,5 +1,12 @@
+import { hasOwnProperty, objectKeys } from '../../captured-globals.js';
+
 /**
  * @typedef {import('@duckduckgo/privacy-configuration/schema/features/web-detection.ts').ConditionTypes} ConditionTypes
+ */
+
+/**
+ * @template Final
+ * @typedef {import('@duckduckgo/privacy-configuration/schema/features/web-detection.ts').ConditionBranch<Final>} ConditionBranch
  */
 
 /**
@@ -106,7 +113,7 @@ function evaluateSingleElementCondition(config) {
  * Sibling operator keys are AND-combined.
  *
  * @template Final
- * @param {import('@duckduckgo/privacy-configuration/schema/features/web-detection.ts').ConditionBranch<Final> | undefined} node
+ * @param {ConditionBranch<Final> | undefined} node
  * @param {(final: Final) => boolean} evalFinal
  * @returns {boolean}
  */
@@ -130,9 +137,10 @@ function evaluateNode(node, evalFinal) {
         throw new Error(`Condition node mixes operator keys [${opKeys.join(', ')}] with leaf fields [${otherKeys.join(', ')}]`);
     }
 
-    if ('all' in node && !asArray(node.all).every((n) => evaluateNode(n, evalFinal))) return false;
-    if ('any' in node && !asArray(node.any).some((n) => evaluateNode(n, evalFinal))) return false;
-    if ('none' in node && asArray(node.none).some((n) => evaluateNode(n, evalFinal))) return false;
+    const block = /** @type {Partial<Record<'all' | 'any' | 'none', ConditionBranch<Final>>>} */ (node);
+    if (hasOwnProperty.call(block, 'all') && !asArray(block.all).every((n) => evaluateNode(n, evalFinal))) return false;
+    if (hasOwnProperty.call(block, 'any') && !asArray(block.any).some((n) => evaluateNode(n, evalFinal))) return false;
+    if (hasOwnProperty.call(block, 'none') && asArray(block.none).some((n) => evaluateNode(n, evalFinal))) return false;
     return true;
 }
 

--- a/injected/src/features/web-detection/matching.js
+++ b/injected/src/features/web-detection/matching.js
@@ -128,11 +128,11 @@ function evaluateNode(node, evalFinal) {
 
     const operatorKeys = ['any', 'all', 'none'];
 
-    const opKeys = operatorKeys.filter((k) => k in node);
+    const opKeys = operatorKeys.filter((k) => hasOwnProperty.call(node, k));
     if (opKeys.length === 0) {
         return evalFinal(/** @type {Final} */ (node));
     }
-    const otherKeys = Object.keys(node).filter((k) => !operatorKeys.includes(k));
+    const otherKeys = objectKeys(node).filter((k) => !operatorKeys.includes(k));
     if (otherKeys.length > 0) {
         throw new Error(`Condition node mixes operator keys [${opKeys.join(', ')}] with leaf fields [${otherKeys.join(', ')}]`);
     }

--- a/injected/src/features/web-detection/matching.js
+++ b/injected/src/features/web-detection/matching.js
@@ -1,3 +1,4 @@
+// eslint-disable-next-line no-redeclare
 import { hasOwnProperty, objectKeys } from '../../captured-globals.js';
 
 /**

--- a/injected/src/features/web-detection/matching.js
+++ b/injected/src/features/web-detection/matching.js
@@ -96,37 +96,61 @@ function evaluateSingleElementCondition(config) {
 }
 
 /**
- * Evaluate an OR condition
- * @template T
- * @param {T | T[] | undefined} condition
- * @param {(value: T) => boolean} singleConditionEvaluator
+ * Evaluate a condition node that may be a final-condition object, an operator
+ * block (`{ any | all | none: ... }`), or an array (treated as `any`).
+ *
+ * Operator blocks and final-condition objects are mutually exclusive at the
+ * same node — mixing operator keys with leaf fields throws (surfaced as
+ * `detected: 'error'` by the caller in web-detection.js).
+ *
+ * Sibling operator keys are AND-combined.
+ *
+ * @template Final
+ * @param {import('@duckduckgo/privacy-configuration/schema/features/web-detection.ts').ConditionBranch<Final> | undefined} node
+ * @param {(final: Final) => boolean} evalFinal
  * @returns {boolean}
  */
-function evaluateORCondition(condition, singleConditionEvaluator) {
-    if (condition === undefined) return true;
-    if (Array.isArray(condition)) {
-        return condition.some((v) => singleConditionEvaluator(v));
+function evaluateNode(node, evalFinal) {
+    if (node === undefined) return true;
+    if (Array.isArray(node)) {
+        return node.some((n) => evaluateNode(n, evalFinal));
     }
-    return singleConditionEvaluator(condition);
+    if (node === null || typeof node !== 'object') {
+        return evalFinal(/** @type {Final} */ (node));
+    }
+
+    const operatorKeys = ['any', 'all', 'none'];
+
+    const opKeys = operatorKeys.filter((k) => k in node);
+    if (opKeys.length === 0) {
+        return evalFinal(/** @type {Final} */ (node));
+    }
+    const otherKeys = Object.keys(node).filter((k) => !operatorKeys.includes(k));
+    if (otherKeys.length > 0) {
+        throw new Error(`Condition node mixes operator keys [${opKeys.join(', ')}] with leaf fields [${otherKeys.join(', ')}]`);
+    }
+
+    if ('all' in node && !asArray(node.all).every((n) => evaluateNode(n, evalFinal))) return false;
+    if ('any' in node && !asArray(node.any).some((n) => evaluateNode(n, evalFinal))) return false;
+    if ('none' in node && asArray(node.none).some((n) => evaluateNode(n, evalFinal))) return false;
+    return true;
 }
 
 /**
  * Evaluate match conditions for a detector.
  *
- * This may be either a single condition or an array of conditions.
- *
- * Each key references a condition which must match. If an array is specified,
- * any condition in the array must match.
+ * Each key references a condition which must match (conjunction on keys).
+ * Each per-key value is itself a condition node, which may be a final-condition
+ * object, an array (OR), or an operator block.
  *
  * @param {import('./parse.js').MatchConditionSingle} condition
  * @returns {boolean}
  */
 function evaluateSingleMatchCondition(condition) {
-    // conjunction on keys
-    if (!evaluateORCondition(condition.text, evaluateSingleTextCondition)) {
+    if (!evaluateNode(condition.text, evaluateSingleTextCondition)) {
         return false;
     }
-    if (!evaluateORCondition(condition.element, evaluateSingleElementCondition)) {
+    if (!evaluateNode(condition.element, evaluateSingleElementCondition)) {
         return false;
     }
     return true;
@@ -137,10 +161,12 @@ function evaluateSingleMatchCondition(condition) {
  *
  * This determines whether the detector is considered to have successfully matched when run.
  *
- * Objects represent conjunction (AND), arrays represent disjunction (OR)
+ * Objects represent conjunction on their keys (AND); arrays represent disjunction (OR);
+ * operator blocks (`{ any | all | none: ... }`) are supported recursively at every layer.
+ *
  * @param {import('./parse.js').MatchCondition} conditions
  * @returns {boolean}
  */
 export function evaluateMatch(conditions) {
-    return evaluateORCondition(conditions, evaluateSingleMatchCondition);
+    return evaluateNode(conditions, evaluateSingleMatchCondition);
 }

--- a/injected/src/features/web-detection/parse.js
+++ b/injected/src/features/web-detection/parse.js
@@ -9,14 +9,11 @@
  */
 
 /**
- * Extract the member type of an array-like type. (T | T[]) -> T.
+ * Final-condition shape at the top-level match node — what
+ * `evaluateSingleMatchCondition` receives once `evaluateNode` has unwrapped
+ * any operator blocks and array-OR forms.
  *
- * @template T
- * @typedef {T extends (infer U)[] ? U : T} UnArray
- */
-
-/**
- * @typedef {UnArray<MatchCondition>} MatchConditionSingle
+ * @typedef {import('@duckduckgo/privacy-configuration/schema/features/web-detection.ts').MatchConditionSingle} MatchConditionSingle
  */
 
 /**

--- a/injected/unit-test/web-detection.js
+++ b/injected/unit-test/web-detection.js
@@ -256,8 +256,11 @@ describe('WebDetection', () => {
             const result = oneDetectorConfigParsed({
                 match: { text: { pattern: ['adblocker', 'disable'] }, element: { selector: '.overlay', visibility: 'visible' } },
             });
-            expect(asSingle(result.match).text).toEqual({ pattern: ['adblocker', 'disable'] });
-            expect(asSingle(result.match).element).toEqual({ selector: '.overlay', visibility: 'visible' });
+            const leaf = /** @type {import('../src/features/web-detection/parse.js').MatchConditionSingle} */ (
+                asSingle(result.match)
+            );
+            expect(leaf.text).toEqual({ pattern: ['adblocker', 'disable'] });
+            expect(leaf.element).toEqual({ selector: '.overlay', visibility: 'visible' });
         });
 
         it('should handle array of match conditions (OR)', () => {
@@ -476,6 +479,16 @@ describe('WebDetection', () => {
 
         it('should return error for detector with invalid selector', () => {
             const results = runDetector({ match: { element: { selector: '!!!invalid' } } });
+            expect(results.length).toBe(1);
+            expect(results[0].detected).toBe('error');
+        });
+
+        it('should return error when condition mixes operator keys with leaf fields', () => {
+            const results = runDetector({
+                match: /** @type {any} - intentionally invalid: mixes operator + leaf keys */ ({
+                    text: { all: [{ pattern: 'foo' }], pattern: 'bar' },
+                }),
+            });
             expect(results.length).toBe(1);
             expect(results[0].detected).toBe('error');
         });
@@ -998,6 +1011,188 @@ describe('WebDetection', () => {
                         ],
                     }),
                 ).toBe(true);
+            });
+        });
+
+        describe('all operator', () => {
+            it('should require every condition to match', () => {
+                expect(matchInDOM('<p>foo bar</p>', { text: { all: [{ pattern: 'foo' }, { pattern: 'bar' }] } })).toBe(true);
+                expect(matchInDOM('<p>foo</p>', { text: { all: [{ pattern: 'foo' }, { pattern: 'bar' }] } })).toBe(false);
+                expect(matchInDOM('<p>bar</p>', { text: { all: [{ pattern: 'foo' }, { pattern: 'bar' }] } })).toBe(false);
+            });
+
+            it('should accept singleton form (object instead of array)', () => {
+                expect(matchInDOM('<p>foo</p>', { text: { all: { pattern: 'foo' } } })).toBe(true);
+                expect(matchInDOM('<p>baz</p>', { text: { all: { pattern: 'foo' } } })).toBe(false);
+            });
+
+            it('should be vacuously true on empty array', () => {
+                expect(matchInDOM('<p>x</p>', { text: { all: [] } })).toBe(true);
+            });
+        });
+
+        describe('any operator', () => {
+            it('should match if at least one condition matches', () => {
+                expect(matchInDOM('<p>foo</p>', { text: { any: [{ pattern: 'foo' }, { pattern: 'bar' }] } })).toBe(true);
+                expect(matchInDOM('<p>bar</p>', { text: { any: [{ pattern: 'foo' }, { pattern: 'bar' }] } })).toBe(true);
+                expect(matchInDOM('<p>baz</p>', { text: { any: [{ pattern: 'foo' }, { pattern: 'bar' }] } })).toBe(false);
+            });
+
+            it('should be equivalent to bare-array OR form', () => {
+                const html = '<p>foo</p>';
+                const opForm = { text: { any: [{ pattern: 'foo' }, { pattern: 'bar' }] } };
+                const arrayForm = { text: [{ pattern: 'foo' }, { pattern: 'bar' }] };
+                expect(matchInDOM(html, opForm)).toBe(matchInDOM(html, arrayForm));
+            });
+
+            it('should be vacuously false on empty array', () => {
+                expect(matchInDOM('<p>x</p>', { text: { any: [] } })).toBe(false);
+            });
+        });
+
+        describe('none operator', () => {
+            it('should match when no nested condition matches', () => {
+                expect(matchInDOM('<p>welcome</p>', { text: { none: [{ pattern: 'foo' }, { pattern: 'bar' }] } })).toBe(true);
+            });
+
+            it('should fail when any nested condition matches', () => {
+                expect(matchInDOM('<p>foo</p>', { text: { none: [{ pattern: 'foo' }, { pattern: 'bar' }] } })).toBe(false);
+                expect(matchInDOM('<p>bar</p>', { text: { none: [{ pattern: 'foo' }, { pattern: 'bar' }] } })).toBe(false);
+            });
+
+            it('should accept singleton form', () => {
+                expect(matchInDOM('<p>welcome</p>', { text: { none: { pattern: 'foo' } } })).toBe(true);
+                expect(matchInDOM('<p>foo</p>', { text: { none: { pattern: 'foo' } } })).toBe(false);
+            });
+
+            it('should be vacuously true on empty array', () => {
+                expect(matchInDOM('<p>x</p>', { text: { none: [] } })).toBe(true);
+            });
+        });
+
+        describe('sibling operators (AND)', () => {
+            it('should AND-combine all + none', () => {
+                // text contains foo (all) and does not contain bad (none)
+                expect(matchInDOM('<p>foo good</p>', { text: { all: [{ pattern: 'foo' }], none: [{ pattern: 'bad' }] } })).toBe(true);
+                // contains foo but also contains bad -> none fails
+                expect(matchInDOM('<p>foo bad</p>', { text: { all: [{ pattern: 'foo' }], none: [{ pattern: 'bad' }] } })).toBe(false);
+                // missing foo -> all fails
+                expect(matchInDOM('<p>good</p>', { text: { all: [{ pattern: 'foo' }], none: [{ pattern: 'bad' }] } })).toBe(false);
+            });
+
+            it('should AND-combine any + none', () => {
+                expect(
+                    matchInDOM('<p>foo good</p>', { text: { any: [{ pattern: 'foo' }, { pattern: 'baz' }], none: [{ pattern: 'bad' }] } }),
+                ).toBe(true);
+                expect(
+                    matchInDOM('<p>foo bad</p>', { text: { any: [{ pattern: 'foo' }, { pattern: 'baz' }], none: [{ pattern: 'bad' }] } }),
+                ).toBe(false);
+            });
+        });
+
+        describe('operators at top-level match', () => {
+            it('should support all at the match level', () => {
+                expect(
+                    matchInDOM('<div class="overlay">disable adblocker</div>', {
+                        all: [{ text: { pattern: 'adblocker' } }, { element: { selector: '.overlay', visibility: 'any' } }],
+                    }),
+                ).toBe(true);
+            });
+
+            it('should support any at the match level', () => {
+                expect(
+                    matchInDOM('<p>welcome</p>', {
+                        any: [{ text: { pattern: 'adblocker' } }, { text: { pattern: 'welcome' } }],
+                    }),
+                ).toBe(true);
+            });
+
+            it('should support none at the match level', () => {
+                expect(matchInDOM('<p>welcome</p>', { none: [{ text: { pattern: 'adblocker' } }] })).toBe(true);
+                expect(matchInDOM('<p>adblocker</p>', { none: [{ text: { pattern: 'adblocker' } }] })).toBe(false);
+            });
+        });
+
+        describe('nested operators', () => {
+            it('should evaluate deeply nested operator trees', () => {
+                // (any[a, b]) AND (none[c])
+                const condition = {
+                    text: {
+                        all: [{ any: [{ pattern: 'a' }, { pattern: 'b' }] }, { none: [{ pattern: 'c' }] }],
+                    },
+                };
+                expect(matchInDOM('<p>a</p>', condition)).toBe(true);
+                expect(matchInDOM('<p>b</p>', condition)).toBe(true);
+                expect(matchInDOM('<p>a c</p>', condition)).toBe(false);
+                expect(matchInDOM('<p>x</p>', condition)).toBe(false);
+            });
+        });
+
+        describe('operator children of mixed shape (operator-block and leaf siblings)', () => {
+            // Each child of any/all/none is its own ConditionNode and may independently be
+            // either an operator block or a leaf — they just can't be mixed *within the same object*.
+
+            it('should allow all to mix an operator-block child and a leaf child at match level', () => {
+                // all[ any[ text=foo, text=bar ], element=.overlay ]
+                const condition = {
+                    all: [
+                        { any: [{ text: { pattern: 'foo' } }, { text: { pattern: 'bar' } }] },
+                        { element: { selector: '.overlay', visibility: 'any' } },
+                    ],
+                };
+                expect(matchInDOM('<div class="overlay">foo</div>', condition)).toBe(true);
+                expect(matchInDOM('<div class="overlay">bar</div>', condition)).toBe(true);
+                // text matches but element doesn't
+                expect(matchInDOM('<p>foo</p>', condition)).toBe(false);
+                // element matches but text doesn't
+                expect(matchInDOM('<div class="overlay">welcome</div>', condition)).toBe(false);
+            });
+
+            it('should allow any to mix an operator-block child and a leaf child at per-type level', () => {
+                // text: any[ none[pattern=bad], pattern=foo ]
+                const condition = {
+                    text: {
+                        any: [{ none: [{ pattern: 'bad' }] }, { pattern: 'foo' }],
+                    },
+                };
+                // none[bad] satisfied (welcome doesn't contain bad) -> any matches
+                expect(matchInDOM('<p>welcome</p>', condition)).toBe(true);
+                // pattern=foo matches -> any matches
+                expect(matchInDOM('<p>foo</p>', condition)).toBe(true);
+                // pattern=bad present (none fails) and pattern=foo missing -> any fails
+                expect(matchInDOM('<p>bad</p>', condition)).toBe(false);
+                // both children satisfied
+                expect(matchInDOM('<p>foo good</p>', condition)).toBe(true);
+            });
+
+            it('should allow none to mix an operator-block child and a leaf child', () => {
+                // text: none[ all[pattern=foo, pattern=bar], pattern=danger ]
+                const condition = {
+                    text: {
+                        none: [{ all: [{ pattern: 'foo' }, { pattern: 'bar' }] }, { pattern: 'danger' }],
+                    },
+                };
+                // neither child matches -> none satisfied
+                expect(matchInDOM('<p>welcome</p>', condition)).toBe(true);
+                // only foo present -> all[foo,bar] fails, danger absent -> none satisfied
+                expect(matchInDOM('<p>foo</p>', condition)).toBe(true);
+                // foo+bar -> all matches -> none fails
+                expect(matchInDOM('<p>foo bar</p>', condition)).toBe(false);
+                // danger leaf matches -> none fails
+                expect(matchInDOM('<p>danger</p>', condition)).toBe(false);
+            });
+
+            it('should allow leaf and operator-block siblings inside a bare-array OR', () => {
+                // text: [ all[pattern=foo, pattern=bar], pattern=quick ]
+                const condition = {
+                    text: [{ all: [{ pattern: 'foo' }, { pattern: 'bar' }] }, { pattern: 'quick' }],
+                };
+                // operator-block child satisfied
+                expect(matchInDOM('<p>foo bar</p>', condition)).toBe(true);
+                // leaf child satisfied
+                expect(matchInDOM('<p>quick</p>', condition)).toBe(true);
+                // neither
+                expect(matchInDOM('<p>welcome</p>', condition)).toBe(false);
             });
         });
     });

--- a/injected/unit-test/web-detection.js
+++ b/injected/unit-test/web-detection.js
@@ -256,9 +256,7 @@ describe('WebDetection', () => {
             const result = oneDetectorConfigParsed({
                 match: { text: { pattern: ['adblocker', 'disable'] }, element: { selector: '.overlay', visibility: 'visible' } },
             });
-            const leaf = /** @type {import('../src/features/web-detection/parse.js').MatchConditionSingle} */ (
-                asSingle(result.match)
-            );
+            const leaf = /** @type {import('../src/features/web-detection/parse.js').MatchConditionSingle} */ (asSingle(result.match));
             expect(leaf.text).toEqual({ pattern: ['adblocker', 'disable'] });
             expect(leaf.element).toEqual({ selector: '.overlay', visibility: 'visible' });
         });

--- a/package-lock.json
+++ b/package-lock.json
@@ -881,7 +881,7 @@
     },
     "node_modules/@duckduckgo/privacy-configuration": {
       "version": "1.0.0",
-      "resolved": "git+ssh://git@github.com/duckduckgo/privacy-configuration.git#998ecf54b9cae1cf327dc2c26a543232cf45b1d4",
+      "resolved": "git+ssh://git@github.com/duckduckgo/privacy-configuration.git#ed5684f99865755c322207e58d461c51d41add4f",
       "license": "Apache 2.0",
       "dependencies": {
         "eslint-plugin-json": "^4.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,7 @@
     "injected": {
       "hasInstallScript": true,
       "dependencies": {
-        "@duckduckgo/privacy-configuration": "github:duckduckgo/privacy-configuration#1779290401870",
+        "@duckduckgo/privacy-configuration": "github:duckduckgo/privacy-configuration#1782146788039",
         "@duckduckgo/tracker-surrogates": "github:duckduckgo/tracker-surrogates#0528e3226df15b1a3e319ad68ef76612a8f26623",
         "esbuild": "^0.27.4",
         "minimist": "^1.2.8",


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1212311623899110/task/1213082156771927?focus=true

## Description

Adds support for extended conditional logic to web detection.

Note: requires https://github.com/duckduckgo/privacy-configuration/pull/5126 for type checks to pass.

## Testing Steps

Unit tests.

## Checklist

<!--
  These questions are a friendly reminder to shipping code, if you're uncertain ask the AoR owners.
  It's also totally appropriate to not check some of these boxes, if they don't apply to your change.
-->
*Please tick all that apply:*

- [ ] I have tested this change locally
- [ ] I have tested this change locally in all supported browsers
- [ ] This change will be visible to users
- [ ] I have added automated tests that cover this change
- [ ] I have ensured the change is gated by config
- [ ] This change was covered by a ship review
- [ ] This change was covered by a tech design
- [ ] Any dependent config has been merged


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how detector match configs are interpreted on-page; misconfigured or newly authored rules could change detection outcomes, though invalid mixed nodes fail safely as errors.
> 
> **Overview**
> Web detection **match** evaluation now understands recursive **`any`**, **`all`**, and **`none`** operator blocks (plus array OR), not only flat text/element leaves and simple OR arrays. Sibling operators on the same node are **AND**-combined; invalid configs that mix operator keys with leaf fields throw and surface as **`detected: 'error'`**.
> 
> Types align with the updated **`@duckduckgo/privacy-configuration`** pin (`MatchConditionSingle` / `ConditionBranch` from schema). Unit coverage adds operator semantics, nesting, top-level match operators, and the mixed-key error path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5178238ec92d8269e5c598239544b5afc3a9e5f2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->