### PR TITLE
ci(dependabot-gate): scope the pre-Anthropic wait to an allowlist

### DIFF
--- a/.github/scripts/dependabot-anthropic-gate.mjs
+++ b/.github/scripts/dependabot-anthropic-gate.mjs
@@ -16,6 +16,23 @@ export const EXPECTED_CHECKS = [
     { name: 'Cursor Automation: Review dependabot', appSlug: CURSOR_APP_SLUG, detailsHost: CURSOR_DETAILS_HOST },
     { name: 'Cursor Automation: Web compat and sec', appSlug: CURSOR_APP_SLUG, detailsHost: CURSOR_DETAILS_HOST },
 ];
+// Names of check runs / commit statuses that must complete and pass before
+// the gate calls Anthropic. The gate is a token-spend optimisation: it
+// avoids asking Anthropic to assess a PR whose test signal is already red.
+// Real merge enforcement still runs through GitHub branch protection, so
+// this list only needs to cover the test signals we'd refuse to spend
+// Anthropic tokens around — admin workflows (`sync` / asana sync) and
+// human-gated checks (`Authorized Review`) are intentionally excluded.
+//
+// Cursor checks aren't on this list; they're already gated separately via
+// EXPECTED_CHECKS (which carries app + host trust signals beyond a name).
+export const REQUIRED_PREREQ_CHECK_NAMES = new Set([
+    // `CI gate` in `.github/workflows/tests.yml` `needs:` every test job
+    // (github-scripts-unit, unit, unit-tests, integration, integration-tests,
+    // integration-tests-special-pages, production-deps) and only succeeds
+    // if all of them do. Gating on it alone covers full test signal.
+    'CI gate',
+]);
 const ANTHROPIC_API_URL = 'https://api.anthropic.com/v1/messages';
 const MAX_BODY_CHARS = 12000;
 const CHECK_WAIT_TIMEOUT_MS = 30 * 60 * 1000;
@@ -231,17 +248,40 @@ export function latestOtherCheckRunsByName(checkRuns, currentRunCheckIds) {
     return [...byKey.values()];
 }
 
+export function isRequiredPrereqCheck(name) {
+    return !!name && REQUIRED_PREREQ_CHECK_NAMES.has(name);
+}
+
 export function checkRunState(checkRuns, currentRunCheckIds) {
-    const latestRuns = latestOtherCheckRunsByName(checkRuns, currentRunCheckIds);
+    const latestRuns = latestOtherCheckRunsByName(checkRuns, currentRunCheckIds).filter((run) => isRequiredPrereqCheck(run.name));
     const pending = latestRuns.filter((run) => run.status !== 'completed');
     const failed = latestRuns.filter((run) => run.status === 'completed' && !PASSING_CHECK_CONCLUSIONS.has(run.conclusion));
     return { pending, failed };
 }
 
 export function commitStatusState(statuses) {
-    const pending = statuses.filter((status) => status.state === 'pending');
-    const failed = statuses.filter((status) => status.state === 'failure' || status.state === 'error');
+    const filtered = statuses.filter((status) => isRequiredPrereqCheck(status.context));
+    const pending = filtered.filter((status) => status.state === 'pending');
+    const failed = filtered.filter((status) => status.state === 'failure' || status.state === 'error');
     return { pending, failed };
+}
+
+/**
+ * Names from REQUIRED_PREREQ_CHECK_NAMES that have not yet appeared as
+ * either a check run or a commit status on the head SHA. Without this,
+ * the wait loop would exit early (treating "no required pending" as
+ * "all clear") before the required checks have even started — wasting
+ * Anthropic tokens on a PR whose CI hasn't run.
+ */
+export function missingRequiredCheckNames(checkRuns, statuses) {
+    const present = new Set();
+    for (const run of checkRuns) {
+        if (run.name) present.add(run.name);
+    }
+    for (const status of statuses) {
+        if (status.context) present.add(status.context);
+    }
+    return [...REQUIRED_PREREQ_CHECK_NAMES].filter((name) => !present.has(name));
 }
 
 function describeCheckRun(run) {
@@ -305,8 +345,9 @@ async function waitForChecksToSettle({ apiRoot, headSha, token, currentRunCheckI
 
         const missingCursor = missingExpectedCheckNames(checkRuns);
         const pendingCursor = pendingExpectedCheckRuns(checkRuns);
-        const otherIdle = checkRunStatus.pending.length === 0 && commitStatus.pending.length === 0;
-        if (otherIdle && missingCursor.length === 0 && pendingCursor.length === 0) {
+        const missingRequired = missingRequiredCheckNames(checkRuns, statuses);
+        const requiredIdle = checkRunStatus.pending.length === 0 && commitStatus.pending.length === 0;
+        if (requiredIdle && missingRequired.length === 0 && missingCursor.length === 0 && pendingCursor.length === 0) {
             return checkRuns;
         }
 
@@ -315,6 +356,7 @@ async function waitForChecksToSettle({ apiRoot, headSha, token, currentRunCheckI
             ...commitStatus.pending.map(describeCommitStatus),
             ...pendingCursor.map(describeCheckRun),
             ...missingCursor.map((name) => `${name} (missing)`),
+            ...missingRequired.map((name) => `${name} (missing)`),
         ].join(', ');
 
         if (Date.now() >= deadline) {

--- a/.github/scripts/dependabot-anthropic-gate.test.mjs
+++ b/.github/scripts/dependabot-anthropic-gate.test.mjs
@@ -3,6 +3,7 @@ import assert from 'node:assert/strict';
 
 import {
     EXPECTED_CHECKS,
+    REQUIRED_PREREQ_CHECK_NAMES,
     cursorAgentId,
     detailsHost,
     matchExpectedCheck,
@@ -10,6 +11,8 @@ import {
     latestOtherCheckRunsByName,
     checkRunState,
     commitStatusState,
+    isRequiredPrereqCheck,
+    missingRequiredCheckNames,
     missingExpectedCheckNames,
     pendingExpectedCheckRuns,
     isTrustedAutomationActor,
@@ -171,16 +174,16 @@ describe('latestOtherCheckRunsByName / checkRunState', () => {
     });
 
     it('does not let a same-named success from a different app supersede a failure', () => {
-        // Realistic scenario: github-actions reports `lint` as failed,
+        // Realistic scenario: github-actions reports `CI gate` as failed,
         // and another installed App with checks:write later publishes a
-        // newer `lint: success`. Keying dedup by (app, name) rather than
+        // newer `CI gate: success`. Keying dedup by (app, name) rather than
         // name alone means the failure must still surface.
-        const failure = externalRun('lint', 'completed', 'failure', {
+        const failure = externalRun('CI gate', 'completed', 'failure', {
             id: 1,
             appSlug: 'github-actions',
             completedAt: '2026-05-28T00:00:00Z',
         });
-        const spoofedSuccess = externalRun('lint', 'completed', 'success', {
+        const spoofedSuccess = externalRun('CI gate', 'completed', 'success', {
             id: 2,
             appSlug: 'another-app',
             completedAt: '2026-05-28T01:00:00Z',
@@ -207,33 +210,83 @@ describe('latestOtherCheckRunsByName / checkRunState', () => {
         assert.equal(result[0].id, 11);
     });
 
-    it('classifies pending vs failed correctly', () => {
-        const ok = externalRun('lint', 'completed', 'success');
-        const skipped = externalRun('typecheck', 'completed', 'skipped');
-        const failed = externalRun('test', 'completed', 'failure');
-        const queued = externalRun('build', 'queued');
+    it('classifies pending vs failed correctly for required checks', () => {
+        // Required checks are scoped by allowlist, so each scenario uses
+        // the only allowlisted name (`CI gate`) with different app slugs
+        // to keep the (app, name) dedup happy.
+        const ok = externalRun('CI gate', 'completed', 'success', { id: 80, appSlug: 'app-ok' });
+        const skipped = externalRun('CI gate', 'completed', 'skipped', { id: 81, appSlug: 'app-skipped' });
+        const failed = externalRun('CI gate', 'completed', 'failure', { id: 82, appSlug: 'app-failed' });
+        const queued = externalRun('CI gate', 'queued', null, { id: 83, appSlug: 'app-queued' });
         const { pending, failed: f } = checkRunState([ok, skipped, failed, queued], new Set());
         assert.equal(pending.length, 1);
-        assert.equal(pending[0].name, 'build');
+        assert.equal(pending[0].id, 83);
         assert.equal(f.length, 1);
-        assert.equal(f[0].name, 'test');
+        assert.equal(f[0].id, 82);
+    });
+
+    it('ignores check runs whose name is not in the required allowlist', () => {
+        // `sync` (asana sync) and `Authorized Review` are intentionally
+        // not on REQUIRED_PREREQ_CHECK_NAMES — failures or pending states
+        // on them must not block the gate.
+        const asanaSync = externalRun('sync', 'completed', 'failure');
+        const authorizedReview = externalRun('Authorized Review', 'queued');
+        const otherCi = externalRun('lint', 'completed', 'failure');
+        const { pending, failed } = checkRunState([asanaSync, authorizedReview, otherCi], new Set());
+        assert.equal(pending.length, 0);
+        assert.equal(failed.length, 0);
     });
 });
 
 describe('commitStatusState', () => {
-    it('separates pending statuses from failures and successes', () => {
+    it('separates pending statuses from failures and successes for required contexts', () => {
         const statuses = [
-            { context: 'ci/a', state: 'success' },
-            { context: 'ci/b', state: 'pending' },
-            { context: 'ci/c', state: 'failure' },
-            { context: 'ci/d', state: 'error' },
+            { context: 'CI gate', state: 'success' },
+            { context: 'CI gate', state: 'pending' },
+            { context: 'CI gate', state: 'failure' },
+            { context: 'CI gate', state: 'error' },
         ];
         const { pending, failed } = commitStatusState(statuses);
         assert.deepEqual(
-            pending.map((s) => s.context),
-            ['ci/b'],
+            pending.map((s) => s.state),
+            ['pending'],
         );
-        assert.deepEqual(failed.map((s) => s.context).sort(), ['ci/c', 'ci/d']);
+        assert.deepEqual(failed.map((s) => s.state).sort(), ['error', 'failure']);
+    });
+
+    it('ignores statuses whose context is not in the required allowlist', () => {
+        const statuses = [
+            { context: 'sync', state: 'failure' },
+            { context: 'Authorized Review', state: 'pending' },
+        ];
+        const { pending, failed } = commitStatusState(statuses);
+        assert.equal(pending.length, 0);
+        assert.equal(failed.length, 0);
+    });
+});
+
+describe('isRequiredPrereqCheck / missingRequiredCheckNames', () => {
+    it('isRequiredPrereqCheck only returns true for names on the allowlist', () => {
+        for (const name of REQUIRED_PREREQ_CHECK_NAMES) {
+            assert.equal(isRequiredPrereqCheck(name), true);
+        }
+        assert.equal(isRequiredPrereqCheck('sync'), false);
+        assert.equal(isRequiredPrereqCheck('Authorized Review'), false);
+        assert.equal(isRequiredPrereqCheck(undefined), false);
+        assert.equal(isRequiredPrereqCheck(null), false);
+        assert.equal(isRequiredPrereqCheck(''), false);
+    });
+
+    it('missingRequiredCheckNames lists allowlist names absent from checks and statuses', () => {
+        const missing = missingRequiredCheckNames([], []);
+        assert.deepEqual(missing.sort(), [...REQUIRED_PREREQ_CHECK_NAMES].sort());
+    });
+
+    it('missingRequiredCheckNames treats either a check run or a commit status as present', () => {
+        const fromCheck = missingRequiredCheckNames([{ name: 'CI gate', status: 'queued' }], []);
+        assert.deepEqual(fromCheck, []);
+        const fromStatus = missingRequiredCheckNames([], [{ context: 'CI gate', state: 'pending' }]);
+        assert.deepEqual(fromStatus, []);
     });
 });
 


### PR DESCRIPTION
## Summary

- The Anthropic gate is an optimisation step — its job is to avoid spending Anthropic tokens when a PR's test signal is already red. It is not the merge gate; branch protection still enforces what actually merges.
- The current wait loop treats *every* non-gate check on the head SHA as a hard pre-req, including admin workflows (`sync` / asana sync) and human-gated checks (`Authorized Review`). Both kept the gate from ever reaching the Anthropic call on recent dependabot PRs (#2740, #2739, #2736, #2722, #2717).
- Replace the "every other check must pass" rule with an explicit allowlist (`REQUIRED_PREREQ_CHECK_NAMES`). `CI gate` in `.github/workflows/tests.yml` already `needs:` every test job and only succeeds if all of them do, so gating on it alone covers the full test signal. Cursor checks stay handled via the existing `EXPECTED_CHECKS` path.
- Extend `waitForChecksToSettle()` with `missingRequiredCheckNames()` so it doesn't treat "no required checks present yet" as "all clear" and fire Anthropic before CI has even started.

## Test plan

- [x] Run `node --test .github/scripts/dependabot-anthropic-gate.test.mjs` — all 60 tests pass (5 new, covering the allowlist filter, missing-required handling, and updated classification behaviour)
- [ ] On merge, verify a dependabot PR with `sync` failing or `Authorized Review` pending now reaches the Anthropic call instead of bailing
- [ ] Confirm the new `ANTHROPIC_API_KEY` is exercised end-to-end on at least one PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes only Dependabot gate wait logic in `.github/scripts/` with thorough unit tests; merge enforcement remains on branch protection.
> 
> **Overview**
> The Dependabot Anthropic gate no longer waits for **every** non-gate check on the PR head to pass before calling Anthropic. It now uses an explicit allowlist (`REQUIRED_PREREQ_CHECK_NAMES`) that currently only includes **`CI gate`**, so admin workflows like `sync` and human gates like `Authorized Review` no longer block the optimization step. Cursor checks are unchanged and still enforced via `EXPECTED_CHECKS`.
> 
> `checkRunState` and `commitStatusState` only consider allowlisted names. **`missingRequiredCheckNames()`** was added so `waitForChecksToSettle()` does not treat “no required checks yet” as ready and invoke Anthropic before CI has started. Unit tests were extended for the allowlist filter, missing-required handling, and updated classification behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 786dd1dd6ab7b0573aca4d2a825298349c005be4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->