### PR TITLE
Update "Visit YouTube" PT translation to more widely accepted term "Visitar"

### DIFF
--- a/special-pages/pages/new-tab/public/locales/pt/new-tab.json
+++ b/special-pages/pages/new-tab/public/locales/pt/new-tab.json
@@ -386,7 +386,7 @@
     "note": "Summary of the Next Steps List card for YouTube ad blocking"
   },
   "nextStepsList_youtubeAdBlocking_actionText": {
-    "title": "Visita o YouTube",
+    "title": "Visitar o YouTube",
     "note": "Button text of the Next Steps List card for YouTube ad blocking"
   },
   "nextStepsList_emailProtection_title": {
@@ -522,7 +522,7 @@
     "note": "Summary of the Next Steps card for YouTube ad blocking"
   },
   "nextSteps_youtubeAdBlocking_actionText": {
-    "title": "Visita o YouTube",
+    "title": "Visitar o YouTube",
     "note": "Button text of the Next Steps card for YouTube ad blocking"
   },
   "nextSteps_addAppDockMac_title": {


### PR DESCRIPTION
**Asana Task/Github Issue:** <!-- Link to Asana Task/Github Issue -->

## Description

Follow-up to https://github.com/duckduckgo/content-scope-scripts/pull/2709 .

The original translation "Visita o YouTube" (imperative) sounds weird in Brazilian Portuguese and apparently isn't even that widely agreed upon for European Portuguese. After debating with the PT-speakers in the org, we've agreed that the infinitive form "Visitar" has better acceptance among most Portuguese variants.

I've also updated the Smartling strings so that the wrong translation doesn't make its way to the codebase in the future.

<!--
  Provide a terse summary of what the change is, detailed descriptions should belong in ship reviews or tech designs
-->

## Testing Steps

- <!-- Include simple steps on how to check this change is working. Write "N/A" if not applicable. -->

## Checklist

<!--
  These questions are a friendly reminder to shipping code, if you're uncertain ask the AoR owners.
  It's also totally appropriate to not check some of these boxes, if they don't apply to your change.
-->
*Please tick all that apply:*

- [ ] I have tested this change locally
- [ ] I have tested this change locally in all supported browsers
- [ ] This change will be visible to users
- [ ] I have added automated tests that cover this change
- [ ] I have ensured the change is gated by config
- [ ] This change was covered by a ship review
- [ ] This change was covered by a tech design
- [ ] Any dependent config has been merged


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Locale-only string updates with no logic, security, or data-handling changes; no secrets in the diff.
> 
> **Overview**
> Updates Portuguese (`pt`) new-tab copy for the YouTube ad-blocking **Next Steps** CTAs: button labels change from the imperative **"Visita o YouTube"** to the infinitive **"Visitar o YouTube"** in both `nextStepsList_youtubeAdBlocking_actionText` and `nextSteps_youtubeAdBlocking_actionText`. The diff also normalizes the JSON file ending (closing brace and newline).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 797f006e0b7f8532cfb88ffc11e12cd1a4baf174. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->