### PR TITLE
Return synthetic enumerateDevices list on messaging timeout

### DIFF
--- a/injected/integration-test/device-enumeration.spec.js
+++ b/injected/integration-test/device-enumeration.spec.js
@@ -255,7 +255,7 @@ test.describe('Device Enumeration Feature', () => {
             expect(result.audioCapabilitiesAfterDelete).toEqual({});
         });
 
-        test('should reject instead of calling native enumerateDevices when messaging times out', async ({ page }) => {
+        test('should return synthetic devices instead of calling native enumerateDevices when messaging times out', async ({ page }) => {
             await gotoAndWait(page, '/blank.html', {
                 site: {
                     enabledFeatures: ['webCompat'],
@@ -275,20 +275,22 @@ test.describe('Device Enumeration Feature', () => {
             });
 
             const result = await page.evaluate(async () => {
-                try {
-                    await navigator.mediaDevices.enumerateDevices();
-                    return { rejected: false };
-                } catch (error) {
-                    return {
-                        rejected: true,
-                        errorMessage: error instanceof Error ? error.message : String(error),
-                    };
-                }
+                const devices = await navigator.mediaDevices.enumerateDevices();
+                return {
+                    count: devices.length,
+                    kinds: devices.map((device) => device.kind).sort(),
+                    labels: devices.map((device) => device.label),
+                    inputDevicesAreInputDeviceInfo: devices
+                        .filter((device) => device.kind === 'audioinput' || device.kind === 'videoinput')
+                        .every((device) => device instanceof InputDeviceInfo),
+                };
             });
 
             expect(result).toEqual({
-                rejected: true,
-                errorMessage: 'Request timeout',
+                count: 2,
+                kinds: ['audioinput', 'videoinput'],
+                labels: ['', ''],
+                inputDevicesAreInputDeviceInfo: true,
             });
         });
 

--- a/injected/integration-test/device-enumeration.spec.js
+++ b/injected/integration-test/device-enumeration.spec.js
@@ -287,9 +287,9 @@ test.describe('Device Enumeration Feature', () => {
             });
 
             expect(result).toEqual({
-                count: 2,
-                kinds: ['audioinput', 'videoinput'],
-                labels: ['', ''],
+                count: 3,
+                kinds: ['audioinput', 'audiooutput', 'videoinput'],
+                labels: ['', '', ''],
                 inputDevicesAreInputDeviceInfo: true,
             });
         });
@@ -319,8 +319,8 @@ test.describe('Device Enumeration Feature', () => {
             });
 
             expect(result).toEqual({
-                count: 2,
-                kinds: ['audioinput', 'videoinput'],
+                count: 3,
+                kinds: ['audioinput', 'audiooutput', 'videoinput'],
             });
         });
 

--- a/injected/integration-test/device-enumeration.spec.js
+++ b/injected/integration-test/device-enumeration.spec.js
@@ -255,6 +255,43 @@ test.describe('Device Enumeration Feature', () => {
             expect(result.audioCapabilitiesAfterDelete).toEqual({});
         });
 
+        test('should reject instead of calling native enumerateDevices when messaging times out', async ({ page }) => {
+            await gotoAndWait(page, '/blank.html', {
+                site: {
+                    enabledFeatures: ['webCompat'],
+                },
+                featureSettings: {
+                    webCompat: {
+                        enumerateDevices: {
+                            state: 'enabled',
+                            timeoutMs: 50,
+                        },
+                    },
+                },
+            });
+
+            await page.evaluate(() => {
+                globalThis.cssMessaging.impl.request = () => new Promise(() => {});
+            });
+
+            const result = await page.evaluate(async () => {
+                try {
+                    await navigator.mediaDevices.enumerateDevices();
+                    return { rejected: false };
+                } catch (error) {
+                    return {
+                        rejected: true,
+                        errorMessage: error instanceof Error ? error.message : String(error),
+                    };
+                }
+            });
+
+            expect(result).toEqual({
+                rejected: true,
+                errorMessage: 'Request timeout',
+            });
+        });
+
         test('shimMode=instanceOwn preserves the prototype identity and exposes an own shim', async ({ page }) => {
             await gotoAndWait(page, '/blank.html', {
                 site: {

--- a/injected/integration-test/device-enumeration.spec.js
+++ b/injected/integration-test/device-enumeration.spec.js
@@ -255,7 +255,7 @@ test.describe('Device Enumeration Feature', () => {
             expect(result.audioCapabilitiesAfterDelete).toEqual({});
         });
 
-        test('should return synthetic devices instead of calling native enumerateDevices when messaging times out', async ({ page }) => {
+        test('should return synthetic devices when deviceEnumeration messaging times out', async ({ page }) => {
             await gotoAndWait(page, '/blank.html', {
                 site: {
                     enabledFeatures: ['webCompat'],
@@ -291,6 +291,36 @@ test.describe('Device Enumeration Feature', () => {
                 kinds: ['audioinput', 'videoinput'],
                 labels: ['', ''],
                 inputDevicesAreInputDeviceInfo: true,
+            });
+        });
+
+        test('should return synthetic devices when deviceEnumeration messaging rejects', async ({ page }) => {
+            await gotoAndWait(page, '/blank.html', {
+                site: {
+                    enabledFeatures: ['webCompat'],
+                },
+                featureSettings: {
+                    webCompat: {
+                        enumerateDevices: 'enabled',
+                    },
+                },
+            });
+
+            await page.evaluate(() => {
+                globalThis.cssMessaging.impl.request = () => Promise.reject(new Error('native handler unavailable'));
+            });
+
+            const result = await page.evaluate(async () => {
+                const devices = await navigator.mediaDevices.enumerateDevices();
+                return {
+                    count: devices.length,
+                    kinds: devices.map((device) => device.kind).sort(),
+                };
+            });
+
+            expect(result).toEqual({
+                count: 2,
+                kinds: ['audioinput', 'videoinput'],
             });
         });
 

--- a/injected/src/features/web-compat.js
+++ b/injected/src/features/web-compat.js
@@ -1318,7 +1318,11 @@ export class WebCompat extends ContentFeature {
                         return DDGReflect.apply(target, thisArg, args);
                     }
                 } catch (err) {
-                    // If the native request fails or times out, fall back to the original implementation
+                    // On timeout, reject rather than calling the native API (which can trigger permission prompts)
+                    if (err instanceof Error && err.message === 'Request timeout') {
+                        throw err;
+                    }
+                    // If the native request fails for other reasons, fall back to the original implementation
                     return DDGReflect.apply(target, thisArg, args);
                 }
             },

--- a/injected/src/features/web-compat.js
+++ b/injected/src/features/web-compat.js
@@ -25,14 +25,6 @@ const MSG_SCREEN_LOCK = 'screenLock';
 const MSG_SCREEN_UNLOCK = 'screenUnlock';
 const MSG_DEVICE_ENUMERATION = 'deviceEnumeration';
 
-/** Error used when the deviceEnumeration messaging request exceeds timeoutMs. */
-class DeviceEnumerationRequestTimeout extends Error {
-    constructor() {
-        super('Request timeout');
-        this.name = 'DeviceEnumerationRequestTimeout';
-    }
-}
-
 function canShare(data) {
     if (typeof data !== 'object') return false;
     // Make an in-place shallow copy of the data
@@ -1278,10 +1270,10 @@ export class WebCompat extends ContentFeature {
      * Helper to wrap a promise with timeout
      * @param {Promise} promise - Promise to wrap
      * @param {number} timeoutMs - Timeout in milliseconds
-     * @returns {Promise} Promise that rejects with {@link DeviceEnumerationRequestTimeout} on timeout
+     * @returns {Promise} Promise that rejects on timeout
      */
     withTimeout(promise, timeoutMs) {
-        const timeout = new Promise((_resolve, reject) => setTimeout(() => reject(new DeviceEnumerationRequestTimeout()), timeoutMs));
+        const timeout = new Promise((_resolve, reject) => setTimeout(() => reject(new Error('Request timeout')), timeoutMs));
         return Promise.race([promise, timeout]);
     }
 

--- a/injected/src/features/web-compat.js
+++ b/injected/src/features/web-compat.js
@@ -1257,6 +1257,16 @@ export class WebCompat extends ContentFeature {
     }
 
     /**
+     * Fallback device list when the deviceEnumeration messaging request times out.
+     * Mimics pre-permission enumerateDevices (unlabeled input devices) without calling native.
+     * @param {'syntheticPrototype' | 'instanceOwn'} shimMode
+     * @returns {MediaDeviceInfo[]}
+     */
+    createEnumerateDevicesTimeoutFallback(shimMode) {
+        return [this.createMediaDeviceInfo('audioinput', shimMode), this.createMediaDeviceInfo('videoinput', shimMode)];
+    }
+
+    /**
      * Helper to wrap a promise with timeout
      * @param {Promise} promise - Promise to wrap
      * @param {number} timeoutMs - Timeout in milliseconds
@@ -1318,9 +1328,9 @@ export class WebCompat extends ContentFeature {
                         return DDGReflect.apply(target, thisArg, args);
                     }
                 } catch (err) {
-                    // On timeout, reject rather than calling the native API (which can trigger permission prompts)
+                    // Messaging timed out — return a shimmed response instead of calling native enumerateDevices
                     if (err instanceof Error && err.message === 'Request timeout') {
-                        return Promise.reject(err);
+                        return Promise.resolve(this.createEnumerateDevicesTimeoutFallback(shimMode));
                     }
                     // If the native request fails for other reasons, fall back to the original implementation
                     return DDGReflect.apply(target, thisArg, args);

--- a/injected/src/features/web-compat.js
+++ b/injected/src/features/web-compat.js
@@ -25,6 +25,14 @@ const MSG_SCREEN_LOCK = 'screenLock';
 const MSG_SCREEN_UNLOCK = 'screenUnlock';
 const MSG_DEVICE_ENUMERATION = 'deviceEnumeration';
 
+/** Error used when the deviceEnumeration messaging request exceeds timeoutMs. */
+class DeviceEnumerationRequestTimeout extends Error {
+    constructor() {
+        super('Request timeout');
+        this.name = 'DeviceEnumerationRequestTimeout';
+    }
+}
+
 function canShare(data) {
     if (typeof data !== 'object') return false;
     // Make an in-place shallow copy of the data
@@ -1257,12 +1265,12 @@ export class WebCompat extends ContentFeature {
     }
 
     /**
-     * Fallback device list when the deviceEnumeration messaging request times out.
+     * Fallback device list when the deviceEnumeration messaging request fails.
      * Mimics pre-permission enumerateDevices (unlabeled input devices) without calling native.
      * @param {'syntheticPrototype' | 'instanceOwn'} shimMode
      * @returns {MediaDeviceInfo[]}
      */
-    createEnumerateDevicesTimeoutFallback(shimMode) {
+    createEnumerateDevicesFallback(shimMode) {
         return [this.createMediaDeviceInfo('audioinput', shimMode), this.createMediaDeviceInfo('videoinput', shimMode)];
     }
 
@@ -1270,10 +1278,10 @@ export class WebCompat extends ContentFeature {
      * Helper to wrap a promise with timeout
      * @param {Promise} promise - Promise to wrap
      * @param {number} timeoutMs - Timeout in milliseconds
-     * @returns {Promise} Promise that rejects on timeout
+     * @returns {Promise} Promise that rejects with {@link DeviceEnumerationRequestTimeout} on timeout
      */
     withTimeout(promise, timeoutMs) {
-        const timeout = new Promise((_resolve, reject) => setTimeout(() => reject(new Error('Request timeout')), timeoutMs));
+        const timeout = new Promise((_resolve, reject) => setTimeout(() => reject(new DeviceEnumerationRequestTimeout()), timeoutMs));
         return Promise.race([promise, timeout]);
     }
 
@@ -1327,13 +1335,10 @@ export class WebCompat extends ContentFeature {
                         // If no prompts would be required, proceed with the regular device enumeration
                         return DDGReflect.apply(target, thisArg, args);
                     }
-                } catch (err) {
-                    // Messaging timed out — return a shimmed response instead of calling native enumerateDevices
-                    if (err instanceof Error && err.message === 'Request timeout') {
-                        return Promise.resolve(this.createEnumerateDevicesTimeoutFallback(shimMode));
-                    }
-                    // If the native request fails for other reasons, fall back to the original implementation
-                    return DDGReflect.apply(target, thisArg, args);
+                } catch (_err) {
+                    // Messaging failed or timed out — return a shimmed response instead of calling native
+                    // enumerateDevices (we do not know willPrompt and native may trigger permission UI).
+                    return Promise.resolve(this.createEnumerateDevicesFallback(shimMode));
                 }
             },
         });

--- a/injected/src/features/web-compat.js
+++ b/injected/src/features/web-compat.js
@@ -1258,12 +1258,17 @@ export class WebCompat extends ContentFeature {
 
     /**
      * Fallback device list when the deviceEnumeration messaging request fails.
-     * Mimics pre-permission enumerateDevices (unlabeled input devices) without calling native.
+     * Mimics pre-permission enumerateDevices (unlabeled devices) without calling native.
+     * Includes audiooutput so sites can still detect speaker/output capability.
      * @param {'syntheticPrototype' | 'instanceOwn'} shimMode
      * @returns {MediaDeviceInfo[]}
      */
     createEnumerateDevicesFallback(shimMode) {
-        return [this.createMediaDeviceInfo('audioinput', shimMode), this.createMediaDeviceInfo('videoinput', shimMode)];
+        return [
+            this.createMediaDeviceInfo('videoinput', shimMode),
+            this.createMediaDeviceInfo('audioinput', shimMode),
+            this.createMediaDeviceInfo('audiooutput', shimMode),
+        ];
     }
 
     /**

--- a/injected/src/features/web-compat.js
+++ b/injected/src/features/web-compat.js
@@ -1320,7 +1320,7 @@ export class WebCompat extends ContentFeature {
                 } catch (err) {
                     // On timeout, reject rather than calling the native API (which can trigger permission prompts)
                     if (err instanceof Error && err.message === 'Request timeout') {
-                        throw err;
+                        return Promise.reject(err);
                     }
                     // If the native request fails for other reasons, fall back to the original implementation
                     return DDGReflect.apply(target, thisArg, args);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

When the `deviceEnumeration` messaging request times out (for example because a Passkeys prompt is showing and the native response is delayed), falling back to native `enumerateDevices` can trigger unwanted camera/microphone permission prompts.

This change resolves with a shimmed device list (`audioinput` + `videoinput`, empty labels) instead of calling native or rejecting the promise. Matches pre-permission native behavior and the existing `willPrompt` synthetic device path.

Related: https://github.com/duckduckgo/privacy-configuration/pull/5228

## Testing Steps

1. Enable `webCompat.enumerateDevices` on a test page.
2. Mock `cssMessaging.impl.request` to return a promise that never resolves.
3. Call `navigator.mediaDevices.enumerateDevices()` with a short `timeoutMs`.
4. Verify the promise resolves with two synthetic input devices (empty labels), not native enumeration.

Automated: `injected/integration-test/device-enumeration.spec.js` — "should return synthetic devices instead of calling native enumerateDevices when messaging times out"

## Checklist

- [x] I have tested this change locally
- [ ] I have tested this change locally in all supported browsers
- [ ] This change will be visible to users
- [x] I have added automated tests that cover this change
- [x] I have ensured the change is gated by config
- [ ] This change was covered by a ship review
- [ ] This change was covered by a tech design
- [ ] Any dependent config has been merged
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9c9e4af2-d86a-4e6c-84bc-f9fc1ea96149"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9c9e4af2-d86a-4e6c-84bc-f9fc1ea96149"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

