### PR TITLE
Retry release branch push

### DIFF
--- a/.github/workflows/build-branch.yml
+++ b/.github/workflows/build-branch.yml
@@ -65,7 +65,28 @@ jobs:
                   git checkout -b "${BUILD_BRANCH}"
                   git add -f build Sources/ContentScopeScripts/dist docs
                   git commit -m "Build artifacts for ${SOURCE_BRANCH}"
-                  git push -u origin "${BUILD_BRANCH}" --force
+
+                  push_build_branch() {
+                      local attempt
+                      local delay
+
+                      for attempt in 1 2 3 4 5; do
+                          if git push -u origin "${BUILD_BRANCH}" --force; then
+                              return 0
+                          fi
+
+                          if [ "${attempt}" -eq 5 ]; then
+                              echo "Failed to push ${BUILD_BRANCH} after ${attempt} attempts"
+                              return 1
+                          fi
+
+                          delay=$((attempt * 5))
+                          echo "::warning::Push to ${BUILD_BRANCH} failed on attempt ${attempt}; retrying in ${delay}s"
+                          sleep "${delay}"
+                      done
+                  }
+
+                  push_build_branch
 
                   echo "BUILD_BRANCH=${BUILD_BRANCH}" >> $GITHUB_ENV
                   echo "COMMIT_HASH=$(git rev-parse HEAD)" >> $GITHUB_ENV


### PR DESCRIPTION
**Asana Task/Github Issue:** <!-- Link to Asana Task/Github Issue -->

## Description

Increasingly, we've been seeing that these branches don't get created for some reason. I am going to add a retry to pushing this to see if it resolves the issue.

## Testing Steps

- <!-- Include simple steps on how to check this change is working. Write "N/A" if not applicable. -->

## Checklist

<!--
  These questions are a friendly reminder to shipping code, if you're uncertain ask the AoR owners.
  It's also totally appropriate to not check some of these boxes, if they don't apply to your change.
-->
*Please tick all that apply:*

- [ ] I have tested this change locally
- [ ] I have tested this change locally in all supported browsers
- [ ] This change will be visible to users
- [ ] I have added automated tests that cover this change
- [ ] I have ensured the change is gated by config
- [ ] This change was covered by a ship review
- [ ] This change was covered by a tech design
- [ ] Any dependent config has been merged


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change around git push reliability; no product runtime, auth, or data paths affected.
> 
> **Overview**
> The **Build Release Branch** workflow no longer does a single force-push of `pr-releases/<source>` after committing build artifacts. It now runs that push through a shell helper that retries up to **five** times with linear backoff (5s, 10s, …) and GitHub **::warning::** annotations between attempts, failing the step only after the last attempt.
> 
> Downstream steps (env vars for `BUILD_BRANCH` / `COMMIT_HASH` and the PR comment with preview links) are unchanged and still run only after a successful push.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b9d3cf1dbc961de946bed8dd963efc4f3afcedff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->