### PR TITLE
Api manipulation method values

### DIFF
--- a/injected/integration-test/test-pages/tab-suspension/config/tab-suspension.json
+++ b/injected/integration-test/test-pages/tab-suspension/config/tab-suspension.json
@@ -6,7 +6,9 @@
       "state": "enabled",
       "exceptions": [],
       "settings": {
-        "inputFieldFocusDetection": "enabled"
+        "inputFieldFocusDetection": {
+            "state": "enabled"
+        }
       }
     }
   },

--- a/injected/package.json
+++ b/injected/package.json
@@ -35,7 +35,7 @@
   },
   "type": "module",
   "dependencies": {
-    "@duckduckgo/privacy-configuration": "github:duckduckgo/privacy-configuration#1772634901001",
+    "@duckduckgo/privacy-configuration": "github:duckduckgo/privacy-configuration#1779290401870",
     "@duckduckgo/tracker-surrogates": "github:duckduckgo/tracker-surrogates#0528e3226df15b1a3e319ad68ef76612a8f26623",
     "esbuild": "^0.27.4",
     "minimist": "^1.2.8",

--- a/injected/src/captured-globals.js
+++ b/injected/src/captured-globals.js
@@ -38,6 +38,7 @@ export const JSONstringify = JSON.stringify;
 export const JSONparse = JSON.parse;
 export const Arrayfrom = Array.from;
 export const ReflectDeleteProperty = Reflect.deleteProperty.bind(Reflect);
+export const ReflectApply = Reflect.apply.bind(Reflect);
 export const getRandomValues = globalThis.crypto?.getRandomValues?.bind(globalThis.crypto);
 
 // Secure context only - crypto.subtle is unavailable on HTTP

--- a/injected/src/features/api-manipulation.js
+++ b/injected/src/features/api-manipulation.js
@@ -79,7 +79,7 @@ export default class ApiManipulation extends ContentFeature {
      * @property {import('../utils.js').ConfigSetting} [value] - The value assigned to a value descriptor, including methods.
      * @property {boolean} [enumerable] - Whether the property is enumerable.
      * @property {boolean} [configurable] - Whether the property is configurable.
-     * @property {boolean} [define] - When true, define an own property on `api` if the key is not already own (including shadow-defining inherited APIs), or if the key is absent from the entire prototype chain. When false (default), skip changes for properties that do not exist at all; only override properties that are already own on `api` via `wrapProperty`.
+     * @property {boolean} [define] - When true, define a new own property if the key is absent from `api` and its entire prototype chain. When false (default), skip changes for properties that do not exist at all; override own properties via `wrapProperty`; override inherited properties by shadow-defining an own property on `api`.
      */
 
     /**
@@ -164,15 +164,15 @@ export default class ApiManipulation extends ContentFeature {
                 );
             }
         }
-        if (change.define === true && !hasOwnProperty.call(api, key)) {
+        if (hasOwnProperty.call(api, key)) {
+            this.wrapProperty(api, key, descriptor);
+        } else {
+            // API exists via the prototype chain (e.g. MediaDevices.prototype.addEventListener
+            // on EventTarget.prototype). Shadow-define an own property without requiring `define`.
             const merged = mergePropertyDescriptors(origDescriptor, descriptor);
             if (merged) {
                 this.defineProperty(api, key, merged);
             }
-            return;
-        }
-        if (hasOwnProperty.call(api, key)) {
-            this.wrapProperty(api, key, descriptor);
         }
     }
 

--- a/injected/src/features/api-manipulation.js
+++ b/injected/src/features/api-manipulation.js
@@ -9,7 +9,7 @@ import ContentFeature from '../content-feature.js';
 // eslint-disable-next-line no-redeclare
 import { ReflectApply, getOwnPropertyDescriptor, hasOwnProperty, objectDefineProperty } from '../captured-globals.js';
 import { processAttr } from '../utils.js';
-import { wrapToString } from '../wrapper-utils.js';
+import { mergePropertyDescriptors, wrapToString } from '../wrapper-utils.js';
 
 /**
  * @internal
@@ -79,7 +79,7 @@ export default class ApiManipulation extends ContentFeature {
      * @property {import('../utils.js').ConfigSetting} [value] - The value assigned to a value descriptor, including methods.
      * @property {boolean} [enumerable] - Whether the property is enumerable.
      * @property {boolean} [configurable] - Whether the property is configurable.
-     * @property {boolean} [define] - When true, define the property only if it does not exist on `api` or anywhere on its prototype chain. When false (default), skip changes for properties that do not exist at all; existing own or inherited APIs are overridden (inherited properties are shadow-defined as own properties on `api`).
+     * @property {boolean} [define] - When true, define a new own property only when the key is absent from `api` and its entire prototype chain. When false (default), skip changes for properties that do not exist at all; override own properties via `wrapProperty`; override inherited properties by shadow-defining an own property on `api` (without requiring `define`).
      */
 
     /**
@@ -169,7 +169,12 @@ export default class ApiManipulation extends ContentFeature {
         } else {
             // API exists via the prototype chain (e.g. MediaDevices.prototype.addEventListener
             // on EventTarget.prototype). Shadow-define an own property without requiring `define`.
-            this.defineProperty(api, key, { ...origDescriptor, ...descriptor });
+            // `define: true` is only for keys missing from the chain; inherited overrides rely on
+            // this path so deployed remote config (privacy-configuration #5215) need not set `define`.
+            const merged = mergePropertyDescriptors(origDescriptor, descriptor);
+            if (merged) {
+                this.defineProperty(api, key, merged);
+            }
         }
     }
 

--- a/injected/src/features/api-manipulation.js
+++ b/injected/src/features/api-manipulation.js
@@ -79,7 +79,7 @@ export default class ApiManipulation extends ContentFeature {
      * @property {import('../utils.js').ConfigSetting} [value] - The value assigned to a value descriptor, including methods.
      * @property {boolean} [enumerable] - Whether the property is enumerable.
      * @property {boolean} [configurable] - Whether the property is configurable.
-     * @property {boolean} [define] - Whether to define the property if it is not already an own property of `api`. When true and the property is missing or only inherited via the prototype chain, a new own property is defined (shadowing any inherited one). When false (default), the change is merged with any existing own descriptor; properties that exist only via the prototype chain are skipped.
+     * @property {boolean} [define] - Whether to define the property if it does not exist.
      */
 
     /**
@@ -134,11 +134,8 @@ export default class ApiManipulation extends ContentFeature {
             return;
         }
         const descriptor = this.createApiDescriptor(descriptorKind, configSetting, change);
-        // If `define` is true and the property is not already an OWN property of `api`, define it
-        // directly. This covers both the "property does not exist at all" case and the
-        // "property is inherited via the prototype chain" case (e.g. shadow-defining
-        // MediaDevices.prototype.addEventListener which is inherited from EventTarget.prototype).
-        if (change.define === true && !hasOwnProperty.call(api, key)) {
+        // If 'define' is true and property does not exist, define it directly
+        if (change.define === true && !(key in api)) {
             this.defineProperty(api, key, this.createDefineDescriptor(descriptor, descriptorKind));
             return;
         }

--- a/injected/src/features/api-manipulation.js
+++ b/injected/src/features/api-manipulation.js
@@ -79,7 +79,7 @@ export default class ApiManipulation extends ContentFeature {
      * @property {import('../utils.js').ConfigSetting} [value] - The value assigned to a value descriptor, including methods.
      * @property {boolean} [enumerable] - Whether the property is enumerable.
      * @property {boolean} [configurable] - Whether the property is configurable.
-     * @property {boolean} [define] - Whether to define the property if it is not already an own property of `api`. When true and the property is missing or only inherited via the prototype chain, a new own property is defined (shadowing any inherited one). When false (default), the change is merged with any existing own descriptor; properties that exist only via the prototype chain are skipped.
+     * @property {boolean} [define] - When true, define the property only if it does not exist on `api` or anywhere on its prototype chain. When false (default), skip changes for properties that do not exist at all; existing own or inherited APIs are overridden (inherited properties are shadow-defined as own properties on `api`).
      */
 
     /**
@@ -134,22 +134,20 @@ export default class ApiManipulation extends ContentFeature {
             return;
         }
         const descriptor = this.createApiDescriptor(descriptorKind, configSetting, change);
-        // If `define` is true and the property is not already an OWN property of `api`, define it
-        // directly. This covers both the "property does not exist at all" case and the
-        // "property is inherited via the prototype chain" case (e.g. shadow-defining
-        // MediaDevices.prototype.addEventListener which is inherited from EventTarget.prototype).
-        if (change.define === true && !hasOwnProperty.call(api, key)) {
-            this.defineProperty(api, key, this.createDefineDescriptor(descriptor, descriptorKind));
+        const origDescriptor = this.findPropertyDescriptor(api, key);
+        if (!origDescriptor) {
+            if (change.define === true) {
+                this.defineProperty(api, key, this.createDefineDescriptor(descriptor, descriptorKind));
+            }
             return;
         }
         // When replacing an existing method-valued descriptor, mask the replacement
         // against the original method so `toString()`, `toString.toString()`, `.name`
         // and `.length` continue to resemble the native method. Without this, sites can
         // trivially detect the override via `fn.toString()` / `fn.name`.
-        const origDescriptor = getOwnPropertyDescriptor(api, key);
         if (descriptorKind === 'value') {
             const valueDescriptor = /** @type {{ value?: any }} */ (descriptor);
-            if (typeof valueDescriptor.value === 'function' && origDescriptor && typeof origDescriptor.value === 'function') {
+            if (typeof valueDescriptor.value === 'function' && typeof origDescriptor.value === 'function') {
                 valueDescriptor.value = this.maskMethodReplacement(valueDescriptor.value, origDescriptor.value);
             }
         } else if (descriptorKind === 'getter') {
@@ -160,13 +158,37 @@ export default class ApiManipulation extends ContentFeature {
             // `MediaDevices.prototype.ondevicechange` expose a native setter; without
             // masking, descriptor probes would see our JS `setter(v) {...}` shape.
             const accessorDescriptor = /** @type {{ get?: () => any, set?: (v: any) => void }} */ (descriptor);
-            if (typeof accessorDescriptor.set === 'function' && origDescriptor && typeof origDescriptor.set === 'function') {
+            if (typeof accessorDescriptor.set === 'function' && typeof origDescriptor.set === 'function') {
                 accessorDescriptor.set = /** @type {(v: any) => void} */ (
                     this.maskMethodReplacement(accessorDescriptor.set, origDescriptor.set)
                 );
             }
         }
-        this.wrapProperty(api, key, descriptor);
+        if (hasOwnProperty.call(api, key)) {
+            this.wrapProperty(api, key, descriptor);
+        } else {
+            // API exists via the prototype chain (e.g. MediaDevices.prototype.addEventListener
+            // on EventTarget.prototype). Shadow-define an own property without requiring `define`.
+            this.defineProperty(api, key, { ...origDescriptor, ...descriptor });
+        }
+    }
+
+    /**
+     * Returns the property descriptor for `key` on `obj` or an ancestor in its prototype chain.
+     * @param {object} obj
+     * @param {string} key
+     * @returns {PropertyDescriptor | undefined}
+     */
+    findPropertyDescriptor(obj, key) {
+        let current = obj;
+        while (current) {
+            const descriptor = getOwnPropertyDescriptor(current, key);
+            if (descriptor) {
+                return descriptor;
+            }
+            current = Object.getPrototypeOf(current);
+        }
+        return undefined;
     }
 
     /**

--- a/injected/src/features/api-manipulation.js
+++ b/injected/src/features/api-manipulation.js
@@ -57,8 +57,13 @@ export default class ApiManipulation extends ContentFeature {
                 return false;
             }
             const hasGetterValue = typeof change.getterValue !== 'undefined';
+            const hasSetterValue = typeof change.setterValue !== 'undefined';
             const hasValue = typeof change.value !== 'undefined';
-            return hasGetterValue !== hasValue;
+            // Either a value descriptor (with `value`) or an accessor descriptor (with `getterValue`
+            // and/or `setterValue`) - the two shapes are mutually exclusive.
+            const isAccessorShape = hasGetterValue || hasSetterValue;
+            const isValueShape = hasValue;
+            return isAccessorShape !== isValueShape;
         }
         return false;
     }
@@ -70,10 +75,11 @@ export default class ApiManipulation extends ContentFeature {
      * @typedef {Object} APIChange
      * @property {"remove"|"descriptor"} type
      * @property {import('../utils.js').ConfigSetting} [getterValue] - The value returned from a getter.
+     * @property {import('../utils.js').ConfigSetting} [setterValue] - The function invoked when the property is assigned. Used alongside (or instead of) getterValue to override accessor-style properties such as event handlers (e.g., `MediaDevices.prototype.ondevicechange`).
      * @property {import('../utils.js').ConfigSetting} [value] - The value assigned to a value descriptor, including methods.
      * @property {boolean} [enumerable] - Whether the property is enumerable.
      * @property {boolean} [configurable] - Whether the property is configurable.
-     * @property {boolean} [define] - Whether to define the property if it does not exist.
+     * @property {boolean} [define] - Whether to define the property if it is not already an own property of `api`. When true and the property is missing or only inherited via the prototype chain, a new own property is defined (shadowing any inherited one). When false (default), the change is merged with any existing own descriptor; properties that exist only via the prototype chain are skipped.
      */
 
     /**
@@ -116,15 +122,22 @@ export default class ApiManipulation extends ContentFeature {
      */
     wrapApiDescriptor(api, key, change) {
         const getterValue = change.getterValue;
+        const setterValue = change.setterValue;
         const value = change.value;
-        const descriptorKind = getterValue !== undefined ? 'getter' : value !== undefined ? 'value' : undefined;
+        const descriptorKind = getterValue !== undefined || setterValue !== undefined ? 'getter' : value !== undefined ? 'value' : undefined;
         const configSetting = descriptorKind === 'getter' ? getterValue : value;
-        if (!descriptorKind || configSetting === undefined) {
+        // `setterValue` may be supplied on its own (override only the setter, keep the original
+        // getter); in that case configSetting (getterValue) is undefined and createApiDescriptor
+        // skips the `get` half.
+        if (!descriptorKind || (descriptorKind === 'value' && configSetting === undefined)) {
             return;
         }
         const descriptor = this.createApiDescriptor(descriptorKind, configSetting, change);
-        // If 'define' is true and property does not exist, define it directly
-        if (change.define === true && !(key in api)) {
+        // If `define` is true and the property is not already an OWN property of `api`, define it
+        // directly. This covers both the "property does not exist at all" case and the
+        // "property is inherited via the prototype chain" case (e.g. shadow-defining
+        // MediaDevices.prototype.addEventListener which is inherited from EventTarget.prototype).
+        if (change.define === true && !hasOwnProperty.call(api, key)) {
             this.defineProperty(api, key, this.createDefineDescriptor(descriptor, descriptorKind));
             return;
         }
@@ -177,14 +190,30 @@ export default class ApiManipulation extends ContentFeature {
      * @returns {Partial<import('../wrapper-utils.js').StrictPropertyDescriptor>}
      */
     createApiDescriptor(descriptorKind, configSetting, change) {
-        const descriptor =
-            descriptorKind === 'getter'
-                ? {
-                      get: () => processAttr(configSetting, undefined),
-                  }
-                : {
-                      value: processAttr(configSetting, undefined),
-                  };
+        /** @type {Partial<import('../wrapper-utils.js').StrictPropertyDescriptor>} */
+        let descriptor;
+        if (descriptorKind === 'value') {
+            descriptor = { value: processAttr(configSetting, undefined) };
+        } else {
+            descriptor = {};
+            // `configSetting` is the getterValue (may be undefined if only setterValue is set).
+            if (configSetting !== undefined) {
+                descriptor.get = () => processAttr(configSetting, undefined);
+            }
+            // `setterValue` is intentionally invoked through processAttr on every assignment so
+            // configurations using `functionMap.debug` log per-assignment. When omitted, we leave
+            // `set` unset on the new descriptor so wrapProperty's spread merge preserves the
+            // original setter (existing behaviour).
+            if (change.setterValue !== undefined) {
+                const setterSetting = change.setterValue;
+                descriptor.set = function setter(v) {
+                    const fn = processAttr(setterSetting, undefined);
+                    if (typeof fn === 'function') {
+                        ReflectApply(fn, this, [v]);
+                    }
+                };
+            }
+        }
         if ('enumerable' in change) {
             descriptor.enumerable = change.enumerable;
         }
@@ -209,12 +238,20 @@ export default class ApiManipulation extends ContentFeature {
                 configurable: typeof valueDescriptor.configurable !== 'boolean' ? true : valueDescriptor.configurable,
             };
         }
-        const getterDescriptor = /** @type {{ get: () => any, enumerable?: boolean, configurable?: boolean }} */ (descriptor);
-        return {
-            get: getterDescriptor.get,
+        const getterDescriptor =
+            /** @type {{ get?: () => any, set?: (v: any) => void, enumerable?: boolean, configurable?: boolean }} */ (descriptor);
+        /** @type {any} */
+        const result = {
             enumerable: typeof getterDescriptor.enumerable !== 'boolean' ? true : getterDescriptor.enumerable,
             configurable: typeof getterDescriptor.configurable !== 'boolean' ? true : getterDescriptor.configurable,
         };
+        if (typeof getterDescriptor.get === 'function') {
+            result.get = getterDescriptor.get;
+        }
+        if (typeof getterDescriptor.set === 'function') {
+            result.set = getterDescriptor.set;
+        }
+        return result;
     }
 
     /**

--- a/injected/src/features/api-manipulation.js
+++ b/injected/src/features/api-manipulation.js
@@ -114,37 +114,62 @@ export default class ApiManipulation extends ContentFeature {
      * @param {APIChange} change
      */
     wrapApiDescriptor(api, key, change) {
-        const hasGetterValue = typeof change.getterValue !== 'undefined';
-        const hasValue = typeof change.value !== 'undefined';
+        const getterValue = change.getterValue;
+        const value = change.value;
+        const hasGetterValue = typeof getterValue !== 'undefined';
+        const hasValue = typeof value !== 'undefined';
         if (!hasGetterValue && !hasValue) {
             return;
         }
-        const descriptor = hasGetterValue
-            ? {
-                  get: () => processAttr(change.getterValue, undefined),
-              }
-            : {
-                  value: processAttr(change.value, undefined),
-              };
-        if ('enumerable' in change) {
-            descriptor.enumerable = change.enumerable;
-        }
-        if ('configurable' in change) {
-            descriptor.configurable = change.configurable;
-        }
-        // If 'define' is true and property does not exist, define it directly
-        if (change.define === true && !(key in api)) {
-            // Ensure descriptor has required boolean fields
-            const defineDescriptor = {
-                ...descriptor,
-                enumerable: typeof descriptor.enumerable !== 'boolean' ? true : descriptor.enumerable,
-                configurable: typeof descriptor.configurable !== 'boolean' ? true : descriptor.configurable,
-                ...(hasValue ? { writable: true } : {}),
+        if (hasGetterValue && getterValue !== undefined) {
+            const descriptor = {
+                get: () => processAttr(getterValue, undefined),
             };
-            this.defineProperty(api, key, defineDescriptor);
+            if ('enumerable' in change) {
+                descriptor.enumerable = change.enumerable;
+            }
+            if ('configurable' in change) {
+                descriptor.configurable = change.configurable;
+            }
+            // If 'define' is true and property does not exist, define it directly
+            if (change.define === true && !(key in api)) {
+                // Ensure descriptor has required boolean fields
+                const defineDescriptor = {
+                    ...descriptor,
+                    enumerable: typeof descriptor.enumerable !== 'boolean' ? true : descriptor.enumerable,
+                    configurable: typeof descriptor.configurable !== 'boolean' ? true : descriptor.configurable,
+                };
+                this.defineProperty(api, key, defineDescriptor);
+                return;
+            }
+            this.wrapProperty(api, key, descriptor);
             return;
         }
-        this.wrapProperty(api, key, descriptor);
+
+        if (hasValue && value !== undefined) {
+            const descriptor = {
+                value: processAttr(value, undefined),
+            };
+            if ('enumerable' in change) {
+                descriptor.enumerable = change.enumerable;
+            }
+            if ('configurable' in change) {
+                descriptor.configurable = change.configurable;
+            }
+            // If 'define' is true and property does not exist, define it directly
+            if (change.define === true && !(key in api)) {
+                // Ensure descriptor has required boolean fields
+                const defineDescriptor = {
+                    ...descriptor,
+                    writable: true,
+                    enumerable: typeof descriptor.enumerable !== 'boolean' ? true : descriptor.enumerable,
+                    configurable: typeof descriptor.configurable !== 'boolean' ? true : descriptor.configurable,
+                };
+                this.defineProperty(api, key, defineDescriptor);
+                return;
+            }
+            this.wrapProperty(api, key, descriptor);
+        }
     }
 
     /**

--- a/injected/src/features/api-manipulation.js
+++ b/injected/src/features/api-manipulation.js
@@ -79,7 +79,7 @@ export default class ApiManipulation extends ContentFeature {
      * @property {import('../utils.js').ConfigSetting} [value] - The value assigned to a value descriptor, including methods.
      * @property {boolean} [enumerable] - Whether the property is enumerable.
      * @property {boolean} [configurable] - Whether the property is configurable.
-     * @property {boolean} [define] - When true, define a new own property only when the key is absent from `api` and its entire prototype chain. When false (default), skip changes for properties that do not exist at all; override own properties via `wrapProperty`; override inherited properties by shadow-defining an own property on `api` (without requiring `define`).
+     * @property {boolean} [define] - When true, define an own property on `api` if the key is not already own (including shadow-defining inherited APIs), or if the key is absent from the entire prototype chain. When false (default), skip changes for properties that do not exist at all; only override properties that are already own on `api` via `wrapProperty`.
      */
 
     /**
@@ -164,17 +164,15 @@ export default class ApiManipulation extends ContentFeature {
                 );
             }
         }
-        if (hasOwnProperty.call(api, key)) {
-            this.wrapProperty(api, key, descriptor);
-        } else {
-            // API exists via the prototype chain (e.g. MediaDevices.prototype.addEventListener
-            // on EventTarget.prototype). Shadow-define an own property without requiring `define`.
-            // `define: true` is only for keys missing from the chain; inherited overrides rely on
-            // this path so deployed remote config (privacy-configuration #5215) need not set `define`.
+        if (change.define === true && !hasOwnProperty.call(api, key)) {
             const merged = mergePropertyDescriptors(origDescriptor, descriptor);
             if (merged) {
                 this.defineProperty(api, key, merged);
             }
+            return;
+        }
+        if (hasOwnProperty.call(api, key)) {
+            this.wrapProperty(api, key, descriptor);
         }
     }
 

--- a/injected/src/features/api-manipulation.js
+++ b/injected/src/features/api-manipulation.js
@@ -124,7 +124,8 @@ export default class ApiManipulation extends ContentFeature {
         const getterValue = change.getterValue;
         const setterValue = change.setterValue;
         const value = change.value;
-        const descriptorKind = getterValue !== undefined || setterValue !== undefined ? 'getter' : value !== undefined ? 'value' : undefined;
+        const descriptorKind =
+            getterValue !== undefined || setterValue !== undefined ? 'getter' : value !== undefined ? 'value' : undefined;
         const configSetting = descriptorKind === 'getter' ? getterValue : value;
         // `setterValue` may be supplied on its own (override only the setter, keep the original
         // getter); in that case configSetting (getterValue) is undefined and createApiDescriptor
@@ -145,13 +146,24 @@ export default class ApiManipulation extends ContentFeature {
         // against the original method so `toString()`, `toString.toString()`, `.name`
         // and `.length` continue to resemble the native method. Without this, sites can
         // trivially detect the override via `fn.toString()` / `fn.name`.
+        const origDescriptor = getOwnPropertyDescriptor(api, key);
         if (descriptorKind === 'value') {
-            const valueDescriptor = /** @type {{ value: any, enumerable?: boolean, configurable?: boolean }} */ (descriptor);
-            if (typeof valueDescriptor.value === 'function') {
-                const origDescriptor = getOwnPropertyDescriptor(api, key);
-                if (origDescriptor && typeof origDescriptor.value === 'function') {
-                    valueDescriptor.value = this.maskMethodReplacement(valueDescriptor.value, origDescriptor.value);
-                }
+            const valueDescriptor = /** @type {{ value?: any }} */ (descriptor);
+            if (typeof valueDescriptor.value === 'function' && origDescriptor && typeof origDescriptor.value === 'function') {
+                valueDescriptor.value = this.maskMethodReplacement(valueDescriptor.value, origDescriptor.value);
+            }
+        } else if (descriptorKind === 'getter') {
+            // Mask the new setter against the original native setter (if any) so that
+            // descriptor inspection (`getOwnPropertyDescriptor(...).set.toString()` /
+            // `.set.name`) still resembles the original accessor. Event-handler IDL
+            // attributes such as `Element.prototype.onclick` and
+            // `MediaDevices.prototype.ondevicechange` expose a native setter; without
+            // masking, descriptor probes would see our JS `setter(v) {...}` shape.
+            const accessorDescriptor = /** @type {{ get?: () => any, set?: (v: any) => void }} */ (descriptor);
+            if (typeof accessorDescriptor.set === 'function' && origDescriptor && typeof origDescriptor.set === 'function') {
+                accessorDescriptor.set = /** @type {(v: any) => void} */ (
+                    this.maskMethodReplacement(accessorDescriptor.set, origDescriptor.set)
+                );
             }
         }
         this.wrapProperty(api, key, descriptor);
@@ -185,27 +197,33 @@ export default class ApiManipulation extends ContentFeature {
 
     /**
      * @param {'getter' | 'value'} descriptorKind
-     * @param {import('../utils.js').ConfigSetting | import('../utils.js').ConfigSetting[]} configSetting
+     * @param {import('../utils.js').ConfigSetting | import('../utils.js').ConfigSetting[] | undefined} configSetting
      * @param {APIChange} change
      * @returns {Partial<import('../wrapper-utils.js').StrictPropertyDescriptor>}
      */
     createApiDescriptor(descriptorKind, configSetting, change) {
-        /** @type {Partial<import('../wrapper-utils.js').StrictPropertyDescriptor>} */
+        // `Partial<StrictPropertyDescriptor>` is a union (data | accessor | get-only | set-only),
+        // so direct property access narrows poorly. Build with a permissive intermediate shape
+        // then return as the public type.
+        /** @type {{ value?: any, get?: () => any, set?: (v: any) => void, enumerable?: boolean, configurable?: boolean }} */
         let descriptor;
         if (descriptorKind === 'value') {
-            descriptor = { value: processAttr(configSetting, undefined) };
+            // `wrapApiDescriptor` guarantees `configSetting` is defined for the value kind.
+            const valueSetting = /** @type {import('../utils.js').ConfigSetting | import('../utils.js').ConfigSetting[]} */ (configSetting);
+            descriptor = { value: processAttr(valueSetting, undefined) };
         } else {
             descriptor = {};
             // `configSetting` is the getterValue (may be undefined if only setterValue is set).
             if (configSetting !== undefined) {
-                descriptor.get = () => processAttr(configSetting, undefined);
+                const getterSetting = configSetting;
+                descriptor.get = () => processAttr(getterSetting, undefined);
             }
             // `setterValue` is intentionally invoked through processAttr on every assignment so
             // configurations using `functionMap.debug` log per-assignment. When omitted, we leave
             // `set` unset on the new descriptor so wrapProperty's spread merge preserves the
             // original setter (existing behaviour).
             if (change.setterValue !== undefined) {
-                const setterSetting = change.setterValue;
+                const setterSetting = /** @type {import('../utils.js').ConfigSetting} */ (change.setterValue);
                 descriptor.set = function setter(v) {
                     const fn = processAttr(setterSetting, undefined);
                     if (typeof fn === 'function') {
@@ -220,7 +238,7 @@ export default class ApiManipulation extends ContentFeature {
         if ('configurable' in change) {
             descriptor.configurable = change.configurable;
         }
-        return descriptor;
+        return /** @type {Partial<import('../wrapper-utils.js').StrictPropertyDescriptor>} */ (descriptor);
     }
 
     /**
@@ -238,8 +256,9 @@ export default class ApiManipulation extends ContentFeature {
                 configurable: typeof valueDescriptor.configurable !== 'boolean' ? true : valueDescriptor.configurable,
             };
         }
-        const getterDescriptor =
-            /** @type {{ get?: () => any, set?: (v: any) => void, enumerable?: boolean, configurable?: boolean }} */ (descriptor);
+        const getterDescriptor = /** @type {{ get?: () => any, set?: (v: any) => void, enumerable?: boolean, configurable?: boolean }} */ (
+            descriptor
+        );
         /** @type {any} */
         const result = {
             enumerable: typeof getterDescriptor.enumerable !== 'boolean' ? true : getterDescriptor.enumerable,

--- a/injected/src/features/api-manipulation.js
+++ b/injected/src/features/api-manipulation.js
@@ -1,6 +1,7 @@
 /**
  * This feature allows remote configuration of APIs that exist within the DOM.
- * We support removal of APIs and returning different values from getters.
+ * We support removal of APIs, returning different values from getters, and
+ * replacing value-based properties such as methods.
  *
  * @module API manipulation
  */
@@ -45,16 +46,18 @@ export default class ApiManipulation extends ContentFeature {
             return true;
         }
         if (change.type === 'descriptor') {
-            if (change.enumerable && typeof change.enumerable !== 'boolean') {
+            if ('enumerable' in change && typeof change.enumerable !== 'boolean') {
                 return false;
             }
-            if (change.configurable && typeof change.configurable !== 'boolean') {
+            if ('configurable' in change && typeof change.configurable !== 'boolean') {
                 return false;
             }
             if ('define' in change && typeof change.define !== 'boolean') {
                 return false;
             }
-            return typeof change.getterValue !== 'undefined';
+            const hasGetterValue = typeof change.getterValue !== 'undefined';
+            const hasValue = typeof change.value !== 'undefined';
+            return hasGetterValue !== hasValue;
         }
         return false;
     }
@@ -66,6 +69,7 @@ export default class ApiManipulation extends ContentFeature {
      * @typedef {Object} APIChange
      * @property {"remove"|"descriptor"} type
      * @property {import('../utils.js').ConfigSetting} [getterValue] - The value returned from a getter.
+     * @property {import('../utils.js').ConfigSetting} [value] - The value assigned to a value descriptor, including methods.
      * @property {boolean} [enumerable] - Whether the property is enumerable.
      * @property {boolean} [configurable] - Whether the property is configurable.
      * @property {boolean} [define] - Whether to define the property if it does not exist.
@@ -110,30 +114,37 @@ export default class ApiManipulation extends ContentFeature {
      * @param {APIChange} change
      */
     wrapApiDescriptor(api, key, change) {
-        const getterValue = change.getterValue;
-        if (getterValue) {
-            const descriptor = {
-                get: () => processAttr(getterValue, undefined),
-            };
-            if ('enumerable' in change) {
-                descriptor.enumerable = change.enumerable;
-            }
-            if ('configurable' in change) {
-                descriptor.configurable = change.configurable;
-            }
-            // If 'define' is true and property does not exist, define it directly
-            if (change.define === true && !(key in api)) {
-                // Ensure descriptor has required boolean fields
-                const defineDescriptor = {
-                    ...descriptor,
-                    enumerable: typeof descriptor.enumerable !== 'boolean' ? true : descriptor.enumerable,
-                    configurable: typeof descriptor.configurable !== 'boolean' ? true : descriptor.configurable,
-                };
-                this.defineProperty(api, key, defineDescriptor);
-                return;
-            }
-            this.wrapProperty(api, key, descriptor);
+        const hasGetterValue = typeof change.getterValue !== 'undefined';
+        const hasValue = typeof change.value !== 'undefined';
+        if (!hasGetterValue && !hasValue) {
+            return;
         }
+        const descriptor = hasGetterValue
+            ? {
+                  get: () => processAttr(change.getterValue, undefined),
+              }
+            : {
+                  value: processAttr(change.value, undefined),
+              };
+        if ('enumerable' in change) {
+            descriptor.enumerable = change.enumerable;
+        }
+        if ('configurable' in change) {
+            descriptor.configurable = change.configurable;
+        }
+        // If 'define' is true and property does not exist, define it directly
+        if (change.define === true && !(key in api)) {
+            // Ensure descriptor has required boolean fields
+            const defineDescriptor = {
+                ...descriptor,
+                enumerable: typeof descriptor.enumerable !== 'boolean' ? true : descriptor.enumerable,
+                configurable: typeof descriptor.configurable !== 'boolean' ? true : descriptor.configurable,
+                ...(hasValue ? { writable: true } : {}),
+            };
+            this.defineProperty(api, key, defineDescriptor);
+            return;
+        }
+        this.wrapProperty(api, key, descriptor);
     }
 
     /**

--- a/injected/src/features/api-manipulation.js
+++ b/injected/src/features/api-manipulation.js
@@ -79,7 +79,7 @@ export default class ApiManipulation extends ContentFeature {
      * @property {import('../utils.js').ConfigSetting} [value] - The value assigned to a value descriptor, including methods.
      * @property {boolean} [enumerable] - Whether the property is enumerable.
      * @property {boolean} [configurable] - Whether the property is configurable.
-     * @property {boolean} [define] - Whether to define the property if it does not exist.
+     * @property {boolean} [define] - When true, define the property only if it does not exist on `api` or anywhere on its prototype chain. When false (default), skip changes for properties that do not exist at all; existing own or inherited APIs are overridden (inherited properties are shadow-defined as own properties on `api`).
      */
 
     /**
@@ -134,19 +134,20 @@ export default class ApiManipulation extends ContentFeature {
             return;
         }
         const descriptor = this.createApiDescriptor(descriptorKind, configSetting, change);
-        // If 'define' is true and property does not exist, define it directly
-        if (change.define === true && !(key in api)) {
-            this.defineProperty(api, key, this.createDefineDescriptor(descriptor, descriptorKind));
+        const origDescriptor = this.findPropertyDescriptor(api, key);
+        if (!origDescriptor) {
+            if (change.define === true) {
+                this.defineProperty(api, key, this.createDefineDescriptor(descriptor, descriptorKind));
+            }
             return;
         }
         // When replacing an existing method-valued descriptor, mask the replacement
         // against the original method so `toString()`, `toString.toString()`, `.name`
         // and `.length` continue to resemble the native method. Without this, sites can
         // trivially detect the override via `fn.toString()` / `fn.name`.
-        const origDescriptor = getOwnPropertyDescriptor(api, key);
         if (descriptorKind === 'value') {
             const valueDescriptor = /** @type {{ value?: any }} */ (descriptor);
-            if (typeof valueDescriptor.value === 'function' && origDescriptor && typeof origDescriptor.value === 'function') {
+            if (typeof valueDescriptor.value === 'function' && typeof origDescriptor.value === 'function') {
                 valueDescriptor.value = this.maskMethodReplacement(valueDescriptor.value, origDescriptor.value);
             }
         } else if (descriptorKind === 'getter') {
@@ -157,13 +158,37 @@ export default class ApiManipulation extends ContentFeature {
             // `MediaDevices.prototype.ondevicechange` expose a native setter; without
             // masking, descriptor probes would see our JS `setter(v) {...}` shape.
             const accessorDescriptor = /** @type {{ get?: () => any, set?: (v: any) => void }} */ (descriptor);
-            if (typeof accessorDescriptor.set === 'function' && origDescriptor && typeof origDescriptor.set === 'function') {
+            if (typeof accessorDescriptor.set === 'function' && typeof origDescriptor.set === 'function') {
                 accessorDescriptor.set = /** @type {(v: any) => void} */ (
                     this.maskMethodReplacement(accessorDescriptor.set, origDescriptor.set)
                 );
             }
         }
-        this.wrapProperty(api, key, descriptor);
+        if (hasOwnProperty.call(api, key)) {
+            this.wrapProperty(api, key, descriptor);
+        } else {
+            // API exists via the prototype chain (e.g. MediaDevices.prototype.addEventListener
+            // on EventTarget.prototype). Shadow-define an own property without requiring `define`.
+            this.defineProperty(api, key, { ...origDescriptor, ...descriptor });
+        }
+    }
+
+    /**
+     * Returns the property descriptor for `key` on `obj` or an ancestor in its prototype chain.
+     * @param {object} obj
+     * @param {string} key
+     * @returns {PropertyDescriptor | undefined}
+     */
+    findPropertyDescriptor(obj, key) {
+        let current = obj;
+        while (current) {
+            const descriptor = getOwnPropertyDescriptor(current, key);
+            if (descriptor) {
+                return descriptor;
+            }
+            current = Object.getPrototypeOf(current);
+        }
+        return undefined;
     }
 
     /**

--- a/injected/src/features/api-manipulation.js
+++ b/injected/src/features/api-manipulation.js
@@ -116,60 +116,65 @@ export default class ApiManipulation extends ContentFeature {
     wrapApiDescriptor(api, key, change) {
         const getterValue = change.getterValue;
         const value = change.value;
-        const hasGetterValue = typeof getterValue !== 'undefined';
-        const hasValue = typeof value !== 'undefined';
-        if (!hasGetterValue && !hasValue) {
+        const descriptorKind = getterValue !== undefined ? 'getter' : value !== undefined ? 'value' : undefined;
+        const configSetting = descriptorKind === 'getter' ? getterValue : value;
+        if (!descriptorKind || configSetting === undefined) {
             return;
         }
-        if (hasGetterValue && getterValue !== undefined) {
-            const descriptor = {
-                get: () => processAttr(getterValue, undefined),
-            };
-            if ('enumerable' in change) {
-                descriptor.enumerable = change.enumerable;
-            }
-            if ('configurable' in change) {
-                descriptor.configurable = change.configurable;
-            }
-            // If 'define' is true and property does not exist, define it directly
-            if (change.define === true && !(key in api)) {
-                // Ensure descriptor has required boolean fields
-                const defineDescriptor = {
-                    ...descriptor,
-                    enumerable: typeof descriptor.enumerable !== 'boolean' ? true : descriptor.enumerable,
-                    configurable: typeof descriptor.configurable !== 'boolean' ? true : descriptor.configurable,
-                };
-                this.defineProperty(api, key, defineDescriptor);
-                return;
-            }
-            this.wrapProperty(api, key, descriptor);
+        const descriptor = this.createApiDescriptor(descriptorKind, configSetting, change);
+        // If 'define' is true and property does not exist, define it directly
+        if (change.define === true && !(key in api)) {
+            this.defineProperty(api, key, this.createDefineDescriptor(descriptor, descriptorKind));
             return;
         }
+        this.wrapProperty(api, key, descriptor);
+    }
 
-        if (hasValue && value !== undefined) {
-            const descriptor = {
-                value: processAttr(value, undefined),
-            };
-            if ('enumerable' in change) {
-                descriptor.enumerable = change.enumerable;
-            }
-            if ('configurable' in change) {
-                descriptor.configurable = change.configurable;
-            }
-            // If 'define' is true and property does not exist, define it directly
-            if (change.define === true && !(key in api)) {
-                // Ensure descriptor has required boolean fields
-                const defineDescriptor = {
-                    ...descriptor,
-                    writable: true,
-                    enumerable: typeof descriptor.enumerable !== 'boolean' ? true : descriptor.enumerable,
-                    configurable: typeof descriptor.configurable !== 'boolean' ? true : descriptor.configurable,
-                };
-                this.defineProperty(api, key, defineDescriptor);
-                return;
-            }
-            this.wrapProperty(api, key, descriptor);
+    /**
+     * @param {'getter' | 'value'} descriptorKind
+     * @param {import('../utils.js').ConfigSetting | import('../utils.js').ConfigSetting[]} configSetting
+     * @param {APIChange} change
+     * @returns {Partial<import('../wrapper-utils.js').StrictPropertyDescriptor>}
+     */
+    createApiDescriptor(descriptorKind, configSetting, change) {
+        const descriptor =
+            descriptorKind === 'getter'
+                ? {
+                      get: () => processAttr(configSetting, undefined),
+                  }
+                : {
+                      value: processAttr(configSetting, undefined),
+                  };
+        if ('enumerable' in change) {
+            descriptor.enumerable = change.enumerable;
         }
+        if ('configurable' in change) {
+            descriptor.configurable = change.configurable;
+        }
+        return descriptor;
+    }
+
+    /**
+     * @param {Partial<import('../wrapper-utils.js').StrictPropertyDescriptor>} descriptor
+     * @param {'getter' | 'value'} descriptorKind
+     * @returns {import('../wrapper-utils.js').StrictPropertyDescriptor}
+     */
+    createDefineDescriptor(descriptor, descriptorKind) {
+        if (descriptorKind === 'value') {
+            const valueDescriptor = /** @type {{ value: any, enumerable?: boolean, configurable?: boolean }} */ (descriptor);
+            return {
+                value: valueDescriptor.value,
+                writable: true,
+                enumerable: typeof valueDescriptor.enumerable !== 'boolean' ? true : valueDescriptor.enumerable,
+                configurable: typeof valueDescriptor.configurable !== 'boolean' ? true : valueDescriptor.configurable,
+            };
+        }
+        const getterDescriptor = /** @type {{ get: () => any, enumerable?: boolean, configurable?: boolean }} */ (descriptor);
+        return {
+            get: getterDescriptor.get,
+            enumerable: typeof getterDescriptor.enumerable !== 'boolean' ? true : getterDescriptor.enumerable,
+            configurable: typeof getterDescriptor.configurable !== 'boolean' ? true : getterDescriptor.configurable,
+        };
     }
 
     /**

--- a/injected/src/features/api-manipulation.js
+++ b/injected/src/features/api-manipulation.js
@@ -79,7 +79,7 @@ export default class ApiManipulation extends ContentFeature {
      * @property {import('../utils.js').ConfigSetting} [value] - The value assigned to a value descriptor, including methods.
      * @property {boolean} [enumerable] - Whether the property is enumerable.
      * @property {boolean} [configurable] - Whether the property is configurable.
-     * @property {boolean} [define] - When true, define the property only if it does not exist on `api` or anywhere on its prototype chain. When false (default), skip changes for properties that do not exist at all; existing own or inherited APIs are overridden (inherited properties are shadow-defined as own properties on `api`).
+     * @property {boolean} [define] - Whether to define the property if it is not already an own property of `api`. When true and the property is missing or only inherited via the prototype chain, a new own property is defined (shadowing any inherited one). When false (default), the change is merged with any existing own descriptor; properties that exist only via the prototype chain are skipped.
      */
 
     /**
@@ -134,20 +134,22 @@ export default class ApiManipulation extends ContentFeature {
             return;
         }
         const descriptor = this.createApiDescriptor(descriptorKind, configSetting, change);
-        const origDescriptor = this.findPropertyDescriptor(api, key);
-        if (!origDescriptor) {
-            if (change.define === true) {
-                this.defineProperty(api, key, this.createDefineDescriptor(descriptor, descriptorKind));
-            }
+        // If `define` is true and the property is not already an OWN property of `api`, define it
+        // directly. This covers both the "property does not exist at all" case and the
+        // "property is inherited via the prototype chain" case (e.g. shadow-defining
+        // MediaDevices.prototype.addEventListener which is inherited from EventTarget.prototype).
+        if (change.define === true && !hasOwnProperty.call(api, key)) {
+            this.defineProperty(api, key, this.createDefineDescriptor(descriptor, descriptorKind));
             return;
         }
         // When replacing an existing method-valued descriptor, mask the replacement
         // against the original method so `toString()`, `toString.toString()`, `.name`
         // and `.length` continue to resemble the native method. Without this, sites can
         // trivially detect the override via `fn.toString()` / `fn.name`.
+        const origDescriptor = getOwnPropertyDescriptor(api, key);
         if (descriptorKind === 'value') {
             const valueDescriptor = /** @type {{ value?: any }} */ (descriptor);
-            if (typeof valueDescriptor.value === 'function' && typeof origDescriptor.value === 'function') {
+            if (typeof valueDescriptor.value === 'function' && origDescriptor && typeof origDescriptor.value === 'function') {
                 valueDescriptor.value = this.maskMethodReplacement(valueDescriptor.value, origDescriptor.value);
             }
         } else if (descriptorKind === 'getter') {
@@ -158,37 +160,13 @@ export default class ApiManipulation extends ContentFeature {
             // `MediaDevices.prototype.ondevicechange` expose a native setter; without
             // masking, descriptor probes would see our JS `setter(v) {...}` shape.
             const accessorDescriptor = /** @type {{ get?: () => any, set?: (v: any) => void }} */ (descriptor);
-            if (typeof accessorDescriptor.set === 'function' && typeof origDescriptor.set === 'function') {
+            if (typeof accessorDescriptor.set === 'function' && origDescriptor && typeof origDescriptor.set === 'function') {
                 accessorDescriptor.set = /** @type {(v: any) => void} */ (
                     this.maskMethodReplacement(accessorDescriptor.set, origDescriptor.set)
                 );
             }
         }
-        if (hasOwnProperty.call(api, key)) {
-            this.wrapProperty(api, key, descriptor);
-        } else {
-            // API exists via the prototype chain (e.g. MediaDevices.prototype.addEventListener
-            // on EventTarget.prototype). Shadow-define an own property without requiring `define`.
-            this.defineProperty(api, key, { ...origDescriptor, ...descriptor });
-        }
-    }
-
-    /**
-     * Returns the property descriptor for `key` on `obj` or an ancestor in its prototype chain.
-     * @param {object} obj
-     * @param {string} key
-     * @returns {PropertyDescriptor | undefined}
-     */
-    findPropertyDescriptor(obj, key) {
-        let current = obj;
-        while (current) {
-            const descriptor = getOwnPropertyDescriptor(current, key);
-            if (descriptor) {
-                return descriptor;
-            }
-            current = Object.getPrototypeOf(current);
-        }
-        return undefined;
+        this.wrapProperty(api, key, descriptor);
     }
 
     /**

--- a/injected/src/features/api-manipulation.js
+++ b/injected/src/features/api-manipulation.js
@@ -7,7 +7,7 @@
  */
 import ContentFeature from '../content-feature.js';
 // eslint-disable-next-line no-redeclare
-import { getOwnPropertyDescriptor, hasOwnProperty } from '../captured-globals.js';
+import { ReflectApply, getOwnPropertyDescriptor, hasOwnProperty, objectDefineProperty } from '../captured-globals.js';
 import { processAttr } from '../utils.js';
 import { wrapToString } from '../wrapper-utils.js';
 
@@ -158,11 +158,15 @@ export default class ApiManipulation extends ContentFeature {
      * @returns {Function}
      */
     maskMethodReplacement(replacementFn, origFn) {
+        // Use captured `ReflectApply` and `objectDefineProperty` so a hostile page
+        // cannot intercept the call into the configured replacement, nor tamper with
+        // the `name`/`length` masking, by reassigning `globalThis.Reflect.apply` or
+        // `globalThis.Object.defineProperty` after content scope has initialised.
         const wrapper = function () {
-            return Reflect.apply(replacementFn, this, arguments);
+            return ReflectApply(replacementFn, this, arguments);
         };
-        Object.defineProperty(wrapper, 'name', { value: origFn.name, configurable: true });
-        Object.defineProperty(wrapper, 'length', { value: origFn.length, configurable: true });
+        objectDefineProperty(wrapper, 'name', { value: origFn.name, configurable: true });
+        objectDefineProperty(wrapper, 'length', { value: origFn.length, configurable: true });
         return wrapToString(wrapper, origFn);
     }
 

--- a/injected/src/features/api-manipulation.js
+++ b/injected/src/features/api-manipulation.js
@@ -7,8 +7,9 @@
  */
 import ContentFeature from '../content-feature.js';
 // eslint-disable-next-line no-redeclare
-import { hasOwnProperty } from '../captured-globals.js';
+import { getOwnPropertyDescriptor, hasOwnProperty } from '../captured-globals.js';
 import { processAttr } from '../utils.js';
+import { wrapToString } from '../wrapper-utils.js';
 
 /**
  * @internal
@@ -127,7 +128,42 @@ export default class ApiManipulation extends ContentFeature {
             this.defineProperty(api, key, this.createDefineDescriptor(descriptor, descriptorKind));
             return;
         }
+        // When replacing an existing method-valued descriptor, mask the replacement
+        // against the original method so `toString()`, `toString.toString()`, `.name`
+        // and `.length` continue to resemble the native method. Without this, sites can
+        // trivially detect the override via `fn.toString()` / `fn.name`.
+        if (descriptorKind === 'value') {
+            const valueDescriptor = /** @type {{ value: any, enumerable?: boolean, configurable?: boolean }} */ (descriptor);
+            if (typeof valueDescriptor.value === 'function') {
+                const origDescriptor = getOwnPropertyDescriptor(api, key);
+                if (origDescriptor && typeof origDescriptor.value === 'function') {
+                    valueDescriptor.value = this.maskMethodReplacement(valueDescriptor.value, origDescriptor.value);
+                }
+            }
+        }
         this.wrapProperty(api, key, descriptor);
+    }
+
+    /**
+     * Wraps a config-supplied function so its observable identity (`toString`,
+     * `toString.toString`, `name`, `length`) mirrors the original DOM method it is
+     * replacing. The call itself still executes the configured replacement.
+     *
+     * Note: `processAttr` may return a shared function (e.g. `functionMap.noop`),
+     * so we always create a fresh wrapper before redefining `name`/`length` to
+     * avoid mutating module-level singletons.
+     *
+     * @param {Function} replacementFn - configured replacement to invoke
+     * @param {Function} origFn - original DOM method we are masking against
+     * @returns {Function}
+     */
+    maskMethodReplacement(replacementFn, origFn) {
+        const wrapper = function () {
+            return Reflect.apply(replacementFn, this, arguments);
+        };
+        Object.defineProperty(wrapper, 'name', { value: origFn.name, configurable: true });
+        Object.defineProperty(wrapper, 'length', { value: origFn.length, configurable: true });
+        return wrapToString(wrapper, origFn);
     }
 
     /**

--- a/injected/src/wrapper-utils.js
+++ b/injected/src/wrapper-utils.js
@@ -118,7 +118,7 @@ export function wrapFunction(functionValue, realTarget) {
  *
  * @param {PropertyDescriptor} origDescriptor
  * @param {Partial<PropertyDescriptor>} partialDescriptor
- * @returns {PropertyDescriptor | undefined} merged descriptor, or undefined when kinds disagree
+ * @returns {import('./wrapper-utils').StrictPropertyDescriptor | undefined} merged descriptor, or undefined when kinds disagree
  */
 export function mergePropertyDescriptors(origDescriptor, partialDescriptor) {
     if (
@@ -126,10 +126,26 @@ export function mergePropertyDescriptors(origDescriptor, partialDescriptor) {
         ('get' in origDescriptor && 'get' in partialDescriptor) ||
         ('set' in origDescriptor && 'set' in partialDescriptor)
     ) {
-        return {
+        const merged = {
             ...origDescriptor,
             ...partialDescriptor,
         };
+        // DOM descriptors always include configurable/enumerable at runtime; default when absent
+        // so the result satisfies StrictPropertyDescriptor for defineProperty().
+        if ('value' in merged) {
+            return /** @type {import('./wrapper-utils').StrictPropertyDescriptor} */ ({
+                value: merged.value,
+                writable: typeof merged.writable === 'boolean' ? merged.writable : true,
+                configurable: typeof merged.configurable === 'boolean' ? merged.configurable : true,
+                enumerable: typeof merged.enumerable === 'boolean' ? merged.enumerable : true,
+            });
+        }
+        return /** @type {import('./wrapper-utils').StrictPropertyDescriptor} */ ({
+            get: merged.get,
+            set: merged.set,
+            configurable: typeof merged.configurable === 'boolean' ? merged.configurable : true,
+            enumerable: typeof merged.enumerable === 'boolean' ? merged.enumerable : true,
+        });
     }
     return undefined;
 }

--- a/injected/src/wrapper-utils.js
+++ b/injected/src/wrapper-utils.js
@@ -112,6 +112,29 @@ export function wrapFunction(functionValue, realTarget) {
 }
 
 /**
+ * Merge `partial` into `orig` only when the partial supplies the same descriptor kind
+ * (data `value` vs accessor `get`/`set`). Spreading incompatible shapes produces an
+ * invalid ECMAScript property descriptor and makes `Object.defineProperty` throw.
+ *
+ * @param {PropertyDescriptor} origDescriptor
+ * @param {Partial<PropertyDescriptor>} partialDescriptor
+ * @returns {PropertyDescriptor | undefined} merged descriptor, or undefined when kinds disagree
+ */
+export function mergePropertyDescriptors(origDescriptor, partialDescriptor) {
+    if (
+        ('value' in origDescriptor && 'value' in partialDescriptor) ||
+        ('get' in origDescriptor && 'get' in partialDescriptor) ||
+        ('set' in origDescriptor && 'set' in partialDescriptor)
+    ) {
+        return {
+            ...origDescriptor,
+            ...partialDescriptor,
+        };
+    }
+    return undefined;
+}
+
+/**
  * Wrap a `get`/`set` or `value` property descriptor. Only for data properties. For methods, use wrapMethod(). For constructors, use wrapConstructor().
  * @param {object} object - object whose property we are wrapping (most commonly a prototype, e.g. globalThis.Screen.prototype)
  * @param {string} propertyName
@@ -132,20 +155,13 @@ export function wrapProperty(object, propertyName, descriptor, definePropertyFn)
         return;
     }
 
-    if (
-        ('value' in origDescriptor && 'value' in descriptor) ||
-        ('get' in origDescriptor && 'get' in descriptor) ||
-        ('set' in origDescriptor && 'set' in descriptor)
-    ) {
-        definePropertyFn(object, propertyName, {
-            ...origDescriptor,
-            ...descriptor,
-        });
-        return origDescriptor;
-    } else {
+    const merged = mergePropertyDescriptors(origDescriptor, descriptor);
+    if (!merged) {
         // if the property is defined with get/set it must be wrapped with a get/set. If it's defined with a `value`, it must be wrapped with a `value`
         throw new Error(`Property descriptor for ${propertyName} may only include the following keys: ${objectKeys(origDescriptor)}`);
     }
+    definePropertyFn(object, propertyName, merged);
+    return origDescriptor;
 }
 
 /**

--- a/injected/unit-test/features.js
+++ b/injected/unit-test/features.js
@@ -373,12 +373,12 @@ describe('ApiManipulation', () => {
         expect(apiManipulation.checkIsValidAPIChange(change)).toBeFalse();
     });
 
-    // --- inherited methods (shadow-define on the target object via define: true) ---
+    // --- inherited methods (implicit shadow-define on the target object) ---
     //
-    // `MediaDevices.prototype.addEventListener` lives on `EventTarget.prototype`. Inherited
-    // overrides require `define: true` so we shadow-define an own property on `api`.
+    // `MediaDevices.prototype.addEventListener` lives on `EventTarget.prototype`. Remote config
+    // overrides it via value descriptors without `define: true`.
 
-    it('shadow-defines an own property when the key is only inherited and define is true', () => {
+    it('shadow-defines an own property when the key is only inherited', () => {
         const proto = { inheritedMethod: () => 'inherited' };
         const target = Object.create(proto);
         expect('inheritedMethod' in target).toBeTrue();
@@ -387,7 +387,6 @@ describe('ApiManipulation', () => {
         const change = {
             type: 'descriptor',
             value: { type: 'function', functionName: 'noop' },
-            define: true,
         };
         apiManipulation.wrapApiDescriptor(target, 'inheritedMethod', change);
 
@@ -405,21 +404,18 @@ describe('ApiManipulation', () => {
         expect(dummyTarget.missingMethod).toBeUndefined();
     });
 
-    it('does not shadow-define an inherited property when define is omitted', () => {
-        const proto = { inheritedMethod: () => 'inherited' };
-        const target = Object.create(proto);
-
+    it('does not define a property when it is missing from the prototype chain and define is true', () => {
         const change = {
             type: 'descriptor',
             value: { type: 'function', functionName: 'noop' },
+            define: true,
         };
-        apiManipulation.wrapApiDescriptor(target, 'inheritedMethod', change);
-
-        expect(Object.prototype.hasOwnProperty.call(target, 'inheritedMethod')).toBeFalse();
-        expect(target.inheritedMethod()).toBe('inherited');
+        apiManipulation.wrapApiDescriptor(dummyTarget, 'brandNewMethod', change);
+        expect(typeof dummyTarget.brandNewMethod).toBe('function');
+        expect(dummyTarget.brandNewMethod()).toBeUndefined();
     });
 
-    it('does not shadow-define an inherited accessor when define is true but config supplies a value descriptor', () => {
+    it('does not shadow-define an inherited accessor when config supplies a value descriptor', () => {
         const proto = {};
         Object.defineProperty(proto, 'handler', {
             get: () => 'orig',
@@ -431,7 +427,6 @@ describe('ApiManipulation', () => {
         const change = {
             type: 'descriptor',
             value: { type: 'function', functionName: 'noop' },
-            define: true,
         };
         apiManipulation.wrapApiDescriptor(target, 'handler', change);
 
@@ -439,14 +434,13 @@ describe('ApiManipulation', () => {
         expect(target.handler).toBe('orig');
     });
 
-    it('does not shadow-define an inherited value property when define is true but config supplies only a getter', () => {
+    it('does not shadow-define an inherited value property when config supplies only a getter', () => {
         const proto = { dataProp: 'orig' };
         const target = Object.create(proto);
 
         const change = {
             type: 'descriptor',
             getterValue: { type: 'string', value: 'new' },
-            define: true,
         };
         apiManipulation.wrapApiDescriptor(target, 'dataProp', change);
 
@@ -454,7 +448,7 @@ describe('ApiManipulation', () => {
         expect(target.dataProp).toBe('orig');
     });
 
-    it('applies MediaDevices-style apiChanges with define: true on inherited keys', () => {
+    it('applies MediaDevices-style apiChanges without define: true', () => {
         const eventTargetProto = {
             addEventListener: () => 'et-add',
             removeEventListener: () => 'et-remove',
@@ -474,18 +468,15 @@ describe('ApiManipulation', () => {
             addEventListener: {
                 type: 'descriptor',
                 value: { type: 'function', functionName: 'noop' },
-                define: true,
             },
             ondevicechange: {
                 type: 'descriptor',
                 getterValue: { type: 'undefined' },
                 setterValue: { type: 'function', functionName: 'noop' },
-                define: true,
             },
             removeEventListener: {
                 type: 'descriptor',
                 value: { type: 'function', functionName: 'noop' },
-                define: true,
             },
         };
 

--- a/injected/unit-test/features.js
+++ b/injected/unit-test/features.js
@@ -372,4 +372,127 @@ describe('ApiManipulation', () => {
         };
         expect(apiManipulation.checkIsValidAPIChange(change)).toBeFalse();
     });
+
+    // --- define: true + inherited methods (shadow-define on the target object) ---
+    //
+    // The native API surface for MediaDevices and related interfaces relies on inheritance:
+    // `MediaDevices.prototype.addEventListener` lives on `EventTarget.prototype`, not as an own
+    // property of `MediaDevices.prototype`. Configurations targeting `MediaDevices.prototype.addEventListener`
+    // need a way to shadow-define an own property on `MediaDevices.prototype` while leaving
+    // `EventTarget.prototype` (and therefore other EventTarget consumers like `window`, `document`,
+    // and DOM elements) untouched.
+
+    it('shadow-defines an own property when define: true is set and the key is only inherited', () => {
+        // Construct a target with a method only reachable via the prototype chain.
+        const proto = { inheritedMethod: () => 'inherited' };
+        const target = Object.create(proto);
+        expect('inheritedMethod' in target).toBeTrue();
+        expect(Object.prototype.hasOwnProperty.call(target, 'inheritedMethod')).toBeFalse();
+
+        const change = {
+            type: 'descriptor',
+            value: { type: 'function', functionName: 'noop' },
+            define: true,
+        };
+        apiManipulation.wrapApiDescriptor(target, 'inheritedMethod', change);
+
+        // After wrapping, the property is now own on the target (shadowing the inherited one)
+        // and calls the configured replacement, while the prototype's original is left intact.
+        expect(Object.prototype.hasOwnProperty.call(target, 'inheritedMethod')).toBeTrue();
+        expect(target.inheritedMethod()).toBeUndefined();
+        expect(proto.inheritedMethod()).toBe('inherited');
+    });
+
+    it('does not shadow-define when define: true is omitted, even if the key is only inherited', () => {
+        // Without `define: true`, the feature must remain backwards-compatible: it should
+        // continue to bail out via wrapProperty rather than silently shadowing the prototype.
+        const proto = { inheritedMethod: () => 'inherited' };
+        const target = Object.create(proto);
+        const change = {
+            type: 'descriptor',
+            value: { type: 'function', functionName: 'noop' },
+        };
+        apiManipulation.wrapApiDescriptor(target, 'inheritedMethod', change);
+        expect(Object.prototype.hasOwnProperty.call(target, 'inheritedMethod')).toBeFalse();
+        expect(target.inheritedMethod()).toBe('inherited');
+    });
+
+    // --- setterValue: override the setter half of an accessor (for event-handler IDL
+    // attributes such as `MediaDevices.prototype.ondevicechange`). Without this, the original
+    // setter survives the spread-merge in wrapProperty and assigning to the property still
+    // registers a real listener.
+
+    it('overrides the setter when setterValue is supplied alongside getterValue', () => {
+        let originalGet = 'original-value';
+        let originalSetCalls = 0;
+        Object.defineProperty(dummyTarget, 'ondevicechange', {
+            get: () => originalGet,
+            set: (v) => {
+                originalSetCalls++;
+                originalGet = v;
+            },
+            configurable: true,
+            enumerable: true,
+        });
+        const change = {
+            type: 'descriptor',
+            getterValue: { type: 'string', value: 'overridden-getter' },
+            setterValue: { type: 'function', functionName: 'noop' },
+        };
+        apiManipulation.wrapApiDescriptor(dummyTarget, 'ondevicechange', change);
+
+        expect(dummyTarget.ondevicechange).toBe('overridden-getter');
+        // Assigning must not invoke the original setter - the override swallows it.
+        dummyTarget.ondevicechange = 'attempt-to-set';
+        expect(originalSetCalls).toBe(0);
+        // Getter is unaffected by the assignment because the override returns a constant.
+        expect(dummyTarget.ondevicechange).toBe('overridden-getter');
+    });
+
+    it('overrides only the setter when setterValue is supplied without getterValue', () => {
+        // When only `setterValue` is set the original getter must continue to work so reads
+        // remain accurate. Only assignments are intercepted.
+        let originalGet = 'original-value';
+        let originalSetCalls = 0;
+        Object.defineProperty(dummyTarget, 'ondevicechange', {
+            get: () => originalGet,
+            set: (v) => {
+                originalSetCalls++;
+                originalGet = v;
+            },
+            configurable: true,
+            enumerable: true,
+        });
+        const change = {
+            type: 'descriptor',
+            setterValue: { type: 'function', functionName: 'noop' },
+        };
+        apiManipulation.wrapApiDescriptor(dummyTarget, 'ondevicechange', change);
+
+        // Original getter still active.
+        expect(dummyTarget.ondevicechange).toBe('original-value');
+        // Setter swallowed.
+        dummyTarget.ondevicechange = 'attempt-to-set';
+        expect(originalSetCalls).toBe(0);
+        expect(dummyTarget.ondevicechange).toBe('original-value');
+    });
+
+    it('accepts descriptor changes that provide only setterValue', () => {
+        // Validation must allow accessor-shape changes where only the setter is being overridden.
+        const change = {
+            type: 'descriptor',
+            setterValue: { type: 'function', functionName: 'noop' },
+        };
+        expect(apiManipulation.checkIsValidAPIChange(change)).toBeTrue();
+    });
+
+    it('rejects descriptor changes that supply both setterValue and value', () => {
+        // Mixing accessor and value-descriptor shapes is invalid for a single change.
+        const change = {
+            type: 'descriptor',
+            setterValue: { type: 'function', functionName: 'noop' },
+            value: { type: 'function', functionName: 'noop' },
+        };
+        expect(apiManipulation.checkIsValidAPIChange(change)).toBeFalse();
+    });
 });

--- a/injected/unit-test/features.js
+++ b/injected/unit-test/features.js
@@ -404,6 +404,39 @@ describe('ApiManipulation', () => {
         expect(dummyTarget.missingMethod).toBeUndefined();
     });
 
+    it('does not shadow-define an inherited accessor when config supplies a value descriptor', () => {
+        const proto = {};
+        Object.defineProperty(proto, 'handler', {
+            get: () => 'orig',
+            configurable: true,
+            enumerable: true,
+        });
+        const target = Object.create(proto);
+
+        const change = {
+            type: 'descriptor',
+            value: { type: 'function', functionName: 'noop' },
+        };
+        apiManipulation.wrapApiDescriptor(target, 'handler', change);
+
+        expect(Object.prototype.hasOwnProperty.call(target, 'handler')).toBeFalse();
+        expect(target.handler).toBe('orig');
+    });
+
+    it('does not shadow-define an inherited value property when config supplies only a getter', () => {
+        const proto = { dataProp: 'orig' };
+        const target = Object.create(proto);
+
+        const change = {
+            type: 'descriptor',
+            getterValue: { type: 'string', value: 'new' },
+        };
+        apiManipulation.wrapApiDescriptor(target, 'dataProp', change);
+
+        expect(Object.prototype.hasOwnProperty.call(target, 'dataProp')).toBeFalse();
+        expect(target.dataProp).toBe('orig');
+    });
+
     it('applies MediaDevices-style apiChanges without define: true', () => {
         const eventTargetProto = {
             addEventListener: () => 'et-add',

--- a/injected/unit-test/features.js
+++ b/injected/unit-test/features.js
@@ -373,16 +373,17 @@ describe('ApiManipulation', () => {
         expect(apiManipulation.checkIsValidAPIChange(change)).toBeFalse();
     });
 
-    // --- inherited methods (shadow-define on the target object) ---
+    // --- define: true + inherited methods (shadow-define on the target object) ---
     //
     // The native API surface for MediaDevices and related interfaces relies on inheritance:
     // `MediaDevices.prototype.addEventListener` lives on `EventTarget.prototype`, not as an own
     // property of `MediaDevices.prototype`. Configurations targeting `MediaDevices.prototype.addEventListener`
-    // shadow-define an own property on `MediaDevices.prototype` while leaving
+    // need a way to shadow-define an own property on `MediaDevices.prototype` while leaving
     // `EventTarget.prototype` (and therefore other EventTarget consumers like `window`, `document`,
     // and DOM elements) untouched.
 
-    it('shadow-defines an own property when the key is only inherited', () => {
+    it('shadow-defines an own property when define: true is set and the key is only inherited', () => {
+        // Construct a target with a method only reachable via the prototype chain.
         const proto = { inheritedMethod: () => 'inherited' };
         const target = Object.create(proto);
         expect('inheritedMethod' in target).toBeTrue();
@@ -391,73 +392,29 @@ describe('ApiManipulation', () => {
         const change = {
             type: 'descriptor',
             value: { type: 'function', functionName: 'noop' },
+            define: true,
         };
         apiManipulation.wrapApiDescriptor(target, 'inheritedMethod', change);
 
+        // After wrapping, the property is now own on the target (shadowing the inherited one)
+        // and calls the configured replacement, while the prototype's original is left intact.
         expect(Object.prototype.hasOwnProperty.call(target, 'inheritedMethod')).toBeTrue();
         expect(target.inheritedMethod()).toBeUndefined();
         expect(proto.inheritedMethod()).toBe('inherited');
     });
 
-    it('does not define a property when it is missing from the prototype chain and define is omitted', () => {
+    it('does not shadow-define when define: true is omitted, even if the key is only inherited', () => {
+        // Without `define: true`, the feature must remain backwards-compatible: it should
+        // continue to bail out via wrapProperty rather than silently shadowing the prototype.
+        const proto = { inheritedMethod: () => 'inherited' };
+        const target = Object.create(proto);
         const change = {
             type: 'descriptor',
             value: { type: 'function', functionName: 'noop' },
         };
-        apiManipulation.wrapApiDescriptor(dummyTarget, 'missingMethod', change);
-        expect(dummyTarget.missingMethod).toBeUndefined();
-    });
-
-    it('applies MediaDevices-style apiChanges without define: true', () => {
-        const eventTargetProto = {
-            addEventListener: () => 'et-add',
-            removeEventListener: () => 'et-remove',
-        };
-        const mediaDevicesProto = Object.create(eventTargetProto);
-        Object.defineProperty(mediaDevicesProto, 'ondevicechange', {
-            get: () => 'original-handler',
-            set: () => {
-                throw new Error('original setter must not run');
-            },
-            configurable: true,
-            enumerable: true,
-        });
-        const target = Object.create(mediaDevicesProto);
-
-        const apiChanges = {
-            'MediaDevices.prototype.addEventListener': {
-                type: 'descriptor',
-                value: { type: 'function', functionName: 'noop' },
-            },
-            'MediaDevices.prototype.ondevicechange': {
-                type: 'descriptor',
-                getterValue: { type: 'undefined' },
-                setterValue: { type: 'function', functionName: 'noop' },
-            },
-            'MediaDevices.prototype.removeEventListener': {
-                type: 'descriptor',
-                value: { type: 'function', functionName: 'noop' },
-            },
-        };
-
-        for (const [scope, change] of Object.entries(apiChanges)) {
-            const key = scope.split('.').pop();
-            apiManipulation.wrapApiDescriptor(target, /** @type {string} */ (key), /** @type {any} */ (change));
-        }
-
-        expect(Object.prototype.hasOwnProperty.call(target, 'addEventListener')).toBeTrue();
-        expect(target.addEventListener()).toBeUndefined();
-        expect(eventTargetProto.addEventListener()).toBe('et-add');
-
-        expect(Object.prototype.hasOwnProperty.call(target, 'removeEventListener')).toBeTrue();
-        expect(target.removeEventListener()).toBeUndefined();
-        expect(eventTargetProto.removeEventListener()).toBe('et-remove');
-
-        expect(target.ondevicechange).toBeUndefined();
-        expect(() => {
-            target.ondevicechange = () => {};
-        }).not.toThrow();
-        expect(target.ondevicechange).toBeUndefined();
+        apiManipulation.wrapApiDescriptor(target, 'inheritedMethod', change);
+        expect(Object.prototype.hasOwnProperty.call(target, 'inheritedMethod')).toBeFalse();
+        expect(target.inheritedMethod()).toBe('inherited');
     });
 
     // --- setterValue: override the setter half of an accessor (for event-handler IDL

--- a/injected/unit-test/features.js
+++ b/injected/unit-test/features.js
@@ -257,6 +257,65 @@ describe('ApiManipulation', () => {
         expect(dummyTarget.nativeMethod('foo')).toBeUndefined();
     });
 
+    it('uses captured globals so page tampering with Reflect.apply / Object.defineProperty cannot subvert the masking helper', () => {
+        function originalNativeLike(a, b, c) {
+            return [a, b, c];
+        }
+
+        const realReflectApply = Reflect.apply;
+        const realObjectDefineProperty = Object.defineProperty;
+        // Use the real defineProperty before tampering to set up the target.
+        realObjectDefineProperty.call(Object, dummyTarget, 'protectedMethod', {
+            value: originalNativeLike,
+            writable: true,
+            configurable: true,
+            enumerable: false,
+        });
+
+        // Replace page-visible globals AFTER constructing the feature. The
+        // helper imports captured primitives (`ReflectApply`,
+        // `objectDefineProperty`) which were bound at module load, so masking
+        // must continue to work and `Object.defineProperty` must never be
+        // routed through the page-tampered version.
+        const defineSpy = jasmine
+            .createSpy('Object.defineProperty')
+            .and.callFake((...args) => realObjectDefineProperty.apply(Object, args));
+        const applySpy = jasmine.createSpy('Reflect.apply').and.callFake((...args) => realReflectApply.apply(Reflect, args));
+        Object.defineProperty = defineSpy;
+        Reflect.apply = applySpy;
+
+        const change = {
+            type: 'descriptor',
+            value: {
+                type: 'function',
+                functionValue: { type: 'string', value: 'still-routed' },
+            },
+        };
+
+        try {
+            apiManipulation.wrapApiDescriptor(dummyTarget, 'protectedMethod', change);
+            // Helper does not route name/length masking through the tampered
+            // `Object.defineProperty`. If the helper regresses to using
+            // `Object.defineProperty` directly, defineSpy would be hit during
+            // wrapping.
+            expect(defineSpy).not.toHaveBeenCalled();
+            // Masked identity is intact regardless of tampering.
+            expect(dummyTarget.protectedMethod.name).toBe('originalNativeLike');
+            expect(dummyTarget.protectedMethod.length).toBe(originalNativeLike.length);
+            expect(dummyTarget.protectedMethod.toString()).toBe(Function.prototype.toString.call(originalNativeLike));
+            // End-to-end invocation still routes to the configured replacement.
+            // Note: the outer call goes through `ContentFeature.defineProperty`'s
+            // debug-wrapper which still reads `Reflect.apply` from the page —
+            // that is outside the scope of this PR's helper. The captured
+            // `ReflectApply` inside the helper is what guarantees the inner
+            // step (helper -> replacement) cannot be intercepted.
+            expect(dummyTarget.protectedMethod(1, 2, 3)).toBe('still-routed');
+        } finally {
+            Object.defineProperty = realObjectDefineProperty;
+            Reflect.apply = realReflectApply;
+        }
+    });
+
     it('overrides an existing method value descriptor even when define: true is set', () => {
         const originalFn = function originalFn() {
             return 'original';

--- a/injected/unit-test/features.js
+++ b/injected/unit-test/features.js
@@ -373,17 +373,16 @@ describe('ApiManipulation', () => {
         expect(apiManipulation.checkIsValidAPIChange(change)).toBeFalse();
     });
 
-    // --- define: true + inherited methods (shadow-define on the target object) ---
+    // --- inherited methods (shadow-define on the target object) ---
     //
     // The native API surface for MediaDevices and related interfaces relies on inheritance:
     // `MediaDevices.prototype.addEventListener` lives on `EventTarget.prototype`, not as an own
     // property of `MediaDevices.prototype`. Configurations targeting `MediaDevices.prototype.addEventListener`
-    // need a way to shadow-define an own property on `MediaDevices.prototype` while leaving
+    // shadow-define an own property on `MediaDevices.prototype` while leaving
     // `EventTarget.prototype` (and therefore other EventTarget consumers like `window`, `document`,
     // and DOM elements) untouched.
 
-    it('shadow-defines an own property when define: true is set and the key is only inherited', () => {
-        // Construct a target with a method only reachable via the prototype chain.
+    it('shadow-defines an own property when the key is only inherited', () => {
         const proto = { inheritedMethod: () => 'inherited' };
         const target = Object.create(proto);
         expect('inheritedMethod' in target).toBeTrue();
@@ -392,29 +391,73 @@ describe('ApiManipulation', () => {
         const change = {
             type: 'descriptor',
             value: { type: 'function', functionName: 'noop' },
-            define: true,
         };
         apiManipulation.wrapApiDescriptor(target, 'inheritedMethod', change);
 
-        // After wrapping, the property is now own on the target (shadowing the inherited one)
-        // and calls the configured replacement, while the prototype's original is left intact.
         expect(Object.prototype.hasOwnProperty.call(target, 'inheritedMethod')).toBeTrue();
         expect(target.inheritedMethod()).toBeUndefined();
         expect(proto.inheritedMethod()).toBe('inherited');
     });
 
-    it('does not shadow-define when define: true is omitted, even if the key is only inherited', () => {
-        // Without `define: true`, the feature must remain backwards-compatible: it should
-        // continue to bail out via wrapProperty rather than silently shadowing the prototype.
-        const proto = { inheritedMethod: () => 'inherited' };
-        const target = Object.create(proto);
+    it('does not define a property when it is missing from the prototype chain and define is omitted', () => {
         const change = {
             type: 'descriptor',
             value: { type: 'function', functionName: 'noop' },
         };
-        apiManipulation.wrapApiDescriptor(target, 'inheritedMethod', change);
-        expect(Object.prototype.hasOwnProperty.call(target, 'inheritedMethod')).toBeFalse();
-        expect(target.inheritedMethod()).toBe('inherited');
+        apiManipulation.wrapApiDescriptor(dummyTarget, 'missingMethod', change);
+        expect(dummyTarget.missingMethod).toBeUndefined();
+    });
+
+    it('applies MediaDevices-style apiChanges without define: true', () => {
+        const eventTargetProto = {
+            addEventListener: () => 'et-add',
+            removeEventListener: () => 'et-remove',
+        };
+        const mediaDevicesProto = Object.create(eventTargetProto);
+        Object.defineProperty(mediaDevicesProto, 'ondevicechange', {
+            get: () => 'original-handler',
+            set: () => {
+                throw new Error('original setter must not run');
+            },
+            configurable: true,
+            enumerable: true,
+        });
+        const target = Object.create(mediaDevicesProto);
+
+        const apiChanges = {
+            'MediaDevices.prototype.addEventListener': {
+                type: 'descriptor',
+                value: { type: 'function', functionName: 'noop' },
+            },
+            'MediaDevices.prototype.ondevicechange': {
+                type: 'descriptor',
+                getterValue: { type: 'undefined' },
+                setterValue: { type: 'function', functionName: 'noop' },
+            },
+            'MediaDevices.prototype.removeEventListener': {
+                type: 'descriptor',
+                value: { type: 'function', functionName: 'noop' },
+            },
+        };
+
+        for (const [scope, change] of Object.entries(apiChanges)) {
+            const key = scope.split('.').pop();
+            apiManipulation.wrapApiDescriptor(target, /** @type {string} */ (key), /** @type {any} */ (change));
+        }
+
+        expect(Object.prototype.hasOwnProperty.call(target, 'addEventListener')).toBeTrue();
+        expect(target.addEventListener()).toBeUndefined();
+        expect(eventTargetProto.addEventListener()).toBe('et-add');
+
+        expect(Object.prototype.hasOwnProperty.call(target, 'removeEventListener')).toBeTrue();
+        expect(target.removeEventListener()).toBeUndefined();
+        expect(eventTargetProto.removeEventListener()).toBe('et-remove');
+
+        expect(target.ondevicechange).toBeUndefined();
+        expect(() => {
+            target.ondevicechange = () => {};
+        }).not.toThrow();
+        expect(target.ondevicechange).toBeUndefined();
     });
 
     // --- setterValue: override the setter half of an accessor (for event-handler IDL

--- a/injected/unit-test/features.js
+++ b/injected/unit-test/features.js
@@ -373,12 +373,12 @@ describe('ApiManipulation', () => {
         expect(apiManipulation.checkIsValidAPIChange(change)).toBeFalse();
     });
 
-    // --- inherited methods (shadow-define on the target object) ---
+    // --- inherited methods (shadow-define on the target object via define: true) ---
     //
-    // `MediaDevices.prototype.addEventListener` lives on `EventTarget.prototype`. Remote config
-    // (privacy-configuration #5215) overrides it via value descriptors without `define: true`.
+    // `MediaDevices.prototype.addEventListener` lives on `EventTarget.prototype`. Inherited
+    // overrides require `define: true` so we shadow-define an own property on `api`.
 
-    it('shadow-defines an own property when the key is only inherited', () => {
+    it('shadow-defines an own property when the key is only inherited and define is true', () => {
         const proto = { inheritedMethod: () => 'inherited' };
         const target = Object.create(proto);
         expect('inheritedMethod' in target).toBeTrue();
@@ -387,6 +387,7 @@ describe('ApiManipulation', () => {
         const change = {
             type: 'descriptor',
             value: { type: 'function', functionName: 'noop' },
+            define: true,
         };
         apiManipulation.wrapApiDescriptor(target, 'inheritedMethod', change);
 
@@ -404,7 +405,21 @@ describe('ApiManipulation', () => {
         expect(dummyTarget.missingMethod).toBeUndefined();
     });
 
-    it('does not shadow-define an inherited accessor when config supplies a value descriptor', () => {
+    it('does not shadow-define an inherited property when define is omitted', () => {
+        const proto = { inheritedMethod: () => 'inherited' };
+        const target = Object.create(proto);
+
+        const change = {
+            type: 'descriptor',
+            value: { type: 'function', functionName: 'noop' },
+        };
+        apiManipulation.wrapApiDescriptor(target, 'inheritedMethod', change);
+
+        expect(Object.prototype.hasOwnProperty.call(target, 'inheritedMethod')).toBeFalse();
+        expect(target.inheritedMethod()).toBe('inherited');
+    });
+
+    it('does not shadow-define an inherited accessor when define is true but config supplies a value descriptor', () => {
         const proto = {};
         Object.defineProperty(proto, 'handler', {
             get: () => 'orig',
@@ -416,6 +431,7 @@ describe('ApiManipulation', () => {
         const change = {
             type: 'descriptor',
             value: { type: 'function', functionName: 'noop' },
+            define: true,
         };
         apiManipulation.wrapApiDescriptor(target, 'handler', change);
 
@@ -423,13 +439,14 @@ describe('ApiManipulation', () => {
         expect(target.handler).toBe('orig');
     });
 
-    it('does not shadow-define an inherited value property when config supplies only a getter', () => {
+    it('does not shadow-define an inherited value property when define is true but config supplies only a getter', () => {
         const proto = { dataProp: 'orig' };
         const target = Object.create(proto);
 
         const change = {
             type: 'descriptor',
             getterValue: { type: 'string', value: 'new' },
+            define: true,
         };
         apiManipulation.wrapApiDescriptor(target, 'dataProp', change);
 
@@ -437,7 +454,7 @@ describe('ApiManipulation', () => {
         expect(target.dataProp).toBe('orig');
     });
 
-    it('applies MediaDevices-style apiChanges without define: true', () => {
+    it('applies MediaDevices-style apiChanges with define: true on inherited keys', () => {
         const eventTargetProto = {
             addEventListener: () => 'et-add',
             removeEventListener: () => 'et-remove',
@@ -457,15 +474,18 @@ describe('ApiManipulation', () => {
             addEventListener: {
                 type: 'descriptor',
                 value: { type: 'function', functionName: 'noop' },
+                define: true,
             },
             ondevicechange: {
                 type: 'descriptor',
                 getterValue: { type: 'undefined' },
                 setterValue: { type: 'function', functionName: 'noop' },
+                define: true,
             },
             removeEventListener: {
                 type: 'descriptor',
                 value: { type: 'function', functionName: 'noop' },
+                define: true,
             },
         };
 

--- a/injected/unit-test/features.js
+++ b/injected/unit-test/features.js
@@ -373,50 +373,6 @@ describe('ApiManipulation', () => {
         expect(apiManipulation.checkIsValidAPIChange(change)).toBeFalse();
     });
 
-    // --- define: true + inherited methods (shadow-define on the target object) ---
-    //
-    // The native API surface for MediaDevices and related interfaces relies on inheritance:
-    // `MediaDevices.prototype.addEventListener` lives on `EventTarget.prototype`, not as an own
-    // property of `MediaDevices.prototype`. Configurations targeting `MediaDevices.prototype.addEventListener`
-    // need a way to shadow-define an own property on `MediaDevices.prototype` while leaving
-    // `EventTarget.prototype` (and therefore other EventTarget consumers like `window`, `document`,
-    // and DOM elements) untouched.
-
-    it('shadow-defines an own property when define: true is set and the key is only inherited', () => {
-        // Construct a target with a method only reachable via the prototype chain.
-        const proto = { inheritedMethod: () => 'inherited' };
-        const target = Object.create(proto);
-        expect('inheritedMethod' in target).toBeTrue();
-        expect(Object.prototype.hasOwnProperty.call(target, 'inheritedMethod')).toBeFalse();
-
-        const change = {
-            type: 'descriptor',
-            value: { type: 'function', functionName: 'noop' },
-            define: true,
-        };
-        apiManipulation.wrapApiDescriptor(target, 'inheritedMethod', change);
-
-        // After wrapping, the property is now own on the target (shadowing the inherited one)
-        // and calls the configured replacement, while the prototype's original is left intact.
-        expect(Object.prototype.hasOwnProperty.call(target, 'inheritedMethod')).toBeTrue();
-        expect(target.inheritedMethod()).toBeUndefined();
-        expect(proto.inheritedMethod()).toBe('inherited');
-    });
-
-    it('does not shadow-define when define: true is omitted, even if the key is only inherited', () => {
-        // Without `define: true`, the feature must remain backwards-compatible: it should
-        // continue to bail out via wrapProperty rather than silently shadowing the prototype.
-        const proto = { inheritedMethod: () => 'inherited' };
-        const target = Object.create(proto);
-        const change = {
-            type: 'descriptor',
-            value: { type: 'function', functionName: 'noop' },
-        };
-        apiManipulation.wrapApiDescriptor(target, 'inheritedMethod', change);
-        expect(Object.prototype.hasOwnProperty.call(target, 'inheritedMethod')).toBeFalse();
-        expect(target.inheritedMethod()).toBe('inherited');
-    });
-
     // --- setterValue: override the setter half of an accessor (for event-handler IDL
     // attributes such as `MediaDevices.prototype.ondevicechange`). Without this, the original
     // setter survives the spread-merge in wrapProperty and assigning to the property still

--- a/injected/unit-test/features.js
+++ b/injected/unit-test/features.js
@@ -199,6 +199,64 @@ describe('ApiManipulation', () => {
         expect(descriptor.enumerable).toBeFalse();
     });
 
+    it('masks the replacement method so toString() and metadata resemble the original', () => {
+        function originalGetUserMedia(constraints, opts) {
+            return constraints || opts;
+        }
+        Object.defineProperty(dummyTarget, 'getUserMedia', {
+            value: originalGetUserMedia,
+            writable: true,
+            configurable: true,
+            enumerable: false,
+        });
+        const change = {
+            type: 'descriptor',
+            value: {
+                type: 'function',
+                functionValue: { type: 'string', value: 'replacement' },
+            },
+        };
+        apiManipulation.wrapApiDescriptor(dummyTarget, 'getUserMedia', change);
+
+        // Function still executes the configured replacement.
+        expect(dummyTarget.getUserMedia()).toBe('replacement');
+        // .name / .length resemble the original method.
+        expect(dummyTarget.getUserMedia.name).toBe('originalGetUserMedia');
+        expect(dummyTarget.getUserMedia.length).toBe(originalGetUserMedia.length);
+        // toString() returns the original method's source rather than the replacement's body.
+        const toStringResult = dummyTarget.getUserMedia.toString();
+        expect(toStringResult).toBe(Function.prototype.toString.call(originalGetUserMedia));
+        expect(toStringResult).toContain('originalGetUserMedia');
+        // toString.toString() should still look like Function.prototype.toString itself,
+        // mirroring native methods rather than the configured replacement.
+        expect(dummyTarget.getUserMedia.toString.toString()).toBe(Function.prototype.toString.toString());
+    });
+
+    it('preserves [native code] in toString() when overriding a real native method', () => {
+        // Install an actual native function as the existing descriptor so we can
+        // assert the override masks against the genuine "[native code]" output
+        // rather than against a user-land source string.
+        const nativeFn = Object.prototype.hasOwnProperty;
+        Object.defineProperty(dummyTarget, 'nativeMethod', {
+            value: nativeFn,
+            writable: true,
+            configurable: true,
+            enumerable: false,
+        });
+        const change = {
+            type: 'descriptor',
+            value: { type: 'function', functionName: 'noop' },
+        };
+        apiManipulation.wrapApiDescriptor(dummyTarget, 'nativeMethod', change);
+
+        expect(dummyTarget.nativeMethod.toString()).toContain('[native code]');
+        expect(dummyTarget.nativeMethod.toString()).toBe(Function.prototype.toString.call(nativeFn));
+        expect(dummyTarget.nativeMethod.name).toBe('hasOwnProperty');
+        expect(dummyTarget.nativeMethod.length).toBe(nativeFn.length);
+        // Call still resolves to the configured noop replacement (returns undefined).
+        expect(dummyTarget.nativeMethod('foo')).toBeUndefined();
+    });
+
     it('overrides an existing method value descriptor even when define: true is set', () => {
         const originalFn = function originalFn() {
             return 'original';

--- a/injected/unit-test/features.js
+++ b/injected/unit-test/features.js
@@ -158,4 +158,49 @@ describe('ApiManipulation', () => {
         // The getter should now return 222
         expect(dummyTarget.hardwareConcurrency).toBe(222);
     });
+
+    it('replaces an existing method value descriptor if present', () => {
+        dummyTarget.getUserMedia = () => 'original';
+        const change = {
+            type: 'descriptor',
+            value: { type: 'function', functionName: 'noop' },
+        };
+        apiManipulation.wrapApiDescriptor(dummyTarget, 'getUserMedia', change);
+        expect(typeof dummyTarget.getUserMedia).toBe('function');
+        expect(dummyTarget.getUserMedia()).toBeUndefined();
+    });
+
+    it('defines a new method if define: true is set and property does not exist', () => {
+        const change = {
+            type: 'descriptor',
+            value: {
+                type: 'function',
+                functionValue: {
+                    type: 'string',
+                    value: 'defined by config',
+                },
+            },
+            define: true,
+        };
+        apiManipulation.wrapApiDescriptor(dummyTarget, 'definedMethodByConfig', change);
+        expect(typeof dummyTarget.definedMethodByConfig).toBe('function');
+        expect(dummyTarget.definedMethodByConfig()).toBe('defined by config');
+    });
+
+    it('treats value descriptors as valid api changes', () => {
+        const change = {
+            type: 'descriptor',
+            value: { type: 'function', functionName: 'noop' },
+        };
+        expect(apiManipulation.checkIsValidAPIChange(change)).toBeTrue();
+    });
+
+    it('rejects descriptor changes that define both getterValue and value', () => {
+        const change = {
+            type: 'descriptor',
+            getterValue: { type: 'string', value: 'getter' },
+            value: { type: 'function', functionName: 'noop' },
+        };
+        expect(apiManipulation.checkIsValidAPIChange(change)).toBeFalse();
+    });
 });

--- a/injected/unit-test/features.js
+++ b/injected/unit-test/features.js
@@ -373,6 +373,132 @@ describe('ApiManipulation', () => {
         expect(apiManipulation.checkIsValidAPIChange(change)).toBeFalse();
     });
 
+    // --- inherited methods (shadow-define on the target object) ---
+    //
+    // `MediaDevices.prototype.addEventListener` lives on `EventTarget.prototype`. Remote config
+    // (privacy-configuration #5215) overrides it via value descriptors without `define: true`.
+
+    it('shadow-defines an own property when the key is only inherited', () => {
+        const proto = { inheritedMethod: () => 'inherited' };
+        const target = Object.create(proto);
+        expect('inheritedMethod' in target).toBeTrue();
+        expect(Object.prototype.hasOwnProperty.call(target, 'inheritedMethod')).toBeFalse();
+
+        const change = {
+            type: 'descriptor',
+            value: { type: 'function', functionName: 'noop' },
+        };
+        apiManipulation.wrapApiDescriptor(target, 'inheritedMethod', change);
+
+        expect(Object.prototype.hasOwnProperty.call(target, 'inheritedMethod')).toBeTrue();
+        expect(target.inheritedMethod()).toBeUndefined();
+        expect(proto.inheritedMethod()).toBe('inherited');
+    });
+
+    it('does not define a property when it is missing from the prototype chain and define is omitted', () => {
+        const change = {
+            type: 'descriptor',
+            value: { type: 'function', functionName: 'noop' },
+        };
+        apiManipulation.wrapApiDescriptor(dummyTarget, 'missingMethod', change);
+        expect(dummyTarget.missingMethod).toBeUndefined();
+    });
+
+    it('applies MediaDevices-style apiChanges without define: true', () => {
+        const eventTargetProto = {
+            addEventListener: () => 'et-add',
+            removeEventListener: () => 'et-remove',
+        };
+        const mediaDevicesProto = Object.create(eventTargetProto);
+        Object.defineProperty(mediaDevicesProto, 'ondevicechange', {
+            get: () => 'original-handler',
+            set: () => {
+                throw new Error('original setter must not run');
+            },
+            configurable: true,
+            enumerable: true,
+        });
+        const target = Object.create(mediaDevicesProto);
+
+        const apiChanges = {
+            addEventListener: {
+                type: 'descriptor',
+                value: { type: 'function', functionName: 'noop' },
+            },
+            ondevicechange: {
+                type: 'descriptor',
+                getterValue: { type: 'undefined' },
+                setterValue: { type: 'function', functionName: 'noop' },
+            },
+            removeEventListener: {
+                type: 'descriptor',
+                value: { type: 'function', functionName: 'noop' },
+            },
+        };
+
+        for (const [key, change] of Object.entries(apiChanges)) {
+            apiManipulation.wrapApiDescriptor(target, key, change);
+        }
+
+        expect(Object.prototype.hasOwnProperty.call(target, 'addEventListener')).toBeTrue();
+        expect(target.addEventListener()).toBeUndefined();
+        expect(eventTargetProto.addEventListener()).toBe('et-add');
+
+        expect(Object.prototype.hasOwnProperty.call(target, 'removeEventListener')).toBeTrue();
+        expect(target.removeEventListener()).toBeUndefined();
+        expect(eventTargetProto.removeEventListener()).toBe('et-remove');
+
+        expect(target.ondevicechange).toBeUndefined();
+        expect(() => {
+            target.ondevicechange = () => {};
+        }).not.toThrow();
+        expect(target.ondevicechange).toBeUndefined();
+    });
+
+    it('validates privacy-configuration #5215 MediaDevices apiChanges against schema', async () => {
+        const Ajv = (await import('ajv')).default;
+        const schemaGenerator = await import('ts-json-schema-generator');
+        const schema = schemaGenerator
+            .createGenerator({
+                path: path.resolve(__dirname, '../../node_modules/@duckduckgo/privacy-configuration/schema/config.ts'),
+            })
+            .createSchema('CurrentGenericConfig');
+        const validate = new Ajv({ allowUnionTypes: true }).compile(schema);
+        const config = {
+            readme: 'MediaDevices apiManipulation overrides from privacy-configuration #5215',
+            version: 1,
+            unprotectedTemporary: [],
+            features: {
+                apiManipulation: {
+                    state: 'enabled',
+                    exceptions: [],
+                    hash: '',
+                    settings: {
+                        apiChanges: {
+                            'MediaDevices.prototype.addEventListener': {
+                                type: 'descriptor',
+                                value: { type: 'function', functionName: 'noop' },
+                            },
+                            'MediaDevices.prototype.removeEventListener': {
+                                type: 'descriptor',
+                                value: { type: 'function', functionName: 'noop' },
+                            },
+                            'MediaDevices.prototype.ondevicechange': {
+                                type: 'descriptor',
+                                getterValue: { type: 'undefined' },
+                                setterValue: { type: 'function', functionName: 'noop' },
+                            },
+                        },
+                    },
+                },
+            },
+        };
+        const valid = validate(config);
+        if (!valid) {
+            throw new Error('Schema validation failed: ' + formatErrors(validate.errors));
+        }
+    });
+
     // --- setterValue: override the setter half of an accessor (for event-handler IDL
     // attributes such as `MediaDevices.prototype.ondevicechange`). Without this, the original
     // setter survives the spread-merge in wrapProperty and assigning to the property still

--- a/injected/unit-test/features.js
+++ b/injected/unit-test/features.js
@@ -170,6 +170,58 @@ describe('ApiManipulation', () => {
         expect(dummyTarget.getUserMedia()).toBeUndefined();
     });
 
+    it('replaces a DOM-style method value descriptor without define: true', () => {
+        const originalFn = function originalFn() {
+            return 'original';
+        };
+        Object.defineProperty(dummyTarget, 'getUserMedia', {
+            value: originalFn,
+            writable: true,
+            configurable: true,
+            enumerable: false,
+        });
+        const change = {
+            type: 'descriptor',
+            value: {
+                type: 'function',
+                functionValue: { type: 'string', value: 'overridden' },
+            },
+        };
+        apiManipulation.wrapApiDescriptor(dummyTarget, 'getUserMedia', change);
+        const descriptor = /** @type {PropertyDescriptor} */ (Object.getOwnPropertyDescriptor(dummyTarget, 'getUserMedia'));
+        expect(descriptor).toBeDefined();
+        expect(typeof descriptor.value).toBe('function');
+        expect(descriptor.value).not.toBe(originalFn);
+        expect(descriptor.value()).toBe('overridden');
+        // Original descriptor attributes are preserved through the merge in wrapProperty.
+        expect(descriptor.writable).toBeTrue();
+        expect(descriptor.configurable).toBeTrue();
+        expect(descriptor.enumerable).toBeFalse();
+    });
+
+    it('overrides an existing method value descriptor even when define: true is set', () => {
+        const originalFn = function originalFn() {
+            return 'original';
+        };
+        Object.defineProperty(dummyTarget, 'getUserMedia', {
+            value: originalFn,
+            writable: true,
+            configurable: true,
+            enumerable: false,
+        });
+        const change = {
+            type: 'descriptor',
+            value: {
+                type: 'function',
+                functionValue: { type: 'string', value: 'overridden' },
+            },
+            define: true,
+        };
+        apiManipulation.wrapApiDescriptor(dummyTarget, 'getUserMedia', change);
+        expect(dummyTarget.getUserMedia).not.toBe(originalFn);
+        expect(dummyTarget.getUserMedia()).toBe('overridden');
+    });
+
     it('defines a new method if define: true is set and property does not exist', () => {
         const change = {
             type: 'descriptor',

--- a/injected/unit-test/features.js
+++ b/injected/unit-test/features.js
@@ -477,6 +477,47 @@ describe('ApiManipulation', () => {
         expect(dummyTarget.ondevicechange).toBe('original-value');
     });
 
+    it('masks a setterValue replacement against the original setter', () => {
+        // Mirror an event-handler IDL accessor shape: when the original accessor
+        // exposes a native setter (e.g. `Element.prototype.onclick`), the
+        // replacement setter's observable identity (`toString()`, `.name`,
+        // `.length`) must mirror that original rather than expose our internal
+        // `setter(v) {...}` shape.
+        let originalCalls = 0;
+        function originalOndevicechange(handler) {
+            originalCalls++;
+            return handler;
+        }
+        Object.defineProperty(dummyTarget, 'ondevicechange', {
+            get: () => null,
+            set: originalOndevicechange,
+            configurable: true,
+            enumerable: true,
+        });
+
+        const change = {
+            type: 'descriptor',
+            setterValue: { type: 'function', functionName: 'noop' },
+        };
+        apiManipulation.wrapApiDescriptor(dummyTarget, 'ondevicechange', change);
+
+        const wrapped = /** @type {PropertyDescriptor} */ (Object.getOwnPropertyDescriptor(dummyTarget, 'ondevicechange'));
+        expect(wrapped).toBeDefined();
+        const wrappedSetter = /** @type {(v:any) => void} */ (wrapped.set);
+        expect(typeof wrappedSetter).toBe('function');
+        // Descriptor inspection of `.set` must mirror the original setter rather
+        // than expose our JS `setter(v) {...}` shape.
+        expect(wrappedSetter.toString()).toBe(Function.prototype.toString.call(originalOndevicechange));
+        expect(wrappedSetter.toString()).toContain('originalOndevicechange');
+        expect(wrappedSetter.toString.toString()).toBe(Function.prototype.toString.toString());
+        expect(wrappedSetter.name).toBe('originalOndevicechange');
+        expect(wrappedSetter.length).toBe(originalOndevicechange.length);
+        // The configured override still swallows the assignment - the original
+        // setter is NOT invoked.
+        dummyTarget.ondevicechange = 'attempt';
+        expect(originalCalls).toBe(0);
+    });
+
     it('accepts descriptor changes that provide only setterValue', () => {
         // Validation must allow accessor-shape changes where only the setter is being overridden.
         const change = {

--- a/injected/unit-test/wrapper-utils.js
+++ b/injected/unit-test/wrapper-utils.js
@@ -1,4 +1,12 @@
-import { shimInterface, shimProperty, wrapProperty, wrapMethod, wrapFunction, wrapToString } from '../src/wrapper-utils.js';
+import {
+    mergePropertyDescriptors,
+    shimInterface,
+    shimProperty,
+    wrapProperty,
+    wrapMethod,
+    wrapFunction,
+    wrapToString,
+} from '../src/wrapper-utils.js';
 
 describe('Shim API', () => {
     // MediaSession is just an example, to make it close to reality
@@ -264,6 +272,24 @@ describe('Shim API', () => {
 
             expect(getter.toString()).toBe('function get mediaSession() { [native code] }');
         });
+    });
+});
+
+describe('mergePropertyDescriptors', () => {
+    it('merges compatible value descriptors', () => {
+        const orig = { value: () => 'orig', writable: true, configurable: true, enumerable: false };
+        const merged = mergePropertyDescriptors(orig, { value: () => 'new' });
+        expect(merged).toEqual({ value: jasmine.any(Function), writable: true, configurable: true, enumerable: false });
+    });
+
+    it('returns undefined when value is applied to an accessor descriptor', () => {
+        const orig = { get: () => 'orig', configurable: true, enumerable: true };
+        expect(mergePropertyDescriptors(orig, { value: 'mismatch' })).toBeUndefined();
+    });
+
+    it('returns undefined when accessor fields are applied to a value descriptor', () => {
+        const orig = { value: 'orig', writable: true, configurable: true, enumerable: true };
+        expect(mergePropertyDescriptors(orig, { get: () => 'mismatch' })).toBeUndefined();
     });
 });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,7 @@
     "injected": {
       "hasInstallScript": true,
       "dependencies": {
-        "@duckduckgo/privacy-configuration": "github:duckduckgo/privacy-configuration#1772634901001",
+        "@duckduckgo/privacy-configuration": "github:duckduckgo/privacy-configuration#1779290401870",
         "@duckduckgo/tracker-surrogates": "github:duckduckgo/tracker-surrogates#0528e3226df15b1a3e319ad68ef76612a8f26623",
         "esbuild": "^0.27.4",
         "minimist": "^1.2.8",
@@ -870,7 +870,7 @@
     },
     "node_modules/@duckduckgo/privacy-configuration": {
       "version": "1.0.0",
-      "resolved": "git+ssh://git@github.com/duckduckgo/privacy-configuration.git#1c1a5a413d25c32ecf5ba92dc5c1e5d1f89a6592",
+      "resolved": "git+ssh://git@github.com/duckduckgo/privacy-configuration.git#998ecf54b9cae1cf327dc2c26a543232cf45b1d4",
       "license": "Apache 2.0",
       "dependencies": {
         "eslint-plugin-json": "^4.0.1",


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/task/1214898456412755?focus=true

## Description

This should allow remote configuration of value descriptors that are functions.

## Testing Steps

Set the following config:

```json
                    {
                        "condition": [
                            {
                                "domain": "claude.ai"
                            }
                        ],
                        "patchSettings": [
                            {
                                "op": "add",
                                "path": "/apiChanges/MediaDevices.prototype.getUserMedia",
                                "value": {
                                    "type": "descriptor",
                                    "getterValue": {
                                        "type": "function",
                                        "functionName": "debug"
                                    }
                                }
                            }
                        ]
                    },
```



<img width="1772" height="1416" alt="image" src="https://github.com/user-attachments/assets/bb5b00b9-1a38-4443-93b6-ed0de5146b51" />


## Checklist

<!--
  These questions are a friendly reminder to shipping code, if you're uncertain ask the AoR owners.
  It's also totally appropriate to not check some of these boxes, if they don't apply to your change.
-->
*Please tick all that apply:*

- [ ] I have tested this change locally
- [ ] I have tested this change locally in all supported browsers
- [ ] This change will be visible to users
- [ ] I have added automated tests that cover this change
- [ ] I have ensured the change is gated by config
- [ ] This change was covered by a ship review
- [ ] This change was covered by a tech design
- [ ] Any dependent config has been merged




<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Expands DOM API override capabilities (including methods and setters) and changes descriptor wrapping/definition behavior, which could affect site compatibility or detection resistance if edge cases are missed. Risk is mitigated by extensive new unit tests and schema validation coverage.
> 
> **Overview**
> Enables remote `apiManipulation` config to override **value descriptors** (including methods) and **setter-only/accessor overrides** via new `value` and `setterValue` fields, with stricter validation to prevent mixing accessor/value descriptor shapes.
> 
> When overriding functions, replacements are now *masked* to preserve observable identity (`toString()`, `name`, `length`, including native-code appearance) and use captured globals (`Reflect.apply`, `Object.defineProperty`) to reduce page tampering. Inherited/prototype-chain properties can be overridden by shadow-defining an own property (without requiring `define: true`), using a new `mergePropertyDescriptors` helper shared by `wrapProperty`.
> 
> Updates the privacy-config dependency and adjusts an integration test config JSON shape; adds extensive unit tests for method replacement, inherited overrides, setter interception, and schema validation against updated privacy-configuration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d2209bb7f4fc0f8ffae14e9768eb06a83d6b7b0b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->