### PR TITLE
Remove Cursor review suggestion automation

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -35,22 +35,3 @@ jobs:
               env:
                   PR_URL: ${{ github.event.pull_request.html_url }}
                   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-            - name: Request Cursor review
-              if: github.event.action == 'opened'
-              run: |
-                  gh pr comment "$PR_URL" --body "**Suggested comment for Cursor review** (copy and paste as a new comment):
-
-                  \`\`\`
-                  @cursoragent can you review against the current code and outline potential impacts based on the changelogs of the update?
-
-                  Can you check the test coverage and ensure that the new code is covered?
-                  Can you think through if this dependency is still needed or if there's better practices used elsewhere.
-
-                  Can you draft a separate PR with any fixes that might be needed?
-                  \`\`\`
-
-                  *Note: GitHub Actions bot cannot trigger Cursor agent directly. Please copy the above comment to invoke the review.*"
-              env:
-                  PR_URL: ${{ github.event.pull_request.html_url }}
-                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
**Asana Task/Github Issue:** <!-- Link to Asana Task/Github Issue -->

## Description

We no longer need this as we have a cursor automation that does the same.

## Testing Steps

- <!-- Include simple steps on how to check this change is working. Write "N/A" if not applicable. -->

## Checklist

<!--
  These questions are a friendly reminder to shipping code, if you're uncertain ask the AoR owners.
  It's also totally appropriate to not check some of these boxes, if they don't apply to your change.
-->
*Please tick all that apply:*

- [ ] I have tested this change locally
- [ ] I have tested this change locally in all supported browsers
- [ ] This change will be visible to users
- [ ] I have added automated tests that cover this change
- [ ] I have ensured the change is gated by config
- [ ] This change was covered by a ship review
- [ ] This change was covered by a tech design
- [ ] Any dependent config has been merged


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only deletion with no runtime or dependency behavior changes.
> 
> **Overview**
> Removes the **Request Cursor review** step from `dependabot-auto-merge.yml`, which used to post a PR comment with copy-paste instructions for `@cursoragent` when Dependabot opened a PR.
> 
> **npm** auto-merge and patch auto-approve behavior in that workflow are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ef765c86db6abda28c3b85ef140e3c8d1250e506. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->