### PR TITLE
ci(asana): skip Asana sync for Dependabot pull requests

### DIFF
--- a/.github/workflows/asana.yml
+++ b/.github/workflows/asana.yml
@@ -14,6 +14,7 @@ jobs:
     sync:
         if: >-
             !github.event.pull_request.head.repo.fork &&
+            github.event.pull_request.user.login != 'dependabot[bot]' &&
             !startsWith(github.event.pull_request.head.ref, 'cursor/') &&
             !startsWith(github.event.pull_request.head.ref, 'claude/')
         runs-on: ubuntu-latest


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Skip the `asana sync` workflow for Dependabot PRs. Dependabot-triggered runs use the Dependabot secret context, which does not include `ASANA_ACCESS_TOKEN`, producing spurious `sync` check failures on dependency bumps.

## Test plan

- [ ] Open a Dependabot PR after merge — `asana sync` should not run on `pull_request` / `pull_request_review` events from `dependabot[bot]`
- [ ] Non-Dependabot PRs should continue to sync to Asana as before
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b1c50e00-7c7d-407d-b9c6-a26b819436b7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b1c50e00-7c7d-407d-b9c6-a26b819436b7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

