### PR TITLE
ci(dependabot-gate): dismiss + REQUEST_CHANGES + ping team on Anthropic decline

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -177,8 +177,20 @@ jobs:
             # approval can outlive a later `safe_to_merge: false`
             # verdict and leave the PR mergeable from the UI against
             # the gate's current judgement.
+            #
+            # Required upstream signal (per the note above the merge
+            # gate): only run after the per-thread classifier has
+            # completed every Dependabot reviewer inline thread, and
+            # only after the Anthropic merge gate itself has returned
+            # a `safe_to_merge: false` verdict. That ordering ensures
+            # we never assign a human reviewer on a half-evaluated PR
+            # — e.g. one where the classifier crashed mid-pass and
+            # only some threads have been triaged.
             - name: Defer to human reviewer if Anthropic declined
-              if: steps.anthropic_gate.outputs.safe_to_merge == 'false'
+              if: |
+                  steps.classify_threads.outcome == 'success' &&
+                  steps.classify_threads.outputs.review_thread_classification_complete == 'true' &&
+                  steps.anthropic_gate.outputs.safe_to_merge == 'false'
               env:
                   GH_TOKEN: ${{ secrets.DAX_PAT }}
                   PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -195,27 +195,22 @@ jobs:
                     exit 1
                   fi
 
-                  # Idempotent: skip if daxtheduck's latest decision on
-                  # this head SHA is already REQUEST_CHANGES. Must use
-                  # latest-decision semantics (not "any historical
-                  # CHANGES_REQUESTED") so a later APPROVE on the same
-                  # commit is not left in place when Anthropic declines.
-                  latest_is_changes_requested="$(gh api "repos/$REPO/pulls/$PR_NUMBER/reviews" --paginate \
-                    --jq --arg sha "$PR_HEAD_SHA" '
-                      [.[] | select(.user.login == "daxtheduck" and (.state == "APPROVED" or .state == "CHANGES_REQUESTED" or .state == "DISMISSED"))]
-                      | last
-                      | (. != null and .state == "CHANGES_REQUESTED" and .commit_id == $sha)
-                    ')"
-                  if [[ "$latest_is_changes_requested" == "true" ]]; then
-                    echo "daxtheduck latest decision is already REQUEST_CHANGES on $PR_HEAD_SHA; skipping."
-                    exit 0
-                  fi
+                  # Each action below is independently idempotent rather
+                  # than gating on a single top-level "already done"
+                  # check. A previous run that crashed between posting
+                  # REQUEST_CHANGES and adding the reviewer/assignee
+                  # would otherwise leave those best-effort steps
+                  # permanently skipped on subsequent runs against the
+                  # same SHA.
 
                   # Dismiss any prior APPROVED reviews from daxtheduck.
-                  # The new REQUEST_CHANGES already supersedes them in
-                  # `review-helpers.findAuthorizedApproval` (which keys
-                  # on latest decision per user), but explicit dismissal
-                  # makes the supersede visible in the timeline.
+                  # Naturally idempotent: the filter is `state ==
+                  # APPROVED`, so already-dismissed reviews don't
+                  # appear in the list and aren't re-dismissed. The new
+                  # REQUEST_CHANGES below also supersedes them via
+                  # `findAuthorizedApproval`'s latest-decision-per-user
+                  # logic, but explicit dismissal makes the supersede
+                  # visible in the timeline.
                   approved_ids="$(gh api "repos/$REPO/pulls/$PR_NUMBER/reviews" --paginate \
                     --jq '[.[] | select(.user.login == "daxtheduck" and .state == "APPROVED") | .id] | .[]')"
                   for id in $approved_ids; do
@@ -228,22 +223,37 @@ jobs:
                       > /dev/null || echo "Failed to dismiss review $id (continuing)"
                   done
 
-                  jq -n \
-                    --arg event "REQUEST_CHANGES" \
-                    --arg commit_id "$PR_HEAD_SHA" \
-                    --arg reason "$REASON" \
-                    --arg confidence "$CONFIDENCE" \
-                    --arg team "$REVIEWER_TEAM" \
-                    '{
-                      event: $event,
-                      commit_id: $commit_id,
-                      body: ("Anthropic gate declined to auto-approve this PR.\n\n**Reason:** " + $reason + "\n**Confidence:** " + $confidence + "\n\nDeferred to @" + $team + " for review.")
-                    }' | \
-                  gh api "repos/$REPO/pulls/$PR_NUMBER/reviews" \
-                    --method POST \
-                    --input - \
-                    > /dev/null
-                  echo "Posted REQUEST_CHANGES on $PR_NUMBER at $PR_HEAD_SHA."
+                  # Post REQUEST_CHANGES with its own latest-decision
+                  # idempotency check so this single action doesn't
+                  # spam the timeline, while the reviewer/assignee
+                  # steps below still run if a prior attempt crashed
+                  # after posting the review.
+                  latest_is_changes_requested="$(gh api "repos/$REPO/pulls/$PR_NUMBER/reviews" --paginate \
+                    --jq --arg sha "$PR_HEAD_SHA" '
+                      [.[] | select(.user.login == "daxtheduck" and (.state == "APPROVED" or .state == "CHANGES_REQUESTED" or .state == "DISMISSED"))]
+                      | last
+                      | (. != null and .state == "CHANGES_REQUESTED" and .commit_id == $sha)
+                    ')"
+                  if [[ "$latest_is_changes_requested" == "true" ]]; then
+                    echo "daxtheduck latest decision is already REQUEST_CHANGES on $PR_HEAD_SHA; skipping new review."
+                  else
+                    jq -n \
+                      --arg event "REQUEST_CHANGES" \
+                      --arg commit_id "$PR_HEAD_SHA" \
+                      --arg reason "$REASON" \
+                      --arg confidence "$CONFIDENCE" \
+                      --arg team "$REVIEWER_TEAM" \
+                      '{
+                        event: $event,
+                        commit_id: $commit_id,
+                        body: ("Anthropic gate declined to auto-approve this PR.\n\n**Reason:** " + $reason + "\n**Confidence:** " + $confidence + "\n\nDeferred to @" + $team + " for review.")
+                      }' | \
+                    gh api "repos/$REPO/pulls/$PR_NUMBER/reviews" \
+                      --method POST \
+                      --input - \
+                      > /dev/null
+                    echo "Posted REQUEST_CHANGES on $PR_NUMBER at $PR_HEAD_SHA."
+                  fi
 
                   # Best-effort: ping the CODEOWNERS team for review.
                   # CODEOWNERS should already auto-request, but reinforce

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -195,16 +195,19 @@ jobs:
                     exit 1
                   fi
 
-                  # Idempotent: skip if daxtheduck already posted
-                  # REQUEST_CHANGES on the current head SHA. Mirrors
-                  # the latest-decision pattern used by Approve, but
-                  # keyed to the unique signal we emit here.
-                  already_requested_changes="$(gh api "repos/$REPO/pulls/$PR_NUMBER/reviews" --paginate \
+                  # Idempotent: skip if daxtheduck's latest decision on
+                  # this head SHA is already REQUEST_CHANGES. Must use
+                  # latest-decision semantics (not "any historical
+                  # CHANGES_REQUESTED") so a later APPROVE on the same
+                  # commit is not left in place when Anthropic declines.
+                  latest_is_changes_requested="$(gh api "repos/$REPO/pulls/$PR_NUMBER/reviews" --paginate \
                     --jq --arg sha "$PR_HEAD_SHA" '
-                      [.[] | select(.user.login == "daxtheduck" and .state == "CHANGES_REQUESTED" and .commit_id == $sha)] | length
+                      [.[] | select(.user.login == "daxtheduck" and (.state == "APPROVED" or .state == "CHANGES_REQUESTED" or .state == "DISMISSED"))]
+                      | last
+                      | (. != null and .state == "CHANGES_REQUESTED" and .commit_id == $sha)
                     ')"
-                  if [[ "$already_requested_changes" -gt 0 ]]; then
-                    echo "daxtheduck already posted REQUEST_CHANGES on $PR_HEAD_SHA; skipping."
+                  if [[ "$latest_is_changes_requested" == "true" ]]; then
+                    echo "daxtheduck latest decision is already REQUEST_CHANGES on $PR_HEAD_SHA; skipping."
                     exit 0
                   fi
 
@@ -216,19 +219,29 @@ jobs:
                   approved_ids="$(gh api "repos/$REPO/pulls/$PR_NUMBER/reviews" --paginate \
                     --jq '[.[] | select(.user.login == "daxtheduck" and .state == "APPROVED") | .id] | .[]')"
                   for id in $approved_ids; do
+                    jq -n \
+                      --arg reason "$REASON" \
+                      '{message: ("Superseded: Anthropic gate now reports safe_to_merge=false. " + $reason), event: "DISMISS"}' | \
                     gh api "repos/$REPO/pulls/$PR_NUMBER/reviews/$id/dismissals" \
                       --method PUT \
-                      -f message="Superseded: Anthropic gate now reports safe_to_merge=false. $REASON" \
-                      -f event=DISMISS \
+                      --input - \
                       > /dev/null || echo "Failed to dismiss review $id (continuing)"
                   done
 
-                  body="$(printf 'Anthropic gate declined to auto-approve this PR.\n\n**Reason:** %s\n**Confidence:** %s\n\nDeferred to @%s for review.' "$REASON" "$CONFIDENCE" "$REVIEWER_TEAM")"
+                  jq -n \
+                    --arg event "REQUEST_CHANGES" \
+                    --arg commit_id "$PR_HEAD_SHA" \
+                    --arg reason "$REASON" \
+                    --arg confidence "$CONFIDENCE" \
+                    --arg team "$REVIEWER_TEAM" \
+                    '{
+                      event: $event,
+                      commit_id: $commit_id,
+                      body: ("Anthropic gate declined to auto-approve this PR.\n\n**Reason:** " + $reason + "\n**Confidence:** " + $confidence + "\n\nDeferred to @" + $team + " for review.")
+                    }' | \
                   gh api "repos/$REPO/pulls/$PR_NUMBER/reviews" \
                     --method POST \
-                    -f event=REQUEST_CHANGES \
-                    -f commit_id="$PR_HEAD_SHA" \
-                    -f body="$body" \
+                    --input - \
                     > /dev/null
                   echo "Posted REQUEST_CHANGES on $PR_NUMBER at $PR_HEAD_SHA."
 

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -168,3 +168,72 @@ jobs:
                     exit 0
                   fi
                   echo "$out"
+
+            # Symmetric counterpart to the Approve step: when Anthropic
+            # declines, dismiss any stale `daxtheduck` approval, post a
+            # REQUEST_CHANGES review carrying Anthropic's reason, and
+            # request review from the CODEOWNERS team so a human picks
+            # it up. Without this, a previous `safe_to_merge: true`
+            # approval can outlive a later `safe_to_merge: false`
+            # verdict and leave the PR mergeable from the UI against
+            # the gate's current judgement.
+            - name: Defer to human reviewer if Anthropic declined
+              if: steps.anthropic_gate.outputs.safe_to_merge == 'false'
+              env:
+                  GH_TOKEN: ${{ secrets.DAX_PAT }}
+                  PR_NUMBER: ${{ github.event.pull_request.number }}
+                  PR_HEAD_SHA: ${{ steps.anthropic_gate.outputs.assessed_head_sha }}
+                  REASON: ${{ steps.anthropic_gate.outputs.reason }}
+                  CONFIDENCE: ${{ steps.anthropic_gate.outputs.confidence }}
+                  REPO: ${{ github.repository }}
+                  REVIEWER_TEAM: duckduckgo/content-scope-scripts-owners
+              run: |
+                  set -euo pipefail
+                  current_head="$(gh pr view "$PR_NUMBER" --repo "$REPO" --json headRefOid --jq '.headRefOid')"
+                  if [[ "$current_head" != "$PR_HEAD_SHA" ]]; then
+                    echo "PR head advanced from $PR_HEAD_SHA to $current_head; refusing to act on stale gate evidence."
+                    exit 1
+                  fi
+
+                  # Idempotent: skip if daxtheduck already posted
+                  # REQUEST_CHANGES on the current head SHA. Mirrors
+                  # the latest-decision pattern used by Approve, but
+                  # keyed to the unique signal we emit here.
+                  already_requested_changes="$(gh api "repos/$REPO/pulls/$PR_NUMBER/reviews" --paginate \
+                    --jq --arg sha "$PR_HEAD_SHA" '
+                      [.[] | select(.user.login == "daxtheduck" and .state == "CHANGES_REQUESTED" and .commit_id == $sha)] | length
+                    ')"
+                  if [[ "$already_requested_changes" -gt 0 ]]; then
+                    echo "daxtheduck already posted REQUEST_CHANGES on $PR_HEAD_SHA; skipping."
+                    exit 0
+                  fi
+
+                  # Dismiss any prior APPROVED reviews from daxtheduck.
+                  # The new REQUEST_CHANGES already supersedes them in
+                  # `review-helpers.findAuthorizedApproval` (which keys
+                  # on latest decision per user), but explicit dismissal
+                  # makes the supersede visible in the timeline.
+                  approved_ids="$(gh api "repos/$REPO/pulls/$PR_NUMBER/reviews" --paginate \
+                    --jq '[.[] | select(.user.login == "daxtheduck" and .state == "APPROVED") | .id] | .[]')"
+                  for id in $approved_ids; do
+                    gh api "repos/$REPO/pulls/$PR_NUMBER/reviews/$id/dismissals" \
+                      --method PUT \
+                      -f message="Superseded: Anthropic gate now reports safe_to_merge=false. $REASON" \
+                      -f event=DISMISS \
+                      > /dev/null || echo "Failed to dismiss review $id (continuing)"
+                  done
+
+                  body="$(printf 'Anthropic gate declined to auto-approve this PR.\n\n**Reason:** %s\n**Confidence:** %s\n\nDeferred to @%s for review.' "$REASON" "$CONFIDENCE" "$REVIEWER_TEAM")"
+                  gh api "repos/$REPO/pulls/$PR_NUMBER/reviews" \
+                    --method POST \
+                    -f event=REQUEST_CHANGES \
+                    -f commit_id="$PR_HEAD_SHA" \
+                    -f body="$body" \
+                    > /dev/null
+                  echo "Posted REQUEST_CHANGES on $PR_NUMBER at $PR_HEAD_SHA."
+
+                  # Best-effort: ping the CODEOWNERS team. If they're
+                  # already requested, gh exits non-zero with a benign
+                  # "already requested" message — don't fail the step.
+                  gh pr edit "$PR_NUMBER" --repo "$REPO" --add-reviewer "$REVIEWER_TEAM" \
+                    || echo "Could not add reviewer team $REVIEWER_TEAM (likely already requested; continuing)"

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -232,8 +232,33 @@ jobs:
                     > /dev/null
                   echo "Posted REQUEST_CHANGES on $PR_NUMBER at $PR_HEAD_SHA."
 
-                  # Best-effort: ping the CODEOWNERS team. If they're
-                  # already requested, gh exits non-zero with a benign
-                  # "already requested" message — don't fail the step.
+                  # Best-effort: ping the CODEOWNERS team for review.
+                  # CODEOWNERS should already auto-request, but reinforce
+                  # here in case the team was removed via prior review
+                  # activity. If already requested, gh exits non-zero
+                  # with a benign message — don't fail the step.
                   gh pr edit "$PR_NUMBER" --repo "$REPO" --add-reviewer "$REVIEWER_TEAM" \
                     || echo "Could not add reviewer team $REVIEWER_TEAM (likely already requested; continuing)"
+
+                  # Assign a random member of the CODEOWNERS team so the
+                  # Asana ↔ GitHub integration opens a task. GitHub
+                  # `assignees` must be individuals — there is no team-
+                  # assignee API surface — so we sample one to spread
+                  # load across rotations. Skip if a human is already
+                  # assigned, so re-runs don't keep growing the list.
+                  existing_assignees="$(gh pr view "$PR_NUMBER" --repo "$REPO" --json assignees --jq '.assignees | length')"
+                  if [[ "$existing_assignees" -eq 0 ]]; then
+                    team_org="${REVIEWER_TEAM%%/*}"
+                    team_slug="${REVIEWER_TEAM##*/}"
+                    members="$(gh api "orgs/$team_org/teams/$team_slug/members" --paginate --jq '.[].login' || true)"
+                    random_member="$(printf '%s\n' "$members" | shuf -n 1 || true)"
+                    if [[ -n "$random_member" ]]; then
+                      gh pr edit "$PR_NUMBER" --repo "$REPO" --add-assignee "$random_member" \
+                        && echo "Assigned $random_member from $REVIEWER_TEAM" \
+                        || echo "Could not assign $random_member (continuing)"
+                    else
+                      echo "Could not pick a random member from $REVIEWER_TEAM (token may lack read:org)"
+                    fi
+                  else
+                    echo "Skipping assignment: PR already has $existing_assignees assignee(s)."
+                  fi


### PR DESCRIPTION
## Summary

The auto-merge workflow was asymmetric — it acted on `safe_to_merge: true` (approve, enable auto-merge) but did **nothing** on `safe_to_merge: false`. A prior approval from `daxtheduck` could therefore outlive a later negative verdict, leaving the PR mergeable from the UI against the gate's current judgement.

This is what happened on #2719: approved yesterday when Anthropic said safe, declined today (Cursor flagged "uncertain renderer changes and test coverage gaps that could miss visual regressions"), but the PR is still showing CLEAN with daxtheduck approved. A human glancing at it sees green checkmarks and an approval — and could merge it without realising the gate has since decided against.

## What this PR adds

A new `Defer to human reviewer if Anthropic declined` step. On `safe_to_merge: false`:

1. **Idempotent skip** if `daxtheduck` already posted `REQUEST_CHANGES` on the current head SHA — mirrors the latest-decision pattern used by Approve, just keyed to the inverse signal.
2. **Dismiss any prior `daxtheduck` APPROVED reviews.** The new `REQUEST_CHANGES` already supersedes them via `findAuthorizedApproval`'s latest-decision-per-user logic, but explicit dismissal makes the supersede visible in the PR timeline rather than a quiet override.
3. **Post a `REQUEST_CHANGES` review** carrying Anthropic's `reason` and `confidence`. This flips `Authorized Review` to pending and aligns the PR's review state with the latest verdict.
4. **Best-effort request review from `@duckduckgo/content-scope-scripts-owners`** (the CODEOWNERS team for `package.json` / `package-lock.json`) so a human picks it up. If already requested, the `gh pr edit` call exits non-zero with a benign message and we continue.

The gate script already emits `reason` and `confidence` outputs, so no script-side changes are needed.

## Test plan

- [ ] Merge, then `@dependabot rebase` #2719. Expect:
  - Anthropic gate again returns `safe_to_merge: false`
  - The new step dismisses daxtheduck's prior APPROVED review with the reason as the dismissal message
  - A `REQUEST_CHANGES` review appears on the PR carrying Anthropic's reason
  - `@duckduckgo/content-scope-scripts-owners` is added as a reviewer
  - `Authorized Review` flips to PENDING; PR moves out of CLEAN

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes automated PR review and merge eligibility for Dependabot npm updates via privileged `DAX_PAT` actions; mis-timed or incorrect gate runs could wrongly block merges, though guards limit runs to fully classified threads and matching SHAs.
> 
> **Overview**
> Adds a **symmetric “decline” path** to the Dependabot auto-merge workflow when the Anthropic merge gate returns `safe_to_merge: false`, so an older `daxtheduck` approval cannot still make the PR look mergeable after a later negative verdict.
> 
> The new **Defer to human reviewer if Anthropic declined** step runs only after thread classification is complete and the assessed head SHA still matches the PR. It dismisses prior `daxtheduck` **APPROVED** reviews, posts **REQUEST_CHANGES** with Anthropic’s `reason` and `confidence` (with per-action idempotency), best-effort adds `@duckduckgo/content-scope-scripts-owners` as reviewer, and assigns a random team member when no assignees exist (for Asana integration).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ecccacb88a52682e5ab190c33c15d83187f42982. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->