### PR TITLE
chore(codeowners): add @daxtheduck as owner of package.json and package-lock.json

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -48,5 +48,5 @@ injected/src/navigator-global.js @duckduckgo/content-scope-scripts-owners
 
 # Workflows and admin
 .github/ @duckduckgo/content-scope-scripts-owners
-package.json @duckduckgo/content-scope-scripts-owners
-package-lock.json @duckduckgo/content-scope-scripts-owners
+package.json @duckduckgo/content-scope-scripts-owners @daxtheduck
+package-lock.json @duckduckgo/content-scope-scripts-owners @daxtheduck


### PR DESCRIPTION
## Summary

Final piece of the dependabot auto-merge chain (#2742, #2743, #2745). The gate now approves PRs as `daxtheduck` via DAX_PAT, which satisfies the `Authorized Review` status the org enforces via `review-check.yml`. But branch protection's native `require_code_owner_reviews: true` is a separate, GitHub-level requirement: it needs approval from someone listed as a CODEOWNER for the files touched.

Dependabot PRs only ever touch `package.json` (root + per-workspace) and `package-lock.json`, so add `@daxtheduck` to the two existing patterns. Patterns are unanchored (gitignore-style), so they cover all workspace `package.json` files too — verified against #2722 which touches `injected/package.json`, `package-lock.json`, `special-pages/package.json`.

After this lands, the end-to-end flow is:
1. Anthropic gate decides `safe_to_merge: true` (allowlist + tool_use from #2742/#2743)
2. Auto-merge workflow approves as `daxtheduck` (#2745) → `Authorized Review` flips green, CODEOWNERS satisfied (this PR)
3. Branch protection's required checks (`snapshots`, `CI gate`, `review_validation`) land green
4. Auto-merge fires

## Test plan

- [ ] On merge, kick `@dependabot rebase` on one of the previously auto-approved PRs (#2723, #2722, #2721, #2718, #2717). Expect the merge to actually complete this time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CODEOWNERS-only change with no runtime or application code impact.
> 
> **Overview**
> Adds **`@daxtheduck`** as a CODEOWNER on root **`package.json`** and **`package-lock.json`** (alongside `@duckduckgo/content-scope-scripts-owners`), so auto-merge approvals from that account satisfy GitHub’s required code-owner review on Dependabot dependency bumps.
> 
> This is the governance follow-up to the Dependabot auto-merge workflow: the bot can approve as `daxtheduck`, but branch protection still needs an owner listed for the touched manifest files.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 00e09947019ad1efabc69f5ac7c6046827c8e0c6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->