### PR TITLE
fix allow first video for iPad

### DIFF
--- a/injected/integration-test/duckplayer.spec.js
+++ b/injected/integration-test/duckplayer.spec.js
@@ -358,6 +358,38 @@ test.describe('Video Player overlays', () => {
             // Then our player loads for the correct video
             await overlays.duckPlayerLoadsFor('1');
         });
+
+        test('allows first video when dp_allowFirstVideo=true', async ({ page }, workerInfo) => {
+            const overlays = DuckplayerOverlays.create(page, workerInfo);
+
+            // Given overlays feature is enabled
+            await overlays.withRemoteConfig();
+
+            // And my setting is 'always ask'
+            await overlays.initialSetupIs('always ask');
+
+            // When the player page is opened with an allow-first-video query override
+            await overlays.gotoPlayerPage({ allowFirstVideo: 'true' });
+
+            // Then the blocking overlay does not show on first load
+            await overlays.videoOverlayDoesntShow();
+        });
+
+        test('allows first video when dp_allowFirstVideo=1', async ({ page }, workerInfo) => {
+            const overlays = DuckplayerOverlays.create(page, workerInfo);
+
+            // Given overlays feature is enabled
+            await overlays.withRemoteConfig();
+
+            // And my setting is 'always ask'
+            await overlays.initialSetupIs('always ask');
+
+            // When the player page is opened with an allow-first-video query override
+            await overlays.gotoPlayerPage({ allowFirstVideo: '1' });
+
+            // Then the blocking overlay does not show on first load
+            await overlays.videoOverlayDoesntShow();
+        });
     });
 });
 

--- a/injected/integration-test/page-objects/duckplayer-overlays.js
+++ b/injected/integration-test/page-objects/duckplayer-overlays.js
@@ -176,15 +176,19 @@ export class DuckplayerOverlays {
      * @param {object} [params]
      * @param {"default" | "incremental-dom"} [params.variant]
      * @param {string} [params.videoID]
+     * @param {'1' | 'true'} [params.allowFirstVideo]
      * @param {'playerPage' | 'videoAltSelectors'} [params.pageType]
      *  - we are replicating different strategies in the HTML to capture regressions/bugs
      */
     async gotoPlayerPage(params = {}) {
-        const { variant = 'default', videoID = '123', pageType = 'playerPage' } = params;
+        const { variant = 'default', videoID = '123', allowFirstVideo, pageType = 'playerPage' } = params;
         const urlParams = new URLSearchParams([
             ['v', videoID],
             ['variant', variant],
         ]);
+        if (allowFirstVideo) {
+            urlParams.set('dp_allowFirstVideo', allowFirstVideo);
+        }
 
         const page = this[pageType];
 

--- a/injected/src/features/duckplayer/overlays.js
+++ b/injected/src/features/duckplayer/overlays.js
@@ -36,6 +36,7 @@ export async function initOverlays(settings, environment, messages) {
     }
 
     let { userValues, ui } = initialSetup;
+    ui = withAllowFirstVideoQueryFallback(ui);
 
     /**
      * Create the instance - this might fail if settings or user preferences prevent it
@@ -92,9 +93,27 @@ export async function initOverlays(settings, environment, messages) {
      * Continue to listen for updated UI settings and try to re-initiate
      */
     messages.onUIValuesChanged((_ui) => {
-        ui = _ui;
+        ui = withAllowFirstVideoQueryFallback(_ui);
         update();
     });
+}
+
+/**
+ * Ensures query-string overrides can opt into allowing first video playback.
+ * Supports both dp_allowFirstVideo=1 and dp_allowFirstVideo=true.
+ * @param {import("../duck-player.js").UISettings | undefined} ui
+ * @returns {import("../duck-player.js").UISettings}
+ */
+function withAllowFirstVideoQueryFallback(ui) {
+    const queryValue = new URL(globalThis.location.href).searchParams.get('dp_allowFirstVideo');
+    const normalized = queryValue?.trim().toLowerCase();
+    const allowsFirstVideo = normalized === '1' || normalized === 'true';
+    if (!allowsFirstVideo) return ui || {};
+    if (ui?.allowFirstVideo === true) return ui;
+    return {
+        ...(ui || {}),
+        allowFirstVideo: true,
+    };
 }
 
 /**


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/392891325557410/task/1215066305724674?focus=true

cc @Bunn, @miasma13 

## Description

iPad sends dp_allowFirstVideo=1 when opening in YouTube from SERP, but CCS was expecting 'true'.  However changing iOS to send `true` wasn't enough so have updated this to support both `1` and `true` properly.

## Testing Steps

1/ iOS
* Reference from iOS source and run on iPad (without the YouTube app installed)
* Search for a video on SERP 
* Tap video and choose "Watch in YouTube"
* Video opens in new tab and plays video

2/ Repeat above test using macOS app

## Checklist

*Please tick all that apply:*

- [x] I have tested this change locally
- [x] I have tested this change locally in all supported browsers
- [x] This change will be visible to users
- [x] I have added automated tests that cover this change
- [ ] I have ensured the change is gated by config
- [ ] This change was covered by a ship review
- [ ] This change was covered by a tech design
- [ ] Any dependent config has been merged


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk behavior change limited to Duck Player overlay gating; main impact is potential UX regression if the query param is mis-parsed, and it is covered by new integration tests.
> 
> **Overview**
> Updates Duck Player overlays to treat the `dp_allowFirstVideo` query parameter as an opt-in override when set to either `1` or `true`, forcing `ui.allowFirstVideo` to `true` during initial setup and subsequent `onUIValuesChanged` updates.
> 
> Extends Playwright integration coverage by adding player-page tests for both `dp_allowFirstVideo=true` and `dp_allowFirstVideo=1`, and updates the test page-object helper to generate the query string.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f6b6059dbf02ab334769431c2e50b978de7a45ad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->