### PR TITLE
build(types): commit generated autofill-passkeys.ts

### DIFF
--- a/injected/src/types/autofill-passkeys.ts
+++ b/injected/src/types/autofill-passkeys.ts
@@ -1,0 +1,62 @@
+/**
+ * These types are auto-generated from schema files.
+ * scripts/build-types.mjs is responsible for type generation.
+ * **DO NOT** edit this file directly as your changes will be lost.
+ *
+ * @module AutofillPasskeys Messages
+ */
+
+/**
+ * Requests, Notifications and Subscriptions from the AutofillPasskeys feature
+ */
+export interface AutofillPasskeysMessages {
+  notifications: RegisterPasskeyRequestNotification;
+  subscriptions: PasskeySelectedSubscription;
+}
+/**
+ * Generated from @see "../messages/autofill-passkeys/registerPasskeyRequest.notify.json"
+ */
+export interface RegisterPasskeyRequestNotification {
+  method: "registerPasskeyRequest";
+  params: RegisterPasskeyRequestParams;
+}
+/**
+ * Registers a pending conditional passkey request with native Autofill.
+ */
+export interface RegisterPasskeyRequestParams {
+  /**
+   * The relying party ID for the pending WebAuthn request.
+   */
+  rpId: string;
+  /**
+   * Opaque request ID echoed by the native passkey selection event.
+   */
+  requestId: string;
+}
+/**
+ * Generated from @see "../messages/autofill-passkeys/passkeySelected.subscribe.json"
+ */
+export interface PasskeySelectedSubscription {
+  subscriptionEvent: "passkeySelected";
+  params: PasskeySelectedParams;
+}
+/**
+ * Subscription payload sent when native Autofill selects a passkey for a pending request.
+ */
+export interface PasskeySelectedParams {
+  /**
+   * Base64-encoded (standard Base64, not Base64URL) WebAuthn credential ID selected by native Autofill.
+   */
+  credentialId: string;
+  /**
+   * Opaque request ID from the matching registerPasskeyRequest notification.
+   */
+  requestId: string;
+}
+
+declare module "../features/autofill-passkeys.js" {
+  export interface AutofillPasskeys {
+    notify: import("@duckduckgo/messaging/lib/shared-types").MessagingBase<AutofillPasskeysMessages>['notify'],
+    subscribe: import("@duckduckgo/messaging/lib/shared-types").MessagingBase<AutofillPasskeysMessages>['subscribe']
+  }
+}


### PR DESCRIPTION
**Asana Task/Github Issue:** Follow-up to #2571

## Description

`injected/src/types/autofill-passkeys.ts` is generated from the autofill-passkeys message schemas, but it never got committed alongside the feature and its schemas in #2571. Nothing actually broke, because the build regenerates types before tsc runs, so CI never noticed it was missing. Committing it just so `src/types/` matches what `build-types` emits and the file isn't mysteriously absent from the tree.

## Testing Steps

- `cd injected && npm run build-types`, then `git status` – no diff, i.e. the committed file already matches the generated output.

## Checklist

*Please tick all that apply:*

- [x] I have tested this change locally
- [ ] I have tested this change locally in all supported browsers
- [ ] This change will be visible to users
- [ ] I have added automated tests that cover this change
- [ ] I have ensured the change is gated by config
- [ ] This change was covered by a ship review
- [ ] This change was covered by a tech design
- [ ] Any dependent config has been merged

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Generated types only; no behavior change and build already produced the same file locally.
> 
> **Overview**
> Adds the missing **generated** `injected/src/types/autofill-passkeys.ts` so the repo matches what `scripts/build-types.mjs` emits for the Autofill Passkeys messaging schemas from #2571.
> 
> The file defines TypeScript types for `registerPasskeyRequest` notifications and `passkeySelected` subscriptions, plus module augmentation on `AutofillPasskeys` for typed `notify` / `subscribe`. **No runtime or schema changes**—only checking in output that CI already regenerates before `tsc`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cb0d84321261f06f0978975e2df4312f1ecbc7fd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->