### PR TITLE
ci(semver): fail-soft on Anthropic errors instead of blocking merges

### DIFF
--- a/.github/scripts/semver-analysis.mjs
+++ b/.github/scripts/semver-analysis.mjs
@@ -170,8 +170,43 @@ async function main() {
     }
 
     const userPrompt = buildUserPrompt({ buildDiff, title, body, files });
-    const rawResponse = await callAnthropic(SYSTEM_PROMPT, userPrompt, apiKey);
-    const result = parseResponse(rawResponse);
+
+    // Fail-soft on Anthropic outages. The check is informational — it picks
+    // a default semver label for the PR — and shouldn't gate merges if the
+    // API key has been rotated, the service is down, or rate limits hit.
+    // External (fork) PRs are already excluded by the workflow's
+    // `head.repo.fork` guard, so anyone reaching this code has push access
+    // and can manually correct the label if needed. Log loudly to stderr so
+    // a degraded run is visible in the job summary.
+    let rawResponse;
+    try {
+        rawResponse = await callAnthropic(SYSTEM_PROMPT, userPrompt, apiKey);
+    } catch (error) {
+        console.error(`[semver-analysis] Anthropic call failed (${error?.message ?? error}); defaulting to patch.`);
+        console.log(
+            JSON.stringify({
+                severity: 'patch',
+                reasoning:
+                    'Anthropic classification unavailable — defaulted to patch. Re-label manually if this PR ships a breaking or feature-level change.',
+            }),
+        );
+        return;
+    }
+
+    let result;
+    try {
+        result = parseResponse(rawResponse);
+    } catch (error) {
+        console.error(`[semver-analysis] Could not parse Anthropic response (${error?.message ?? error}); defaulting to patch.`);
+        console.log(
+            JSON.stringify({
+                severity: 'patch',
+                reasoning:
+                    'Anthropic returned an unparseable response — defaulted to patch. Re-label manually if this PR ships a breaking or feature-level change.',
+            }),
+        );
+        return;
+    }
 
     console.log(JSON.stringify(result));
 }


### PR DESCRIPTION
## Summary

The `semver_label` check is informational — it picks a default semver label by asking Anthropic to classify the build diff. Today it hard-fails the entire workflow on any error: 401 (rotated API key), 5xx (Anthropic outage), rate limits, or unparseable responses.

Right now the `ANTHROPIC_API_KEY` secret is 401'ing repo-wide, which has blocked **38+ open PRs** solely on this check (verified live at 12:06 today on a fresh run on #2126 — same `invalid x-api-key` error).

## What this PR does

Wraps the Anthropic call and the response parser in try/catch. On either failure:

- Log the error to stderr (visible in the job summary)
- Emit `{ severity: 'patch', reasoning: 'Anthropic classification unavailable — defaulted to patch. Re-label manually if this PR ships a breaking or feature-level change.' }`
- Exit 0 so downstream label-application still runs and lands the `semver-patch` label

The merge gate stops being held hostage by a secret rotation or upstream outage.

## Security posture

External (fork) PRs are already excluded from this workflow by the existing `if: !github.event.pull_request.head.repo.fork && ...` guard, so anyone reaching this fallback path has push access to the repo. Org members can correct the label manually if the default `patch` is wrong (e.g. a breaking change). No trust boundary is widened.

## Test plan

- [ ] Merge, then rerun a currently-failing `semver_label` job (e.g. on #2126). Expect:
  - Step logs `[semver-analysis] Anthropic call failed (Anthropic API error 401: ...); defaulting to patch.`
  - Job exits 0
  - `semver-patch` label gets applied to the PR
  - `semver_label` check on the PR flips to SUCCESS
- [ ] Once `ANTHROPIC_API_KEY` is rotated to a working key, behaviour returns to the existing real-classification path automatically — no further change needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change to an informational label script; no runtime or shipped code paths are affected.
> 
> **Overview**
> The informational `semver_label` CI step no longer fails the workflow when Anthropic classification breaks. **`semver-analysis.mjs`** now wraps the API call and JSON parsing in separate try/catch blocks.
> 
> On API errors (401, outages, rate limits) or unparseable LLM output, the script logs **`[semver-analysis]`** errors to stderr, prints **`{ severity: 'patch', reasoning: '...' }`** to stdout, and exits successfully so the workflow still applies **`semver-patch`** and downstream steps run. Missing **`ANTHROPIC_API_KEY`** and the existing no-build-diff early path are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 845234c9eec2fa9ec703c58601c3f84808415e3d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->