### PR TITLE
ci(cursor-review): verify Cursor PRs via commit committer, not bot author

### DIFF
--- a/.github/workflows/cursor-review.yml
+++ b/.github/workflows/cursor-review.yml
@@ -11,31 +11,62 @@ jobs:
         outputs:
             is_member: ${{ steps.membership.outputs.is_member }}
         steps:
-            - name: Verify author is in duckduckgo/core
+            - name: Verify trusted launcher
               uses: actions/github-script@v9
               id: membership
               with:
                   github-token: ${{ secrets.DAX_PAT }}
                   script: |
-                      const author = context.payload.pull_request.user.login;
+                      const prAuthor = context.payload.pull_request.user.login;
+
+                      // For human-authored PRs the PR author IS the launcher
+                      // — check team membership against them. For Cursor-app
+                      // PRs (`cursor[bot]`) the PR author is the bot, which
+                      // is never a team member, so we instead use the commit
+                      // committer of the head commit. The committer is the
+                      // GitHub identity that actually pushed the commit, so
+                      // it carries the same trust the team-membership lookup
+                      // intends to verify. Same-repo branches are already
+                      // required (the `head.repo.fork` check on this job),
+                      // so the committer can only have been a user with
+                      // push access to this repo.
+                      let userToCheck = prAuthor;
+                      if (prAuthor === 'cursor[bot]') {
+                          const { data: commits } = await github.rest.pulls.listCommits({
+                              owner: context.repo.owner,
+                              repo: context.repo.repo,
+                              pull_number: context.payload.pull_request.number,
+                              per_page: 100,
+                          });
+                          const headCommit = commits[commits.length - 1];
+                          const committer = headCommit?.committer?.login;
+                          if (!committer) {
+                              console.log(`⏭️ ${prAuthor} PR has no resolvable committer — skipping auto-review`);
+                              core.setOutput('is_member', 'false');
+                              return;
+                          }
+                          console.log(`Resolved ${prAuthor} launcher to committer: ${committer}`);
+                          userToCheck = committer;
+                      }
+
                       try {
                           const { data } = await github.rest.teams.getMembershipForUserInOrg({
                               org: 'duckduckgo',
                               team_slug: 'core',
-                              username: author
+                              username: userToCheck
                           });
                           if (data.state === 'active') {
-                              console.log(`✅ ${author} is an active member of duckduckgo/core`);
+                              console.log(`✅ ${userToCheck} is an active member of duckduckgo/core`);
                               core.setOutput('is_member', 'true');
                           } else {
-                              console.log(`⏭️ ${author} is not an active member — skipping auto-review`);
+                              console.log(`⏭️ ${userToCheck} is not an active member — skipping auto-review`);
                               core.setOutput('is_member', 'false');
                           }
                       } catch (error) {
                           if (error.status === 404) {
-                              console.log(`⏭️ ${author} is not a member of duckduckgo/core — skipping auto-review`);
+                              console.log(`⏭️ ${userToCheck} is not a member of duckduckgo/core — skipping auto-review`);
                           } else {
-                              console.log(`⚠️ Could not verify ${author}: ${error.message} (status: ${error.status})`);
+                              console.log(`⚠️ Could not verify ${userToCheck}: ${error.message} (status: ${error.status})`);
                           }
                           core.setOutput('is_member', 'false');
                       }

--- a/.github/workflows/cursor-review.yml
+++ b/.github/workflows/cursor-review.yml
@@ -22,31 +22,35 @@ jobs:
                       // For human-authored PRs the PR author IS the launcher
                       // — check team membership against them. For Cursor-app
                       // PRs (`cursor[bot]`) the PR author is the bot, which
-                      // is never a team member, so we instead use the commit
-                      // committer of the head commit. The committer is the
-                      // GitHub identity that actually pushed the commit, so
-                      // it carries the same trust the team-membership lookup
-                      // intends to verify. Same-repo branches are already
+                      // is never a team member, so we resolve a human identity
+                      // from the head commit instead. Prefer the committer
+                      // (who pushed); Cursor app commits often keep
+                      // `cursor[bot]` as committer, so fall back to the
+                      // commit author. Same-repo branches are already
                       // required (the `head.repo.fork` check on this job),
-                      // so the committer can only have been a user with
+                      // so a human committer can only have been a user with
                       // push access to this repo.
                       let userToCheck = prAuthor;
                       if (prAuthor === 'cursor[bot]') {
-                          const { data: commits } = await github.rest.pulls.listCommits({
+                          const { data: headCommit } = await github.rest.repos.getCommit({
                               owner: context.repo.owner,
                               repo: context.repo.repo,
-                              pull_number: context.payload.pull_request.number,
-                              per_page: 100,
+                              ref: context.payload.pull_request.head.sha,
                           });
-                          const headCommit = commits[commits.length - 1];
-                          const committer = headCommit?.committer?.login;
-                          if (!committer) {
-                              console.log(`⏭️ ${prAuthor} PR has no resolvable committer — skipping auto-review`);
+                          const candidates = [
+                              { label: 'committer', user: headCommit.committer },
+                              { label: 'author', user: headCommit.author },
+                          ];
+                          const resolved = candidates.find(
+                              ({ user }) => user?.login && user.type !== 'Bot'
+                          );
+                          if (!resolved) {
+                              console.log(`⏭️ ${prAuthor} PR has no resolvable human committer/author — skipping auto-review`);
                               core.setOutput('is_member', 'false');
                               return;
                           }
-                          console.log(`Resolved ${prAuthor} launcher to committer: ${committer}`);
-                          userToCheck = committer;
+                          console.log(`Resolved ${prAuthor} launcher to ${resolved.label}: ${resolved.user.login}`);
+                          userToCheck = resolved.user.login;
                       }
 
                       try {


### PR DESCRIPTION
## Summary

The Cursor Auto Review workflow's \`check_membership\` job gates the downstream \`cursor_auto_review\` job on the PR author being an active member of \`duckduckgo/core\`. PRs opened by the Cursor app arrive authored as \`cursor[bot]\` — a bot account, never a team member — so the team-membership lookup returns 404, \`is_member\` is set to false, and the **entire** \`cursor_auto_review\` job skips. Result: no Cursor Bugbot risk read, no Low Risk auto-approve, no "manual review required" comment.

## Why not just trust \`cursor[bot]\`

A naive fix — trusting any \`cursor[bot]\` PR — isn't safe: anyone with access to the Cursor app installation can open a \`cursor[bot]\` PR. The bot identity alone is not a trust signal.

## The trustworthy signal

The **commit committer** of the head commit: the GitHub identity that actually pushed the commit to this repo. Same-repo branches are already required (the existing \`head.repo.fork\` check on the \`check_membership\` job), so the committer can only have been a user with push access to this repo. Examples sampled across current open Cursor PRs:

| PR | author | committer |
|---|---|---|
| #2751 | \`cursor[bot]\` | \`jonathanKingston\` ✓ |
| #2752 | \`cursor[bot]\` | \`jonathanKingston\` ✓ |
| #2738 | \`cursor[bot]\` | \`jonathanKingston\` ✓ |
| #2731 | \`cursor[bot]\` | \`cursoragent\` (no human pusher) |
| #2746 | \`cursor[bot]\` | \`cursoragent\` (no human pusher) |

## The fix

When \`pull_request.user.login === 'cursor[bot]'\`, resolve the user to check by looking at the committer of the head commit (via \`pulls.listCommits\`) and run the existing team-membership lookup against them. PRs from Cursor with no resolvable human committer (cloud-only \`cursoragent\` commits) fall through to the 404 path and remain unreviewed — correctly, since there's no team member to trust through.

No behaviour change for non-\`cursor[bot]\` authors — the existing team-membership lookup runs unchanged against \`pull_request.user.login\`.

## Test plan

- [ ] Merge, then sync one of the existing Cursor-bot PRs with a team-member committer (e.g. #2751 — committer is \`jonathanKingston\`). Expect:
  - \`check_membership\` logs \`Resolved cursor[bot] launcher to committer: jonathanKingston\` then \`✅ jonathanKingston is an active member of duckduckgo/core\`
  - \`cursor_auto_review\` job runs to completion
  - If Cursor Bugbot reported **Low Risk** → daxtheduck approval lands
  - Otherwise → "manual review required" comment appears
- [ ] Sync a Cursor-bot PR with no human committer (e.g. #2731 — committer is \`cursoragent\`). Expect: \`check_membership\` logs \`⏭️ cursoragent is not a member of duckduckgo/core — skipping auto-review\` and the job skips (no false-positive trust).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes who can trigger automated PR approval in CI; logic is narrow (head commit, non-bot, existing core check) but affects security-sensitive automation.
> 
> **Overview**
> **Cursor Auto Review** no longer treats `cursor[bot]` as the membership subject, so Cursor-app PRs were incorrectly skipping the whole `cursor_auto_review` job.
> 
> When `pull_request.user.login` is **`cursor[bot]`**, `check_membership` loads the PR head commit and picks the first **non-bot** identity from **committer**, then **author**. It runs the existing **`duckduckgo/core`** lookup on that user. If no human is found, it sets `is_member` to false and exits early. Human-authored PRs still use the PR author only; the fork gate is unchanged.
> 
> This restores Bugbot wait, low-risk auto-approve, and manual-review comments for Cursor PRs pushed by a core member, without trusting every `cursor[bot]` PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2c9a43503259b8448146b63d3106f3deed14d07d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->