### PR TITLE
Gate inline Ask Duck.ai suggestion on enableAskAiSuggestion

### DIFF
--- a/special-pages/pages/new-tab/app/omnibar/components/Omnibar.js
+++ b/special-pages/pages/new-tab/app/omnibar/components/Omnibar.js
@@ -45,6 +45,7 @@ import { useSelectedReasoningEffort } from './useSelectedReasoningEffort';
  * @param {boolean} props.showViewAllAiChats
  * @param {boolean} props.showCustomizePopover
  * @param {boolean} [props.enableVoiceChatAccess]
+ * @param {boolean} [props.enableAskAiSuggestion]
  * @param {string|null|undefined} props.tabId
  */
 export function Omnibar({
@@ -55,6 +56,7 @@ export function Omnibar({
     showViewAllAiChats = false,
     showCustomizePopover,
     enableVoiceChatAccess = false,
+    enableAskAiSuggestion = true,
     tabId,
 }) {
     const { t } = useTypedTranslationWith(/** @type {Strings} */ ({}));
@@ -132,7 +134,7 @@ export function Omnibar({
                     )}
                 </div>
             )}
-            <SearchFormProvider term={query} setTerm={setQuery} enableAi={enableAi}>
+            <SearchFormProvider term={query} setTerm={setQuery} enableAi={enableAi} enableAskAiSuggestion={enableAskAiSuggestion}>
                 <AiChatsProvider
                     query={query}
                     autoFocus={autoFocus}

--- a/special-pages/pages/new-tab/app/omnibar/components/OmnibarConsumer.js
+++ b/special-pages/pages/new-tab/app/omnibar/components/OmnibarConsumer.js
@@ -57,6 +57,7 @@ function OmnibarReadyState({ config, tabId }) {
         enableRecentAiChats = false,
         showViewAllAiChats = false,
         enableVoiceChatAccess = false,
+        enableAskAiSuggestion = true,
         mode: defaultMode,
     } = config;
     const { setMode } = useContext(OmnibarContext);
@@ -71,6 +72,7 @@ function OmnibarReadyState({ config, tabId }) {
             showViewAllAiChats={showViewAllAiChats}
             showCustomizePopover={showCustomizePopover}
             enableVoiceChatAccess={enableVoiceChatAccess}
+            enableAskAiSuggestion={enableAskAiSuggestion}
             tabId={tabId}
         />
     );

--- a/special-pages/pages/new-tab/app/omnibar/components/SearchFormProvider.js
+++ b/special-pages/pages/new-tab/app/omnibar/components/SearchFormProvider.js
@@ -23,10 +23,11 @@ export const SearchFormContext = createContext(null);
  * @param {string} props.term
  * @param {(term: string) => void} props.setTerm
  * @param {boolean} props.enableAi
+ * @param {boolean} [props.enableAskAiSuggestion]
  * @param {import('preact').ComponentChildren} props.children
  */
-export function SearchFormProvider({ term, setTerm, enableAi, children }) {
-    const suggestions = useSuggestions({ term, setTerm, enableAi });
+export function SearchFormProvider({ term, setTerm, enableAi, enableAskAiSuggestion = true, children }) {
+    const suggestions = useSuggestions({ term, setTerm, enableAi, enableAskAiSuggestion });
     const suggestionsListId = useId();
     return (
         <SearchFormContext.Provider

--- a/special-pages/pages/new-tab/app/omnibar/components/useSuggestions.js
+++ b/special-pages/pages/new-tab/app/omnibar/components/useSuggestions.js
@@ -124,8 +124,9 @@ function reducer(state, action) {
  * @param {string} props.term
  * @param {(term: string) => void} props.setTerm
  * @param {boolean} props.enableAi
+ * @param {boolean} [props.enableAskAiSuggestion]
  */
-export function useSuggestions({ term, setTerm, enableAi }) {
+export function useSuggestions({ term, setTerm, enableAi, enableAskAiSuggestion = true }) {
     const { onSuggestions, getSuggestions } = useContext(OmnibarContext);
     const [state, dispatch] = useReducer(reducer, initialState);
 
@@ -141,7 +142,7 @@ export function useSuggestions({ term, setTerm, enableAi }) {
                 id: `suggestion-${index}`,
             }));
 
-            if (term.trim().length > 0 && enableAi) {
+            if (term.trim().length > 0 && enableAi && enableAskAiSuggestion) {
                 suggestions.push({
                     kind: 'aiChat',
                     chat: term,
@@ -155,7 +156,7 @@ export function useSuggestions({ term, setTerm, enableAi }) {
                 suggestions,
             });
         });
-    }, [onSuggestions, enableAi]);
+    }, [onSuggestions, enableAi, enableAskAiSuggestion]);
 
     const selectedSuggestion = state.selectedIndex !== null ? state.suggestions[state.selectedIndex] : null;
 

--- a/special-pages/pages/new-tab/app/omnibar/integration-tests/omnibar.spec.js
+++ b/special-pages/pages/new-tab/app/omnibar/integration-tests/omnibar.spec.js
@@ -376,6 +376,47 @@ test.describe('omnibar widget', () => {
         await expect(omnibar.suggestions().getByText('pizza dough – Ask Duck.ai')).not.toBeVisible();
     });
 
+    test('suggestions do not include Ask Duck.ai entry when enableAskAiSuggestion is false', async ({ page }, workerInfo) => {
+        const ntp = NewtabPage.create(page, workerInfo);
+        const omnibar = new OmnibarPage(ntp);
+        await ntp.reducedMotion();
+
+        await ntp.openPage({ additional: { omnibar: true, 'omnibar.enableAskAiSuggestion': false } });
+        await omnibar.ready();
+
+        await omnibar.searchInput().fill('pizza dough');
+        await omnibar.waitForSuggestions();
+
+        // Mode pills are still visible — enableAi defaults to true and is unaffected
+        await expect(omnibar.tabList()).toBeVisible();
+        // Inline Ask Duck.ai entry is gone
+        await expect(omnibar.suggestions().getByText('pizza dough – Ask Duck.ai')).not.toBeVisible();
+    });
+
+    test('Ask Duck.ai suggestion reacts live to enableAskAiSuggestion config update', async ({ page }, workerInfo) => {
+        const ntp = NewtabPage.create(page, workerInfo);
+        const omnibar = new OmnibarPage(ntp);
+        await ntp.reducedMotion();
+
+        await ntp.openPage({ additional: { omnibar: true } });
+        await omnibar.ready();
+
+        // Default (missing → true): Ask Duck.ai entry is visible
+        await omnibar.searchInput().fill('pizza dough');
+        await omnibar.waitForSuggestions();
+        await expect(omnibar.suggestions().getByText('pizza dough – Ask Duck.ai')).toBeVisible();
+
+        // Native pushes a config update disabling the suggestion
+        await omnibar.didReceiveConfig({ mode: 'search', enableAi: true, enableAskAiSuggestion: false });
+
+        // Re-trigger suggestions; entry is gone, mode pills still visible
+        await omnibar.searchInput().fill('');
+        await omnibar.searchInput().fill('pizza dough');
+        await omnibar.waitForSuggestions();
+        await expect(omnibar.suggestions().getByText('pizza dough – Ask Duck.ai')).not.toBeVisible();
+        await expect(omnibar.tabList()).toBeVisible();
+    });
+
     test('suggestions list arrow down navigation', async ({ page }, workerInfo) => {
         const ntp = NewtabPage.create(page, workerInfo);
         const omnibar = new OmnibarPage(ntp);

--- a/special-pages/pages/new-tab/app/omnibar/mocks/omnibar.mock-transport.js
+++ b/special-pages/pages/new-tab/app/omnibar/mocks/omnibar.mock-transport.js
@@ -159,6 +159,7 @@ export function omnibarMockTransport() {
         ],
         showViewAllAiChats: false,
         enableVoiceChatAccess: false,
+        enableAskAiSuggestion: true,
     };
 
     /** @type {Map<string, (d: any) => void>} */
@@ -223,6 +224,7 @@ export function omnibarMockTransport() {
                         parseReasoningEffortQueryParam('omnibar.selectedReasoningEffort') ?? config.selectedReasoningEffort;
                     config.showViewAllAiChats = parseBooleanQueryParam('omnibar.showViewAllAiChats') ?? config.showViewAllAiChats;
                     config.enableVoiceChatAccess = parseBooleanQueryParam('omnibar.enableVoiceChatAccess') ?? config.enableVoiceChatAccess;
+                    config.enableAskAiSuggestion = parseBooleanQueryParam('omnibar.enableAskAiSuggestion') ?? config.enableAskAiSuggestion;
                     return config;
                 }
                 case 'omnibar_getSuggestions': {

--- a/special-pages/pages/new-tab/app/omnibar/omnibar.md
+++ b/special-pages/pages/new-tab/app/omnibar/omnibar.md
@@ -35,6 +35,7 @@ title: Omnibar Widget
   - `enableImageGeneration` — shows "Create Image" in the tools menu (default `false`)
   - `enableWebSearch` — shows "Web Search" in the tools menu (default `false`)
   - `enableVoiceChatAccess` — when true and the input is empty, replaces the AI chat submit button with a 1-click voice-chat button. Click/Enter sends `omnibar_submitChat` with an empty `chat` and `mode: "voice-mode"` — native handles the voice handoff (default `false`)
+  - `enableAskAiSuggestion` — when `false`, hides the inline "Ask Duck.ai: <query>" entry in the suggestions dropdown. Missing/undefined is treated as `true` (default `true`). Does not affect the Duck.ai mode pill or any other AI affordance — those remain governed by `enableAi`
   - `aiModelSections` — array of model sections for the model selector. Each model may include `supportedReasoningEffort` (e.g. `["none", "low", "medium"]`) to surface the reasoning picker
   - `selectedModelId` — the user's persisted model choice
   - `selectedReasoningEffort` — the user's persisted reasoning-effort choice for the active model. Native validates against the model's `supportedReasoningEffort` on write
@@ -45,7 +46,8 @@ title: Omnibar Widget
    "enableAiChatTools": false,
    "enableImageGeneration": false,
    "enableWebSearch": false,
-   "enableVoiceChatAccess": false
+   "enableVoiceChatAccess": false,
+   "enableAskAiSuggestion": true
 }
 ```
 

--- a/special-pages/pages/new-tab/messages/types/omnibar-config.json
+++ b/special-pages/pages/new-tab/messages/types/omnibar-config.json
@@ -130,6 +130,12 @@
       "description": "Show a 1-click voice-chat button in place of the AI chat submit button when the input is empty.",
       "type": "boolean",
       "default": false
+    },
+    "enableAskAiSuggestion": {
+      "title": "Enable Ask Duck.ai Suggestion",
+      "description": "Controls whether the inline 'Ask Duck.ai: <query>' suggestion is rendered in the omnibar dropdown. Missing/undefined is treated as true for back-compat with older native clients. Does not affect the Duck.ai mode pill or any other AI affordance — those remain governed by enableAi.",
+      "type": "boolean",
+      "default": true
     }
   }
 }

--- a/special-pages/pages/new-tab/messages/types/omnibar-config.json
+++ b/special-pages/pages/new-tab/messages/types/omnibar-config.json
@@ -133,7 +133,7 @@
     },
     "enableAskAiSuggestion": {
       "title": "Enable Ask Duck.ai Suggestion",
-      "description": "Controls whether the inline 'Ask Duck.ai: <query>' suggestion is rendered in the omnibar dropdown. Missing/undefined is treated as true for back-compat with older native clients. Does not affect the Duck.ai mode pill or any other AI affordance — those remain governed by enableAi.",
+      "description": "Controls whether the inline 'Ask Duck.ai: <query>' suggestion is rendered in the omnibar dropdown. Missing/undefined is treated as true for backward compatibility. Does not affect the Duck.ai mode pill or any other AI affordance — those remain governed by enableAi.",
       "type": "boolean",
       "default": true
     }

--- a/special-pages/pages/new-tab/types/new-tab.ts
+++ b/special-pages/pages/new-tab/types/new-tab.ts
@@ -111,7 +111,7 @@ export type EnableWebSearch = boolean;
  */
 export type EnableVoiceChatAccess = boolean;
 /**
- * Controls whether the inline 'Ask Duck.ai: <query>' suggestion is rendered in the omnibar dropdown. Missing/undefined is treated as true for back-compat with older native clients. Does not affect the Duck.ai mode pill or any other AI affordance — those remain governed by enableAi.
+ * Controls whether the inline 'Ask Duck.ai: <query>' suggestion is rendered in the omnibar dropdown. Missing/undefined is treated as true for backward compatibility. Does not affect the Duck.ai mode pill or any other AI affordance — those remain governed by enableAi.
  */
 export type EnableAskDuckAiSuggestion = boolean;
 export type FeedType = "privacy-stats" | "activity";

--- a/special-pages/pages/new-tab/types/new-tab.ts
+++ b/special-pages/pages/new-tab/types/new-tab.ts
@@ -110,6 +110,10 @@ export type EnableWebSearch = boolean;
  * Show a 1-click voice-chat button in place of the AI chat submit button when the input is empty.
  */
 export type EnableVoiceChatAccess = boolean;
+/**
+ * Controls whether the inline 'Ask Duck.ai: <query>' suggestion is rendered in the omnibar dropdown. Missing/undefined is treated as true for back-compat with older native clients. Does not affect the Duck.ai mode pill or any other AI affordance — those remain governed by enableAi.
+ */
+export type EnableAskDuckAiSuggestion = boolean;
 export type FeedType = "privacy-stats" | "activity";
 /**
  * The visibility state of the widget, as configured by the user
@@ -631,6 +635,7 @@ export interface OmnibarConfig {
   enableImageGeneration?: EnableImageGeneration;
   enableWebSearch?: EnableWebSearch;
   enableVoiceChatAccess?: EnableVoiceChatAccess;
+  enableAskAiSuggestion?: EnableAskDuckAiSuggestion;
 }
 /**
  * A section of AI models with an optional header and a list of model items.


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1148564399326804/task/1213453546415638

**Native PR:** https://github.com/duckduckgo/apple-browsers/pull/4958 (commit `d872a34869` adds the `enableAskAiSuggestion` field)

## Description

The macOS DuckDuckGo browser has a user-facing toggle **Settings → Private Search → "Autocomplete suggestions"**. When OFF, the address bar correctly hides its entire suggestions dropdown — including the inline "Ask Duck.ai" entry. But on the **NTP omnibar**, the inline "Ask Duck.ai: `<query>`" entry still appears. This PR makes the NTP match the address bar.

Native PR #4958 adds a new optional `enableAskAiSuggestion: Bool?` field to `OmnibarConfig`, delivered via `omnibar_getConfig` and `omnibar_onConfigUpdate`. This PR wires JS to read it.

**Semantics**
- `true` → render the entry as today
- `false` → do NOT render it
- missing / undefined → treat as `true` (back-compat with older native that doesn't send the field)

**Scope**
- The Duck.ai mode pills at the top of the omnibar are untouched (still gated by `enableAi`).
- The inline "Ask Duck.ai: `<query>`" entry inside the suggestions dropdown is the only thing gated by the new flag.
- Live updates via `omnibar_onConfigUpdate` work the same way as `enableAi` / `enableVoiceChatAccess`.

**Where the gate lives**
- `useSuggestions.js`: the condition that pushes the inline `aiChat` suggestion now ANDs in `enableAskAiSuggestion` (defaulted to `true` at the consumer boundary, matching the existing convention for `enableAi`).
- The prop is threaded `OmnibarConsumer → Omnibar → SearchFormProvider → useSuggestions`, mirroring the existing path used by `enableAi`.

## Testing Steps

- `npm run lint` — passes (no new warnings)
- `npm run test-unit` — 104/104 pass
- `npm run test-int -- pages/new-tab/app/omnibar/integration-tests --reporter list` — 112/112 pass (includes 2 new tests + 110 regressions)
- `npm run test-int -- pages/new-tab/app/omnibar/integration-tests/omnibar.persistence.spec.js --reporter list` — 5/5 pass
- Manual smoke (optional): `npm run watch -- --page new-tab` and visit `?omnibar=true&omnibar.enableAskAiSuggestion=false` — mode pills stay, inline Ask Duck.ai entry is gone. Visit without the param: default behaviour (entry visible).
- Native validation (after this lands and apple-browsers #4958 is built locally):
  - Settings → Private Search → toggle Autocomplete suggestions OFF → new tab → type → no inline entry
  - Toggle ON without reloading → type again → entry reappears
  - With an older native build (no `enableAskAiSuggestion` field) → entry still appears (back-compat)

## Checklist

- [x] I have tested this change locally
- [ ] I have tested this change locally in all supported browsers
- [x] This change will be visible to users
- [x] I have added automated tests that cover this change
- [x] I have ensured the change is gated by config
- [ ] This change was covered by a ship review
- [ ] This change was covered by a tech design
- [ ] Any dependent config has been merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small, config-gated UI behavior change limited to suggestion rendering, with added integration coverage for config updates and backwards-compatible defaults.
> 
> **Overview**
> Adds a new `enableAskAiSuggestion` config flag (defaulting to `true`) that specifically controls whether the omnibar suggestions dropdown includes the inline “Ask Duck.ai: <query>” entry.
> 
> Threads the flag from config (`OmnibarConsumer` → `Omnibar` → `SearchFormProvider` → `useSuggestions`) and updates mocks/docs/schema/types accordingly, plus adds integration tests for disabling the entry and for live `omnibar_onConfigUpdate` changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 683613bbf53680d86b7b46ec5a4eb74b48a08492. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->