### PR TITLE
Change next step card action from "Open YouTube" to "Visit YouTube"

### DIFF
--- a/special-pages/pages/new-tab/app/next-steps-list/strings.json
+++ b/special-pages/pages/new-tab/app/next-steps-list/strings.json
@@ -64,7 +64,7 @@
     "note": "Summary of the Next Steps List card for YouTube ad blocking"
   },
   "nextStepsList_youtubeAdBlocking_actionText": {
-    "title": "Open YouTube",
+    "title": "Visit YouTube",
     "note": "Button text of the Next Steps List card for YouTube ad blocking"
   },
   "nextStepsList_emailProtection_title": {

--- a/special-pages/pages/new-tab/app/next-steps/strings.json
+++ b/special-pages/pages/new-tab/app/next-steps/strings.json
@@ -72,7 +72,7 @@
     "note": "Summary of the Next Steps card for YouTube ad blocking"
   },
   "nextSteps_youtubeAdBlocking_actionText": {
-    "title": "Open YouTube",
+    "title": "Visit YouTube",
     "note": "Button text of the Next Steps card for YouTube ad blocking"
   },
   "nextSteps_addAppDockMac_title": {

--- a/special-pages/pages/new-tab/public/locales/de/new-tab.json
+++ b/special-pages/pages/new-tab/public/locales/de/new-tab.json
@@ -386,7 +386,7 @@
     "note": "Summary of the Next Steps List card for YouTube ad blocking"
   },
   "nextStepsList_youtubeAdBlocking_actionText": {
-    "title": "YouTube öffnen",
+    "title": "YouTube besuchen",
     "note": "Button text of the Next Steps List card for YouTube ad blocking"
   },
   "nextStepsList_emailProtection_title": {
@@ -522,7 +522,7 @@
     "note": "Summary of the Next Steps card for YouTube ad blocking"
   },
   "nextSteps_youtubeAdBlocking_actionText": {
-    "title": "YouTube öffnen",
+    "title": "YouTube besuchen",
     "note": "Button text of the Next Steps card for YouTube ad blocking"
   },
   "nextSteps_addAppDockMac_title": {

--- a/special-pages/pages/new-tab/public/locales/en/new-tab.json
+++ b/special-pages/pages/new-tab/public/locales/en/new-tab.json
@@ -390,7 +390,7 @@
     "note": "Summary of the Next Steps List card for YouTube ad blocking"
   },
   "nextStepsList_youtubeAdBlocking_actionText": {
-    "title": "Open YouTube",
+    "title": "Visit YouTube",
     "note": "Button text of the Next Steps List card for YouTube ad blocking"
   },
   "nextStepsList_emailProtection_title": {
@@ -526,7 +526,7 @@
     "note": "Summary of the Next Steps card for YouTube ad blocking"
   },
   "nextSteps_youtubeAdBlocking_actionText": {
-    "title": "Open YouTube",
+    "title": "Visit YouTube",
     "note": "Button text of the Next Steps card for YouTube ad blocking"
   },
   "nextSteps_addAppDockMac_title": {

--- a/special-pages/pages/new-tab/public/locales/es/new-tab.json
+++ b/special-pages/pages/new-tab/public/locales/es/new-tab.json
@@ -386,7 +386,7 @@
     "note": "Summary of the Next Steps List card for YouTube ad blocking"
   },
   "nextStepsList_youtubeAdBlocking_actionText": {
-    "title": "Abre YouTube",
+    "title": "Visitar YouTube",
     "note": "Button text of the Next Steps List card for YouTube ad blocking"
   },
   "nextStepsList_emailProtection_title": {
@@ -522,7 +522,7 @@
     "note": "Summary of the Next Steps card for YouTube ad blocking"
   },
   "nextSteps_youtubeAdBlocking_actionText": {
-    "title": "Abre YouTube",
+    "title": "Visitar YouTube",
     "note": "Button text of the Next Steps card for YouTube ad blocking"
   },
   "nextSteps_addAppDockMac_title": {

--- a/special-pages/pages/new-tab/public/locales/fr/new-tab.json
+++ b/special-pages/pages/new-tab/public/locales/fr/new-tab.json
@@ -386,7 +386,7 @@
     "note": "Summary of the Next Steps List card for YouTube ad blocking"
   },
   "nextStepsList_youtubeAdBlocking_actionText": {
-    "title": "Ouvrir YouTube",
+    "title": "Accéder à YouTube",
     "note": "Button text of the Next Steps List card for YouTube ad blocking"
   },
   "nextStepsList_emailProtection_title": {
@@ -522,7 +522,7 @@
     "note": "Summary of the Next Steps card for YouTube ad blocking"
   },
   "nextSteps_youtubeAdBlocking_actionText": {
-    "title": "Ouvrir YouTube",
+    "title": "Accéder à YouTube",
     "note": "Button text of the Next Steps card for YouTube ad blocking"
   },
   "nextSteps_addAppDockMac_title": {

--- a/special-pages/pages/new-tab/public/locales/it/new-tab.json
+++ b/special-pages/pages/new-tab/public/locales/it/new-tab.json
@@ -386,7 +386,7 @@
     "note": "Summary of the Next Steps List card for YouTube ad blocking"
   },
   "nextStepsList_youtubeAdBlocking_actionText": {
-    "title": "Apri YouTube",
+    "title": "Visita YouTube",
     "note": "Button text of the Next Steps List card for YouTube ad blocking"
   },
   "nextStepsList_emailProtection_title": {
@@ -522,7 +522,7 @@
     "note": "Summary of the Next Steps card for YouTube ad blocking"
   },
   "nextSteps_youtubeAdBlocking_actionText": {
-    "title": "Apri YouTube",
+    "title": "Visita YouTube",
     "note": "Button text of the Next Steps card for YouTube ad blocking"
   },
   "nextSteps_addAppDockMac_title": {

--- a/special-pages/pages/new-tab/public/locales/nl/new-tab.json
+++ b/special-pages/pages/new-tab/public/locales/nl/new-tab.json
@@ -386,7 +386,7 @@
     "note": "Summary of the Next Steps List card for YouTube ad blocking"
   },
   "nextStepsList_youtubeAdBlocking_actionText": {
-    "title": "YouTube openen",
+    "title": "Bezoek YouTube",
     "note": "Button text of the Next Steps List card for YouTube ad blocking"
   },
   "nextStepsList_emailProtection_title": {
@@ -522,7 +522,7 @@
     "note": "Summary of the Next Steps card for YouTube ad blocking"
   },
   "nextSteps_youtubeAdBlocking_actionText": {
-    "title": "YouTube openen",
+    "title": "Bezoek YouTube",
     "note": "Button text of the Next Steps card for YouTube ad blocking"
   },
   "nextSteps_addAppDockMac_title": {

--- a/special-pages/pages/new-tab/public/locales/pl/new-tab.json
+++ b/special-pages/pages/new-tab/public/locales/pl/new-tab.json
@@ -386,7 +386,7 @@
     "note": "Summary of the Next Steps List card for YouTube ad blocking"
   },
   "nextStepsList_youtubeAdBlocking_actionText": {
-    "title": "Otwórz YouTube",
+    "title": "Odwiedź YouTube",
     "note": "Button text of the Next Steps List card for YouTube ad blocking"
   },
   "nextStepsList_emailProtection_title": {
@@ -522,7 +522,7 @@
     "note": "Summary of the Next Steps card for YouTube ad blocking"
   },
   "nextSteps_youtubeAdBlocking_actionText": {
-    "title": "Otwórz YouTube",
+    "title": "Odwiedź YouTube",
     "note": "Button text of the Next Steps card for YouTube ad blocking"
   },
   "nextSteps_addAppDockMac_title": {

--- a/special-pages/pages/new-tab/public/locales/pt/new-tab.json
+++ b/special-pages/pages/new-tab/public/locales/pt/new-tab.json
@@ -386,7 +386,7 @@
     "note": "Summary of the Next Steps List card for YouTube ad blocking"
   },
   "nextStepsList_youtubeAdBlocking_actionText": {
-    "title": "Abrir o YouTube",
+    "title": "Visita o YouTube",
     "note": "Button text of the Next Steps List card for YouTube ad blocking"
   },
   "nextStepsList_emailProtection_title": {
@@ -522,7 +522,7 @@
     "note": "Summary of the Next Steps card for YouTube ad blocking"
   },
   "nextSteps_youtubeAdBlocking_actionText": {
-    "title": "Abrir o YouTube",
+    "title": "Visita o YouTube",
     "note": "Button text of the Next Steps card for YouTube ad blocking"
   },
   "nextSteps_addAppDockMac_title": {

--- a/special-pages/pages/new-tab/public/locales/ru/new-tab.json
+++ b/special-pages/pages/new-tab/public/locales/ru/new-tab.json
@@ -386,7 +386,7 @@
     "note": "Summary of the Next Steps List card for YouTube ad blocking"
   },
   "nextStepsList_youtubeAdBlocking_actionText": {
-    "title": "Открыть YouTube",
+    "title": "Откройте YouTube",
     "note": "Button text of the Next Steps List card for YouTube ad blocking"
   },
   "nextStepsList_emailProtection_title": {
@@ -522,7 +522,7 @@
     "note": "Summary of the Next Steps card for YouTube ad blocking"
   },
   "nextSteps_youtubeAdBlocking_actionText": {
-    "title": "Открыть YouTube",
+    "title": "Откройте YouTube",
     "note": "Button text of the Next Steps card for YouTube ad blocking"
   },
   "nextSteps_addAppDockMac_title": {


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/38424471409662/task/1214934618730802?focus=true

## Description

Updates the action button text on the YouTube ad blocking Next Steps card from "Open YouTube" to "Visit YouTube". Applies to both the `next-steps` and `next-steps-list` variants. The compiled `public/locales/en/new-tab.json` is regenerated from the source `strings.json` files.

## Testing Steps

- Open the New Tab page and find the YouTube ad blocking Next Steps card (both the `next-steps` and `next-steps-list` variants).
- Confirm the action button reads "Visit YouTube".

## Checklist

*Please tick all that apply:*

- [x] I have tested this change locally
- [ ] I have tested this change locally in all supported browsers
- [x] This change will be visible to users
- [ ] I have added automated tests that cover this change
- [ ] I have ensured the change is gated by config
- [ ] This change was covered by a ship review
- [ ] This change was covered by a tech design
- [ ] Any dependent config has been merged

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk copy-only localization updates; no logic changes, data handling, or security impact.
> 
> **Overview**
> Updates the YouTube ad-blocking Next Steps CTA text from **"Open YouTube"** to **"Visit YouTube"** for both `next-steps` and `next-steps-list`.
> 
> Regenerates the corresponding localized strings in `public/locales/*/new-tab.json` (including English and multiple translated locales) to reflect the updated button label.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 592d24e7c0ae2c953a9e3b1844c088e37ec5be57. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->