### PR TITLE
fix(types): replace any/* casts with specific types across injected/

### DIFF
--- a/injected/entry-points/android.js
+++ b/injected/entry-points/android.js
@@ -29,7 +29,7 @@ function initCode() {
 
     load(getLoadArgs(processedConfig));
 
-    init(processedConfig);
+    init(/** @type {import('../src/content-scope-features.js').LoadArgs} */ (processedConfig));
 }
 
 initCode();

--- a/injected/entry-points/android.js
+++ b/injected/entry-points/android.js
@@ -2,7 +2,7 @@
  * @module Android integration
  */
 import { load, init } from '../src/content-scope-features.js';
-import { processConfig, getLoadArgs } from './../src/utils';
+import { processConfig, getLoadArgs, getInitArgs } from './../src/utils';
 import { AndroidMessagingConfig } from '../../messaging/index.js';
 
 function initCode() {
@@ -29,7 +29,7 @@ function initCode() {
 
     load(getLoadArgs(processedConfig));
 
-    init(getLoadArgs(processedConfig));
+    init(getInitArgs(processedConfig));
 }
 
 initCode();

--- a/injected/entry-points/android.js
+++ b/injected/entry-points/android.js
@@ -29,7 +29,7 @@ function initCode() {
 
     load(getLoadArgs(processedConfig));
 
-    init(/** @type {import('../src/content-scope-features.js').LoadArgs} */ (processedConfig));
+    init(getLoadArgs(processedConfig));
 }
 
 initCode();

--- a/injected/entry-points/apple.js
+++ b/injected/entry-points/apple.js
@@ -2,7 +2,7 @@
  * @module Apple integration
  */
 import { load, init } from '../src/content-scope-features.js';
-import { processConfig, platformSpecificFeatures, getLoadArgs } from './../src/utils';
+import { processConfig, platformSpecificFeatures, getLoadArgs, getInitArgs } from './../src/utils';
 import { WebkitMessagingConfig } from '../../messaging/index.js';
 
 function initCode() {
@@ -21,7 +21,7 @@ function initCode() {
 
     load(getLoadArgs(processedConfig));
 
-    init(getLoadArgs(processedConfig));
+    init(getInitArgs(processedConfig));
 
     // Not supported:
     // update(message)

--- a/injected/entry-points/apple.js
+++ b/injected/entry-points/apple.js
@@ -21,7 +21,7 @@ function initCode() {
 
     load(getLoadArgs(processedConfig));
 
-    init(/** @type {import('../src/content-scope-features.js').LoadArgs} */ (processedConfig));
+    init(getLoadArgs(processedConfig));
 
     // Not supported:
     // update(message)

--- a/injected/entry-points/apple.js
+++ b/injected/entry-points/apple.js
@@ -21,7 +21,7 @@ function initCode() {
 
     load(getLoadArgs(processedConfig));
 
-    init(processedConfig);
+    init(/** @type {import('../src/content-scope-features.js').LoadArgs} */ (processedConfig));
 
     // Not supported:
     // update(message)

--- a/injected/entry-points/windows.js
+++ b/injected/entry-points/windows.js
@@ -2,7 +2,7 @@
  * @module Windows integration
  */
 import { load, init } from '../src/content-scope-features.js';
-import { processConfig, platformSpecificFeatures, getLoadArgs } from './../src/utils';
+import { processConfig, platformSpecificFeatures, getLoadArgs, getInitArgs } from './../src/utils';
 import { WindowsMessagingConfig } from '../../messaging/index.js';
 
 function initCode() {
@@ -28,7 +28,7 @@ function initCode() {
 
     load(getLoadArgs(processedConfig));
 
-    init(getLoadArgs(processedConfig));
+    init(getInitArgs(processedConfig));
 
     // Not supported:
     // update(message)

--- a/injected/entry-points/windows.js
+++ b/injected/entry-points/windows.js
@@ -28,7 +28,7 @@ function initCode() {
 
     load(getLoadArgs(processedConfig));
 
-    init(processedConfig);
+    init(/** @type {import('../src/content-scope-features.js').LoadArgs} */ (processedConfig));
 
     // Not supported:
     // update(message)

--- a/injected/entry-points/windows.js
+++ b/injected/entry-points/windows.js
@@ -28,7 +28,7 @@ function initCode() {
 
     load(getLoadArgs(processedConfig));
 
-    init(/** @type {import('../src/content-scope-features.js').LoadArgs} */ (processedConfig));
+    init(getLoadArgs(processedConfig));
 
     // Not supported:
     // update(message)

--- a/injected/src/canvas.js
+++ b/injected/src/canvas.js
@@ -5,7 +5,7 @@ import Seedrandom from 'seedrandom';
  * @param {HTMLCanvasElement} canvas
  * @param {string} domainKey
  * @param {string} sessionKey
- * @param {any} getImageDataProxy
+ * @param {import('./utils').DDGProxy} getImageDataProxy
  * @param {CanvasRenderingContext2D | WebGL2RenderingContext | WebGLRenderingContext} ctx?
  */
 export function computeOffScreenCanvas(canvas, domainKey, sessionKey, getImageDataProxy, ctx) {

--- a/injected/src/config-feature.js
+++ b/injected/src/config-feature.js
@@ -131,12 +131,13 @@ export default class ConfigFeature {
      */
     matchConditionalFeatureSetting(featureKeyName) {
         const conditionalChanges = this._getFeatureSettings()?.[featureKeyName] || [];
-        return conditionalChanges.filter((/** @type {any} */ rule) => {
+        return conditionalChanges.filter((/** @type {ConditionalSettingEntry} */ rule) => {
             let condition = rule.condition;
             // Support shorthand for domain matching for backwards compatibility
-            if (condition === undefined && 'domain' in rule) {
+            if (condition === undefined && 'domain' in rule && rule.domain !== undefined) {
                 condition = this._domainToConditonBlocks(rule.domain);
             }
+            if (condition === undefined) return false;
             return this._matchConditionalBlockOrArray(condition);
         });
     }

--- a/injected/src/config-feature.js
+++ b/injected/src/config-feature.js
@@ -137,7 +137,8 @@ export default class ConfigFeature {
             if (condition === undefined && 'domain' in rule && rule.domain !== undefined) {
                 condition = this._domainToConditonBlocks(rule.domain);
             }
-            if (condition === undefined) return false;
+            // condition-less rules (no condition, no domain) match unconditionally
+            if (condition === undefined) return true;
             return this._matchConditionalBlockOrArray(condition);
         });
     }

--- a/injected/src/config-feature.js
+++ b/injected/src/config-feature.js
@@ -57,21 +57,7 @@ export default class ConfigFeature {
     /** @type {string} */
     name;
 
-    /**
-     * @type {{
-     *   debug?: boolean,
-     *   platform: import('./utils.js').Platform,
-     *   desktopModeEnabled?: boolean,
-     *   forcedZoomEnabled?: boolean,
-     *   featureSettings?: Record<string, unknown>,
-     *   assets?: import('./content-feature.js').AssetConfig | undefined,
-     *   site: import('./content-feature.js').Site,
-     *   messagingConfig?: import('@duckduckgo/messaging').MessagingConfig,
-     *   messagingContextName: string,
-     *   currentCohorts?: Array<{feature: string, cohort: string, subfeature: string}>,
-     *   trackerData?: import('./features/tracker-protection/tracker-resolver.js').TrackerData,
-     * } | null}
-     */
+    /** @type {import('./content-scope-features.js').LoadArgs | null} */
     #args;
 
     /**

--- a/injected/src/content-feature.js
+++ b/injected/src/content-feature.js
@@ -15,6 +15,12 @@ import ConfigFeature from './config-feature.js';
  */
 
 /**
+ * @typedef {object} ContentFeatureImportMeta
+ * @property {import('./trackers.js').TrackerNode} [trackerLookup]
+ * @property {ImportMeta['injectName']} [injectName]
+ */
+
+/**
  * @typedef {object} Site
  * @property {string | null} domain
  * @property {string | null} url
@@ -83,7 +89,7 @@ export default class ContentFeature extends ConfigFeature {
      */
     listenForConfigUpdates = false;
 
-    /** @type {ImportMeta} */
+    /** @type {ContentFeatureImportMeta} */
     #importConfig;
 
     /**
@@ -110,13 +116,13 @@ export default class ContentFeature extends ConfigFeature {
 
     /**
      * @param {string} featureName
-     * @param {*} importConfig
+     * @param {ContentFeatureImportMeta} importConfig
      * @param {Partial<FeatureMap>} features
-     * @param {*} args
+     * @param {import('./content-scope-features.js').LoadArgs} args
      */
     constructor(featureName, importConfig, features, args) {
         super(featureName, args);
-        this.setArgs(this.args);
+        this.setArgs(args);
         this.monitor = new PerformanceMonitor();
         this.#features = features;
         this.#importConfig = importConfig;
@@ -355,7 +361,7 @@ export default class ContentFeature extends ConfigFeature {
     }
 
     /**
-     * @param {any} args
+     * @param {import('./content-scope-features.js').LoadArgs} args
      */
     setArgs(args) {
         this.args = args;
@@ -504,7 +510,7 @@ export default class ContentFeature extends ConfigFeature {
      * Wrap a method descriptor. Only for function properties. For data properties, use wrapProperty(). For constructors, use wrapConstructor().
      * @param {object} object - object whose property we are wrapping (most commonly a prototype, e.g. globalThis.Bluetooth.prototype)
      * @param {string} propertyName
-     * @param {(originalFn: any, ...args: any[]) => any } wrapperFn - wrapper function receives the original function as the first argument
+     * @param {(originalFn: Function, ...args: any[]) => any } wrapperFn - wrapper function receives the original function as the first argument
      * @returns {PropertyDescriptor|undefined} original property descriptor, or undefined if it's not found
      */
     wrapMethod(object, propertyName, wrapperFn) {

--- a/injected/src/content-feature.js
+++ b/injected/src/content-feature.js
@@ -329,7 +329,7 @@ export default class ContentFeature extends ConfigFeature {
     init(_args) {}
 
     /**
-     * @param {object} args
+     * @param {import('./content-scope-features.js').LoadArgs} args
      */
     async callInit(args) {
         const mark = this.monitor.mark(this.name + 'CallInit');

--- a/injected/src/content-scope-features.js
+++ b/injected/src/content-scope-features.js
@@ -102,7 +102,7 @@ async function getFeatures() {
 }
 
 /**
- * @param {any} args
+ * @param {LoadArgs} args
  */
 export async function init(args) {
     const mark = performanceMonitor.mark('init');

--- a/injected/src/content-scope-features.js
+++ b/injected/src/content-scope-features.js
@@ -39,6 +39,9 @@ const isHTMLDocument =
  * @property {import('./content-feature.js').AssetConfig} [assets]
  * @property {Record<string, string[]>} [stringExemptionLists]
  * @property {import('./features/tracker-protection/tracker-resolver.js').TrackerData} [trackerData]
+ * @property {boolean} [desktopModeEnabled]
+ * @property {boolean} [forcedZoomEnabled]
+ * @property {boolean} [isDdgWebView]
  */
 
 /**

--- a/injected/src/content-scope-features.js
+++ b/injected/src/content-scope-features.js
@@ -174,7 +174,7 @@ export function update(args) {
  * Update the args for feature instances that opt in to configuration updates.
  * This is useful for applying configuration updates received after initial loading.
  *
- * @param {object} updatedArgs - The new arguments to apply to opted-in features
+ * @param {LoadArgs} updatedArgs - The new arguments to apply to opted-in features
  */
 export async function updateFeatureArgs(updatedArgs) {
     if (!isHTMLDocument) {

--- a/injected/src/dom-utils.js
+++ b/injected/src/dom-utils.js
@@ -90,9 +90,7 @@ export function trustedUnsafe(string) {
  * @return {{createHTML: (s: string) => string}}
  */
 export function createPolicy() {
-    const trustedTypes = /** @type {TrustedTypesLike | undefined} */ (
-        /** @type {{trustedTypes?: unknown}} */ (globalThis).trustedTypes
-    );
+    const trustedTypes = /** @type {TrustedTypesLike | undefined} */ (/** @type {{trustedTypes?: unknown}} */ (globalThis).trustedTypes);
     if (trustedTypes?.createPolicy) {
         return trustedTypes.createPolicy('ddg-default', { createHTML: (s) => s });
     }

--- a/injected/src/dom-utils.js
+++ b/injected/src/dom-utils.js
@@ -82,17 +82,13 @@ export function trustedUnsafe(string) {
 }
 
 /**
- * @typedef {{ createPolicy?: (name: string, rules: {createHTML: (s: string) => string}) => {createHTML: (s: string) => string} }} TrustedTypesLike
- */
-
-/**
  * Use a policy if trustedTypes is available
  * @return {{createHTML: (s: string) => string}}
  */
 export function createPolicy() {
-    const trustedTypes = /** @type {TrustedTypesLike | undefined} */ (/** @type {{trustedTypes?: unknown}} */ (globalThis).trustedTypes);
-    if (trustedTypes?.createPolicy) {
-        return trustedTypes.createPolicy('ddg-default', { createHTML: (s) => s });
+    const tt = /** @type {{trustedTypes?: TrustedTypePolicyFactory}} */ (globalThis).trustedTypes;
+    if (tt) {
+        return tt.createPolicy('ddg-default', { createHTML: (s) => s });
     }
     return {
         createHTML: (s) => s,

--- a/injected/src/dom-utils.js
+++ b/injected/src/dom-utils.js
@@ -82,12 +82,19 @@ export function trustedUnsafe(string) {
 }
 
 /**
+ * @typedef {{ createPolicy?: (name: string, rules: {createHTML: (s: string) => string}) => {createHTML: (s: string) => string} }} TrustedTypesLike
+ */
+
+/**
  * Use a policy if trustedTypes is available
- * @return {{createHTML: (s: string) => any}}
+ * @return {{createHTML: (s: string) => string}}
  */
 export function createPolicy() {
-    if (/** @type {any} */ (globalThis).trustedTypes) {
-        return /** @type {any} */ (globalThis).trustedTypes?.createPolicy?.('ddg-default', { createHTML: (/** @type {string} */ s) => s });
+    const trustedTypes = /** @type {TrustedTypesLike | undefined} */ (
+        /** @type {{trustedTypes?: unknown}} */ (globalThis).trustedTypes
+    );
+    if (trustedTypes?.createPolicy) {
+        return trustedTypes.createPolicy('ddg-default', { createHTML: (s) => s });
     }
     return {
         createHTML: (s) => s,

--- a/injected/src/features/broker-protection/actions/build-url.js
+++ b/injected/src/features/broker-protection/actions/build-url.js
@@ -6,7 +6,7 @@ import { ErrorResponse, SuccessResponse } from '../types.js';
  *
  * @param action
  * @param {Record<string, any>} userData
- * @return {import('../types.js').ActionResponse}
+ * @return {import('../types.js').ActionResponse<{url: string}>}
  */
 export function buildUrl(action, userData) {
     const result = replaceTemplatedUrl(action, userData);

--- a/injected/src/features/broker-protection/actions/navigate.js
+++ b/injected/src/features/broker-protection/actions/navigate.js
@@ -23,8 +23,8 @@ export function navigate(action, userData) {
     }
 
     const response = {
-        .../** @type {Record<string, unknown>} */ (urlResult.success.response),
-        .../** @type {Record<string, unknown>} */ (codeToInjectResponse.success.response),
+        ...urlResult.success.response,
+        ...codeToInjectResponse.success.response,
     };
 
     return new SuccessResponse({ actionID, actionType, response });

--- a/injected/src/features/broker-protection/actions/navigate.js
+++ b/injected/src/features/broker-protection/actions/navigate.js
@@ -23,8 +23,8 @@ export function navigate(action, userData) {
     }
 
     const response = {
-        ...urlResult.success.response,
-        ...codeToInjectResponse.success.response,
+        .../** @type {Record<string, unknown>} */ (urlResult.success.response),
+        .../** @type {Record<string, unknown>} */ (codeToInjectResponse.success.response),
     };
 
     return new SuccessResponse({ actionID, actionType, response });

--- a/injected/src/features/broker-protection/captcha-services/captcha.service.js
+++ b/injected/src/features/broker-protection/captcha-services/captcha.service.js
@@ -28,7 +28,7 @@ const getCaptchaContainer = (root, selector) => {
  * Returns the supporting code to inject for the given captcha type
  *
  * @param {import('../types.js').PirAction} action
- * @return {import('../types.js').ActionResponse}
+ * @return {import('../types.js').ActionResponse<Record<string, unknown>>}
  */
 export function getSupportingCodeToInject(action) {
     const { id: actionID, actionType, injectCaptchaHandler: captchaType } = action;

--- a/injected/src/features/broker-protection/types.js
+++ b/injected/src/features/broker-protection/types.js
@@ -1,5 +1,6 @@
 /**
- * @typedef {SuccessResponse | ErrorResponse} ActionResponse
+ * @template [T=unknown]
+ * @typedef {SuccessResponse<T> | ErrorResponse} ActionResponse
  * @typedef {{ result: true } | { result: false; error: string }} BooleanResult
  * @typedef {{type: "element" | "text" | "url"; selector: string; parent?: string; expect?: string; failSilently?: boolean}} Expectation
  */
@@ -131,28 +132,31 @@ export class ErrorResponse {
 }
 
 /**
+ * @template [T=unknown]
  * @typedef {object} SuccessResponseInterface
  * @property {PirAction['id']} actionID
  * @property {PirAction['actionType']} actionType
- * @property {unknown} response
+ * @property {T} response
  * @property {import("./actions/extract").Action[]} [next]
  * @property {Record<string, unknown>} [meta] - optional meta data
  */
 
 /**
  * Represents success, `response` can contain other complex types
+ * @template [T=unknown]
  */
 export class SuccessResponse {
     /**
-     * @param {SuccessResponseInterface} params
+     * @param {SuccessResponseInterface<T>} params
      */
     constructor(params) {
         this.success = params;
     }
 
     /**
-     * @param {SuccessResponseInterface} params
-     * @return {SuccessResponse}
+     * @template U
+     * @param {SuccessResponseInterface<U>} params
+     * @return {SuccessResponse<U>}
      * @static
      * @memberof SuccessResponse
      */

--- a/injected/src/features/broker-protection/types.js
+++ b/injected/src/features/broker-protection/types.js
@@ -134,9 +134,9 @@ export class ErrorResponse {
  * @typedef {object} SuccessResponseInterface
  * @property {PirAction['id']} actionID
  * @property {PirAction['actionType']} actionType
- * @property {any} response
+ * @property {unknown} response
  * @property {import("./actions/extract").Action[]} [next]
- * @property {Record<string, any>} [meta] - optional meta data
+ * @property {Record<string, unknown>} [meta] - optional meta data
  */
 
 /**
@@ -172,7 +172,7 @@ export class ProfileResult {
      * @param {string[]} params.matchedFields - a list of the fields in the data that were matched.
      * @param {number} params.score - value to determine
      * @param {HTMLElement} [params.element] - the parent element that was matched. Not present in JSON
-     * @param {Record<string, any>} params.scrapedData
+     * @param {Record<string, unknown>} params.scrapedData
      */
     constructor(params) {
         this.scrapedData = params.scrapedData;
@@ -184,7 +184,7 @@ export class ProfileResult {
 
     /**
      * Convert this structure into a format that can be sent between JS contexts/native
-     * @return {{result: boolean, score: number, matchedFields: string[], scrapedData: Record<string, any>}}
+     * @return {{result: boolean, score: number, matchedFields: string[], scrapedData: Record<string, unknown>}}
      */
     asData() {
         return {
@@ -217,9 +217,9 @@ export class Extractor {
  */
 export class AsyncProfileTransform {
     /**
-     * @param {Record<string, any>} _profile - The current profile value
-     * @param {Record<string, any>} _profileParams - the original action params from `action.profile`
-     * @return {Promise<Record<string, any>>}
+     * @param {Record<string, unknown>} _profile - The current profile value
+     * @param {Record<string, unknown>} _profileParams - the original action params from `action.profile`
+     * @return {Promise<Record<string, unknown>>}
      */
 
     transform(_profile, _profileParams) {

--- a/injected/src/features/broker-protection/utils/utils.js
+++ b/injected/src/features/broker-protection/utils/utils.js
@@ -211,8 +211,8 @@ export function cleanArray(input, prev = []) {
 /**
  * Determines whether the given input is a non-empty string.
  *
- * @param {any} [input] - The input to be checked.
- * @return {boolean} - True if the input is a non-empty string, false otherwise.
+ * @param {unknown} [input] - The input to be checked.
+ * @return {input is string} True if the input is a non-empty string, false otherwise.
  */
 export function nonEmptyString(input) {
     if (typeof input !== 'string') return false;
@@ -222,8 +222,8 @@ export function nonEmptyString(input) {
 /**
  * Checks if two strings are a matching pair, ignoring case and leading/trailing white spaces.
  *
- * @param {any} a - The first string to compare.
- * @param {any} b - The second string to compare.
+ * @param {unknown} a - The first string to compare.
+ * @param {unknown} b - The second string to compare.
  * @return {boolean} - Returns true if the strings are a matching pair, false otherwise.
  */
 export function matchingPair(a, b) {
@@ -235,8 +235,8 @@ export function matchingPair(a, b) {
 /**
  * Sorts an array of addresses by state, then by city within the state.
  *
- * @param {any} addresses
- * @return {Array}
+ * @param {Array<{state: string, city: string} & Record<string, unknown>>} addresses
+ * @return {Array<{state: string, city: string} & Record<string, unknown>>}
  */
 export function sortAddressesByStateAndCity(addresses) {
     return addresses.sort((a, b) => {

--- a/injected/src/globals.d.ts
+++ b/injected/src/globals.d.ts
@@ -47,6 +47,14 @@ declare var BatteryManager: {
     new (): BatteryManager;
 };
 
+interface TrustedTypesPolicy {
+    createHTML(input: string): string;
+}
+
+interface TrustedTypePolicyFactory {
+    createPolicy(name: string, rules: { createHTML: (s: string) => string }): TrustedTypesPolicy;
+}
+
 declare module '*.svg' {
     const content: string;
     export default content;

--- a/injected/src/sendmessage-transport.js
+++ b/injected/src/sendmessage-transport.js
@@ -90,10 +90,10 @@ export class SendMessageMessagingTransport {
 
     /**
      * @param {import('@duckduckgo/messaging').RequestMessage} req
-     * @return {Promise<any>}
+     * @return {Promise<unknown>}
      */
     request(req) {
-        /** @type {(eventData: any) => boolean} */
+        /** @type {(eventData: Record<string, any>) => boolean} */
         let comparator = (eventData) => {
             return eventData.responseMessageType === req.method;
         };
@@ -129,14 +129,14 @@ export class SendMessageMessagingTransport {
      * @param {(value: unknown | undefined) => void} callback
      */
     subscribe(msg, callback) {
-        /** @type {(eventData: any) => boolean} */
+        /** @type {(eventData: Record<string, any>) => boolean} */
         const comparator = (eventData) => {
             return eventData.messageType === msg.subscriptionName || eventData.responseMessageType === msg.subscriptionName;
         };
 
         // only forward the 'params' ('response' in current format), to match expected
         // callback from a SubscriptionEvent
-        /** @type {(eventData: any) => void} */
+        /** @type {(eventData: Record<string, any>) => void} */
         const cb = (eventData) => {
             return callback(eventData.response);
         };
@@ -144,8 +144,8 @@ export class SendMessageMessagingTransport {
     }
 
     /**
-     * @param {(eventData: any) => boolean} comparator
-     * @param {(value: any, unsubscribe: (()=>void)) => void} callback
+     * @param {(eventData: Record<string, any>) => boolean} comparator
+     * @param {(value: Record<string, any>, unsubscribe: (()=>void)) => void} callback
      * @internal
      */
     _subscribe(comparator, callback) {

--- a/injected/src/utils.js
+++ b/injected/src/utils.js
@@ -578,7 +578,7 @@ const DEBUG_MAX_TIMES = 5000;
 
 /**
  * @param {string} feature
- * @param {Record<string, any>} message
+ * @param {Record<string, unknown>} message
  * @param {boolean} [allowNonDebug]
  */
 export function postDebugMessage(feature, message, allowNonDebug = false) {
@@ -588,7 +588,7 @@ export function postDebugMessage(feature, message, allowNonDebug = false) {
     if (numberOfTimesDebugged(feature) > DEBUG_MAX_TIMES) {
         return;
     }
-    if (message.stack) {
+    if (typeof message.stack === 'string') {
         const scriptOrigins = [...getStackTraceOrigins(message.stack)];
         message.scriptOrigins = scriptOrigins;
     }
@@ -984,7 +984,7 @@ export function legacySendMessage(messageType, options) {
 
 /**
  * Takes a function that returns an element and tries to execute it until it returns a valid result or the max attempts are reached.
- * @param {() => any} fn - Function to try executing
+ * @param {() => (Element | HTMLElement | null | undefined)} fn - Function to try executing
  * @param {number} [maxAttempts=4] - The maximum number of attempts to find the element.
  * @param {number} [delay=500] - The initial delay to be used to create the exponential backoff.
  * @param {string} [strategy='exponential'] - The retry strategy

--- a/injected/src/utils.js
+++ b/injected/src/utils.js
@@ -812,13 +812,37 @@ export function processConfig(data, userList, preferences, platformSpecificFeatu
 }
 
 /**
- * Extract the properties needed for the load() function from processedConfig.
+ * Extract LoadArgs properties from processedConfig.
  * @param {Record<string, any>} processedConfig
  * @returns {import('./content-scope-features.js').LoadArgs}
  */
 export function getLoadArgs(processedConfig) {
-    const { platform, site, bundledConfig, messagingConfig, messageSecret, messagingContextName, currentCohorts } = processedConfig;
-    return { platform, site, bundledConfig, messagingConfig, messageSecret, messagingContextName, currentCohorts };
+    const {
+        platform,
+        site,
+        bundledConfig,
+        messagingConfig,
+        messageSecret,
+        messagingContextName,
+        currentCohorts,
+        debug,
+        featureSettings,
+        assets,
+        stringExemptionLists,
+    } = processedConfig;
+    return {
+        platform,
+        site,
+        bundledConfig,
+        messagingConfig,
+        messageSecret,
+        messagingContextName,
+        currentCohorts,
+        debug,
+        featureSettings,
+        assets,
+        stringExemptionLists,
+    };
 }
 
 /**

--- a/injected/src/utils.js
+++ b/injected/src/utils.js
@@ -812,11 +812,22 @@ export function processConfig(data, userList, preferences, platformSpecificFeatu
 }
 
 /**
- * Extract LoadArgs properties from processedConfig.
+ * Extract the minimal properties needed for load() to construct feature instances.
  * @param {Record<string, any>} processedConfig
  * @returns {import('./content-scope-features.js').LoadArgs}
  */
 export function getLoadArgs(processedConfig) {
+    const { platform, site, bundledConfig, messagingConfig, messageSecret, messagingContextName, currentCohorts } = processedConfig;
+    return { platform, site, bundledConfig, messagingConfig, messageSecret, messagingContextName, currentCohorts };
+}
+
+/**
+ * Extract all LoadArgs properties for init(). init() stores these as the feature's
+ * runtime args (this.args), so it gets the full set including debug, featureSettings, etc.
+ * @param {Record<string, any>} processedConfig
+ * @returns {import('./content-scope-features.js').LoadArgs}
+ */
+export function getInitArgs(processedConfig) {
     const {
         platform,
         site,

--- a/injected/src/utils.js
+++ b/injected/src/utils.js
@@ -779,6 +779,7 @@ export function isMaxSupportedVersion(maxSupportedVersion, currentVersion) {
  * @param {string[]} userList
  * @param {UserPreferences} preferences
  * @param {string[]} platformSpecificFeatures
+ * @returns {Record<string, any>}
  */
 export function processConfig(data, userList, preferences, platformSpecificFeatures = []) {
     const topLevelHostname = getTabHostname();

--- a/injected/src/utils.js
+++ b/injected/src/utils.js
@@ -840,6 +840,9 @@ export function getInitArgs(processedConfig) {
         featureSettings,
         assets,
         stringExemptionLists,
+        desktopModeEnabled,
+        forcedZoomEnabled,
+        isDdgWebView,
     } = processedConfig;
     return {
         platform,
@@ -853,6 +856,9 @@ export function getInitArgs(processedConfig) {
         featureSettings,
         assets,
         stringExemptionLists,
+        desktopModeEnabled,
+        forcedZoomEnabled,
+        isDdgWebView,
     };
 }
 

--- a/injected/src/wrapper-utils.js
+++ b/injected/src/wrapper-utils.js
@@ -361,9 +361,10 @@ export function shimProperty(baseObject, propertyName, implInstance, readOnly, d
         }
     }
 
+    const implObj = /** @type {object} */ (implInstance);
     // mask toString() and toString.toString() on the instance
-    const proxiedInstance = new Proxy(implInstance, {
-        get: toStringGetTrap(implInstance, `[object ${ImplClass.name}]`),
+    const proxiedInstance = new Proxy(implObj, {
+        get: toStringGetTrap(implObj, `[object ${ImplClass.name}]`),
     });
 
     /** @type {StrictPropertyDescriptor} */
@@ -376,9 +377,11 @@ export function shimProperty(baseObject, propertyName, implInstance, readOnly, d
         const getter = function get() {
             return proxiedInstance;
         };
-        const proxiedGetter = new Proxy(getter, {
-            get: toStringGetTrap(getter, `function get ${propertyName}() { [native code] }`),
-        });
+        const proxiedGetter = /** @type {() => any} */ (
+            new Proxy(getter, {
+                get: toStringGetTrap(getter, `function get ${propertyName}() { [native code] }`),
+            })
+        );
         descriptor = {
             configurable: true,
             enumerable: true,

--- a/injected/src/wrapper-utils.js
+++ b/injected/src/wrapper-utils.js
@@ -25,8 +25,8 @@ export function defineProperty(object, propertyName, descriptor) {
  * return a proxy to `newFn` that fakes .toString() and .toString.toString() to resemble the `origFn`.
  * WARNING: do NOT proxy toString multiple times, as it will not work as expected.
  *
- * @param {*} newFn
- * @param {*} origFn
+ * @param {unknown} newFn
+ * @param {unknown} origFn
  * @param {string} [mockValue] - when provided, .toString() will return this value
  */
 export function wrapToString(newFn, origFn, mockValue) {
@@ -40,9 +40,9 @@ export function wrapToString(newFn, origFn, mockValue) {
 /**
  * generate a proxy handler trap that fakes .toString() and .toString.toString() to resemble the `targetFn`.
  * Note that it should be used as the get() trap.
- * @param {*} targetFn
+ * @param {object} targetFn
  * @param {string} [mockValue] - when provided, .toString() will return this value
- * @returns { (target: any, prop: string, receiver: any) => any }
+ * @returns { (target: object, prop: string | symbol, receiver: object) => any }
  */
 export function toStringGetTrap(targetFn, mockValue) {
     // We wrap two levels deep to handle toString.toString() calls
@@ -87,9 +87,9 @@ export function toStringGetTrap(targetFn, mockValue) {
 
 /**
  * Wrap functions to fix toString but also behave as closely to their real function as possible like .name and .length etc.
- * @param {*} functionValue
- * @param {*} realTarget
- * @returns {Proxy} a proxy for the function
+ * @param {Function} functionValue
+ * @param {Function} realTarget
+ * @returns {Function} a proxy for the function
  */
 export function wrapFunction(functionValue, realTarget) {
     return new Proxy(realTarget, {
@@ -184,7 +184,7 @@ export function wrapProperty(object, propertyName, descriptor, definePropertyFn)
  * Wrap a method descriptor. Only for function properties. For data properties, use wrapProperty(). For constructors, use wrapConstructor().
  * @param {object} object - object whose property we are wrapping (most commonly a prototype, e.g. globalThis.Bluetooth.prototype)
  * @param {string} propertyName
- * @param {(originalFn: any, ...args: any[]) => any } wrapperFn - wrapper function receives the original function as the first argument
+ * @param {(originalFn: Function, ...args: any[]) => any } wrapperFn - wrapper function receives the original function as the first argument
  * @param {DefinePropertyFn} definePropertyFn - function to use for defining the property
  * @returns {PropertyDescriptor|undefined} original property descriptor, or undefined if it's not found
  */

--- a/injected/src/wrapper-utils.js
+++ b/injected/src/wrapper-utils.js
@@ -184,7 +184,7 @@ export function wrapProperty(object, propertyName, descriptor, definePropertyFn)
  * Wrap a method descriptor. Only for function properties. For data properties, use wrapProperty(). For constructors, use wrapConstructor().
  * @param {object} object - object whose property we are wrapping (most commonly a prototype, e.g. globalThis.Bluetooth.prototype)
  * @param {string} propertyName
- * @param {(originalFn: Function, ...args: any[]) => any } wrapperFn - wrapper function receives the original function as the first argument
+ * @param {(originalFn: any, ...args: any[]) => any } wrapperFn - wrapper function receives the original function as the first argument
  * @param {DefinePropertyFn} definePropertyFn - function to use for defining the property
  * @returns {PropertyDescriptor|undefined} original property descriptor, or undefined if it's not found
  */

--- a/injected/unit-test/content-feature.js
+++ b/injected/unit-test/content-feature.js
@@ -78,7 +78,7 @@ describe('ContentFeature class', () => {
             },
         };
         const me = new MyTestFeature('test', {}, args);
-        me.callInit(args);
+        me.callInit(/** @type {any} */ (args));
         expect(didRun).withContext('Should run').toBeTrue();
     });
 
@@ -196,7 +196,7 @@ describe('ContentFeature class', () => {
             },
         };
         const me = new MyTestFeature2('test', {}, args);
-        me.callInit(args);
+        me.callInit(/** @type {any} */ (args));
         expect(didRun).withContext('Should run').toBeTrue();
     });
 
@@ -304,7 +304,7 @@ describe('ContentFeature class', () => {
             },
         };
         const me = new MyTestFeature3('test', {}, args);
-        me.callInit(args);
+        me.callInit(/** @type {any} */ (args));
         expect(didRun).withContext('Should run').toBeTrue();
     });
     it('Should respect minSupportedVersion as a condition', () => {
@@ -368,7 +368,7 @@ describe('ContentFeature class', () => {
             },
         };
         const me = new MyTestFeature3('test', {}, args);
-        me.callInit(args);
+        me.callInit(/** @type {any} */ (args));
         expect(didRun).withContext('Should run').toBeTrue();
     });
 
@@ -433,7 +433,7 @@ describe('ContentFeature class', () => {
         };
 
         const me = new MyTestFeature4('test', {}, args);
-        me.callInit(args);
+        me.callInit(/** @type {any} */ (args));
         expect(didRun).withContext('Should run').toBeTrue();
     });
 
@@ -1294,7 +1294,7 @@ describe('ContentFeature class', () => {
 
                 const targetFeature = new TargetFeature();
                 if (initFeature) {
-                    await targetFeature.callInit({});
+                    await targetFeature.callInit(/** @type {any} */ ({}));
                 }
                 const features = { targetFeature };
 
@@ -1367,9 +1367,9 @@ describe('ContentFeature class', () => {
                 const CallerFeature = createFeatureClass('callerFeature', {}, []);
 
                 const featureA = new FeatureA();
-                featureA.callInit({});
+                featureA.callInit(/** @type {any} */ ({}));
                 const featureB = new FeatureB();
-                featureB.callInit({});
+                featureB.callInit(/** @type {any} */ ({}));
                 const features = { featureA, featureB };
                 const callerFeature = new CallerFeature(features);
 
@@ -1393,7 +1393,7 @@ describe('ContentFeature class', () => {
                 const CallerFeature = createFeatureClass('callerFeature', {}, []);
 
                 const targetFeature = new TargetFeature();
-                targetFeature.callInit({});
+                targetFeature.callInit(/** @type {any} */ ({}));
                 const features = { targetFeature };
                 const callerFeature = new CallerFeature(features);
 
@@ -1416,7 +1416,7 @@ describe('ContentFeature class', () => {
                     expect(targetMethod).not.toHaveBeenCalled();
 
                     // Initialize the feature
-                    targetFeature.callInit({});
+                    targetFeature.callInit(/** @type {any} */ ({}));
 
                     // Now await the result
                     const result = await resultPromise;
@@ -1460,7 +1460,7 @@ describe('ContentFeature class', () => {
                     const resultPromise = callerFeature.callFeatureMethod('failingFeature', 'someMethod');
 
                     // Try to initialize (this will throw)
-                    await expectAsync(failingFeature.callInit({})).toBeRejectedWithError('init failed');
+                    await expectAsync(failingFeature.callInit(/** @type {any} */ ({}))).toBeRejectedWithError('init failed');
 
                     // The callFeatureMethod should return an error (not reject)
                     const result = await resultPromise;
@@ -1487,7 +1487,7 @@ describe('ContentFeature class', () => {
                     expect(targetMethod).not.toHaveBeenCalled();
 
                     // Initialize the feature
-                    targetFeature.callInit({});
+                    targetFeature.callInit(/** @type {any} */ ({}));
 
                     // Both should resolve
                     const [result1, result2] = await Promise.all([promise1, promise2]);

--- a/injected/unit-test/content-feature.js
+++ b/injected/unit-test/content-feature.js
@@ -1,5 +1,18 @@
 import ContentFeature, { CallFeatureMethodError } from '../src/content-feature.js';
 
+/**
+ * @param {Partial<import('../src/content-scope-features.js').LoadArgs>} [overrides]
+ * @returns {import('../src/content-scope-features.js').LoadArgs}
+ */
+function testArgs(overrides = {}) {
+    return {
+        site: { domain: 'example.com', url: 'https://example.com' },
+        platform: /** @type {import('../src/utils.js').Platform} */ ({ name: 'extension' }),
+        messagingContextName: 'test',
+        ...overrides,
+    };
+}
+
 describe('ContentFeature class', () => {
     class BaseTestFeature extends ContentFeature {
         constructor(featureName, importConfig, args) {
@@ -78,7 +91,7 @@ describe('ContentFeature class', () => {
             },
         };
         const me = new MyTestFeature('test', {}, args);
-        me.callInit(/** @type {any} */ (args));
+        me.callInit(testArgs(args));
         expect(didRun).withContext('Should run').toBeTrue();
     });
 
@@ -196,7 +209,7 @@ describe('ContentFeature class', () => {
             },
         };
         const me = new MyTestFeature2('test', {}, args);
-        me.callInit(/** @type {any} */ (args));
+        me.callInit(testArgs(args));
         expect(didRun).withContext('Should run').toBeTrue();
     });
 
@@ -304,7 +317,7 @@ describe('ContentFeature class', () => {
             },
         };
         const me = new MyTestFeature3('test', {}, args);
-        me.callInit(/** @type {any} */ (args));
+        me.callInit(testArgs(args));
         expect(didRun).withContext('Should run').toBeTrue();
     });
     it('Should respect minSupportedVersion as a condition', () => {
@@ -322,9 +335,10 @@ describe('ContentFeature class', () => {
                 domain: 'example.com',
                 url: 'http://example.com',
             },
-            platform: {
+            platform: /** @type {import('../src/utils.js').Platform} */ ({
+                name: 'extension',
                 version: '1.1.0',
-            },
+            }),
             bundledConfig: {
                 features: {
                     test: {
@@ -368,7 +382,7 @@ describe('ContentFeature class', () => {
             },
         };
         const me = new MyTestFeature3('test', {}, args);
-        me.callInit(/** @type {any} */ (args));
+        me.callInit(testArgs(args));
         expect(didRun).withContext('Should run').toBeTrue();
     });
 
@@ -387,9 +401,10 @@ describe('ContentFeature class', () => {
                 domain: 'example.com',
                 url: 'http://example.com',
             },
-            platform: {
+            platform: /** @type {import('../src/utils.js').Platform} */ ({
+                name: 'extension',
                 version: '1.1.0',
-            },
+            }),
             bundledConfig: {
                 features: {
                     test: {
@@ -429,11 +444,12 @@ describe('ContentFeature class', () => {
                         },
                     },
                 },
+                unprotectedTemporary: [],
             },
         };
 
         const me = new MyTestFeature4('test', {}, args);
-        me.callInit(/** @type {any} */ (args));
+        me.callInit(testArgs(args));
         expect(didRun).withContext('Should run').toBeTrue();
     });
 
@@ -1210,7 +1226,7 @@ describe('ContentFeature class', () => {
                  * @param {Record<string, any>} [features={}]
                  */
                 constructor(features = {}) {
-                    super(name, {}, features, /** @type {any} */ ({}));
+                    super(name, {}, features, testArgs());
                     // Add methods to instance
                     for (const [methodName, fn] of Object.entries(methods)) {
                         this[methodName] = fn.bind(this);
@@ -1294,7 +1310,7 @@ describe('ContentFeature class', () => {
 
                 const targetFeature = new TargetFeature();
                 if (initFeature) {
-                    await targetFeature.callInit(/** @type {any} */ ({}));
+                    await targetFeature.callInit(testArgs());
                 }
                 const features = { targetFeature };
 
@@ -1367,9 +1383,9 @@ describe('ContentFeature class', () => {
                 const CallerFeature = createFeatureClass('callerFeature', {}, []);
 
                 const featureA = new FeatureA();
-                featureA.callInit(/** @type {any} */ ({}));
+                featureA.callInit(testArgs());
                 const featureB = new FeatureB();
-                featureB.callInit(/** @type {any} */ ({}));
+                featureB.callInit(testArgs());
                 const features = { featureA, featureB };
                 const callerFeature = new CallerFeature(features);
 
@@ -1382,7 +1398,7 @@ describe('ContentFeature class', () => {
             it('should maintain correct this context when calling target method', async () => {
                 class TargetFeature extends ContentFeature {
                     constructor() {
-                        super('targetFeature', {}, {}, /** @type {any} */ ({}));
+                        super('targetFeature', {}, {}, testArgs());
                         this._exposedMethods = this._declareExposedMethods(['getFeatureName']);
                         this.customProperty = 'custom value';
                     }
@@ -1393,7 +1409,7 @@ describe('ContentFeature class', () => {
                 const CallerFeature = createFeatureClass('callerFeature', {}, []);
 
                 const targetFeature = new TargetFeature();
-                targetFeature.callInit(/** @type {any} */ ({}));
+                targetFeature.callInit(testArgs());
                 const features = { targetFeature };
                 const callerFeature = new CallerFeature(features);
 
@@ -1416,7 +1432,7 @@ describe('ContentFeature class', () => {
                     expect(targetMethod).not.toHaveBeenCalled();
 
                     // Initialize the feature
-                    targetFeature.callInit(/** @type {any} */ ({}));
+                    targetFeature.callInit(testArgs());
 
                     // Now await the result
                     const result = await resultPromise;
@@ -1440,7 +1456,7 @@ describe('ContentFeature class', () => {
                 it('should return error if target feature init throws an error', async () => {
                     class FailingFeature extends ContentFeature {
                         constructor() {
-                            super('failingFeature', {}, {}, /** @type {any} */ ({}));
+                            super('failingFeature', {}, {}, testArgs());
                             this._exposedMethods = this._declareExposedMethods(['someMethod']);
                         }
                         init() {
@@ -1460,7 +1476,7 @@ describe('ContentFeature class', () => {
                     const resultPromise = callerFeature.callFeatureMethod('failingFeature', 'someMethod');
 
                     // Try to initialize (this will throw)
-                    await expectAsync(failingFeature.callInit(/** @type {any} */ ({}))).toBeRejectedWithError('init failed');
+                    await expectAsync(failingFeature.callInit(testArgs())).toBeRejectedWithError('init failed');
 
                     // The callFeatureMethod should return an error (not reject)
                     const result = await resultPromise;
@@ -1487,7 +1503,7 @@ describe('ContentFeature class', () => {
                     expect(targetMethod).not.toHaveBeenCalled();
 
                     // Initialize the feature
-                    targetFeature.callInit(/** @type {any} */ ({}));
+                    targetFeature.callInit(testArgs());
 
                     // Both should resolve
                     const [result1, result2] = await Promise.all([promise1, promise2]);

--- a/injected/unit-test/content-feature.js
+++ b/injected/unit-test/content-feature.js
@@ -1210,7 +1210,7 @@ describe('ContentFeature class', () => {
                  * @param {Record<string, any>} [features={}]
                  */
                 constructor(features = {}) {
-                    super(name, {}, features, {});
+                    super(name, {}, features, /** @type {any} */ ({}));
                     // Add methods to instance
                     for (const [methodName, fn] of Object.entries(methods)) {
                         this[methodName] = fn.bind(this);
@@ -1382,7 +1382,7 @@ describe('ContentFeature class', () => {
             it('should maintain correct this context when calling target method', async () => {
                 class TargetFeature extends ContentFeature {
                     constructor() {
-                        super('targetFeature', {}, {}, {});
+                        super('targetFeature', {}, {}, /** @type {any} */ ({}));
                         this._exposedMethods = this._declareExposedMethods(['getFeatureName']);
                         this.customProperty = 'custom value';
                     }
@@ -1440,7 +1440,7 @@ describe('ContentFeature class', () => {
                 it('should return error if target feature init throws an error', async () => {
                     class FailingFeature extends ContentFeature {
                         constructor() {
-                            super('failingFeature', {}, {}, {});
+                            super('failingFeature', {}, {}, /** @type {any} */ ({}));
                             this._exposedMethods = this._declareExposedMethods(['someMethod']);
                         }
                         init() {

--- a/injected/unit-test/content-scope-features.js
+++ b/injected/unit-test/content-scope-features.js
@@ -313,7 +313,7 @@ describe('content-scope-features additionalCheck conditional', () => {
 
             const disabledFeature = new MockFeature('testFeature', {}, disabledArgs);
             disabledFeature.callLoad();
-            await disabledFeature.callInit(disabledArgs);
+            await disabledFeature.callInit(/** @type {any} */ (disabledArgs));
 
             expect(disabledFeature.loadCalled).toBe(false); // Should not load
             expect(disabledFeature.initCalled).toBe(false); // Should not init
@@ -346,7 +346,7 @@ describe('content-scope-features additionalCheck conditional', () => {
 
             const enabledFeature = new MockFeature('testFeature', {}, enabledArgs);
             enabledFeature.callLoad();
-            await enabledFeature.callInit(enabledArgs);
+            await enabledFeature.callInit(/** @type {any} */ (enabledArgs));
 
             expect(enabledFeature.loadCalled).toBe(true); // Should load
             expect(enabledFeature.initCalled).toBe(true); // Should init

--- a/injected/unit-test/content-scope-features.js
+++ b/injected/unit-test/content-scope-features.js
@@ -288,7 +288,8 @@ describe('content-scope-features additionalCheck conditional', () => {
             // Test case 1: additionalCheck disabled
             const disabledArgs = {
                 site: { domain: 'blocked-site.com', url: 'http://blocked-site.com' },
-                platform: { name: 'test' },
+                platform: /** @type {import('../src/utils.js').Platform} */ ({ name: 'extension' }),
+                messagingContextName: 'test',
                 bundledConfig: {
                     features: {
                         testFeature: {
@@ -313,7 +314,7 @@ describe('content-scope-features additionalCheck conditional', () => {
 
             const disabledFeature = new MockFeature('testFeature', {}, disabledArgs);
             disabledFeature.callLoad();
-            await disabledFeature.callInit(/** @type {any} */ (disabledArgs));
+            await disabledFeature.callInit(disabledArgs);
 
             expect(disabledFeature.loadCalled).toBe(false); // Should not load
             expect(disabledFeature.initCalled).toBe(false); // Should not init
@@ -321,7 +322,8 @@ describe('content-scope-features additionalCheck conditional', () => {
             // Test case 2: additionalCheck enabled
             const enabledArgs = {
                 site: { domain: 'trusted-site.com', url: 'http://trusted-site.com' },
-                platform: { name: 'test' },
+                platform: /** @type {import('../src/utils.js').Platform} */ ({ name: 'extension' }),
+                messagingContextName: 'test',
                 bundledConfig: {
                     features: {
                         testFeature: {
@@ -346,7 +348,7 @@ describe('content-scope-features additionalCheck conditional', () => {
 
             const enabledFeature = new MockFeature('testFeature', {}, enabledArgs);
             enabledFeature.callLoad();
-            await enabledFeature.callInit(/** @type {any} */ (enabledArgs));
+            await enabledFeature.callInit(enabledArgs);
 
             expect(enabledFeature.loadCalled).toBe(true); // Should load
             expect(enabledFeature.initCalled).toBe(true); // Should init

--- a/injected/unit-test/features.js
+++ b/injected/unit-test/features.js
@@ -116,11 +116,11 @@ describe('ApiManipulation', () => {
             'apiManipulation',
             {},
             {},
-            {
+            /** @type {any} */ ({
                 bundledConfig: { features: { apiManipulation: { state: 'enabled', exceptions: [] } } },
                 site: { domain: 'test.com' },
                 platform: { version: '1.0.0' },
-            },
+            }),
         );
         dummyTarget = {};
     });

--- a/injected/unit-test/features.js
+++ b/injected/unit-test/features.js
@@ -116,11 +116,15 @@ describe('ApiManipulation', () => {
             'apiManipulation',
             {},
             {},
-            /** @type {any} */ ({
-                bundledConfig: { features: { apiManipulation: { state: 'enabled', exceptions: [] } } },
-                site: { domain: 'test.com' },
-                platform: { version: '1.0.0' },
-            }),
+            {
+                bundledConfig: {
+                    features: { apiManipulation: { state: 'enabled', settings: {}, exceptions: [] } },
+                    unprotectedTemporary: [],
+                },
+                site: { domain: 'test.com', url: 'https://test.com' },
+                platform: /** @type {import('../src/utils.js').Platform} */ ({ name: 'extension', version: '1.0.0' }),
+                messagingContextName: 'test',
+            },
         );
         dummyTarget = {};
     });

--- a/injected/unit-test/print.js
+++ b/injected/unit-test/print.js
@@ -26,12 +26,12 @@ describe('Print feature', () => {
             'print',
             {},
             {},
-            {
+            /** @type {any} */ ({
                 site: {
                     domain: 'example.com',
                     url: 'http://example.com',
                 },
-            },
+            }),
         );
 
         // Mock the notify method

--- a/injected/unit-test/print.js
+++ b/injected/unit-test/print.js
@@ -26,12 +26,14 @@ describe('Print feature', () => {
             'print',
             {},
             {},
-            /** @type {any} */ ({
+            {
                 site: {
                     domain: 'example.com',
                     url: 'http://example.com',
                 },
-            }),
+                platform: /** @type {import('../src/utils.js').Platform} */ ({ name: 'extension' }),
+                messagingContextName: 'test',
+            },
         );
 
         // Mock the notify method

--- a/injected/unit-test/web-detection.js
+++ b/injected/unit-test/web-detection.js
@@ -36,7 +36,7 @@ function runDetectorsInEnv(detectorsConfig, env = {}) {
             bundledConfig: undefined,
             messagingContextName: 'test',
         };
-        const instance = new WebDetection('webDetection', /** @type {any} */ (undefined), {}, args);
+        const instance = new WebDetection('webDetection', {}, {}, args);
         instance.init();
         return instance.runDetectors({ trigger: 'breakageReport' });
     } finally {

--- a/injected/unit-test/web-detection.js
+++ b/injected/unit-test/web-detection.js
@@ -498,19 +498,19 @@ describe('WebDetection', () => {
          * @returns {WebDetection}
          */
         function createInstance() {
-            const args = {
+            const args = /** @type {import('../src/content-scope-features.js').LoadArgs} */ ({
                 site: { domain: 'example.com', url: 'https://example.com/page' },
                 platform: {},
                 featureSettings: { webDetection: { detectors: {} } },
                 bundledConfig: undefined,
                 messagingContextName: 'test',
-            };
+            });
             const originalWindow = globalThis.window;
             const mockSelf = {};
             // @ts-expect-error - mocking for test
             globalThis.window = { self: mockSelf, top: mockSelf };
             try {
-                const instance = new WebDetection('webDetection', undefined, {}, args);
+                const instance = new WebDetection('webDetection', {}, {}, args);
                 instance.init();
                 return instance;
             } finally {
@@ -569,13 +569,13 @@ describe('WebDetection', () => {
             globalThis.window = originalWindow;
         });
 
-        const defaultArgs = {
+        const defaultArgs = /** @type {import('../src/content-scope-features.js').LoadArgs} */ ({
             site: { domain: 'example.com', url: 'https://example.com/page' },
             platform: {},
             featureSettings: { webDetection: { detectors: {} } },
             bundledConfig: undefined,
             messagingContextName: 'test',
-        };
+        });
 
         /**
          * @param {Partial<import('../src/features/web-detection/parse.js').DetectorActions>} overrides
@@ -586,7 +586,7 @@ describe('WebDetection', () => {
         const fireEventConfig = actionsConfig({ fireEvent: { type: 'adwall', state: 'enabled' } });
 
         it('should not fire when webEvents feature is not loaded', async () => {
-            const instance = new WebDetection('webDetection', undefined, {}, defaultArgs);
+            const instance = new WebDetection('webDetection', {}, {}, defaultArgs);
             instance.init();
 
             // callFeatureMethod will return CallFeatureMethodError (feature not found)
@@ -597,12 +597,12 @@ describe('WebDetection', () => {
         it('should not fire when webEvents feature is skipped (disabled on page)', async () => {
             /** @type {Partial<import('../src/features.js').FeatureMap>} */
             const features = {};
-            const webEvents = new WebEvents('webEvents', undefined, features, defaultArgs);
+            const webEvents = new WebEvents('webEvents', {}, features, defaultArgs);
             features.webEvents = webEvents;
             webEvents.markFeatureAsSkipped('feature disabled for this site');
             const fireEventSpy = spyOn(webEvents, 'fireEvent');
 
-            const instance = new WebDetection('webDetection', undefined, features, defaultArgs);
+            const instance = new WebDetection('webDetection', {}, features, defaultArgs);
             instance.init();
 
             // callFeatureMethod will return CallFeatureMethodError (skipped)
@@ -613,12 +613,12 @@ describe('WebDetection', () => {
         it('should fire when webEvents feature is loaded and ready', async () => {
             /** @type {Partial<import('../src/features.js').FeatureMap>} */
             const features = {};
-            const webEvents = new WebEvents('webEvents', undefined, features, defaultArgs);
+            const webEvents = new WebEvents('webEvents', {}, features, defaultArgs);
             features.webEvents = webEvents;
             await webEvents.callInit(defaultArgs);
             const fireEventSpy = spyOn(webEvents, 'fireEvent');
 
-            const instance = new WebDetection('webDetection', undefined, features, defaultArgs);
+            const instance = new WebDetection('webDetection', {}, features, defaultArgs);
             instance.init();
 
             await instance._executeFireEvent(fireEventConfig, true);

--- a/injected/unit-test/web-detection.js
+++ b/injected/unit-test/web-detection.js
@@ -36,7 +36,7 @@ function runDetectorsInEnv(detectorsConfig, env = {}) {
             bundledConfig: undefined,
             messagingContextName: 'test',
         };
-        const instance = new WebDetection('webDetection', undefined, {}, args);
+        const instance = new WebDetection('webDetection', /** @type {any} */ (undefined), {}, args);
         instance.init();
         return instance.runDetectors({ trigger: 'breakageReport' });
     } finally {

--- a/injected/unit-test/web-events.js
+++ b/injected/unit-test/web-events.js
@@ -16,7 +16,7 @@ describe('WebEvents', () => {
                 bundledConfig: undefined,
                 messagingContextName: 'test',
             };
-            const instance = new WebEvents('webEvents', undefined, {}, args);
+            const instance = new WebEvents('webEvents', {}, {}, args);
             // @ts-expect-error - partial mock: only notify is needed for this test
             instance._messaging = {
                 notify: (/** @type {string} */ method, /** @type {Record<string, any>} */ params) => {

--- a/injected/unit-test/wrapper-utils.js
+++ b/injected/unit-test/wrapper-utils.js
@@ -373,7 +373,6 @@ describe('wrapFunction', () => {
         const wrapped = wrapFunction(function (/** @type {number} */ a, /** @type {number} */ b) {
             return real(a, b) * 2;
         }, real);
-        // @ts-expect-error - proxy is callable via apply trap
         expect(wrapped(2, 3)).toBe(10); // (2+3)*2
     });
 


### PR DESCRIPTION
Successor to #2382, which got closed before this rebase could land.

Re-opens the 17 \`fix(types)\` commits cleanly on top of current main. The original branch had become 419 commits behind with stale merge-of-main commits that pulled in old state, making the diff appear as 498 files / +5351 / -23903 (mostly carry-over staleness, not real changes).

## What changed since #2382

- **Slim diff**: cherry-picked just the 17 \`fix(types)\` commits onto current main. Final diff is **22 files / +183 / -105** (vs the old 498/+5351/-23903).
- **3 files dropped** — main already absorbed equivalent type improvements:
  - \`injected/src/features/autofill-import.js\`
  - \`injected/src/features/broker-protection/comparisons/is-same-name.js\`
  - \`injected/src/features/broker-protection/actions/navigate.js\`
- **3 cherry-pick conflicts resolved additively** (kept main's recent additions alongside the branch's type improvements):
  - \`globals.d.ts\` — kept main's \`BatteryManager\` interface, added branch's \`TrustedTypesPolicy\` interfaces.
  - \`content-scope-features.js\` \`LoadArgs\` typedef — kept main's \`trackerData\`, added branch's \`desktopModeEnabled\`/\`forcedZoomEnabled\`/\`isDdgWebView\`.
  - \`config-feature.js\` \`#args\` — kept branch's simpler \`LoadArgs\` reference (now that LoadArgs covers \`trackerData\`).

## Files

\`\`\`
injected/entry-points/{android,apple,windows}.js
injected/src/{canvas,config-feature,content-feature,content-scope-features,dom-utils,globals.d.ts,sendmessage-transport,utils,wrapper-utils}.js
injected/src/features/broker-protection/{actions/build-url,captcha-services/captcha.service,types,utils/utils}.js
injected/unit-test/{content-feature,content-scope-features,features,print,web-detection,wrapper-utils}.js
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly documentation and test typing; the `getInitArgs` init path and unconditional conditional rules are small behavioral tweaks in content-script bootstrap and config matching.
> 
> **Overview**
> Tightens JSDoc and TypeScript-checking across **injected/** by replacing broad `any` / loose object types with concrete typedefs (`LoadArgs`, `ContentFeatureImportMeta`, generic `ActionResponse<T>`, `unknown`, type predicates, etc.).
> 
> **Runtime wiring:** Android, Apple, and Windows entry points now call `init(getInitArgs(processedConfig))` instead of passing the full processed config object. `getInitArgs` returns the same field set documented on `LoadArgs` (including `debug`, `featureSettings`, `desktopModeEnabled`, `forcedZoomEnabled`, `isDdgWebView`), paralleling the existing `getLoadArgs` split for `load()`.
> 
> **Small logic / typing fixes:** `ConfigFeature` treats rules with no `condition` or `domain` as unconditionally matching; `ContentFeature` passes constructor `args` into `setArgs` directly; Trusted Types and DOM/messaging helpers get stricter types. Unit tests gain a shared `testArgs()` helper and corrected `LoadArgs` / `Platform` shapes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f845c4c907025189a093c1b17783a9cc245c0ebf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->