### PR TITLE
[WIP] Duck.ai navigation sidebar on the New Tab Page (POC)

### DIFF
--- a/special-pages/pages/new-tab/app/components/App.js
+++ b/special-pages/pages/new-tab/app/components/App.js
@@ -1,8 +1,9 @@
 import { Fragment, h } from 'preact';
 import cn from 'classnames';
 import styles from './App.module.css';
-import { useCustomizerDrawerSettings, usePlatformName } from '../settings.provider.js';
+import { useCustomizerDrawerSettings, useDuckAiSidebar, usePlatformName } from '../settings.provider.js';
 import { WidgetList } from '../widget-list/WidgetList.js';
+import { DuckAiSidebar } from '../duck-ai-sidebar/DuckAiSidebar.js';
 import { useGlobalDropzone } from '../dropzone.js';
 import { CustomizerButton, CustomizerMenuPositionedFixed, useContextMenu } from '../customizer/components/CustomizerMenu.js';
 import { useDrawer, useDrawerControls } from './Drawer.js';
@@ -23,6 +24,7 @@ import { useInitialSetupData } from '../types.js';
 export function App() {
     const platformName = usePlatformName();
     const customizerDrawer = useCustomizerDrawerSettings();
+    const showDuckAiSidebar = useDuckAiSidebar();
 
     useGlobalDropzone();
     useContextMenu();
@@ -55,7 +57,9 @@ export function App() {
                 data-drawer-visibility={visibility}
                 // Widen drawer when it has the new Theme section. Can remove this when theme variants are rolled out to all users
                 data-has-theme-variants={hasThemeVariants}
+                data-duckai-rail={showDuckAiSidebar}
             >
+                {showDuckAiSidebar && <DuckAiSidebar />}
                 <main class={cn(styles.main, styles.mainLayout, styles.mainScroller)} data-main-scroller data-theme={main}>
                     <div class={styles.content}>
                         <div className={styles.tube} data-content-tube data-platform={platformName}>

--- a/special-pages/pages/new-tab/app/components/App.module.css
+++ b/special-pages/pages/new-tab/app/components/App.module.css
@@ -50,6 +50,12 @@ body[data-animate-background="true"] {
 .layout {
     position: relative;
     z-index: 1;
+    --duckai-rail-width: 280px;
+}
+
+/* When the Duck.ai rail is shown, reserve space on the left for the fixed rail. */
+.layout[data-duckai-rail="true"] .main {
+    padding-left: var(--duckai-rail-width);
 }
 
 .main {

--- a/special-pages/pages/new-tab/app/duck-ai-sidebar/DuckAiSidebar.js
+++ b/special-pages/pages/new-tab/app/duck-ai-sidebar/DuckAiSidebar.js
@@ -1,0 +1,145 @@
+import { h } from 'preact';
+import { useContext } from 'preact/hooks';
+import { eventToTarget } from '../../../../shared/handlers.js';
+import { useMessaging } from '../types.js';
+import { usePlatformName } from '../settings.provider.js';
+import { CustomizerThemesContext } from '../customizer/CustomizerProvider.js';
+import { OmnibarProvider, OmnibarContext } from '../omnibar/components/OmnibarProvider.js';
+import { AiChatsProvider } from '../omnibar/components/AiChatsProvider.js';
+import { AiChatsList } from '../omnibar/components/AiChatsList.js';
+import { AiChatColorIcon, VoiceIcon, CreateImageIcon, FireIcon } from '../components/Icons.js';
+import styles from './DuckAiSidebar.module.css';
+
+/**
+ * @typedef {import('../../types/new-tab.js').OpenTarget} OpenTarget
+ */
+
+// Submit modes understood by native `omnibar_submitChat` (see AIChatScriptUserValues).
+/** @type {'voice-mode'} */
+const VOICE_MODE = 'voice-mode';
+/** @type {'image-generation'} */
+const IMAGE_GENERATION_MODE = 'image-generation';
+
+/**
+ * Duck.ai navigation rail shown on the left of the New Tab Page.
+ *
+ * It is a thin presentation layer over the existing omnibar Duck.ai plumbing: every action
+ * routes through `OmnibarContext` / the typed messaging the omnibar already uses, so native
+ * opens Duck.ai exactly as it does from the NTP search box today.
+ */
+export function DuckAiSidebar() {
+    const { browser } = useContext(CustomizerThemesContext);
+    return (
+        <OmnibarProvider>
+            <div class={styles.rail} data-theme={browser} data-duckai-sidebar>
+                <DuckAiSidebarContent />
+            </div>
+        </OmnibarProvider>
+    );
+}
+
+function DuckAiSidebarContent() {
+    const messaging = useMessaging();
+    const platformName = usePlatformName();
+    const { state, submitChat, viewAllAiChats } = useContext(OmnibarContext);
+    // The OmnibarService is created in an effect that runs after this subtree mounts, so the
+    // recent-chats list (which calls into the service on mount) must wait until it's ready —
+    // same gate the omnibar itself uses.
+    const serviceReady = state.status === 'ready';
+
+    /** @param {MouseEvent} event */
+    const targetFor = (event) => /** @type {OpenTarget} */ (eventToTarget(event, platformName));
+
+    /** @param {MouseEvent} event */
+    const onNewChat = (event) => viewAllAiChats({ target: targetFor(event) });
+
+    /** @param {MouseEvent} event */
+    const onNewVoiceChat = (event) => submitChat({ chat: '', mode: VOICE_MODE, target: targetFor(event) });
+
+    /** @param {MouseEvent} event */
+    const onNewImage = (event) => submitChat({ chat: '', mode: IMAGE_GENERATION_MODE, target: targetFor(event) });
+
+    const onOpenSettings = () => messaging.open({ target: 'duckAISettings' });
+
+    return (
+        <div class={styles.inner}>
+            <header class={styles.header}>
+                <AiChatColorIcon />
+                <span class={styles.headerTitle}>Duck.ai</span>
+            </header>
+
+            <nav class={styles.nav} aria-label="Duck.ai">
+                <NavButton icon={<ComposeIcon />} label="New Chat" onClick={onNewChat} />
+                <NavButton icon={<VoiceIcon />} label="New Voice Chat" onClick={onNewVoiceChat} />
+                <NavButton icon={<CreateImageIcon />} label="New Image" onClick={onNewImage} />
+            </nav>
+
+            <section class={styles.chats}>
+                <div class={styles.chatsHeader}>
+                    <span class={styles.chatsTitle}>Chats</span>
+                    {/* Decorative for the POC — the fire/burn action is not wired up yet. */}
+                    <span class={styles.fire} aria-hidden="true">
+                        <FireIcon />
+                    </span>
+                </div>
+                <div class={styles.chatsList}>
+                    {serviceReady && (
+                        <AiChatsProvider query="" autoFocus enableRecentAiChats>
+                            <AiChatsList className={styles.list} />
+                        </AiChatsProvider>
+                    )}
+                </div>
+            </section>
+
+            <footer class={styles.footer}>
+                <button type="button" class={styles.settings} onClick={onOpenSettings}>
+                    <ChevronDownIcon />
+                    <span>Settings &amp; More</span>
+                </button>
+                {/* Pro upsell is a static visual stub for the POC. */}
+                <span class={styles.pro}>
+                    <span class={styles.proLabel}>Pro</span>
+                    <span class={styles.proBadge} aria-hidden="true">
+                        +
+                    </span>
+                </span>
+            </footer>
+        </div>
+    );
+}
+
+/**
+ * @param {object} props
+ * @param {import('preact').ComponentChild} props.icon
+ * @param {string} props.label
+ * @param {(event: MouseEvent) => void} props.onClick
+ */
+function NavButton({ icon, label, onClick }) {
+    return (
+        <button type="button" class={styles.navButton} onClick={onClick}>
+            <span class={styles.navIcon}>{icon}</span>
+            <span class={styles.navLabel}>{label}</span>
+        </button>
+    );
+}
+
+// Compose / "new chat" glyph — not present in the shared Icons set.
+function ComposeIcon() {
+    return (
+        <svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <path
+                d="M4 13.5V16h2.5l7.4-7.4-2.5-2.5L4 13.5Zm11.8-6.9c.26-.26.26-.68 0-.94l-1.46-1.46a.66.66 0 0 0-.94 0l-1.14 1.14 2.5 2.5 1.04-1.04Z"
+                fill="currentColor"
+            />
+        </svg>
+    );
+}
+
+function ChevronDownIcon() {
+    return (
+        <svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <circle cx="10" cy="10" r="8.25" stroke="currentColor" stroke-width="1.5" opacity="0.5" />
+            <path d="M6.8 8.8 10 12l3.2-3.2" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" />
+        </svg>
+    );
+}

--- a/special-pages/pages/new-tab/app/duck-ai-sidebar/DuckAiSidebar.module.css
+++ b/special-pages/pages/new-tab/app/duck-ai-sidebar/DuckAiSidebar.module.css
@@ -1,0 +1,160 @@
+.rail {
+    position: fixed;
+    inset: 0 auto 0 0;
+    width: var(--duckai-rail-width, 280px);
+    z-index: 2;
+    color: var(--ds-color-theme-text-primary);
+    background: var(--ds-color-theme-surface-secondary);
+    border-right: 1px solid var(--ds-color-theme-surface-tertiary);
+    overflow: hidden;
+}
+
+.inner {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    padding: 12px 8px;
+    gap: 4px;
+}
+
+.header {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 8px;
+}
+
+.header svg {
+    width: 24px;
+    height: 24px;
+}
+
+.headerTitle {
+    font-size: 1rem;
+    font-weight: 700;
+}
+
+/* Nav buttons (New Chat / Voice / Image) and the settings button share the row style. */
+.nav {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+}
+
+.navButton,
+.settings {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    width: 100%;
+    padding: 8px;
+    border: none;
+    border-radius: 8px;
+    background: transparent;
+    color: inherit;
+    font: inherit;
+    text-align: left;
+    cursor: pointer;
+}
+
+.navButton:hover,
+.settings:hover {
+    background: var(--ds-color-theme-surface-tertiary);
+}
+
+.navIcon {
+    display: flex;
+    flex: none;
+}
+
+.navIcon svg {
+    width: 20px;
+    height: 20px;
+}
+
+.navLabel {
+    font-weight: 600;
+}
+
+.chats {
+    display: flex;
+    flex-direction: column;
+    flex: 1;
+    min-height: 0;
+    margin-top: 12px;
+}
+
+.chatsHeader {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 8px;
+}
+
+.chatsTitle {
+    font-weight: 700;
+}
+
+.fire {
+    display: flex;
+    color: var(--ds-color-theme-text-secondary);
+}
+
+.fire svg {
+    width: 20px;
+    height: 20px;
+}
+
+.chatsList {
+    flex: 1;
+    min-height: 0;
+    overflow-y: auto;
+}
+
+/* The reused AiChatsList renders its own item styling; just let it fill the rail width. */
+.list {
+    width: 100%;
+}
+
+.footer {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-top: auto;
+    padding-top: 8px;
+    border-top: 1px solid var(--ds-color-theme-surface-tertiary);
+}
+
+.settings {
+    width: auto;
+}
+
+.settings svg {
+    width: 20px;
+    height: 20px;
+    flex: none;
+}
+
+.pro {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding-right: 8px;
+}
+
+.proLabel {
+    color: var(--ds-color-theme-text-secondary);
+    font-size: 0.875rem;
+}
+
+.proBadge {
+    display: grid;
+    place-items: center;
+    width: 22px;
+    height: 22px;
+    border-radius: 50%;
+    background: #e8a33d;
+    color: #fff;
+    font-weight: 700;
+    line-height: 1;
+}

--- a/special-pages/pages/new-tab/app/index.js
+++ b/special-pages/pages/new-tab/app/index.js
@@ -66,7 +66,8 @@ export async function init(root, messaging, telemetry, baseEnvironment) {
         .withPlatformName(init.platform?.name)
         .withPlatformName(baseEnvironment.urlParams.get('platform'))
         .withFeatureState('customizerDrawer', init.settings?.customizerDrawer)
-        .withFeatureState('adBlocking', init.settings?.adBlocking);
+        .withFeatureState('adBlocking', init.settings?.adBlocking)
+        .withFeatureState('duckAiSidebar', init.settings?.duckAiSidebar);
 
     if (!window.__playwright_01) {
         console.log('environment:', environment);

--- a/special-pages/pages/new-tab/app/mock-transport.js
+++ b/special-pages/pages/new-tab/app/mock-transport.js
@@ -141,6 +141,10 @@ export function mockTransport() {
                     broadcast('widget_config');
                     return;
                 }
+                case 'open': {
+                    console.log('ignoring open', msg.params);
+                    return;
+                }
                 case 'rmf_primaryAction': {
                     console.log('ignoring rmf_primaryAction', msg.params);
                     clearRmf();
@@ -613,6 +617,10 @@ export function initialSetup(url) {
     if (url.searchParams.get('adBlocking') === 'enabled') {
         settings.adBlocking = { state: 'enabled' };
     }
+
+    // Duck.ai navigation sidebar (left rail). Enabled by default in the mock so the POC is
+    // visible in the dev harness; pass `?duckAiSidebar=disabled` to hide it.
+    settings.duckAiSidebar = { state: url.searchParams.get('duckAiSidebar') === 'disabled' ? 'disabled' : 'enabled' };
 
     if (url.searchParams.has('tabs')) {
         initial.tabs = { tabId: '01', tabIds: ['01'] };

--- a/special-pages/pages/new-tab/app/settings.js
+++ b/special-pages/pages/new-tab/app/settings.js
@@ -12,15 +12,18 @@ export class Settings {
      * @param {{name: 'macos' | 'windows'}} [params.platform]
      * @param {{state: 'enabled' | 'disabled', autoOpen: boolean}} [params.customizerDrawer]
      * @param {{state: 'enabled' | 'disabled'}} [params.adBlocking]
+     * @param {{state: 'enabled' | 'disabled'}} [params.duckAiSidebar]
      */
     constructor({
         platform = { name: detectPlatform() },
         customizerDrawer = { state: 'enabled', autoOpen: false },
         adBlocking = { state: 'disabled' },
+        duckAiSidebar = { state: 'disabled' },
     }) {
         this.platform = platform;
         this.customizerDrawer = customizerDrawer;
         this.adBlocking = adBlocking;
+        this.duckAiSidebar = duckAiSidebar;
     }
 
     withPlatformName(name) {
@@ -43,7 +46,7 @@ export class Settings {
     withFeatureState(named, settings) {
         if (!settings) return this;
         /** @type {(keyof import("../types/new-tab.js").NewTabPageSettings)[]} */
-        const valid = ['customizerDrawer', 'adBlocking'];
+        const valid = ['customizerDrawer', 'adBlocking', 'duckAiSidebar'];
         if (!valid.includes(named)) {
             console.warn(`Excluding invalid feature key ${named}`);
             return this;

--- a/special-pages/pages/new-tab/app/settings.provider.js
+++ b/special-pages/pages/new-tab/app/settings.provider.js
@@ -35,3 +35,12 @@ export function useAdBlocking() {
     const settings = useContext(SettingsContext).settings;
     return settings.adBlocking.state === 'enabled';
 }
+
+/**
+ * Whether the Duck.ai navigation sidebar (left rail) should be rendered.
+ * @returns {boolean}
+ */
+export function useDuckAiSidebar() {
+    const settings = useContext(SettingsContext).settings;
+    return settings.duckAiSidebar?.state === 'enabled';
+}

--- a/special-pages/pages/new-tab/messages/open.notify.json
+++ b/special-pages/pages/new-tab/messages/open.notify.json
@@ -6,7 +6,8 @@
   "properties": {
     "target": {
       "enum": [
-         "settings"
+         "settings",
+         "duckAISettings"
       ]
     }
   }

--- a/special-pages/pages/new-tab/messages/types/settings.json
+++ b/special-pages/pages/new-tab/messages/types/settings.json
@@ -26,6 +26,16 @@
           "enum": ["enabled", "disabled"]
         }
       }
+    },
+    "duckAiSidebar": {
+      "type": "object",
+      "required": ["state"],
+      "properties": {
+        "state": {
+          "type": "string",
+          "enum": ["enabled", "disabled"]
+        }
+      }
     }
   }
 }

--- a/special-pages/pages/new-tab/types/new-tab.ts
+++ b/special-pages/pages/new-tab/types/new-tab.ts
@@ -821,7 +821,7 @@ export interface OpenNotification {
   params: OpenAction;
 }
 export interface OpenAction {
-  target: "settings";
+  target: "settings" | "duckAISettings";
 }
 /**
  * Generated from @see "../messages/protections_setConfig.notify.json"
@@ -1151,6 +1151,9 @@ export interface NewTabPageSettings {
     autoOpen?: boolean;
   };
   adBlocking?: {
+    state: "enabled" | "disabled";
+  };
+  duckAiSidebar?: {
     state: "enabled" | "disabled";
   };
 }


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/42792087274227/task/1215798721094053?focus=true

## Description

POC: a left navigation rail on the desktop New Tab Page with Duck.ai entry points — New Chat, New Voice Chat, New Image, a recent **Chats** list, and a Settings & More footer (Pro badge is a static stub for now).

The rail is a thin presentation layer over the **existing omnibar Duck.ai plumbing**:
- New Chat → `omnibar_viewAllAIChats`, New Voice Chat / New Image → `omnibar_submitChat` (`voice-mode` / `image-generation`), recent chat → `omnibar_openAiChat` (reuses `AiChatsProvider`/`AiChatsList`), Settings & More → `open` with a new `duckAISettings` target.
- No new messaging beyond the `duckAISettings` target.

Rendering is gated by a new `duckAiSidebar` `initialSetup` setting (mirrors `customizerDrawer`), so native controls availability behind a feature flag. Paired macOS change adds the `newTabPageDuckAISidebar` flag + `HtmlNewTabPageSubfeature.duckAISidebar`.

Opening as **draft/WIP** to get a buildable branch for linking into the apple-browsers macOS PR.

## Testing Steps

- Dev harness: `npm run build -w special-pages` then serve `build/integration/pages/new-tab` — the rail shows by default (mock sets `duckAiSidebar: enabled`); pass `?duckAiSidebar=disabled` to hide it. Recent chats populate; clicking New Chat / Voice / Image / a recent chat / Settings dispatches the expected `omnibar_*` / `open` messages.
- In-app (macOS): behind the `newTabPageDuckAISidebar` flag (internal-only); open a new tab and verify the rail + that actions open Duck.ai as the NTP omnibar does.

## Checklist

- [x] I have tested this change locally
- [x] This change will be visible to users
- [x] I have ensured the change is gated by config