### PR TITLE
fix(ntp): fix mistral icon

### DIFF
--- a/special-pages/pages/new-tab/app/omnibar/components/chat-tools/model-selector/Icons.js
+++ b/special-pages/pages/new-tab/app/omnibar/components/chat-tools/model-selector/Icons.js
@@ -105,7 +105,7 @@ export function OSSIcon(props) {
 export function getModelIcon(modelId) {
     const normalizedModelId = modelId.toLowerCase();
 
-    if (normalizedModelId.startsWith('meta-llama/') || normalizedModelId.startsWith('meta-llama_')) return LlamaIcon;
+    if (normalizedModelId.startsWith('meta-llama')) return LlamaIcon;
     if (normalizedModelId.startsWith('mistral')) return MistralIcon;
     if (normalizedModelId.includes('gpt-oss')) return OSSIcon;
     if (normalizedModelId.startsWith('claude')) return ClaudeIcon;

--- a/special-pages/pages/new-tab/app/omnibar/components/chat-tools/model-selector/Icons.js
+++ b/special-pages/pages/new-tab/app/omnibar/components/chat-tools/model-selector/Icons.js
@@ -103,10 +103,12 @@ export function OSSIcon(props) {
  * @returns {import('preact').ComponentType<import('preact').JSX.SVGAttributes<SVGSVGElement>> | null}
  */
 export function getModelIcon(modelId) {
-    if (modelId.startsWith('meta-llama/') || modelId.startsWith('meta-llama_')) return LlamaIcon;
-    if (modelId.startsWith('mistral')) return MistralIcon;
-    if (modelId.includes('gpt-oss')) return OSSIcon;
-    if (modelId.startsWith('claude')) return ClaudeIcon;
-    if (modelId.startsWith('gpt') || modelId.startsWith('openai')) return OpenAIIcon;
+    const normalizedModelId = modelId.toLowerCase();
+
+    if (normalizedModelId.startsWith('meta-llama/') || normalizedModelId.startsWith('meta-llama_')) return LlamaIcon;
+    if (normalizedModelId.startsWith('mistral')) return MistralIcon;
+    if (normalizedModelId.includes('gpt-oss')) return OSSIcon;
+    if (normalizedModelId.startsWith('claude')) return ClaudeIcon;
+    if (normalizedModelId.startsWith('gpt') || normalizedModelId.startsWith('openai')) return OpenAIIcon;
     return null;
 }

--- a/special-pages/pages/new-tab/app/omnibar/components/chat-tools/model-selector/Icons.js
+++ b/special-pages/pages/new-tab/app/omnibar/components/chat-tools/model-selector/Icons.js
@@ -104,7 +104,7 @@ export function OSSIcon(props) {
  */
 export function getModelIcon(modelId) {
     if (modelId.startsWith('meta-llama/') || modelId.startsWith('meta-llama_')) return LlamaIcon;
-    if (modelId.startsWith('mistralai/') || modelId.startsWith('mistralai_')) return MistralIcon;
+    if (modelId.startsWith('mistral')) return MistralIcon;
     if (modelId.includes('gpt-oss')) return OSSIcon;
     if (modelId.startsWith('claude')) return ClaudeIcon;
     if (modelId.startsWith('gpt') || modelId.startsWith('openai')) return OpenAIIcon;


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1213083312441631/task/1215295182615277?focus=true

## Description
Fix the Mistral icon prefix so the icon displays correctly

<img width="343" height="416" alt="image" src="https://github.com/user-attachments/assets/cde2895e-85ee-43fb-aa83-df73c3f5a8de" />


## Checklist

<!--
  These questions are a friendly reminder to shipping code, if you're uncertain ask the AoR owners.
  It's also totally appropriate to not check some of these boxes, if they don't apply to your change.
-->
*Please tick all that apply:*

- [x] I have tested this change locally
- [ ] I have tested this change locally in all supported browsers
- [x] This change will be visible to users
- [ ] I have added automated tests that cover this change
- [ ] I have ensured the change is gated by config
- [ ] This change was covered by a ship review
- [ ] This change was covered by a tech design
- [ ] Any dependent config has been merged


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only icon lookup change in the new-tab model dropdown with no auth, data, or API impact.
> 
> **Overview**
> Updates **`getModelIcon`** in the NTP omnibar model selector so provider icons match a wider range of model ID strings.
> 
> Model IDs are **lowercased** before prefix checks. **Llama** and **Mistral** no longer require specific `meta-llama/` or `mistralai/` (or underscore) prefixes—matching uses **`meta-llama`** and **`mistral`** instead, so Mistral models show the correct icon when IDs differ from the old patterns.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d0daddc5f847cd052bad424b325e782e7e0ef997. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->