### PR TITLE
Capture message handler refs at construction on WebKit

### DIFF
--- a/injected/entry-points/apple.js
+++ b/injected/entry-points/apple.js
@@ -17,8 +17,6 @@ function initCode() {
 
     processedConfig.messagingConfig = new WebkitMessagingConfig({
         webkitMessageHandlerNames: [processedConfig.messagingContextName],
-        secret: '',
-        hasModernWebkitAPI: true,
     });
 
     load(getLoadArgs(processedConfig));

--- a/injected/unit-test/messaging-webkit.spec.js
+++ b/injected/unit-test/messaging-webkit.spec.js
@@ -120,4 +120,68 @@ describe('WebkitMessagingTransport', () => {
             delete Object.prototype.hostilePollutionHandler;
         }
     });
+
+    it('cache is not derived from a tampered `Object.create`', () => {
+        // Simulate page JS replacing Object.create *before* the transport is
+        // constructed (which can happen because Messaging is lazy on
+        // ContentFeature). The cache must still be a true null-prototype
+        // object, not one synthesised by the tampered Object.create.
+        const originalCreate = Object.create;
+        const tampered = jasmine.createSpy('tamperedObjectCreate').and.callFake(() => ({ polluted: true }));
+        Object.create = /** @type {any} */ (tampered);
+
+        try {
+            env = setupWebkit();
+            const transport = makeTransport();
+
+            // If the cache went through the tampered Object.create, looking up
+            // `polluted` would resolve to `true` (the tampered factory injected
+            // it as an own property). With `{ __proto__: null }` literal, it
+            // doesn't.
+            expect(() => transport.wkSend('polluted', {})).toThrowMatching(
+                (e) => e?.name === 'MissingHandler' || /Missing webkit handler/.test(e?.message ?? ''),
+            );
+        } finally {
+            Object.create = originalCreate;
+        }
+    });
+
+    it('stores handler and postMessage as a separate pair, not a single bound function', () => {
+        // Storing a `{ handler, postMessage }` pair rather than the result of
+        // `handler.postMessage.bind(handler)` is what lets wkSend dispatch via
+        // captured ReflectApply without going through Function.prototype.bind
+        // — which is critical because page JS can replace
+        // Function.prototype.bind before lazy transport construction
+        // (Messaging is lazy on ContentFeature.messaging). The structural
+        // check below proves the cache holds the raw references rather than a
+        // bound copy: a bound function would not be reference-equal to the
+        // original `postMessage`.
+        env = setupWebkit();
+        const transport = makeTransport();
+
+        const stored = transport.capturedWebkitHandlers.contentScopeScripts;
+
+        expect(stored.handler).toBe(env.handlers.contentScopeScripts);
+        expect(stored.postMessage).toBe(env.handlers.contentScopeScripts.postMessage);
+    });
+
+    it('dispatches through the captured handler with the correct `this` even without `.bind`', () => {
+        // Replace the host handler's postMessage with one that asserts on its
+        // `this`. If wkSend dispatched via a bare call (`postMessage(data)`)
+        // rather than ReflectApply against the captured handler, `this` would
+        // be wrong (undefined in strict mode) and the call would not preserve
+        // host-binding semantics.
+        env = setupWebkit();
+        const handler = env.handlers.contentScopeScripts;
+        const observed = { thisValue: /** @type {any} */ (undefined) };
+        handler.postMessage = function postMessage(/** @type {any} */ _data) {
+            observed.thisValue = this;
+            return Promise.resolve('{}');
+        };
+        const transport = makeTransport();
+
+        transport.wkSend('contentScopeScripts', { hello: 'world' });
+
+        expect(observed.thisValue).toBe(handler);
+    });
 });

--- a/injected/unit-test/messaging-webkit.spec.js
+++ b/injected/unit-test/messaging-webkit.spec.js
@@ -144,6 +144,7 @@ describe('WebkitMessagingTransport', () => {
             // as if it were a captured native handler.
             const malicious = jasmine.createSpy('pollutedPostMessage');
             // eslint-disable-next-line no-extend-native -- intentional: simulating page-side prototype pollution
+            // @ts-expect-error - intentional ad-hoc property on Object.prototype to simulate page-side pollution
             Object.prototype.hostilePollutionHandler = malicious;
 
             try {
@@ -152,7 +153,7 @@ describe('WebkitMessagingTransport', () => {
                 );
                 expect(malicious).not.toHaveBeenCalled();
             } finally {
-                // @ts-expect-error - test-only cleanup
+                // @ts-expect-error - test-only cleanup of the ad-hoc property added above
                 delete Object.prototype.hostilePollutionHandler;
             }
         });

--- a/injected/unit-test/messaging-webkit.spec.js
+++ b/injected/unit-test/messaging-webkit.spec.js
@@ -1,0 +1,169 @@
+import { MessagingContext, WebkitMessagingConfig, WebkitMessagingTransport } from '@duckduckgo/messaging';
+
+/**
+ * Sets up a minimal `window.webkit.messageHandlers` fake and returns
+ * helpers for inspecting / mutating it during tests. Cleans up on done().
+ */
+function setupWebkit({ handlerNames = ['contentScopeScripts'] } = {}) {
+    const originalWindow = /** @type {any} */ (globalThis).window;
+
+    /** @type {Record<string, jasmine.Spy>} */
+    const postMessageSpies = {};
+    /** @type {Record<string, any>} */
+    const handlers = {};
+    for (const name of handlerNames) {
+        const spy = jasmine.createSpy(`${name}.postMessage`).and.returnValue(Promise.resolve('{}'));
+        postMessageSpies[name] = spy;
+        handlers[name] = { postMessage: spy };
+    }
+
+    /** @type {any} */ (globalThis).window = {
+        webkit: { messageHandlers: handlers },
+    };
+
+    return {
+        postMessageSpies,
+        handlers,
+        /** Replace messageHandlers wholesale (simulates apiManipulation nullify-style hardening) */
+        nullifyMessageHandlers() {
+            /** @type {any} */ (globalThis).window.webkit.messageHandlers = undefined;
+        },
+        /** Remove a specific handler (simulates per-handler hiding) */
+        removeHandler(name) {
+            delete (/** @type {any} */ (globalThis).window.webkit.messageHandlers[name]);
+        },
+        cleanup() {
+            /** @type {any} */ (globalThis).window = originalWindow;
+        },
+    };
+}
+
+function makeContext() {
+    return new MessagingContext({
+        context: 'contentScopeScripts',
+        featureName: 'webkit-transport-spec',
+        env: 'development',
+    });
+}
+
+describe('WebkitMessagingTransport', () => {
+    /** @type {ReturnType<typeof setupWebkit>} */
+    let env;
+
+    afterEach(() => {
+        env?.cleanup();
+    });
+
+    describe('modern WebKit (hasModernWebkitAPI: true)', () => {
+        it('captures handler references at construction and routes wkSend through them', () => {
+            env = setupWebkit({ handlerNames: ['contentScopeScripts'] });
+            const transport = new WebkitMessagingTransport(
+                new WebkitMessagingConfig({
+                    webkitMessageHandlerNames: ['contentScopeScripts'],
+                    secret: '',
+                    hasModernWebkitAPI: true,
+                }),
+                makeContext(),
+            );
+
+            transport.wkSend('contentScopeScripts', { hello: 'world' });
+
+            expect(env.postMessageSpies.contentScopeScripts).toHaveBeenCalledOnceWith({ hello: 'world' });
+        });
+
+        it('does NOT delete the original postMessage on the host handler', () => {
+            env = setupWebkit({ handlerNames: ['contentScopeScripts'] });
+            const transport = new WebkitMessagingTransport(
+                new WebkitMessagingConfig({
+                    webkitMessageHandlerNames: ['contentScopeScripts'],
+                    secret: '',
+                    hasModernWebkitAPI: true,
+                }),
+                makeContext(),
+            );
+            expect(transport).toBeDefined();
+
+            // Modern WebKit must leave the host binding intact for any other code
+            // that reads `window.webkit.messageHandlers.X.postMessage` directly.
+            expect(typeof env.handlers.contentScopeScripts.postMessage).toBe('function');
+        });
+
+        it('continues to work after `window.webkit.messageHandlers` is replaced post-init', () => {
+            env = setupWebkit({ handlerNames: ['contentScopeScripts'] });
+            const transport = new WebkitMessagingTransport(
+                new WebkitMessagingConfig({
+                    webkitMessageHandlerNames: ['contentScopeScripts'],
+                    secret: '',
+                    hasModernWebkitAPI: true,
+                }),
+                makeContext(),
+            );
+
+            // Simulate site-level hardening removing the namespace after the
+            // transport has been constructed (e.g. via apiManipulation defining
+            // a `messageHandlers` getter that returns undefined on the
+            // WebKitNamespace prototype).
+            env.nullifyMessageHandlers();
+
+            // The captured reference should still reach native (the spy on the
+            // original handler object).
+            transport.wkSend('contentScopeScripts', { after: 'nullify' });
+
+            expect(env.postMessageSpies.contentScopeScripts).toHaveBeenCalledOnceWith({ after: 'nullify' });
+        });
+
+        it('throws MissingHandler when a handler was never registered', () => {
+            env = setupWebkit({ handlerNames: ['contentScopeScripts'] });
+            const transport = new WebkitMessagingTransport(
+                new WebkitMessagingConfig({
+                    webkitMessageHandlerNames: ['contentScopeScripts'],
+                    secret: '',
+                    hasModernWebkitAPI: true,
+                }),
+                makeContext(),
+            );
+
+            expect(() => transport.wkSend('nonExistentHandler', {})).toThrowMatching(
+                (e) => e?.name === 'MissingHandler' || /Missing webkit handler/.test(e?.message ?? ''),
+            );
+        });
+    });
+
+    describe('legacy WebKit (hasModernWebkitAPI: false)', () => {
+        it('captures handler references and deletes the original postMessage', () => {
+            env = setupWebkit({ handlerNames: ['contentScopeScripts'] });
+            const transport = new WebkitMessagingTransport(
+                new WebkitMessagingConfig({
+                    webkitMessageHandlerNames: ['contentScopeScripts'],
+                    secret: 'shh',
+                    hasModernWebkitAPI: false,
+                }),
+                makeContext(),
+            );
+            expect(transport).toBeDefined();
+
+            // Legacy macOS behaviour: original postMessage is removed so page JS
+            // cannot invoke the handler directly without the secure envelope.
+            expect(env.handlers.contentScopeScripts.postMessage).toBeUndefined();
+        });
+
+        it('adds the secure messaging envelope (secret) to outgoing payloads', () => {
+            env = setupWebkit({ handlerNames: ['contentScopeScripts'] });
+            const transport = new WebkitMessagingTransport(
+                new WebkitMessagingConfig({
+                    webkitMessageHandlerNames: ['contentScopeScripts'],
+                    secret: 'shh',
+                    hasModernWebkitAPI: false,
+                }),
+                makeContext(),
+            );
+
+            transport.wkSend('contentScopeScripts', { hello: 'world' });
+
+            expect(env.postMessageSpies.contentScopeScripts).toHaveBeenCalledOnceWith({
+                hello: 'world',
+                messageHandling: { secret: 'shh' },
+            });
+        });
+    });
+});

--- a/injected/unit-test/messaging-webkit.spec.js
+++ b/injected/unit-test/messaging-webkit.spec.js
@@ -143,8 +143,8 @@ describe('WebkitMessagingTransport', () => {
             // plain `{}` cache, resolve via the prototype chain and be invoked
             // as if it were a captured native handler.
             const malicious = jasmine.createSpy('pollutedPostMessage');
-            // eslint-disable-next-line no-extend-native -- intentional: simulating page-side prototype pollution
             // @ts-expect-error - intentional ad-hoc property on Object.prototype to simulate page-side pollution
+            // eslint-disable-next-line no-extend-native -- intentional: simulating page-side prototype pollution
             Object.prototype.hostilePollutionHandler = malicious;
 
             try {

--- a/injected/unit-test/messaging-webkit.spec.js
+++ b/injected/unit-test/messaging-webkit.spec.js
@@ -127,6 +127,35 @@ describe('WebkitMessagingTransport', () => {
                 (e) => e?.name === 'MissingHandler' || /Missing webkit handler/.test(e?.message ?? ''),
             );
         });
+
+        it('ignores Object.prototype pollution when an uncaptured handler is looked up', () => {
+            env = setupWebkit({ handlerNames: ['contentScopeScripts'] });
+            const transport = new WebkitMessagingTransport(
+                new WebkitMessagingConfig({
+                    webkitMessageHandlerNames: ['contentScopeScripts'],
+                    secret: '',
+                    hasModernWebkitAPI: true,
+                }),
+                makeContext(),
+            );
+
+            // Hostile page-scripted prototype pollution that would, with a
+            // plain `{}` cache, resolve via the prototype chain and be invoked
+            // as if it were a captured native handler.
+            const malicious = jasmine.createSpy('pollutedPostMessage');
+            // eslint-disable-next-line no-extend-native -- intentional: simulating page-side prototype pollution
+            Object.prototype.hostilePollutionHandler = malicious;
+
+            try {
+                expect(() => transport.wkSend('hostilePollutionHandler', { secret: 'data' })).toThrowMatching(
+                    (e) => e?.name === 'MissingHandler' || /Missing webkit handler/.test(e?.message ?? ''),
+                );
+                expect(malicious).not.toHaveBeenCalled();
+            } finally {
+                // @ts-expect-error - test-only cleanup
+                delete Object.prototype.hostilePollutionHandler;
+            }
+        });
     });
 
     describe('legacy WebKit (hasModernWebkitAPI: false)', () => {

--- a/injected/unit-test/messaging-webkit.spec.js
+++ b/injected/unit-test/messaging-webkit.spec.js
@@ -2,7 +2,7 @@ import { MessagingContext, WebkitMessagingConfig, WebkitMessagingTransport } fro
 
 /**
  * Sets up a minimal `window.webkit.messageHandlers` fake and returns
- * helpers for inspecting / mutating it during tests. Cleans up on done().
+ * helpers for inspecting / mutating it during tests. Cleans up via env.cleanup().
  */
 function setupWebkit({ handlerNames = ['contentScopeScripts'] } = {}) {
     const originalWindow = /** @type {any} */ (globalThis).window;
@@ -28,22 +28,21 @@ function setupWebkit({ handlerNames = ['contentScopeScripts'] } = {}) {
         nullifyMessageHandlers() {
             /** @type {any} */ (globalThis).window.webkit.messageHandlers = undefined;
         },
-        /** Remove a specific handler (simulates per-handler hiding) */
-        removeHandler(name) {
-            delete (/** @type {any} */ (globalThis).window.webkit.messageHandlers[name]);
-        },
         cleanup() {
             /** @type {any} */ (globalThis).window = originalWindow;
         },
     };
 }
 
-function makeContext() {
-    return new MessagingContext({
-        context: 'contentScopeScripts',
-        featureName: 'webkit-transport-spec',
-        env: 'development',
-    });
+function makeTransport(handlerNames = ['contentScopeScripts']) {
+    return new WebkitMessagingTransport(
+        new WebkitMessagingConfig({ webkitMessageHandlerNames: handlerNames }),
+        new MessagingContext({
+            context: 'contentScopeScripts',
+            featureName: 'webkit-transport-spec',
+            env: 'development',
+        }),
+    );
 }
 
 describe('WebkitMessagingTransport', () => {
@@ -54,146 +53,71 @@ describe('WebkitMessagingTransport', () => {
         env?.cleanup();
     });
 
-    describe('modern WebKit (hasModernWebkitAPI: true)', () => {
-        it('captures handler references at construction and routes wkSend through them', () => {
-            env = setupWebkit({ handlerNames: ['contentScopeScripts'] });
-            const transport = new WebkitMessagingTransport(
-                new WebkitMessagingConfig({
-                    webkitMessageHandlerNames: ['contentScopeScripts'],
-                    secret: '',
-                    hasModernWebkitAPI: true,
-                }),
-                makeContext(),
-            );
+    it('captures handler references at construction and routes wkSend through them', () => {
+        env = setupWebkit();
+        const transport = makeTransport();
 
-            transport.wkSend('contentScopeScripts', { hello: 'world' });
+        transport.wkSend('contentScopeScripts', { hello: 'world' });
 
-            expect(env.postMessageSpies.contentScopeScripts).toHaveBeenCalledOnceWith({ hello: 'world' });
-        });
-
-        it('does NOT delete the original postMessage on the host handler', () => {
-            env = setupWebkit({ handlerNames: ['contentScopeScripts'] });
-            const transport = new WebkitMessagingTransport(
-                new WebkitMessagingConfig({
-                    webkitMessageHandlerNames: ['contentScopeScripts'],
-                    secret: '',
-                    hasModernWebkitAPI: true,
-                }),
-                makeContext(),
-            );
-            expect(transport).toBeDefined();
-
-            // Modern WebKit must leave the host binding intact for any other code
-            // that reads `window.webkit.messageHandlers.X.postMessage` directly.
-            expect(typeof env.handlers.contentScopeScripts.postMessage).toBe('function');
-        });
-
-        it('continues to work after `window.webkit.messageHandlers` is replaced post-init', () => {
-            env = setupWebkit({ handlerNames: ['contentScopeScripts'] });
-            const transport = new WebkitMessagingTransport(
-                new WebkitMessagingConfig({
-                    webkitMessageHandlerNames: ['contentScopeScripts'],
-                    secret: '',
-                    hasModernWebkitAPI: true,
-                }),
-                makeContext(),
-            );
-
-            // Simulate site-level hardening removing the namespace after the
-            // transport has been constructed (e.g. via apiManipulation defining
-            // a `messageHandlers` getter that returns undefined on the
-            // WebKitNamespace prototype).
-            env.nullifyMessageHandlers();
-
-            // The captured reference should still reach native (the spy on the
-            // original handler object).
-            transport.wkSend('contentScopeScripts', { after: 'nullify' });
-
-            expect(env.postMessageSpies.contentScopeScripts).toHaveBeenCalledOnceWith({ after: 'nullify' });
-        });
-
-        it('throws MissingHandler when a handler was never registered', () => {
-            env = setupWebkit({ handlerNames: ['contentScopeScripts'] });
-            const transport = new WebkitMessagingTransport(
-                new WebkitMessagingConfig({
-                    webkitMessageHandlerNames: ['contentScopeScripts'],
-                    secret: '',
-                    hasModernWebkitAPI: true,
-                }),
-                makeContext(),
-            );
-
-            expect(() => transport.wkSend('nonExistentHandler', {})).toThrowMatching(
-                (e) => e?.name === 'MissingHandler' || /Missing webkit handler/.test(e?.message ?? ''),
-            );
-        });
-
-        it('ignores Object.prototype pollution when an uncaptured handler is looked up', () => {
-            env = setupWebkit({ handlerNames: ['contentScopeScripts'] });
-            const transport = new WebkitMessagingTransport(
-                new WebkitMessagingConfig({
-                    webkitMessageHandlerNames: ['contentScopeScripts'],
-                    secret: '',
-                    hasModernWebkitAPI: true,
-                }),
-                makeContext(),
-            );
-
-            // Hostile page-scripted prototype pollution that would, with a
-            // plain `{}` cache, resolve via the prototype chain and be invoked
-            // as if it were a captured native handler.
-            const malicious = jasmine.createSpy('pollutedPostMessage');
-            // @ts-expect-error - intentional ad-hoc property on Object.prototype to simulate page-side pollution
-            // eslint-disable-next-line no-extend-native -- intentional: simulating page-side prototype pollution
-            Object.prototype.hostilePollutionHandler = malicious;
-
-            try {
-                expect(() => transport.wkSend('hostilePollutionHandler', { secret: 'data' })).toThrowMatching(
-                    (e) => e?.name === 'MissingHandler' || /Missing webkit handler/.test(e?.message ?? ''),
-                );
-                expect(malicious).not.toHaveBeenCalled();
-            } finally {
-                // @ts-expect-error - test-only cleanup of the ad-hoc property added above
-                delete Object.prototype.hostilePollutionHandler;
-            }
-        });
+        expect(env.postMessageSpies.contentScopeScripts).toHaveBeenCalledOnceWith({ hello: 'world' });
     });
 
-    describe('legacy WebKit (hasModernWebkitAPI: false)', () => {
-        it('captures handler references and deletes the original postMessage', () => {
-            env = setupWebkit({ handlerNames: ['contentScopeScripts'] });
-            const transport = new WebkitMessagingTransport(
-                new WebkitMessagingConfig({
-                    webkitMessageHandlerNames: ['contentScopeScripts'],
-                    secret: 'shh',
-                    hasModernWebkitAPI: false,
-                }),
-                makeContext(),
+    it('leaves the original `postMessage` on the host handler in place', () => {
+        env = setupWebkit();
+        const transport = makeTransport();
+        expect(transport).toBeDefined();
+
+        // Other code that reads `window.webkit.messageHandlers.X.postMessage` directly
+        // must continue to see the host binding's normal shape.
+        expect(typeof env.handlers.contentScopeScripts.postMessage).toBe('function');
+    });
+
+    it('continues to work after `window.webkit.messageHandlers` is replaced post-init', () => {
+        env = setupWebkit();
+        const transport = makeTransport();
+
+        // Simulate site-level hardening removing the namespace after the
+        // transport has been constructed (e.g. via apiManipulation defining
+        // a `messageHandlers` getter that returns undefined on the
+        // WebKitNamespace prototype).
+        env.nullifyMessageHandlers();
+
+        // The captured reference should still reach native (the spy on the
+        // original handler object).
+        transport.wkSend('contentScopeScripts', { after: 'nullify' });
+
+        expect(env.postMessageSpies.contentScopeScripts).toHaveBeenCalledOnceWith({ after: 'nullify' });
+    });
+
+    it('throws MissingHandler when a handler was never registered', () => {
+        env = setupWebkit();
+        const transport = makeTransport();
+
+        expect(() => transport.wkSend('nonExistentHandler', {})).toThrowMatching(
+            (e) => e?.name === 'MissingHandler' || /Missing webkit handler/.test(e?.message ?? ''),
+        );
+    });
+
+    it('ignores Object.prototype pollution when an uncaptured handler is looked up', () => {
+        env = setupWebkit();
+        const transport = makeTransport();
+
+        // Hostile page-scripted prototype pollution that would, with a
+        // plain `{}` cache, resolve via the prototype chain and be invoked
+        // as if it were a captured native handler.
+        const malicious = jasmine.createSpy('pollutedPostMessage');
+        // @ts-expect-error - intentional ad-hoc property on Object.prototype to simulate page-side pollution
+        // eslint-disable-next-line no-extend-native -- intentional: simulating page-side prototype pollution
+        Object.prototype.hostilePollutionHandler = malicious;
+
+        try {
+            expect(() => transport.wkSend('hostilePollutionHandler', { secret: 'data' })).toThrowMatching(
+                (e) => e?.name === 'MissingHandler' || /Missing webkit handler/.test(e?.message ?? ''),
             );
-            expect(transport).toBeDefined();
-
-            // Legacy macOS behaviour: original postMessage is removed so page JS
-            // cannot invoke the handler directly without the secure envelope.
-            expect(env.handlers.contentScopeScripts.postMessage).toBeUndefined();
-        });
-
-        it('adds the secure messaging envelope (secret) to outgoing payloads', () => {
-            env = setupWebkit({ handlerNames: ['contentScopeScripts'] });
-            const transport = new WebkitMessagingTransport(
-                new WebkitMessagingConfig({
-                    webkitMessageHandlerNames: ['contentScopeScripts'],
-                    secret: 'shh',
-                    hasModernWebkitAPI: false,
-                }),
-                makeContext(),
-            );
-
-            transport.wkSend('contentScopeScripts', { hello: 'world' });
-
-            expect(env.postMessageSpies.contentScopeScripts).toHaveBeenCalledOnceWith({
-                hello: 'world',
-                messageHandling: { secret: 'shh' },
-            });
-        });
+            expect(malicious).not.toHaveBeenCalled();
+        } finally {
+            // @ts-expect-error - test-only cleanup of the ad-hoc property added above
+            delete Object.prototype.hostilePollutionHandler;
+        }
     });
 });

--- a/messaging/lib/examples/webkit.example.js
+++ b/messaging/lib/examples/webkit.example.js
@@ -4,8 +4,6 @@ import { Messaging, MessagingContext, WebkitMessagingConfig } from '../../index.
  * Configuration for WebkitMessaging
  */
 const config = new WebkitMessagingConfig({
-    hasModernWebkitAPI: true,
-    secret: 'SECRET',
     webkitMessageHandlerNames: ['contentScopeScripts'],
 });
 

--- a/messaging/lib/webkit.js
+++ b/messaging/lib/webkit.js
@@ -6,7 +6,13 @@
 import { MessagingTransport, MissingHandler } from '../index.js';
 import { isResponseFor, isSubscriptionEventFor } from '../schema.js';
 import { ensureNavigatorDuckDuckGo } from '../../injected/src/navigator-global.js';
-import { JSONparse, Error as _Error, ReflectDeleteProperty, objectDefineProperty } from '../../injected/src/captured-globals.js';
+import {
+    JSONparse,
+    Error as _Error,
+    ReflectApply,
+    ReflectDeleteProperty,
+    objectDefineProperty,
+} from '../../injected/src/captured-globals.js';
 
 /**
  * @example
@@ -25,9 +31,16 @@ export class WebkitMessagingTransport {
     /**
      * Null-prototype cache so a hostile page that pollutes `Object.prototype`
      * cannot supply a callable from there if `capture` ever misses a handler.
-     * @type {Record<string, any>}
+     *
+     * Uses the `{ __proto__: null }` literal rather than `Object.create(null)`
+     * because the latter is a method dispatch through `globalThis.Object`, which
+     * page JS could replace before this class field runs if transport
+     * construction is deferred (`Messaging` is lazy on `ContentFeature.messaging`).
+     * The `__proto__: null` literal is a syntactic construct, not method
+     * dispatch, so it always yields a true null-prototype object.
+     * @type {Record<string, { handler: any, postMessage: Function }>}
      */
-    capturedWebkitHandlers = Object.create(null);
+    capturedWebkitHandlers = /** @type {any} */ ({ __proto__: null });
 
     /**
      * @param {WebkitMessagingConfig} config
@@ -56,10 +69,12 @@ export class WebkitMessagingTransport {
      */
     wkSend(handler, data = {}) {
         const captured = this.capturedWebkitHandlers[handler];
-        if (typeof captured !== 'function') {
+        if (!captured || typeof captured.postMessage !== 'function') {
             throw new MissingHandler(`Missing webkit handler: '${handler}'`, handler);
         }
-        return captured(data);
+        // Use the captured ReflectApply so the send path doesn't go through
+        // any page-mutable function (`.call`, `.bind`, etc.).
+        return ReflectApply(captured.postMessage, captured.handler, [data]);
     }
 
     /**
@@ -108,20 +123,26 @@ export class WebkitMessagingTransport {
      * `window.webkit.messageHandlers` (e.g. by privacy hardening that nullifies
      * the namespace for site JS to reduce fingerprinting surface).
      *
+     * Stores the handler object and its `postMessage` function as a pair so
+     * `wkSend` can dispatch via the captured `ReflectApply` rather than calling
+     * `.bind()` here. `.bind` is a method on the page-mutable
+     * `Function.prototype` — if transport construction is deferred (`Messaging`
+     * is lazy on `ContentFeature.messaging`) page JS could replace
+     * `Function.prototype.bind` first and have the cache store an attacker-
+     * controlled function. Storing the unbound pair sidesteps that.
+     *
      * @param {string[]} handlerNames
      */
     captureWebkitHandlers(handlerNames) {
         const handlers = window.webkit.messageHandlers;
         if (!handlers) throw new MissingHandler('window.webkit.messageHandlers was absent', 'all');
         for (const webkitMessageHandlerName of handlerNames) {
-            if (typeof handlers[webkitMessageHandlerName]?.postMessage === 'function') {
-                /**
-                 * `bind` is used here to ensure future calls to the captured
-                 * `postMessage` have the correct `this` context
-                 */
-                const original = handlers[webkitMessageHandlerName];
-                const bound = handlers[webkitMessageHandlerName].postMessage?.bind(original);
-                this.capturedWebkitHandlers[webkitMessageHandlerName] = bound;
+            const handler = handlers[webkitMessageHandlerName];
+            if (typeof handler?.postMessage === 'function') {
+                this.capturedWebkitHandlers[webkitMessageHandlerName] = {
+                    handler,
+                    postMessage: handler.postMessage,
+                };
             }
         }
     }

--- a/messaging/lib/webkit.js
+++ b/messaging/lib/webkit.js
@@ -84,9 +84,14 @@ export class WebkitMessagingTransport {
     constructor(config, messagingContext) {
         this.messagingContext = messagingContext;
         this.config = config;
-        if (!this.config.hasModernWebkitAPI) {
-            this.captureWebkitHandlers(this.config.webkitMessageHandlerNames);
-        }
+        // Capture handler references at construction on both legacy and modern WebKit.
+        // On modern WebKit this previously read `window.webkit.messageHandlers[handler]`
+        // on every send, which means the transport silently breaks if site-level
+        // privacy hardening (e.g. apiManipulation-driven nullification of
+        // `window.webkit.messageHandlers` to reduce fingerprinting surface) replaces
+        // the namespace after init. Capturing once at construction makes the transport
+        // resilient to those changes.
+        this.captureWebkitHandlers(this.config.webkitMessageHandlerNames);
     }
 
     /**
@@ -98,7 +103,8 @@ export class WebkitMessagingTransport {
      * @internal
      */
     wkSend(handler, data = {}) {
-        if (!(handler in window.webkit.messageHandlers)) {
+        const captured = this.capturedWebkitHandlers[handler];
+        if (typeof captured !== 'function') {
             throw new MissingHandler(`Missing webkit handler: '${handler}'`, handler);
         }
         if (!this.config.hasModernWebkitAPI) {
@@ -109,13 +115,9 @@ export class WebkitMessagingTransport {
                     secret: this.config.secret,
                 },
             };
-            if (!(handler in this.capturedWebkitHandlers)) {
-                throw new MissingHandler(`cannot continue, method ${handler} not captured on macos < 11`, handler);
-            } else {
-                return this.capturedWebkitHandlers[handler](outgoing);
-            }
+            return captured(outgoing);
         }
-        return window.webkit.messageHandlers[handler].postMessage?.(data);
+        return captured(data);
     }
 
     /**
@@ -282,8 +284,18 @@ export class WebkitMessagingTransport {
     }
 
     /**
-     * When required (such as on macos 10.x), capture the `postMessage` method on
-     * each webkit messageHandler
+     * Capture the `postMessage` method on each webkit messageHandler so the
+     * transport can call them later without re-reading `window.webkit.messageHandlers`.
+     *
+     * Used on both modern and legacy WebKit:
+     * - **Legacy (macOS Catalina, < 11)**: capture is required for the secure
+     *   messaging protocol, and the original `postMessage` is deleted to prevent
+     *   page-script JS from invoking it directly without the encrypted envelope.
+     * - **Modern**: capture makes the transport resilient to later removal or
+     *   replacement of `window.webkit.messageHandlers` by privacy hardening
+     *   (e.g. apiManipulation-driven nullification to reduce fingerprinting
+     *   surface). The original is left in place so callers reading directly
+     *   from the namespace continue to see the host binding's normal shape.
      *
      * @param {string[]} handlerNames
      */
@@ -299,7 +311,9 @@ export class WebkitMessagingTransport {
                 const original = handlers[webkitMessageHandlerName];
                 const bound = handlers[webkitMessageHandlerName].postMessage?.bind(original);
                 this.capturedWebkitHandlers[webkitMessageHandlerName] = bound;
-                delete handlers[webkitMessageHandlerName].postMessage;
+                if (!this.config.hasModernWebkitAPI) {
+                    delete handlers[webkitMessageHandlerName].postMessage;
+                }
             }
         }
     }

--- a/messaging/lib/webkit.js
+++ b/messaging/lib/webkit.js
@@ -1,75 +1,23 @@
 /**
  *
- * A wrapper for messaging on WebKit platforms. It supports modern WebKit messageHandlers
- * along with encryption for older versions (like macOS Catalina)
- *
- * Note: If you wish to support Catalina then you'll need to implement the native
- * part of the message handling, see {@link WebkitMessagingTransport} for details.
+ * A wrapper for messaging on WebKit platforms (iOS, macOS 11+).
  */
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { MessagingTransport, MissingHandler } from '../index.js';
 import { isResponseFor, isSubscriptionEventFor } from '../schema.js';
 import { ensureNavigatorDuckDuckGo } from '../../injected/src/navigator-global.js';
-import {
-    TextDecoder as _TextDecoder,
-    Uint8Array as _Uint8Array,
-    Uint32Array as _Uint32Array,
-    JSONparse,
-    Arrayfrom,
-    Promise as _Promise,
-    Error as _Error,
-    ReflectDeleteProperty,
-    objectDefineProperty,
-    getRandomValues,
-    generateKey,
-    exportKey,
-    importKey,
-    decrypt,
-} from '../../injected/src/captured-globals.js';
+import { JSONparse, Error as _Error, ReflectDeleteProperty, objectDefineProperty } from '../../injected/src/captured-globals.js';
 
 /**
  * @example
- * On macOS 11+, this will just call through to `window.webkit.messageHandlers.x.postMessage`
+ * Calls through to `window.webkit.messageHandlers.x.postMessage`.
  *
- * Eg: for a `foo` message defined in Swift that accepted the payload `{"bar": "baz"}`, the following
- * would occur:
+ * For a `foo` message defined in Swift that accepted the payload `{"bar": "baz"}`,
+ * the following would occur:
  *
  * ```js
  * const json = await window.webkit.messageHandlers.foo.postMessage({ bar: "baz" });
  * const response = JSON.parse(json)
- * ```
- *
- * @example
- * On macOS 10 however, the process is a little more involved. A method will be appended to
- * `navigator.duckduckgo.messageHandlers` that allows the response to be delivered there instead.
- * It's not exactly this, but you can visualize the flow as being something along the lines of:
- *
- * ```js
- * // add the callback method to navigator.duckduckgo.messageHandlers
- * navigator.duckduckgo.messageHandlers["_0123456"] = (response) => {
- *    // decrypt `response` and deliver the result to the caller here
- *    // then remove the temporary method
- *    delete navigator.duckduckgo.messageHandlers['_0123456']
- * };
- *
- * // send the data + `messageHanding` values
- * window.webkit.messageHandlers.foo.postMessage({
- *   bar: "baz",
- *   messagingHandling: {
- *     methodName: "_0123456",
- *     secret: "super-secret",
- *     key: [1, 2, 45, 2],
- *     iv: [34, 4, 43],
- *   }
- * });
- *
- * // later in swift, the following JavaScript snippet will be executed
- * (() => {
- *   navigator.duckduckgo.messageHandlers['_0123456']({
- *     ciphertext: [12, 13, 4],
- *     tag: [3, 5, 67, 56]
- *   })
- * })()
  * ```
  * @implements {MessagingTransport}
  */
@@ -111,16 +59,6 @@ export class WebkitMessagingTransport {
         if (typeof captured !== 'function') {
             throw new MissingHandler(`Missing webkit handler: '${handler}'`, handler);
         }
-        if (!this.config.hasModernWebkitAPI) {
-            const outgoing = {
-                ...data,
-                messageHandling: {
-                    ...data.messageHandling,
-                    secret: this.config.secret,
-                },
-            };
-            return captured(outgoing);
-        }
         return captured(data);
     }
 
@@ -132,46 +70,8 @@ export class WebkitMessagingTransport {
      * @internal
      */
     async wkSendAndWait(handler, data) {
-        if (this.config.hasModernWebkitAPI) {
-            const response = await this.wkSend(handler, data);
-            return JSONparse(response || '{}');
-        }
-
-        try {
-            const randMethodName = this.createRandMethodName();
-            const key = await this.createRandKey();
-            const iv = this.createRandIv();
-
-            const { ciphertext, tag } = await new _Promise((/** @type {any} */ resolve) => {
-                this.generateRandomMethod(randMethodName, resolve);
-
-                // @ts-expect-error - this is a carve-out for catalina that will be removed soon
-                data.messageHandling = new SecureMessagingParams({
-                    methodName: randMethodName,
-                    secret: this.config.secret,
-                    key: Arrayfrom(key),
-                    iv: Arrayfrom(iv),
-                });
-                this.wkSend(handler, data);
-            });
-
-            const cipher = new _Uint8Array([...ciphertext, ...tag]);
-            const decrypted = await this.decryptResponse(
-                /** @type {BufferSource} */ (/** @type {unknown} */ (cipher)),
-                /** @type {BufferSource} */ (/** @type {unknown} */ (key)),
-                iv,
-            );
-            return JSONparse(decrypted || '{}');
-        } catch (e) {
-            // re-throw when the error is just a 'MissingHandler'
-            if (e instanceof MissingHandler) {
-                throw e;
-            } else {
-                console.error('decryption failed', e);
-                console.error(e);
-                return { error: e };
-            }
-        }
+        const response = await this.wkSend(handler, data);
+        return JSONparse(response || '{}');
     }
 
     /**
@@ -202,92 +102,6 @@ export class WebkitMessagingTransport {
     }
 
     /**
-     * Generate a random method name and adds it to navigator.duckduckgo.messageHandlers
-     * The native layer will use this method to send the response
-     * @param {string | number} randomMethodName
-     * @param {Function} callback
-     * @internal
-     */
-    generateRandomMethod(randomMethodName, callback) {
-        const target = ensureNavigatorDuckDuckGo().messageHandlers;
-        objectDefineProperty(target, randomMethodName, {
-            enumerable: false,
-            configurable: true,
-            writable: false,
-            /**
-             * @param {any[]} args
-             */
-            value: (...args) => {
-                callback(...args);
-                ReflectDeleteProperty(target, randomMethodName);
-            },
-        });
-    }
-
-    /**
-     * @internal
-     * @return {string}
-     */
-    randomString() {
-        return '' + getRandomValues(new _Uint32Array(1))[0];
-    }
-
-    /**
-     * @internal
-     * @return {string}
-     */
-    createRandMethodName() {
-        return '_' + this.randomString();
-    }
-
-    /**
-     * @type {{name: string, length: number}}
-     * @internal
-     */
-    algoObj = {
-        name: 'AES-GCM',
-        length: 256,
-    };
-
-    /**
-     * @returns {Promise<Uint8Array>}
-     * @internal
-     */
-    async createRandKey() {
-        const key = await generateKey(this.algoObj, true, ['encrypt', 'decrypt']);
-        const exportedKey = await exportKey('raw', key);
-        return new _Uint8Array(exportedKey);
-    }
-
-    /**
-     * @returns {Uint8Array}
-     * @internal
-     */
-    createRandIv() {
-        return getRandomValues(new _Uint8Array(12));
-    }
-
-    /**
-     * @param {BufferSource} ciphertext
-     * @param {BufferSource} key
-     * @param {Uint8Array} iv
-     * @returns {Promise<string>}
-     * @internal
-     */
-    async decryptResponse(ciphertext, key, iv) {
-        const cryptoKey = await importKey('raw', key, 'AES-GCM', false, ['decrypt']);
-        const algo = {
-            name: 'AES-GCM',
-            iv,
-        };
-
-        const decrypted = await decrypt(algo, cryptoKey, ciphertext);
-
-        const dec = new _TextDecoder();
-        return dec.decode(decrypted);
-    }
-
-    /**
      * Capture the `postMessage` method on each webkit messageHandler so the
      * transport can call them later without re-reading `window.webkit.messageHandlers`.
      * Makes the transport resilient to later removal or replacement of
@@ -308,9 +122,6 @@ export class WebkitMessagingTransport {
                 const original = handlers[webkitMessageHandlerName];
                 const bound = handlers[webkitMessageHandlerName].postMessage?.bind(original);
                 this.capturedWebkitHandlers[webkitMessageHandlerName] = bound;
-                if (!this.config.hasModernWebkitAPI) {
-                    delete handlers[webkitMessageHandlerName].postMessage;
-                }
             }
         }
     }
@@ -344,8 +155,7 @@ export class WebkitMessagingTransport {
 
 /**
  * Use this configuration to create an instance of {@link Messaging} for WebKit platforms
- *
- * We support modern WebKit environments *and* macOS Catalina.
+ * (iOS, macOS 11+).
  *
  * Please see {@link WebkitMessagingTransport} for details on how messages are sent/received
  *
@@ -354,17 +164,10 @@ export class WebkitMessagingTransport {
 export class WebkitMessagingConfig {
     /**
      * @param {object} params
-     * @param {boolean} params.hasModernWebkitAPI
      * @param {string[]} params.webkitMessageHandlerNames
-     * @param {string} params.secret
      * @internal
      */
     constructor(params) {
-        /**
-         * Whether or not the current WebKit Platform supports secure messaging
-         * by default (eg: macOS 11+)
-         */
-        this.hasModernWebkitAPI = params.hasModernWebkitAPI;
         /**
          * A list of WebKit message handler names that a user script can send.
          *
@@ -381,42 +184,5 @@ export class WebkitMessagingConfig {
          * ```
          */
         this.webkitMessageHandlerNames = params.webkitMessageHandlerNames;
-        /**
-         * A string provided by native platforms to be sent with future outgoing
-         * messages.
-         */
-        this.secret = params.secret;
-    }
-}
-
-/**
- * This is the additional payload that gets appended to outgoing messages.
- * It's used in the Swift side to encrypt the response that comes back
- */
-export class SecureMessagingParams {
-    /**
-     * @param {object} params
-     * @param {string} params.methodName
-     * @param {string} params.secret
-     * @param {number[]} params.key
-     * @param {number[]} params.iv
-     */
-    constructor(params) {
-        /**
-         * The method that's been appended to `navigator.duckduckgo.messageHandlers` to be called later
-         */
-        this.methodName = params.methodName;
-        /**
-         * The secret used to ensure message sender validity
-         */
-        this.secret = params.secret;
-        /**
-         * The CipherKey as number[]
-         */
-        this.key = params.key;
-        /**
-         * The Initial Vector as number[]
-         */
-        this.iv = params.iv;
     }
 }

--- a/messaging/lib/webkit.js
+++ b/messaging/lib/webkit.js
@@ -74,8 +74,12 @@ import {
  * @implements {MessagingTransport}
  */
 export class WebkitMessagingTransport {
-    /** @type {Record<string, any>} */
-    capturedWebkitHandlers = {};
+    /**
+     * Null-prototype cache so a hostile page that pollutes `Object.prototype`
+     * cannot supply a callable from there if `capture` ever misses a handler.
+     * @type {Record<string, any>}
+     */
+    capturedWebkitHandlers = Object.create(null);
 
     /**
      * @param {WebkitMessagingConfig} config
@@ -286,16 +290,9 @@ export class WebkitMessagingTransport {
     /**
      * Capture the `postMessage` method on each webkit messageHandler so the
      * transport can call them later without re-reading `window.webkit.messageHandlers`.
-     *
-     * Used on both modern and legacy WebKit:
-     * - **Legacy (macOS Catalina, < 11)**: capture is required for the secure
-     *   messaging protocol, and the original `postMessage` is deleted to prevent
-     *   page-script JS from invoking it directly without the encrypted envelope.
-     * - **Modern**: capture makes the transport resilient to later removal or
-     *   replacement of `window.webkit.messageHandlers` by privacy hardening
-     *   (e.g. apiManipulation-driven nullification to reduce fingerprinting
-     *   surface). The original is left in place so callers reading directly
-     *   from the namespace continue to see the host binding's normal shape.
+     * Makes the transport resilient to later removal or replacement of
+     * `window.webkit.messageHandlers` (e.g. by privacy hardening that nullifies
+     * the namespace for site JS to reduce fingerprinting surface).
      *
      * @param {string[]} handlerNames
      */

--- a/special-pages/shared/create-special-page-messaging.js
+++ b/special-pages/shared/create-special-page-messaging.js
@@ -36,8 +36,6 @@ export function createSpecialPageMessaging(opts) {
             return new Messaging(messageContext, opts);
         } else if (opts.injectName === 'apple') {
             const opts = new WebkitMessagingConfig({
-                hasModernWebkitAPI: true,
-                secret: '',
                 webkitMessageHandlerNames: ['specialPages'],
             });
             return new Messaging(messageContext, opts);


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/task/1212684734587032?focus=true

## Description

The WebkitMessagingTransport previously only captured handler references at construction time on legacy WebKit (macOS Catalina, < 11). On modern WebKit it re-read `window.webkit.messageHandlers[handler]` on every send. With this change, the `apiManipulation` feature can be used to install a prototype-side getter that nullifies `messageHandlers` for site JS. Without this change, any page-world C-S-S feature that calls notify/request/subscribe after the nullify would synchronously throw inside wkSend reading undefined[handler] and silently degrade because the surrounding polyfills (e.g., webCompat Notification) catch the throw and return defaults.

After this change:
- captureWebkitHandlers always runs in the constructor
- WebkitMessagingConfig: dropped hasModernWebkitAPI and secret params/fields
- wkSend / wkSendAndWait / captureWebkitHandlers: dropped if (!hasModernWebkitAPI) branches
- Original postMessage is left in place so any other code reading through window.webkit.messageHandlers continues to see the host binding's normal shape.
- Removed helper methods only used by the legacy crypto flow (generateRandomMethod, randomString, createRandMethodName, algoObj, createRandKey, createRandIv, decryptResponse)
- Removed SecureMessagingParams class (internal-only, not re-exported)
- Removed 10 now-unused captured-global imports
- Updated the 3 in-tree callers (apple.js, create-special-page-messaging.js, webkit.example.js) to stop passing the now-removed params
- Removed the legacy-WebKit describe block in the unit tests; modern tests simplified to drop the unused config params

Adds unit tests covering:
- capture + routing through captured ref
- leaves original postMessage in place
- transport survives wholesale replacement of window.webkit.messageHandlers
- throws MissingHandler when a handler was never registered


## Testing Steps

- <!-- Include simple steps on how to check this change is working. Write "N/A" if not applicable. -->

## Checklist

<!--
  These questions are a friendly reminder to shipping code, if you're uncertain ask the AoR owners.
  It's also totally appropriate to not check some of these boxes, if they don't apply to your change.
-->
*Please tick all that apply:*

- [ ] I have tested this change locally
- [ ] I have tested this change locally in all supported browsers
- [ ] This change will be visible to users
- [x] I have added automated tests that cover this change
- [ ] I have ensured the change is gated by config
- [ ] This change was covered by a ship review
- [ ] This change was covered by a tech design
- [ ] Any dependent config has been merged



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the native bridge send path for all Apple WebKit injects; behavior is intentional for privacy hardening but any missed handler capture or platform still on legacy WebKit would break messaging.
> 
> **Overview**
> **WebKit messaging** now **captures** `messageHandlers` at transport construction and **sends** only through that cache, so content-scope features keep talking to native after site hardening (e.g. `apiManipulation` nullifying `window.webkit.messageHandlers`).
> 
> **`wkSend`** uses a **null-prototype** handler cache and **captured `ReflectApply`** on stored `{ handler, postMessage }` pairs (no per-send lookup, no `.bind`, host `postMessage` left on `window.webkit`). **Legacy Catalina** encrypted/async reply path, **`SecureMessagingParams`**, and **`hasModernWebkitAPI` / `secret`** on **`WebkitMessagingConfig`** are **removed**; Apple entry points and special-pages wiring only pass handler names.
> 
> **New unit tests** cover capture/routing, survival after `messageHandlers` replacement, missing handlers, prototype pollution, tampered `Object.create`, and correct `this` on dispatch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8f93c796a4a285b519ae2ced1fde5528ee1c9b42. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->