### PR TITLE
ci(dependabot-gate): enable auto-merge as daxtheduck via DAX_PAT

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -103,10 +103,18 @@ jobs:
                   fi
                   echo "$out"
 
+            # Enable auto-merge as `daxtheduck` (via DAX_PAT) rather than
+            # GITHUB_TOKEN. When github-actions[bot] arms auto-merge and the
+            # PR later enters the merge queue, GitHub attributes the enqueue
+            # to github-actions and merge_group CI often never dispatches —
+            # the queue sits in AWAITING_CHECKS with only incidental push
+            # workflows (e.g. build-branch) reporting. Enabling as a real
+            # user matches manual "Merge when ready" and reliably triggers
+            # the required snapshots / CI gate / review_validation runs.
             - name: Enable auto-merge for npm update
               if: steps.anthropic_gate.outputs.safe_to_merge == 'true'
               env:
-                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  GH_TOKEN: ${{ secrets.DAX_PAT }}
                   PR_NUMBER: ${{ github.event.pull_request.number }}
                   PR_HEAD_SHA: ${{ steps.anthropic_gate.outputs.assessed_head_sha }}
                   REPO: ${{ github.repository }}


### PR DESCRIPTION


**Asana Task/Github Issue:** <!-- Link to Asana Task/Github Issue -->

## Description

When github-actions[bot] arms auto-merge, merge queue entries are attributed to the bot and merge_group CI often fails to dispatch, leaving PRs stuck in AWAITING_CHECKS. Use DAX_PAT for the auto-merge step, matching the approval step in #2745.

## Testing Steps

- <!-- Include simple steps on how to check this change is working. Write "N/A" if not applicable. -->

## Checklist

<!--
  These questions are a friendly reminder to shipping code, if you're uncertain ask the AoR owners.
  It's also totally appropriate to not check some of these boxes, if they don't apply to your change.
-->
*Please tick all that apply:*

- [ ] I have tested this change locally
- [ ] I have tested this change locally in all supported browsers
- [ ] This change will be visible to users
- [ ] I have added automated tests that cover this change
- [ ] I have ensured the change is gated by config
- [ ] This change was covered by a ship review
- [ ] This change was covered by a tech design
- [ ] Any dependent config has been merged


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Swaps the credential used to enable auto-merge to a personal access token with broader GitHub API identity implications; change is limited to one workflow step but affects how Dependabot PRs enter the merge queue.
> 
> **Overview**
> The Dependabot auto-merge workflow’s **Enable auto-merge for npm update** step now uses **`secrets.DAX_PAT`** instead of **`GITHUB_TOKEN`**, so auto-merge is armed as **`daxtheduck`**—the same identity already used for the approve step.
> 
> This targets merge-queue behavior where **`github-actions[bot]`**-attributed auto-merge can leave entries in **AWAITING_CHECKS** without dispatching required **merge_group** CI (snapshots, CI gate, review validation). Enabling as a real user is intended to match manual “Merge when ready” and unblock those checks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a23b5a0bc1cb3f134ce7fd2bbe0321e3d4ab55f3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->