### PR TITLE
ci(dependabot-gate): drop --merge flag so the merge queue can take over

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -134,7 +134,12 @@ jobs:
                       ;;
                   esac
 
-                  if ! out="$(gh pr merge "$PR_NUMBER" --repo "$REPO" --auto --merge --match-head-commit "$PR_HEAD_SHA" 2>&1)"; then
+                  # No strategy flag (`--merge`/`--squash`/`--rebase`):
+                  # `main` is governed by a merge queue, which dictates
+                  # the strategy and rejects any explicit override with
+                  # "The merge strategy for main is set by the merge
+                  # queue", silently leaving the PR unqueued.
+                  if ! out="$(gh pr merge "$PR_NUMBER" --repo "$REPO" --auto --match-head-commit "$PR_HEAD_SHA" 2>&1)"; then
                     echo "Could not enable auto-merge for PR; leaving it unqueued."
                     echo "$out"
                     exit 0


### PR DESCRIPTION
## Summary

One-line fix for the actual reason all 5 fully-CLEAN dependabot PRs (#2723, #2722, #2721, #2718, #2717) are sitting unmerged with auto-merge **not enabled**.

### The bug, verified on #2722 at 15:44 and 16:06

```
merge_state=UNSTABLE ready
Could not enable auto-merge for PR; leaving it unqueued.
! The merge strategy for main is set by the merge queue
```

`main` is governed by a **merge queue**. `gh pr merge --auto --merge` (or any strategy flag) is rejected by the queue, the workflow logs "could not enable auto-merge" and exits 0, and the PR stays unqueued forever.

### The fix

Drop **`--merge`** so the queue picks the strategy. `--auto` (enable merge-when-ready) and `--match-head-commit` (safety guard) stay.

```diff
- gh pr merge "$PR_NUMBER" --repo "$REPO" --auto --merge --match-head-commit "$PR_HEAD_SHA"
+ gh pr merge "$PR_NUMBER" --repo "$REPO" --auto --match-head-commit "$PR_HEAD_SHA"
```

The two earlier scoped-up versions of this PR (idempotent approve, `!cancelled()` re-arm) were dropped — both turned out to be belt-and-braces, not load-bearing: the Approve step doesn't actually fail when there's a prior approval (GitHub allows multiple APPROVED reviews from the same user), so `!cancelled()` isn't needed and the idempotency just removed noise.

## Test plan

- [ ] Merge, then `@dependabot rebase` one of the 5 already-CLEAN PRs. Expect `gh pr merge --auto` to succeed this time and the merge queue to take the PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change to how auto-merge is armed; no application runtime or security behavior changes.
> 
> **Overview**
> Fixes Dependabot auto-merge on **`main`** by removing the explicit **`--merge`** strategy from **`gh pr merge --auto`**.
> 
> When the default branch uses a **merge queue**, GitHub rejects **`--merge`/`--squash`/`--rebase`** with *"The merge strategy for main is set by the merge queue"*, so the workflow logged a failure and exited without queuing otherwise clean PRs. The step now calls **`gh pr merge --auto --match-head-commit`** only, letting the queue choose the strategy, with an inline comment documenting why.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c81092648a2ac0d4e4a0f469299f5417b75ad105. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->