### PR TITLE
Skip Semver Label workflow for Dependabot PRs

### DIFF
--- a/.github/workflows/semver-label.yml
+++ b/.github/workflows/semver-label.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
     semver_label:
-        if: ${{ !github.event.pull_request.head.repo.fork }}
+        if: ${{ !github.event.pull_request.head.repo.fork && github.event.pull_request.user.login != 'dependabot[bot]' }}
         runs-on: ubuntu-latest
         steps:
             - name: Checkout base branch


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

The Semver Label workflow runs builds and LLM-based semver analysis on every non-fork PR. Dependabot dependency updates do not need semver classification or `semver-*` labels.

This adds a job-level condition to skip the workflow when `pull_request.user.login` is `dependabot[bot]`, consistent with `dependabot-auto-merge.yml` and `auto-respond-pr.yml`.

## Testing Steps

- Open or sync a Dependabot PR and confirm the "Semver Label" workflow is skipped (not failed).
- Open a normal contributor PR and confirm the workflow still runs.

## Checklist

- [ ] I have tested this change locally — N/A (workflow-only change)
- [ ] I have tested this change locally in all supported browsers — N/A
- [ ] This change will be visible to users — No
- [ ] I have added automated tests that cover this change — N/A
- [ ] I have ensured the change is gated by config — N/A
- [ ] This change was covered by a ship review — N/A
- [ ] This change was covered by a tech design — N/A
- [ ] Any dependent config has been merged — N/A
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-aafad6b3-68d6-44a4-808d-e92075a439ca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-aafad6b3-68d6-44a4-808d-e92075a439ca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

