### PR TITLE
feat(page-context): collect page-type signals (jsonLdType, ogType, lang)

### DIFF
--- a/injected/integration-test/page-type-signals.spec.js
+++ b/injected/integration-test/page-type-signals.spec.js
@@ -1,0 +1,35 @@
+import { test, expect } from '@playwright/test';
+import { ResultsCollector } from './page-objects/results-collector.js';
+
+const HTML = '/page-context/pages/page-type-signals.html';
+const CONFIG = './integration-test/test-pages/page-context/config/page-type-signals.json';
+
+/**
+ * Return the page-type signals from the first collectionResult message that carries them.
+ * @param {ResultsCollector} collector
+ */
+async function collectedSignals(collector) {
+    const messages = await collector.waitForMessage('collectionResult', 1);
+    for (const message of messages) {
+        const params = /** @type {{ serializedPageData?: string }} */ (message.payload.params);
+        if (!params?.serializedPageData) continue;
+        const data = JSON.parse(params.serializedPageData);
+        if (data.pageTypeSignals) return data.pageTypeSignals;
+    }
+    return null;
+}
+
+test('page-context collects page-type signals end-to-end', async ({ page }, testInfo) => {
+    const collector = ResultsCollector.create(page, testInfo.project.use);
+    await collector.load(HTML, CONFIG);
+
+    const signals = await collectedSignals(collector);
+
+    // jsonLdType is collected in priority order (Recipe before the embedded VideoObject); the
+    // second block uses non-canonical casing to exercise case-insensitive discovery.
+    expect(signals).toStrictEqual({
+        jsonLdType: ['Recipe', 'NewsArticle', 'VideoObject'],
+        ogType: 'article',
+        lang: 'en',
+    });
+});

--- a/injected/integration-test/test-pages/page-context/config/page-type-signals.json
+++ b/injected/integration-test/test-pages/page-context/config/page-type-signals.json
@@ -1,0 +1,26 @@
+{
+    "readme": "Enables page-context collection with includePageTypeSignals to verify end-to-end signal extraction.",
+    "version": 1,
+    "features": {
+        "pageContext": {
+            "state": "enabled",
+            "exceptions": [],
+            "settings": {
+                "collectOnInit": "enabled",
+                "subscribeToLoad": "enabled",
+                "subscribeToCollect": "enabled",
+                "observeMutations": "enabled",
+                "bodyFallback": "enabled",
+                "trimBlankLinks": "enabled",
+                "includeIframes": "enabled",
+                "includePageTypeSignals": "enabled",
+                "maxContentLength": 9500,
+                "maxTitleLength": 100,
+                "maxDepth": 5000,
+                "cacheExpiration": 30000,
+                "recheckLimit": 5
+            }
+        }
+    },
+    "unprotectedTemporary": []
+}

--- a/injected/integration-test/test-pages/page-context/pages/page-type-signals.html
+++ b/injected/integration-test/test-pages/page-context/pages/page-type-signals.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width">
+    <title>Page Type Signals Test</title>
+    <meta name="description" content="Test page exercising page-type-signal collection">
+    <meta property="og:type" content="article">
+    <!-- Multi-@type block: priority order matters to consumers (Recipe before the embedded video). -->
+    <script type="application/ld+json">
+        { "@context": "https://schema.org", "@type": ["Recipe", "NewsArticle"] }
+    </script>
+    <!-- Non-canonical casing must still be discovered (case-insensitive selector). -->
+    <script type="APPLICATION/LD+JSON">
+        { "@graph": [{ "@type": "VideoObject" }] }
+    </script>
+    <link rel="stylesheet" href="../../shared/style.css">
+</head>
+<body>
+    <p><a href="../index.html">[Page Context]</a></p>
+
+    <article>
+        <h1>Page Type Signals Test</h1>
+        <p>This page exposes JSON-LD <code>@type</code>, <code>og:type</code>, and a declared language so
+        the page-context feature can collect normalized page-type signals.</p>
+    </article>
+</body>
+</html>

--- a/injected/playwright.config.js
+++ b/injected/playwright.config.js
@@ -21,6 +21,7 @@ export default defineConfig({
                 'integration-test/web-detection.spec.js',
                 'integration-test/web-events.spec.js',
                 'integration-test/web-interference-detection-events.spec.js',
+                'integration-test/page-type-signals.spec.js',
             ],
             use: { injectName: 'windows', platform: 'windows' },
         },

--- a/injected/src/features/page-context.js
+++ b/injected/src/features/page-context.js
@@ -211,6 +211,104 @@ function getLinkText(node, children, settings) {
     return href ? `[${trimmedContent}](${href})` : collapseWhitespace(children);
 }
 
+/**
+ * Extract cheap, normalized page-type signals from a document: schema.org JSON-LD `@type`,
+ * Open Graph `og:type`, and the declared page language. Every field is best-effort and is empty
+ * or null when the page doesn't expose it. Domain is intentionally omitted; consumers derive it
+ * from the page URL that already accompanies the collected content.
+ * @param {Document} document
+ * @param {{ maxTypes?: number, maxBlockLength?: number }} [options]
+ * @returns {{ jsonLdType: string[], ogType: string | null, lang: string }}
+ */
+export function extractPageTypeSignals(document, { maxTypes = 10, maxBlockLength = 100000 } = {}) {
+    return {
+        jsonLdType: extractJsonLdTypes(document, maxTypes, maxBlockLength),
+        ogType: extractOgType(document),
+        lang: extractLang(document),
+    };
+}
+
+/**
+ * Collect deduped schema.org `@type` values from every JSON-LD block, preserving casing. Handles
+ * `@type` as a string or array and entries nested under `@graph`. Malformed and oversized blocks
+ * are skipped so a bad block never fails the whole collection.
+ * @param {Document} document
+ * @param {number} maxTypes
+ * @param {number} maxBlockLength
+ * @returns {string[]}
+ */
+function extractJsonLdTypes(document, maxTypes, maxBlockLength) {
+    /** @type {string[]} */
+    const types = [];
+    const seen = new Set();
+    /** @param {unknown} value */
+    const add = (value) => {
+        if (typeof value !== 'string') return;
+        const type = value.trim();
+        if (!type || seen.has(type)) return;
+        seen.add(type);
+        types.push(type);
+    };
+
+    const blocks = document.querySelectorAll('script[type="application/ld+json"]');
+    for (const block of blocks) {
+        if (types.length >= maxTypes) break;
+        const text = block.textContent || '';
+        if (!text || text.length > maxBlockLength) continue;
+        let data;
+        try {
+            data = JSON.parse(text);
+        } catch (e) {
+            continue;
+        }
+        collectJsonLdTypes(data, add);
+    }
+
+    return types.slice(0, maxTypes);
+}
+
+/**
+ * Walk a parsed JSON-LD value (object, array, or `@graph` container) and report each `@type`.
+ * @param {unknown} node
+ * @param {(value: unknown) => void} add
+ */
+function collectJsonLdTypes(node, add) {
+    if (Array.isArray(node)) {
+        for (const item of node) collectJsonLdTypes(item, add);
+        return;
+    }
+    if (!node || typeof node !== 'object') return;
+    const obj = /** @type {Record<string, unknown>} */ (node);
+    const type = obj['@type'];
+    if (Array.isArray(type)) {
+        for (const value of type) add(value);
+    } else if (type != null) {
+        add(type);
+    }
+    if (obj['@graph']) {
+        collectJsonLdTypes(obj['@graph'], add);
+    }
+}
+
+/**
+ * @param {Document} document
+ * @returns {string | null}
+ */
+function extractOgType(document) {
+    const meta = document.querySelector('meta[property="og:type"]');
+    const content = meta?.getAttribute('content');
+    const trimmed = typeof content === 'string' ? content.trim() : '';
+    return trimmed || null;
+}
+
+/**
+ * @param {Document} document
+ * @returns {string}
+ */
+function extractLang(document) {
+    return (document.documentElement?.getAttribute('lang') || '').trim();
+}
+
 export default class PageContext extends ContentFeature {
     /** @type {any} */
     #cachedContent = undefined;
@@ -492,6 +590,9 @@ export default class PageContext extends ContentFeature {
         if (this.getFeatureSettingEnabled('includeImages', 'disabled')) {
             content.images = this.getImages();
         }
+        if (this.getFeatureSettingEnabled('includePageTypeSignals', 'disabled')) {
+            content.pageTypeSignals = this.getPageTypeSignals();
+        }
 
         // Cache the result - setter handles timestamp and observer
         // Note: We only cache if content exists. Consider caching empty content too
@@ -618,6 +719,13 @@ export default class PageContext extends ContentFeature {
         });
 
         return links;
+    }
+
+    getPageTypeSignals() {
+        return extractPageTypeSignals(document, {
+            maxTypes: this.getFeatureSetting('maxPageTypeSignals') || 10,
+            maxBlockLength: this.getFeatureSetting('maxJsonLdBlockLength') || 100000,
+        });
     }
 
     getImages() {

--- a/injected/src/features/page-context.js
+++ b/injected/src/features/page-context.js
@@ -742,12 +742,24 @@ export default class PageContext extends ContentFeature {
     }
 
     getPageTypeSignals() {
-        // `??` so an explicit 0 isn't silently replaced by the default; Math.min clamps remote
-        // config to a safe ceiling to bound parse work.
         return extractPageTypeSignals(document, {
-            maxTypes: Math.min(this.getFeatureSetting('maxPageTypeSignals') ?? 10, 50),
-            maxBlockLength: Math.min(this.getFeatureSetting('maxJsonLdBlockLength') ?? 100000, 1000000),
+            maxTypes: this.clampedNumericSetting('maxPageTypeSignals', 10, 50),
+            maxBlockLength: this.clampedNumericSetting('maxJsonLdBlockLength', 100000, 1000000),
         });
+    }
+
+    /**
+     * Read a numeric feature setting, clamped to a safe ceiling. Malformed (non-finite) config
+     * falls back to the default rather than producing NaN — which would disable the cap — while an
+     * explicit 0 is still honored.
+     * @param {string} key
+     * @param {number} fallback
+     * @param {number} max
+     * @returns {number}
+     */
+    clampedNumericSetting(key, fallback, max) {
+        const value = this.getFeatureSetting(key);
+        return Math.min(typeof value === 'number' && Number.isFinite(value) ? value : fallback, max);
     }
 
     getImages() {

--- a/injected/src/features/page-context.js
+++ b/injected/src/features/page-context.js
@@ -248,25 +248,22 @@ export function extractPageTypeSignals(document, { maxTypes = 10, maxBlockLength
  * @returns {string[]}
  */
 function extractJsonLdTypes(document, maxTypes, maxBlockLength) {
-    /** @type {string[]} */
-    const types = [];
-    const seen = new Set();
+    // A Set both dedupes and preserves insertion order, so it doubles as the store and the cap counter.
+    const types = new Set();
     /** @param {unknown} value */
-    const add = (value) => {
+    const recordType = (value) => {
         // Short-circuit once the cap is hit so a single wide `@graph` doesn't keep iterating.
-        if (types.length >= maxTypes) return;
+        if (types.size >= maxTypes) return;
         if (typeof value !== 'string') return;
         const type = value.trim();
-        if (!type || seen.has(type)) return;
-        seen.add(type);
-        types.push(type);
+        if (type) types.add(type);
     };
 
     // Case-insensitive attribute match ("i") so non-canonical casing (e.g. APPLICATION/LD+JSON)
     // is still discovered.
     const blocks = document.querySelectorAll('script[type="application/ld+json" i]');
     for (const block of blocks) {
-        if (types.length >= maxTypes) break;
+        if (types.size >= maxTypes) break;
         const text = block.textContent || '';
         if (!text || text.length > maxBlockLength) continue;
         let data;
@@ -275,10 +272,10 @@ function extractJsonLdTypes(document, maxTypes, maxBlockLength) {
         } catch (e) {
             continue;
         }
-        collectJsonLdTypes(data, add);
+        collectJsonLdTypes(data, recordType);
     }
 
-    return types.slice(0, maxTypes);
+    return Array.from(types);
 }
 
 /**
@@ -286,13 +283,13 @@ function extractJsonLdTypes(document, maxTypes, maxBlockLength) {
  * Own-property checks keep a polluted `Object.prototype` from surfacing spurious `@type` /
  * `@graph` keys, and recursion is bounded by {@link MAX_JSON_LD_DEPTH}.
  * @param {unknown} node
- * @param {(value: unknown) => void} add
+ * @param {(value: unknown) => void} recordType
  * @param {number} [depth]
  */
-function collectJsonLdTypes(node, add, depth = 0) {
+function collectJsonLdTypes(node, recordType, depth = 0) {
     if (depth > MAX_JSON_LD_DEPTH) return;
     if (Array.isArray(node)) {
-        for (const item of node) collectJsonLdTypes(item, add, depth + 1);
+        for (const item of node) collectJsonLdTypes(item, recordType, depth + 1);
         return;
     }
     if (!node || typeof node !== 'object') return;
@@ -300,13 +297,13 @@ function collectJsonLdTypes(node, add, depth = 0) {
     if (hasOwnProperty.call(obj, '@type')) {
         const type = obj['@type'];
         if (Array.isArray(type)) {
-            for (const value of type) add(value);
+            for (const value of type) recordType(value);
         } else if (type != null) {
-            add(type);
+            recordType(type);
         }
     }
     if (hasOwnProperty.call(obj, '@graph')) {
-        collectJsonLdTypes(obj['@graph'], add, depth + 1);
+        collectJsonLdTypes(obj['@graph'], recordType, depth + 1);
     }
 }
 

--- a/injected/src/features/page-context.js
+++ b/injected/src/features/page-context.js
@@ -5,7 +5,13 @@
 import ContentFeature from '../content-feature.js';
 import { getFaviconList } from './favicon.js';
 import { isDuckAi, isBeingFramed, getTabUrl } from '../utils.js';
+// eslint-disable-next-line no-redeclare
+import { JSONparse, Set, hasOwnProperty } from '../captured-globals.js';
 const MSG_PAGE_CONTEXT_RESPONSE = 'collectionResult';
+
+// Bail past this nesting depth when walking JSON-LD so adversarially deep blocks
+// can't blow the stack and fail the whole content collection.
+const MAX_JSON_LD_DEPTH = 32;
 
 export function checkNodeIsVisible(node) {
     try {
@@ -250,14 +256,16 @@ function extractJsonLdTypes(document, maxTypes, maxBlockLength) {
         types.push(type);
     };
 
-    const blocks = document.querySelectorAll('script[type="application/ld+json"]');
+    // Case-insensitive attribute match ("i") so non-canonical casing (e.g. APPLICATION/LD+JSON)
+    // is still discovered.
+    const blocks = document.querySelectorAll('script[type="application/ld+json" i]');
     for (const block of blocks) {
         if (types.length >= maxTypes) break;
         const text = block.textContent || '';
         if (!text || text.length > maxBlockLength) continue;
         let data;
         try {
-            data = JSON.parse(text);
+            data = JSONparse(text);
         } catch (e) {
             continue;
         }
@@ -269,24 +277,30 @@ function extractJsonLdTypes(document, maxTypes, maxBlockLength) {
 
 /**
  * Walk a parsed JSON-LD value (object, array, or `@graph` container) and report each `@type`.
+ * Own-property checks keep a polluted `Object.prototype` from surfacing spurious `@type` /
+ * `@graph` keys, and recursion is bounded by {@link MAX_JSON_LD_DEPTH}.
  * @param {unknown} node
  * @param {(value: unknown) => void} add
+ * @param {number} [depth]
  */
-function collectJsonLdTypes(node, add) {
+function collectJsonLdTypes(node, add, depth = 0) {
+    if (depth > MAX_JSON_LD_DEPTH) return;
     if (Array.isArray(node)) {
-        for (const item of node) collectJsonLdTypes(item, add);
+        for (const item of node) collectJsonLdTypes(item, add, depth + 1);
         return;
     }
     if (!node || typeof node !== 'object') return;
     const obj = /** @type {Record<string, unknown>} */ (node);
-    const type = obj['@type'];
-    if (Array.isArray(type)) {
-        for (const value of type) add(value);
-    } else if (type != null) {
-        add(type);
+    if (hasOwnProperty.call(obj, '@type')) {
+        const type = obj['@type'];
+        if (Array.isArray(type)) {
+            for (const value of type) add(value);
+        } else if (type != null) {
+            add(type);
+        }
     }
-    if (obj['@graph']) {
-        collectJsonLdTypes(obj['@graph'], add);
+    if (hasOwnProperty.call(obj, '@graph')) {
+        collectJsonLdTypes(obj['@graph'], add, depth + 1);
     }
 }
 
@@ -722,9 +736,11 @@ export default class PageContext extends ContentFeature {
     }
 
     getPageTypeSignals() {
+        // `??` so an explicit 0 isn't silently replaced by the default; Math.min clamps remote
+        // config to a safe ceiling to bound parse work.
         return extractPageTypeSignals(document, {
-            maxTypes: this.getFeatureSetting('maxPageTypeSignals') || 10,
-            maxBlockLength: this.getFeatureSetting('maxJsonLdBlockLength') || 100000,
+            maxTypes: Math.min(this.getFeatureSetting('maxPageTypeSignals') ?? 10, 50),
+            maxBlockLength: Math.min(this.getFeatureSetting('maxJsonLdBlockLength') ?? 100000, 1000000),
         });
     }
 

--- a/injected/src/features/page-context.js
+++ b/injected/src/features/page-context.js
@@ -222,6 +222,10 @@ function getLinkText(node, children, settings) {
  * Open Graph `og:type`, and the declared page language. Every field is best-effort and is empty
  * or null when the page doesn't expose it. Domain is intentionally omitted; consumers derive it
  * from the page URL that already accompanies the collected content.
+ *
+ * `jsonLdType` is a shallow harvest: only top-level and `@graph` `@type` values are collected.
+ * Types nested under other properties (e.g. `mainEntity.@type`) are not walked, so consumers
+ * should not treat this as full schema.org graph coverage.
  * @param {Document} document
  * @param {{ maxTypes?: number, maxBlockLength?: number }} [options]
  * @returns {{ jsonLdType: string[], ogType: string | null, lang: string }}
@@ -249,6 +253,8 @@ function extractJsonLdTypes(document, maxTypes, maxBlockLength) {
     const seen = new Set();
     /** @param {unknown} value */
     const add = (value) => {
+        // Short-circuit once the cap is hit so a single wide `@graph` doesn't keep iterating.
+        if (types.length >= maxTypes) return;
         if (typeof value !== 'string') return;
         const type = value.trim();
         if (!type || seen.has(type)) return;

--- a/injected/unit-test/page-context-signals.spec.js
+++ b/injected/unit-test/page-context-signals.spec.js
@@ -1,0 +1,93 @@
+import { JSDOM } from 'jsdom';
+import { extractPageTypeSignals } from '../src/features/page-context.js';
+
+/**
+ * @param {string} html - full document HTML to parse.
+ */
+function signalsFor(html) {
+    const dom = new JSDOM(html);
+    return extractPageTypeSignals(dom.window.document);
+}
+
+function scriptLd(obj) {
+    return '<script type="application/ld+json">' + JSON.stringify(obj) + '</script>';
+}
+
+function pageWithHead(headHtml) {
+    return `<!DOCTYPE html><html><head>${headHtml}</head><body></body></html>`;
+}
+
+describe('page-context.js - extractPageTypeSignals', () => {
+    it('returns empty signals for a bare page', () => {
+        const signals = signalsFor('<!DOCTYPE html><html><head></head><body></body></html>');
+        expect(signals).toEqual({ jsonLdType: [], ogType: null, lang: '' });
+    });
+
+    it('reads and trims og:type', () => {
+        const signals = signalsFor(pageWithHead('<meta property="og:type" content=" video.other ">'));
+        expect(signals.ogType).toBe('video.other');
+    });
+
+    it('returns null og:type when the meta tag is absent', () => {
+        expect(signalsFor(pageWithHead('')).ogType).toBe(null);
+    });
+
+    it('reads the declared page language', () => {
+        const signals = signalsFor('<!DOCTYPE html><html lang="en-US"><head></head><body></body></html>');
+        expect(signals.lang).toBe('en-US');
+    });
+
+    it('reads a string @type from JSON-LD', () => {
+        expect(signalsFor(pageWithHead(scriptLd({ '@type': 'Recipe' }))).jsonLdType).toEqual(['Recipe']);
+    });
+
+    it('reads an array @type from JSON-LD', () => {
+        expect(signalsFor(pageWithHead(scriptLd({ '@type': ['Recipe', 'NewsArticle'] }))).jsonLdType).toEqual(['Recipe', 'NewsArticle']);
+    });
+
+    it('walks @graph entries', () => {
+        const head = scriptLd({ '@graph': [{ '@type': 'Product' }, { '@type': 'Offer' }] });
+        expect(signalsFor(pageWithHead(head)).jsonLdType).toEqual(['Product', 'Offer']);
+    });
+
+    it('dedupes across multiple blocks and preserves schema.org casing', () => {
+        const head = scriptLd({ '@type': 'Recipe' }) + scriptLd({ '@type': ['Recipe', 'VideoObject'] });
+        expect(signalsFor(pageWithHead(head)).jsonLdType).toEqual(['Recipe', 'VideoObject']);
+    });
+
+    it('skips malformed JSON-LD blocks but keeps valid ones', () => {
+        const head = '<script type="application/ld+json">{ not valid json </script>' + scriptLd({ '@type': 'Article' });
+        expect(signalsFor(pageWithHead(head)).jsonLdType).toEqual(['Article']);
+    });
+
+    it('ignores non-string @type values', () => {
+        expect(signalsFor(pageWithHead(scriptLd({ '@type': ['Recipe', 123, null] }))).jsonLdType).toEqual(['Recipe']);
+    });
+
+    it('caps the number of collected types', () => {
+        const many = Array.from({ length: 20 }, (_, i) => ({ '@type': 'T' + i }));
+        const dom = new JSDOM(pageWithHead(scriptLd(many)));
+        const signals = extractPageTypeSignals(dom.window.document, { maxTypes: 3 });
+        expect(signals.jsonLdType).toEqual(['T0', 'T1', 'T2']);
+    });
+
+    it('skips oversized JSON-LD blocks', () => {
+        const big = { '@type': 'Recipe', padding: 'x'.repeat(50) };
+        const dom = new JSDOM(pageWithHead(scriptLd(big)));
+        const signals = extractPageTypeSignals(dom.window.document, { maxBlockLength: 10 });
+        expect(signals.jsonLdType).toEqual([]);
+    });
+
+    it('collects all three signals from a realistic page (recipe with embedded video)', () => {
+        const head =
+            '<meta property="og:type" content="article">' +
+            scriptLd({ '@type': ['Recipe', 'NewsArticle'] }) +
+            scriptLd({ '@type': 'VideoObject' });
+        const dom = new JSDOM(`<!DOCTYPE html><html lang="en"><head>${head}</head><body></body></html>`);
+        expect(extractPageTypeSignals(dom.window.document)).toEqual({
+            jsonLdType: ['Recipe', 'NewsArticle', 'VideoObject'],
+            ogType: 'article',
+            lang: 'en',
+        });
+    });
+});

--- a/injected/unit-test/page-context-signals.spec.js
+++ b/injected/unit-test/page-context-signals.spec.js
@@ -78,6 +78,37 @@ describe('page-context.js - extractPageTypeSignals', () => {
         expect(signals.jsonLdType).toEqual([]);
     });
 
+    it('collects nothing when maxTypes is explicitly 0', () => {
+        const dom = new JSDOM(pageWithHead(scriptLd({ '@type': 'Recipe' })));
+        expect(extractPageTypeSignals(dom.window.document, { maxTypes: 0 }).jsonLdType).toEqual([]);
+    });
+
+    it('discovers JSON-LD with non-canonical script type casing', () => {
+        const head = '<script type="APPLICATION/LD+JSON">' + JSON.stringify({ '@type': 'Recipe' }) + '</script>';
+        expect(signalsFor(pageWithHead(head)).jsonLdType).toEqual(['Recipe']);
+    });
+
+    it('bails out of deeply nested JSON-LD without collecting past the cap (a thrown RangeError fails this test)', () => {
+        let nested = /** @type {any} */ ({ '@type': 'TooDeep' });
+        for (let i = 0; i < 60; i++) nested = { '@graph': [nested] };
+        const head = scriptLd({ '@type': 'Shallow', '@graph': [nested] });
+        const signals = signalsFor(pageWithHead(head));
+        expect(signals.jsonLdType).toContain('Shallow');
+        expect(signals.jsonLdType).not.toContain('TooDeep');
+    });
+
+    it('ignores @type / @graph inherited from a polluted Object.prototype', () => {
+        // Aliased reference so the deliberate pollution doesn't trip the no-extend-native lint rule.
+        const proto = /** @type {Record<string, unknown>} */ (Object.prototype);
+        proto['@type'] = 'Polluted';
+        try {
+            const signals = signalsFor(pageWithHead(scriptLd({ name: 'no own @type' })));
+            expect(signals.jsonLdType).toEqual([]);
+        } finally {
+            delete proto['@type'];
+        }
+    });
+
     it('collects all three signals from a realistic page (recipe with embedded video)', () => {
         const head =
             '<meta property="og:type" content="article">' +


### PR DESCRIPTION
Add an optional pageTypeSignals field to page-context collection, gated behind the includePageTypeSignals feature setting (off by default). It extracts schema.org JSON-LD @type, Open Graph og:type, and the declared page language, riding the existing collectionResult message so consumers (e.g. Duck.ai sidebar shortcuts) get cheap page-type hints with no extra round-trip and no LLM.

- Export extractPageTypeSignals(document) for unit testing (mirrors domToMarkdown); JSON-LD parsed defensively (malformed/oversized skipped), @type collected as string or array and from @graph, deduped, casing preserved, capped.
- Add jasmine unit specs.

**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1209072953775241/task/1215655051685860

## Description

Adds page signal collection to the page context collection script.

## Testing Steps

Added unit tests

## Checklist

<!--
  These questions are a friendly reminder to shipping code, if you're uncertain ask the AoR owners.
  It's also totally appropriate to not check some of these boxes, if they don't apply to your change.
-->
*Please tick all that apply:*

- [x] I have tested this change locally
- [ ] I have tested this change locally in all supported browsers
- [ ] This change will be visible to users
- [x] I have added automated tests that cover this change
- [x] I have ensured the change is gated by config
- [ ] This change was covered by a ship review
- [x] This change was covered by a tech design
- [ ] Any dependent config has been merged


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Feature is config-gated off by default and only adds best-effort metadata to existing collection; JSON-LD handling includes explicit bounds to avoid breaking full page collection.
> 
> **Overview**
> Adds optional **`pageTypeSignals`** to page-context **`collectionResult`** payload when **`includePageTypeSignals`** is enabled (default off), giving consumers cheap page-type hints without an extra round-trip.
> 
> New **`extractPageTypeSignals`** harvests JSON-LD **`@type`** (string/array, **`@graph`**, deduped, order preserved), **`og:type`**, and **`html lang`**. JSON-LD parsing is defensive: malformed/oversized blocks skipped, type count and block size capped via config (**`maxPageTypeSignals`**, **`maxJsonLdBlockLength`**), recursion bounded, case-insensitive script type, **`hasOwnProperty`** for **`@type`/`@graph`**.
> 
> Coverage includes JSDOM unit specs, a Playwright end-to-end spec with fixture HTML/config, and registration of that spec in the Windows Playwright project.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 911adcff37f9a6ffb35c3acbcb592eadb3a23039. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->