### PR TITLE
Generate broker-protection types from JSON schemas

### DIFF
--- a/injected/integration-test/mocks/broker-protection/captcha.js
+++ b/injected/integration-test/mocks/broker-protection/captcha.js
@@ -1,6 +1,6 @@
 import { createPirState, getBrokerProtectionTestPageUrl } from './utils';
 /**
- * @import { PirAction } from '../../../src/features/broker-protection/types.js'
+ * @import { GetCaptchaInfoAction, SolveCaptchaAction } from '../../../src/types/broker-protection.js'
  */
 
 const MOCK_SITE_KEY = '6LeCl8UUAAAAAGssOpatU5nzFXH2D7UZEYelSLTn';
@@ -9,7 +9,7 @@ const MOCK_SITE_KEY = '6LeCl8UUAAAAAGssOpatU5nzFXH2D7UZEYelSLTn';
 
 /**
  * @param {object} params
- * @param {Omit<PirAction, 'id' | 'actionType'>} params.action
+ * @param {Omit<GetCaptchaInfoAction, 'id' | 'actionType'>} params.action
  */
 export function createGetCaptchaInfoAction({ action }) {
     return createPirState({
@@ -22,7 +22,7 @@ export function createGetCaptchaInfoAction({ action }) {
 }
 
 /**
- * @param {Partial<PirAction>} [actionOverrides]
+ * @param {Partial<GetCaptchaInfoAction>} [actionOverrides]
  */
 export function createGetRecaptchaInfoAction(actionOverrides = {}) {
     return createGetCaptchaInfoAction({
@@ -35,9 +35,9 @@ export function createGetRecaptchaInfoAction(actionOverrides = {}) {
 }
 
 /**
- * @param {Partial<PirAction>} [actionOverrides]
+ * @param {Partial<GetCaptchaInfoAction> & Pick<GetCaptchaInfoAction, 'selector'>} actionOverrides
  */
-export function createGetImageCaptchaInfoAction(actionOverrides = {}) {
+export function createGetImageCaptchaInfoAction(actionOverrides) {
     return createGetCaptchaInfoAction({
         action: {
             captchaType: 'image',
@@ -47,9 +47,9 @@ export function createGetImageCaptchaInfoAction(actionOverrides = {}) {
 }
 
 /**
- * @param {Partial<PirAction>} [actionOverrides]
+ * @param {Partial<GetCaptchaInfoAction> & Pick<GetCaptchaInfoAction, 'selector'>} actionOverrides
  */
-export function createGetCloudFlareCaptchaInfoAction(actionOverrides = {}) {
+export function createGetCloudFlareCaptchaInfoAction(actionOverrides) {
     return createGetCaptchaInfoAction({
         action: {
             captchaType: 'cloudFlareTurnstile',
@@ -60,7 +60,7 @@ export function createGetCloudFlareCaptchaInfoAction(actionOverrides = {}) {
 
 /**
  * @param {object} params
- * @param {Omit<PirAction, 'id' | 'actionType'>} params.action
+ * @param {Omit<SolveCaptchaAction, 'id' | 'actionType'>} params.action
  * @param {Record<string, any>} [params.data]
  */
 export function createSolveCaptchaAction({ action, data }) {
@@ -78,7 +78,7 @@ export function createSolveCaptchaAction({ action, data }) {
 }
 
 /**
- * @param {Partial<PirAction>} [actionOverrides]
+ * @param {Partial<SolveCaptchaAction>} [actionOverrides]
  */
 export function createSolveRecaptchaAction(actionOverrides = {}) {
     return createSolveCaptchaAction({
@@ -91,9 +91,9 @@ export function createSolveRecaptchaAction(actionOverrides = {}) {
 }
 
 /**
- * @param {Partial<PirAction>} [actionOverrides]
+ * @param {Partial<SolveCaptchaAction> & Pick<SolveCaptchaAction, 'selector'>} actionOverrides
  */
-export function createSolveImageCaptchaAction(actionOverrides = {}) {
+export function createSolveImageCaptchaAction(actionOverrides) {
     return createSolveCaptchaAction({
         action: {
             captchaType: 'image',
@@ -103,9 +103,9 @@ export function createSolveImageCaptchaAction(actionOverrides = {}) {
 }
 
 /**
- * @param {Partial<PirAction>} [actionOverrides]
+ * @param {Partial<SolveCaptchaAction> & Pick<SolveCaptchaAction, 'selector'>} actionOverrides
  */
-export function createSolveCloudFlareCaptchaAction(actionOverrides = {}) {
+export function createSolveCloudFlareCaptchaAction(actionOverrides) {
     return createSolveCaptchaAction({
         action: {
             captchaType: 'cloudFlareTurnstile',

--- a/injected/src/features/broker-protection.js
+++ b/injected/src/features/broker-protection.js
@@ -3,10 +3,16 @@ import { execute } from './broker-protection/execute.js';
 import { retry } from '../timer-utils.js';
 import { ErrorResponse } from './broker-protection/types.js';
 
+/**
+ * @typedef {import('./broker-protection/types.js').PirAction} PirAction
+ * @typedef {import('./broker-protection/types.js').ActionData} ActionData
+ * @typedef {import('./broker-protection/types.js').ActionResponse} ActionResponse
+ */
+
 export class ActionExecutorBase extends ContentFeature {
     /**
-     * @param {any} action
-     * @param {Record<string, any>} data
+     * @param {PirAction} action
+     * @param {ActionData} data
      */
     async processActionAndNotify(action, data) {
         try {
@@ -48,8 +54,8 @@ export class ActionExecutorBase extends ContentFeature {
     /**
      * Recursively execute actions with the same dataset, collecting all results/exceptions for
      * later analysis
-     * @param {any} action
-     * @param {Record<string, any>} data
+     * @param {PirAction} action
+     * @param {ActionData} data
      * @return {Promise<{results: ActionResponse[], exceptions: string[]}>}
      */
     async exec(action, data) {
@@ -75,6 +81,7 @@ export class ActionExecutorBase extends ContentFeature {
     }
 
     /**
+     * @param {PirAction} action
      * @returns {any}
      */
     retryConfigFor(action) {
@@ -82,9 +89,6 @@ export class ActionExecutorBase extends ContentFeature {
     }
 }
 
-/**
- * @typedef {import("./broker-protection/types.js").ActionResponse} ActionResponse
- */
 export class BrokerProtection extends ActionExecutorBase {
     init() {
         this.subscribe('onActionReceived', async (params) => {
@@ -96,7 +100,7 @@ export class BrokerProtection extends ActionExecutorBase {
     /**
      * Define default retry configurations for certain actions
      *
-     * @param {any} action
+     * @param {PirAction} action
      * @returns
      */
     retryConfigFor(action) {

--- a/injected/src/features/broker-protection.js
+++ b/injected/src/features/broker-protection.js
@@ -11,7 +11,7 @@ export class ActionExecutorBase extends ContentFeature {
     async processActionAndNotify(action, data) {
         try {
             if (!action) {
-                return this.messaging.notify('actionError', { error: 'No action found.' });
+                return this.notify('actionError', { error: 'No action found.' });
             }
 
             const { results, exceptions } = await this.exec(action, data);
@@ -23,7 +23,7 @@ export class ActionExecutorBase extends ContentFeature {
 
                 // if there are no secondary actions, or just no errors in general, just report the parent action
                 if (results.length === 1 || errors.length === 0) {
-                    return this.messaging.notify('actionCompleted', { result: parent });
+                    return this.notify('actionCompleted', { result: parent });
                 }
 
                 // here we must have secondary actions that failed.
@@ -35,13 +35,13 @@ export class ActionExecutorBase extends ContentFeature {
                     message: 'Secondary actions failed: ' + joinedErrors,
                 });
 
-                return this.messaging.notify('actionCompleted', { result: response });
+                return this.notify('actionCompleted', { result: response });
             } else {
-                return this.messaging.notify('actionError', { error: 'No response found, exceptions: ' + exceptions.join(', ') });
+                return this.notify('actionError', { error: 'No response found, exceptions: ' + exceptions.join(', ') });
             }
         } catch (e) {
             this.log.error('unhandled exception: ', e);
-            return this.messaging.notify('actionError', { error: e.toString() });
+            return this.notify('actionError', { error: e.toString() });
         }
     }
 
@@ -85,9 +85,9 @@ export class ActionExecutorBase extends ContentFeature {
 /**
  * @typedef {import("./broker-protection/types.js").ActionResponse} ActionResponse
  */
-export default class BrokerProtection extends ActionExecutorBase {
+export class BrokerProtection extends ActionExecutorBase {
     init() {
-        this.messaging.subscribe('onActionReceived', async (/** @type {any} */ params) => {
+        this.subscribe('onActionReceived', async (params) => {
             const { action, data } = params.state;
             return await this.processActionAndNotify(action, data);
         });
@@ -128,3 +128,5 @@ export default class BrokerProtection extends ActionExecutorBase {
         return retryConfig;
     }
 }
+
+export default BrokerProtection;

--- a/injected/src/features/broker-protection/actions/captcha-deprecated.js
+++ b/injected/src/features/broker-protection/actions/captcha-deprecated.js
@@ -5,7 +5,7 @@ import { ErrorResponse, SuccessResponse } from '../types.js';
 /**
  * Gets the captcha information to send to the backend
  *
- * @param {import('../types.js').PirAction} action
+ * @param {import('../../../types/broker-protection.js').GetCaptchaInfoAction} action
  * @param {Document | HTMLElement} root
  * @return {import('../types.js').ActionResponse}
  */

--- a/injected/src/features/broker-protection/actions/captcha-deprecated.js
+++ b/injected/src/features/broker-protection/actions/captcha-deprecated.js
@@ -3,11 +3,17 @@ import { getElement } from '../utils/utils.js';
 import { ErrorResponse, SuccessResponse } from '../types.js';
 
 /**
+ * @typedef {import('../../../types/broker-protection.js').GetCaptchaInfoAction} GetCaptchaInfoAction
+ * @typedef {import('../../../types/broker-protection.js').SolveCaptchaAction} SolveCaptchaAction
+ * @typedef {import('../types.js').ActionResponse} ActionResponse
+ */
+
+/**
  * Gets the captcha information to send to the backend
  *
- * @param {import('../../../types/broker-protection.js').GetCaptchaInfoAction} action
+ * @param {GetCaptchaInfoAction} action
  * @param {Document | HTMLElement} root
- * @return {import('../types.js').ActionResponse}
+ * @return {ActionResponse}
  */
 export function getCaptchaInfo(action, root = document) {
     const pageUrl = window.location.href;
@@ -87,10 +93,10 @@ export function getCaptchaInfo(action, root = document) {
 /**
  * Takes the solved captcha token and injects it into the page to solve the captcha
  *
- * @param action
+ * @param {SolveCaptchaAction} action
  * @param {string} token
  * @param {Document} root
- * @return {import('../types.js').ActionResponse}
+ * @return {ActionResponse}
  */
 export function solveCaptcha(action, token, root = document) {
     const selectors = ['h-captcha-response', 'g-recaptcha-response'];

--- a/injected/src/features/broker-protection/actions/click.js
+++ b/injected/src/features/broker-protection/actions/click.js
@@ -4,13 +4,20 @@ import { extractProfiles } from './extract.js';
 import { processTemplateStringWithUserData } from './build-url-transforms.js';
 
 /**
- * @param {Record<string, any>} action
+ * @typedef {import('../../../types/broker-protection.js').ClickAction} ClickAction
+ * @typedef {import('../../../types/broker-protection.js').ClickElement} ClickElement
+ * @typedef {import('../../../types/broker-protection.js').Choice} Choice
+ * @typedef {import('../types.js').ActionResponse} ActionResponse
+ */
+
+/**
+ * @param {ClickAction} action
  * @param {Record<string, any>} userData
  * @param {Document | HTMLElement} root
- * @return {import('../types.js').ActionResponse}
+ * @return {ActionResponse}
  */
 export function click(action, userData, root = document) {
-    /** @type {Array<any> | null} */
+    /** @type {ClickElement[] | undefined} */
     let elements = [];
 
     if (action.choices?.length) {
@@ -81,7 +88,7 @@ export function click(action, userData, root = document) {
 }
 
 /**
- * @param {{parent?: {profileMatch?: Record<string, any>}}} clickElement
+ * @param {ClickElement} clickElement
  * @param {Record<string, any>} userData
  * @param {Document | HTMLElement} root
  * @return {Node}
@@ -135,16 +142,16 @@ export function getComparisonFunction(operator) {
 /**
  * Evaluates the defined choices (and/or the default) and returns an array of the elements to be clicked
  *
- * @param {Record<string, any>} action
+ * @param {ClickAction} action
  * @param {Record<string, any>} userData
- * @returns {{ elements: [Record<string, any>] } | { error: String } | null}
+ * @returns {{ elements: ClickElement[] } | { error: string } | null}
  */
 function evaluateChoices(action, userData) {
     if ('elements' in action) {
         return { error: 'Elements should be nested inside of choices' };
     }
 
-    for (const choice of action.choices) {
+    for (const choice of action.choices ?? []) {
         if (!('condition' in choice) || !('elements' in choice)) {
             return { error: 'All choices must have a condition and elements' };
         }
@@ -159,7 +166,7 @@ function evaluateChoices(action, userData) {
     }
 
     // If there's no default defined, return an error.
-    if (!('default' in action)) {
+    if (action.default === undefined) {
         return { error: 'All conditions failed and no default action was provided' };
     }
 
@@ -180,10 +187,10 @@ function evaluateChoices(action, userData) {
 /**
  * Attempts to turn a choice definition into an executable comparison and returns the result
  *
- * @param {Record<string, any>} choice
- * @param {Record<string, any>} action
+ * @param {Choice} choice
+ * @param {ClickAction} action
  * @param {Record<string, any>} userData
- * @returns {{ result: Boolean } | { error: String }}
+ * @returns {{ result: boolean } | { error: string }}
  */
 function runComparison(choice, action, userData) {
     let compare;

--- a/injected/src/features/broker-protection/actions/click.js
+++ b/injected/src/features/broker-protection/actions/click.js
@@ -151,7 +151,11 @@ function evaluateChoices(action, userData) {
         return { error: 'Elements should be nested inside of choices' };
     }
 
-    for (const choice of action.choices ?? []) {
+    if (!action.choices?.length) {
+        throw new Error('evaluateChoices requires a non-empty `choices` array');
+    }
+
+    for (const choice of action.choices) {
         if (!('condition' in choice) || !('elements' in choice)) {
             return { error: 'All choices must have a condition and elements' };
         }

--- a/injected/src/features/broker-protection/actions/condition.js
+++ b/injected/src/features/broker-protection/actions/condition.js
@@ -2,9 +2,14 @@ import { ErrorResponse, SuccessResponse } from '../types.js';
 import { expectMany } from '../utils/expectations.js';
 
 /**
- * @param {Record<string, any>} action
+ * @typedef {import('../../../types/broker-protection.js').ConditionAction} ConditionAction
+ * @typedef {import('../types.js').ActionResponse} ActionResponse
+ */
+
+/**
+ * @param {ConditionAction} action
  * @param {Document} root
- * @return {import('../types.js').ActionResponse}
+ * @return {ActionResponse}
  */
 export function condition(action, root = document) {
     const results = expectMany(action.expectations, root);

--- a/injected/src/features/broker-protection/actions/expectation.js
+++ b/injected/src/features/broker-protection/actions/expectation.js
@@ -2,9 +2,14 @@ import { ErrorResponse, SuccessResponse } from '../types.js';
 import { expectMany } from '../utils/expectations.js';
 
 /**
- * @param {Record<string, any>} action
+ * @typedef {import('../../../types/broker-protection.js').ExpectationAction} ExpectationAction
+ * @typedef {import('../types.js').ActionResponse} ActionResponse
+ */
+
+/**
+ * @param {ExpectationAction} action
  * @param {Document} root
- * @return {import('../types.js').ActionResponse}
+ * @return {ActionResponse}
  */
 export function expectation(action, root = document) {
     const results = expectMany(action.expectations, root);

--- a/injected/src/features/broker-protection/actions/extract.js
+++ b/injected/src/features/broker-protection/actions/extract.js
@@ -11,82 +11,17 @@ import { extractRelatives } from '../extractors/relatives.js';
 import { extractProfileUrl, ProfileHashTransformer } from '../extractors/profile-url.js';
 
 /**
- * Adding these types here so that we can switch to generated ones later
  * @typedef {Record<string, any>} Action
  */
 
 /**
- * How a profile-URL identifier is located: a query `param`, a `path` segment, or the URL `hash`.
- * @typedef {'param'|'path'|'hash'} IdentifierType
- */
-
-/**
- * The text-shaping knobs every selector-based field shares: where the value lives and how to clean
- * the text once read. This is the spec for the majority of fields (name, age, phone, …); city/state
- * and profileUrl extend it (see {@link CityStateSpec}, {@link ProfileUrlSpec}).
- *
- * For example: { "selector": ".//div[@class='col-sm-24 col-md-8 relatives']//li" }
- *
- * @typedef {Object} TextFieldSpec
- * @property {string} [selector] - xpath or css selector
- * @property {boolean} [findElements] - whether to get all occurrences of the selector
- * @property {string} [afterText] - get all text after this string
- * @property {string} [beforeText] - get all text before this string
- * @property {string} [separator] - split the text on this string, or use a regex by passing "/pattern/" (e.g. "/(?<=, [A-Z]{2}), /")
- * @property {string} [attribute] - read this attribute (e.g. "data-link") instead of the element's text
- */
-
-/**
- * The nested city/state shape: the `selector` matches each result row, and `city` (plus optional
- * `state`) sub-selectors are read relative to that row. Two variants:
- * - with state: both sub-selectors present (the `state` selector may even reach outside the row,
- *   e.g. a shared `<h1>`)
- * - city only: `state` omitted, so the state comes out as `null`
- *
- * @typedef {TextFieldSpec & { city: TextFieldSpec, state?: TextFieldSpec }} NestedCityStateSpec
- */
-
-/**
- * Where a city/state field lives. A union of two shapes, discriminated on whether the spec carries
- * its own `city` sub-selector:
- * - combined: a single `selector` whose text is "City, ST" (a plain {@link TextFieldSpec})
- * - nested: per-row `city`/`state` sub-selectors (a {@link NestedCityStateSpec})
- *
- * @typedef {TextFieldSpec | NestedCityStateSpec} CityStateSpec
- */
-
-/**
- * Extends {@link TextFieldSpec} with the knobs unique to profileUrl:
- * - `source: 'pageUrl'` reads the value from the current page URL (`globalThis.location.href`)
- *   instead of from a `selector`
- * - `identifier` is the identifier itself (a param name, or a templated URI) and `identifierType`
- *   ({@link IdentifierType}) says where to find it within the resolved URL
- *
- * @typedef {TextFieldSpec & { source?: 'pageUrl', identifier?: string, identifierType?: IdentifierType }} ProfileUrlSpec
- */
-
-/**
- * Any single field's spec. Most fields are a plain {@link TextFieldSpec}.
+ * @typedef {import('../../../types/broker-protection.js').IdentifierType} IdentifierType
+ * @typedef {import('../../../types/broker-protection.js').TextFieldSpec} TextFieldSpec
+ * @typedef {import('../../../types/broker-protection.js').NestedCityStateSpec} NestedCityStateSpec
+ * @typedef {import('../../../types/broker-protection.js').CityStateSpec} CityStateSpec
+ * @typedef {import('../../../types/broker-protection.js').ProfileUrlSpec} ProfileUrlSpec
+ * @typedef {import('../../../types/broker-protection.js').ProfileSpec} ProfileSpec
  * @typedef {TextFieldSpec | CityStateSpec | ProfileUrlSpec} FieldSpec
- */
-
-/**
- * The `profile` block of an `extract` action: a map of output field name -> how to locate that
- * field. `null` disables a field. This is the per-broker config the native layer sends; the field
- * keys are a contract with that config.
- *
- * @typedef {Object} ProfileSpec
- * @property {TextFieldSpec | null} [name]
- * @property {TextFieldSpec | null} [age]
- * @property {TextFieldSpec | null} [alternativeNamesList]
- * @property {TextFieldSpec | null} [relativesList]
- * @property {TextFieldSpec | null} [phone]
- * @property {TextFieldSpec | null} [phoneList]
- * @property {TextFieldSpec | null} [addressFull]
- * @property {TextFieldSpec | null} [addressFullList]
- * @property {CityStateSpec | null} [addressCityState]
- * @property {CityStateSpec | null} [addressCityStateList]
- * @property {ProfileUrlSpec | null} [profileUrl]
  */
 
 /**

--- a/injected/src/features/broker-protection/actions/extract.js
+++ b/injected/src/features/broker-protection/actions/extract.js
@@ -11,17 +11,18 @@ import { extractRelatives } from '../extractors/relatives.js';
 import { extractProfileUrl, ProfileHashTransformer } from '../extractors/profile-url.js';
 
 /**
- * @typedef {Record<string, any>} Action
- */
-
-/**
  * @typedef {import('../../../types/broker-protection.js').IdentifierType} IdentifierType
  * @typedef {import('../../../types/broker-protection.js').TextFieldSpec} TextFieldSpec
  * @typedef {import('../../../types/broker-protection.js').NestedCityStateSpec} NestedCityStateSpec
  * @typedef {import('../../../types/broker-protection.js').CityStateSpec} CityStateSpec
  * @typedef {import('../../../types/broker-protection.js').ProfileUrlSpec} ProfileUrlSpec
  * @typedef {import('../../../types/broker-protection.js').ProfileSpec} ProfileSpec
+ * @typedef {import('../../../types/broker-protection.js').ExtractAction} ExtractAction
+ * @typedef {import('../../../types/broker-protection.js').UserProfile} UserProfile
+ * @typedef {import('../types.js').ActionResponse} ActionResponse
+ * @typedef {import('../types.js').AsyncProfileTransform} AsyncProfileTransform
  * @typedef {TextFieldSpec | CityStateSpec | ProfileUrlSpec} FieldSpec
+ * @typedef {{ selector: string; profile: ProfileSpec; noResultsSelector?: string }} ExtractSpec - the subset of an extract action that `extractProfiles` reads; satisfied by both ExtractAction and a click action's `parent.profileMatch`
  */
 
 /**
@@ -37,10 +38,10 @@ import { extractProfileUrl, ProfileHashTransformer } from '../extractors/profile
  */
 
 /**
- * @param {Action} action
- * @param {Record<string, any>} userData
+ * @param {ExtractAction} action
+ * @param {UserProfile} userData
  * @param {Document | HTMLElement} root
- * @return {Promise<import('../types.js').ActionResponse>}
+ * @return {Promise<ActionResponse>}
  */
 export async function extract(action, userData, root = document) {
     const extractResult = extractProfiles(action, userData, root);
@@ -90,8 +91,8 @@ function select(root, selector, all = false) {
 }
 
 /**
- * @param {Action} action
- * @param {Record<string, any>} userData
+ * @param {ExtractSpec} action
+ * @param {UserProfile} userData
  * @param {Element | Document} [root]
  * @return {{error: string} | {results: ProfileResult[]}}
  */
@@ -353,7 +354,7 @@ export function aggregateFields(profile) {
  * @return {Promise<Record<string, any>>}
  */
 async function applyPostTransforms(profile, profileSpec) {
-    /** @type {import("../types.js").AsyncProfileTransform[]} */
+    /** @type {AsyncProfileTransform[]} */
     const transforms = [
         // creates a hash if needed
         new ProfileHashTransformer(),

--- a/injected/src/features/broker-protection/actions/fill-form.js
+++ b/injected/src/features/broker-protection/actions/fill-form.js
@@ -4,10 +4,16 @@ import { generatePhoneNumber, generateZipCode, generateStreetAddress } from './g
 import { states } from '../comparisons/constants.js';
 
 /**
- * @param {Record<string, any>} action
+ * @typedef {import('../../../types/broker-protection.js').FillFormAction} FillFormAction
+ * @typedef {import('../../../types/broker-protection.js').FormElement} FormElement
+ * @typedef {import('../types.js').ActionResponse} ActionResponse
+ */
+
+/**
+ * @param {FillFormAction} action
  * @param {Record<string, any>} userData
  * @param {Document | HTMLElement} root
- * @return {import('../types.js').ActionResponse}
+ * @return {ActionResponse}
  */
 export function fillForm(action, userData, root = document) {
     const form = getElement(root, action.selector);
@@ -36,7 +42,7 @@ export function fillForm(action, userData, root = document) {
 /**
  * Try to fill form elements. Collecting results + warnings for reporting.
  * @param {HTMLElement} root
- * @param {{selector: string; type: string; min?: string; max?: string;}[]} elements
+ * @param {FormElement[]} elements
  * @param {Record<string, any>} data
  * @return {({result: true} | {result: false; error: string})[]}
  */

--- a/injected/src/features/broker-protection/actions/navigate.js
+++ b/injected/src/features/broker-protection/actions/navigate.js
@@ -6,7 +6,7 @@ import { buildUrl } from './build-url';
  * This builds the proper URL given the URL template and userData.
  * Also, if the action requires a captcha handler, it will inject the necessary code.
  *
- * @param {import('../types.js').PirAction} action
+ * @param {import('../../../types/broker-protection.js').NavigateAction} action
  * @param {Record<string, any>} userData
  * @return {import('../types.js').ActionResponse}
  */

--- a/injected/src/features/broker-protection/actions/navigate.js
+++ b/injected/src/features/broker-protection/actions/navigate.js
@@ -3,12 +3,17 @@ import { ErrorResponse, SuccessResponse } from '../types';
 import { buildUrl } from './build-url';
 
 /**
+ * @typedef {import('../../../types/broker-protection.js').NavigateAction} NavigateAction
+ * @typedef {import('../types.js').ActionResponse} ActionResponse
+ */
+
+/**
  * This builds the proper URL given the URL template and userData.
  * Also, if the action requires a captcha handler, it will inject the necessary code.
  *
- * @param {import('../../../types/broker-protection.js').NavigateAction} action
+ * @param {NavigateAction} action
  * @param {Record<string, any>} userData
- * @return {import('../types.js').ActionResponse}
+ * @return {ActionResponse}
  */
 export function navigate(action, userData) {
     const { id: actionID, actionType } = action;

--- a/injected/src/features/broker-protection/actions/scroll.js
+++ b/injected/src/features/broker-protection/actions/scroll.js
@@ -2,9 +2,14 @@ import { ErrorResponse, SuccessResponse } from '../types';
 import { getElement } from '../utils/utils';
 
 /**
- * @param {Record<string, any>} action
+ * @typedef {import('../../../types/broker-protection.js').ScrollAction} ScrollAction
+ * @typedef {import('../types.js').ActionResponse} ActionResponse
+ */
+
+/**
+ * @param {ScrollAction} action
  * @param {Document} root
- * @return {import('../types.js').ActionResponse}
+ * @return {ActionResponse}
  */
 // eslint-disable-next-line no-redeclare
 export function scroll(action, root = document) {

--- a/injected/src/features/broker-protection/captcha-services/captcha.service.js
+++ b/injected/src/features/broker-protection/captcha-services/captcha.service.js
@@ -8,7 +8,7 @@ import { getCaptchaInfo as getCaptchaInfoDeprecated, solveCaptcha as solveCaptch
 /**
  *
  * @param {Document | HTMLElement} root
- * @param {import('../types.js').PirAction['selector']} [selector]
+ * @param {string} [selector]
  * @returns {HTMLElement | import('../types.js').PirError}
  */
 const getCaptchaContainer = (root, selector) => {
@@ -27,7 +27,7 @@ const getCaptchaContainer = (root, selector) => {
 /**
  * Returns the supporting code to inject for the given captcha type
  *
- * @param {import('../types.js').PirAction} action
+ * @param {import('../../../types/broker-protection.js').NavigateAction} action
  * @return {import('../types.js').ActionResponse}
  */
 export function getSupportingCodeToInject(action) {
@@ -49,7 +49,7 @@ export function getSupportingCodeToInject(action) {
 /**
  * Gets the captcha information to send to the backend
  *
- * @param {import('../types.js').PirAction} action
+ * @param {import('../../../types/broker-protection.js').GetCaptchaInfoAction} action
  * @param {Document | HTMLElement} root
  * @return {Promise<import('../types.js').ActionResponse>}
  */
@@ -93,7 +93,7 @@ export async function getCaptchaInfo(action, root = document) {
 /**
  * Takes the solved captcha token and injects it into the page to solve the captcha
  *
- * @param {import('../types.js').PirAction} action
+ * @param {import('../../../types/broker-protection.js').SolveCaptchaAction} action
  * @param {string} token
  * @param {Document} root
  * @return {import('../types.js').ActionResponse}

--- a/injected/src/features/broker-protection/captcha-services/captcha.service.js
+++ b/injected/src/features/broker-protection/captcha-services/captcha.service.js
@@ -6,10 +6,17 @@ import { captchaFactory } from './providers/registry.js';
 import { getCaptchaInfo as getCaptchaInfoDeprecated, solveCaptcha as solveCaptchaDeprecated } from '../actions/captcha-deprecated';
 
 /**
+ * @typedef {import('../../../types/broker-protection.js').NavigateAction} NavigateAction
+ * @typedef {import('../../../types/broker-protection.js').GetCaptchaInfoAction} GetCaptchaInfoAction
+ * @typedef {import('../../../types/broker-protection.js').SolveCaptchaAction} SolveCaptchaAction
+ * @typedef {import('../types.js').ActionResponse} ActionResponse
+ */
+
+/**
  *
  * @param {Document | HTMLElement} root
  * @param {string} [selector]
- * @returns {HTMLElement | import('../types.js').PirError}
+ * @returns {HTMLElement | PirError}
  */
 const getCaptchaContainer = (root, selector) => {
     if (!selector) {
@@ -27,8 +34,8 @@ const getCaptchaContainer = (root, selector) => {
 /**
  * Returns the supporting code to inject for the given captcha type
  *
- * @param {import('../../../types/broker-protection.js').NavigateAction} action
- * @return {import('../types.js').ActionResponse}
+ * @param {NavigateAction} action
+ * @return {ActionResponse}
  */
 export function getSupportingCodeToInject(action) {
     const { id: actionID, actionType, injectCaptchaHandler: captchaType } = action;
@@ -49,9 +56,9 @@ export function getSupportingCodeToInject(action) {
 /**
  * Gets the captcha information to send to the backend
  *
- * @param {import('../../../types/broker-protection.js').GetCaptchaInfoAction} action
+ * @param {GetCaptchaInfoAction} action
  * @param {Document | HTMLElement} root
- * @return {Promise<import('../types.js').ActionResponse>}
+ * @return {Promise<ActionResponse>}
  */
 export async function getCaptchaInfo(action, root = document) {
     const { id: actionID, actionType, captchaType, selector } = action;
@@ -93,10 +100,10 @@ export async function getCaptchaInfo(action, root = document) {
 /**
  * Takes the solved captcha token and injects it into the page to solve the captcha
  *
- * @param {import('../../../types/broker-protection.js').SolveCaptchaAction} action
+ * @param {SolveCaptchaAction} action
  * @param {string} token
  * @param {Document} root
- * @return {import('../types.js').ActionResponse}
+ * @return {ActionResponse}
  */
 export function solveCaptcha(action, token, root = document) {
     const { id: actionID, actionType, captchaType, selector } = action;

--- a/injected/src/features/broker-protection/captcha-services/get-captcha-container.js
+++ b/injected/src/features/broker-protection/captcha-services/get-captcha-container.js
@@ -4,7 +4,7 @@ import { PirError } from '../types';
 /**
  *
  * @param {Document | HTMLElement} root
- * @param {import('../types.js').PirAction['selector']} [selector]
+ * @param {string} [selector]
  * @returns {HTMLElement | PirError}
  */
 export function getCaptchaContainer(root, selector) {

--- a/injected/src/features/broker-protection/execute.js
+++ b/injected/src/features/broker-protection/execute.js
@@ -3,28 +3,46 @@ import { navigate, extract, click, scroll, expectation, fillForm, getCaptchaInfo
 import { ErrorResponse } from './types';
 
 /**
- * @param {import('./types.js').PirAction} action
- * @param {Record<string, any>} inputData
+ * @typedef {import('./types.js').PirAction} PirAction
+ * @typedef {import('./types.js').ActionResponse} ActionResponse
+ * @typedef {import('../../types/broker-protection.js').ActionData} ActionData
+ * @typedef {import('../../types/broker-protection.js').UserProfile} UserProfile
+ * @typedef {import('../../types/broker-protection.js').ExtractedProfile} ExtractedProfile
+ */
+
+/**
+ * @param {PirAction} action
+ * @param {ActionData} inputData
  * @param {Document} [root] - optional root element
- * @return {Promise<import('./types.js').ActionResponse>}
+ * @return {Promise<ActionResponse>}
  */
 export async function execute(action, inputData, root = document) {
     try {
         switch (action.actionType) {
-            case 'navigate':
-                return navigate(action, data(action, inputData, 'userProfile'));
-            case 'extract':
-                return await extract(action, data(action, inputData, 'userProfile'), root);
-            case 'click':
-                return click(action, data(action, inputData, 'userProfile'), root);
+            case 'navigate': {
+                const userProfile = /** @type {UserProfile} */ (data(action, inputData, 'userProfile'));
+                return navigate(action, userProfile);
+            }
+            case 'extract': {
+                const userProfile = /** @type {UserProfile} */ (data(action, inputData, 'userProfile'));
+                return await extract(action, userProfile, root);
+            }
+            case 'click': {
+                const userProfile = /** @type {UserProfile} */ (data(action, inputData, 'userProfile'));
+                return click(action, userProfile, root);
+            }
             case 'expectation':
                 return expectation(action, root);
-            case 'fillForm':
-                return fillForm(action, data(action, inputData, 'extractedProfile'), root);
+            case 'fillForm': {
+                const extractedProfile = /** @type {ExtractedProfile} */ (data(action, inputData, 'extractedProfile'));
+                return fillForm(action, extractedProfile, root);
+            }
             case 'getCaptchaInfo':
                 return await getCaptchaInfo(action, root);
-            case 'solveCaptcha':
-                return solveCaptcha(action, data(action, inputData, 'token'), root);
+            case 'solveCaptcha': {
+                const token = /** @type {string} */ (data(action, inputData, 'token'));
+                return solveCaptcha(action, token, root);
+            }
             case 'condition':
                 return condition(action, root);
             case 'scroll':
@@ -49,8 +67,9 @@ export async function execute(action, inputData, root = document) {
 
 /**
  * @param {{dataSource?: string}} action
- * @param {Record<string, any>} data
+ * @param {ActionData} data
  * @param {string} defaultSource
+ * @return {ActionData[keyof ActionData]} the selected bundle value, looked up by the dynamic `dataSource` key (or null when absent). `valueof ActionData` is `unknown` because the bundle allows extra keys, so each call site asserts the concrete bundle it expects.
  */
 function data(action, data, defaultSource) {
     if (!data) return null;

--- a/injected/src/features/broker-protection/execute.js
+++ b/injected/src/features/broker-protection/execute.js
@@ -30,9 +30,11 @@ export async function execute(action, inputData, root = document) {
             case 'scroll':
                 return scroll(action, root);
             default: {
+                // exhaustive switch ⇒ `action` is `never` here; cast to report an unimplemented actionType
+                const unknownAction = /** @type {{ id: string; actionType: string }} */ (action);
                 return new ErrorResponse({
-                    actionID: action.id,
-                    message: `unimplemented actionType: ${action.actionType}`,
+                    actionID: unknownAction.id,
+                    message: `unimplemented actionType: ${unknownAction.actionType}`,
                 });
             }
         }

--- a/injected/src/features/broker-protection/extractors/profile-url.js
+++ b/injected/src/features/broker-protection/extractors/profile-url.js
@@ -109,12 +109,12 @@ function getIdFromProfileUrl(url, identifierType, identifier) {
  */
 export class ProfileHashTransformer {
     /**
-     * @param {Record<string, any>} profile
-     * @param {Record<string, any> } params
+     * @param {Record<string, any>} profile - the extracted/aggregated profile data to transform
+     * @param {import('../../../types/broker-protection.js').ProfileSpec} profileSpec - the action's `profile` block
      * @return {Promise<Record<string, any>>}
      */
-    async transform(profile, params) {
-        if (params?.profileUrl?.identifierType !== 'hash') {
+    async transform(profile, profileSpec) {
+        if (profileSpec?.profileUrl?.identifierType !== 'hash') {
             return profile;
         }
 

--- a/injected/src/features/broker-protection/types.js
+++ b/injected/src/features/broker-protection/types.js
@@ -1,18 +1,11 @@
 /**
  * @typedef {SuccessResponse | ErrorResponse} ActionResponse
  * @typedef {{ result: true } | { result: false; error: string }} BooleanResult
- * @typedef {{type: "element" | "text" | "url"; selector: string; parent?: string; expect?: string; failSilently?: boolean}} Expectation
  */
 
 /**
- * @typedef {object} PirAction
- * @property {string} id
- * @property {"extract" | "fillForm" | "click" | "expectation" | "getCaptchaInfo" | "solveCaptcha" | "navigate" | "condition" | "scroll"} actionType
- * @property {string} [selector]
- * @property {string} [captchaType]
- * @property {string} [injectCaptchaHandler]
- * @property {string} [dataSource]
- * @property {string} [url]
+ * @typedef {import('../../types/broker-protection.js').PirAction} PirAction
+ * @typedef {import('../../types/broker-protection.js').Expectation} Expectation
  */
 
 /**

--- a/injected/src/features/broker-protection/types.js
+++ b/injected/src/features/broker-protection/types.js
@@ -6,6 +6,7 @@
 /**
  * @typedef {import('../../types/broker-protection.js').PirAction} PirAction
  * @typedef {import('../../types/broker-protection.js').Expectation} Expectation
+ * @typedef {import('../../types/broker-protection.js').ActionData} ActionData
  */
 
 /**
@@ -128,7 +129,7 @@ export class ErrorResponse {
  * @property {PirAction['id']} actionID
  * @property {PirAction['actionType']} actionType
  * @property {any} response
- * @property {import("./actions/extract").Action[]} [next]
+ * @property {PirAction[]} [next]
  * @property {Record<string, any>} [meta] - optional meta data
  */
 

--- a/injected/src/messages/broker-protection/actionCompleted.notify.json
+++ b/injected/src/messages/broker-protection/actionCompleted.notify.json
@@ -2,7 +2,7 @@
     "$schema": "http://json-schema.org/draft-07/schema#",
     "type": "object",
     "additionalProperties": false,
-    "description": "Sent back to native when an action finishes (successfully, or with an error captured in the result).",
+    "description": "Emitted when an action finishes (successfully, or with an error captured in the result).",
     "required": ["result"],
     "properties": {
         "result": { "$ref": "types/action-response.json" }

--- a/injected/src/messages/broker-protection/actionCompleted.notify.json
+++ b/injected/src/messages/broker-protection/actionCompleted.notify.json
@@ -1,0 +1,10 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "additionalProperties": false,
+    "description": "Sent back to native when an action finishes (successfully, or with an error captured in the result).",
+    "required": ["result"],
+    "properties": {
+        "result": { "$ref": "types/action-response.json" }
+    }
+}

--- a/injected/src/messages/broker-protection/actionError.notify.json
+++ b/injected/src/messages/broker-protection/actionError.notify.json
@@ -2,7 +2,7 @@
     "$schema": "http://json-schema.org/draft-07/schema#",
     "type": "object",
     "additionalProperties": false,
-    "description": "Sent back to native when an action could not be run at all (no action, unhandled exception, or no response).",
+    "description": "Emitted when an action could not be run at all (no action, unhandled exception, or no response).",
     "required": ["error"],
     "properties": {
         "error": {

--- a/injected/src/messages/broker-protection/actionError.notify.json
+++ b/injected/src/messages/broker-protection/actionError.notify.json
@@ -1,0 +1,13 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "additionalProperties": false,
+    "description": "Sent back to native when an action could not be run at all (no action, unhandled exception, or no response).",
+    "required": ["error"],
+    "properties": {
+        "error": {
+            "type": "string",
+            "description": "human-readable error message"
+        }
+    }
+}

--- a/injected/src/messages/broker-protection/onActionReceived.subscribe.json
+++ b/injected/src/messages/broker-protection/onActionReceived.subscribe.json
@@ -1,0 +1,18 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "additionalProperties": false,
+    "description": "Native pushes the next action (plus its data) for the executor to run on the current page.",
+    "required": ["state"],
+    "properties": {
+        "state": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["action", "data"],
+            "properties": {
+                "action": { "$ref": "types/action.json" },
+                "data": { "$ref": "types/input-data.json" }
+            }
+        }
+    }
+}

--- a/injected/src/messages/broker-protection/onActionReceived.subscribe.json
+++ b/injected/src/messages/broker-protection/onActionReceived.subscribe.json
@@ -2,7 +2,7 @@
     "$schema": "http://json-schema.org/draft-07/schema#",
     "type": "object",
     "additionalProperties": false,
-    "description": "Native pushes the next action (plus its data) for the executor to run on the current page.",
+    "description": "Delivers the next action (plus its data) for the executor to run on the current page.",
     "required": ["state"],
     "properties": {
         "state": {

--- a/injected/src/messages/broker-protection/types/action-response.json
+++ b/injected/src/messages/broker-protection/types/action-response.json
@@ -1,0 +1,9 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "ActionResponse",
+    "description": "The result of executing a single action: success or error.",
+    "oneOf": [
+        { "$ref": "./success-response.json" },
+        { "$ref": "./error-response.json" }
+    ]
+}

--- a/injected/src/messages/broker-protection/types/action.json
+++ b/injected/src/messages/broker-protection/types/action.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "PirAction",
-    "description": "A single instruction sent by native for the broker-protection executor to run on the page. Discriminated on `actionType`.",
+    "description": "A single instruction for the broker-protection executor to run on the page, discriminated on `actionType`.",
     "oneOf": [
         { "$ref": "./actions/extract.json" },
         { "$ref": "./actions/navigate.json" },

--- a/injected/src/messages/broker-protection/types/action.json
+++ b/injected/src/messages/broker-protection/types/action.json
@@ -1,0 +1,16 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "PirAction",
+    "description": "A single instruction sent by native for the broker-protection executor to run on the page. Discriminated on `actionType`.",
+    "oneOf": [
+        { "$ref": "./actions/extract.json" },
+        { "$ref": "./actions/navigate.json" },
+        { "$ref": "./actions/click.json" },
+        { "$ref": "./actions/fill-form.json" },
+        { "$ref": "./actions/expectation.json" },
+        { "$ref": "./actions/condition.json" },
+        { "$ref": "./actions/scroll.json" },
+        { "$ref": "./actions/get-captcha-info.json" },
+        { "$ref": "./actions/solve-captcha.json" }
+    ]
+}

--- a/injected/src/messages/broker-protection/types/actions/click.json
+++ b/injected/src/messages/broker-protection/types/actions/click.json
@@ -1,0 +1,39 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "ClickAction",
+    "type": "object",
+    "description": "Click one or more elements. Either provide `elements` directly, or `choices` (with an optional `default`) to pick elements conditionally.",
+    "required": ["id", "actionType"],
+    "properties": {
+        "id": { "type": "string" },
+        "actionType": { "const": "click" },
+        "elements": {
+            "type": "array",
+            "items": { "$ref": "../click-element.json" },
+            "description": "elements to click; mutually exclusive with `choices`"
+        },
+        "choices": {
+            "type": "array",
+            "items": { "$ref": "../choice.json" },
+            "description": "conditional branches; the first matching choice's elements are clicked"
+        },
+        "default": {
+            "oneOf": [
+                {
+                    "type": "object",
+                    "required": ["elements"],
+                    "properties": {
+                        "elements": {
+                            "type": "array",
+                            "items": { "$ref": "../click-element.json" }
+                        }
+                    }
+                },
+                { "type": "null" }
+            ],
+            "description": "fallback used when no choice matches; `null` means skip without error"
+        },
+        "dataSource": { "type": "string" },
+        "retry": { "$ref": "../retry-config.json" }
+    }
+}

--- a/injected/src/messages/broker-protection/types/actions/condition.json
+++ b/injected/src/messages/broker-protection/types/actions/condition.json
@@ -1,0 +1,22 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "ConditionAction",
+    "type": "object",
+    "description": "Evaluate a set of expectations and report back the `actions` to run when they pass (the caller decides whether to execute them).",
+    "required": ["id", "actionType", "expectations"],
+    "properties": {
+        "id": { "type": "string" },
+        "actionType": { "const": "condition" },
+        "expectations": {
+            "type": "array",
+            "items": { "$ref": "../expectation.json" }
+        },
+        "actions": {
+            "type": "array",
+            "items": { "$ref": "../action.json" },
+            "description": "actions returned for execution when all expectations pass"
+        },
+        "dataSource": { "type": "string" },
+        "retry": { "$ref": "../retry-config.json" }
+    }
+}

--- a/injected/src/messages/broker-protection/types/actions/condition.json
+++ b/injected/src/messages/broker-protection/types/actions/condition.json
@@ -3,7 +3,7 @@
     "title": "ConditionAction",
     "type": "object",
     "description": "Evaluate a set of expectations and report back the `actions` to run when they pass (the caller decides whether to execute them).",
-    "required": ["id", "actionType", "expectations"],
+    "required": ["id", "actionType", "expectations", "actions"],
     "properties": {
         "id": { "type": "string" },
         "actionType": { "const": "condition" },

--- a/injected/src/messages/broker-protection/types/actions/expectation.json
+++ b/injected/src/messages/broker-protection/types/actions/expectation.json
@@ -1,0 +1,22 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "ExpectationAction",
+    "type": "object",
+    "description": "Assert a set of expectations about the page. When they all pass, optionally run further `actions`.",
+    "required": ["id", "actionType", "expectations"],
+    "properties": {
+        "id": { "type": "string" },
+        "actionType": { "const": "expectation" },
+        "expectations": {
+            "type": "array",
+            "items": { "$ref": "../expectation.json" }
+        },
+        "actions": {
+            "type": "array",
+            "items": { "$ref": "../action.json" },
+            "description": "actions to run next when all expectations pass"
+        },
+        "dataSource": { "type": "string" },
+        "retry": { "$ref": "../retry-config.json" }
+    }
+}

--- a/injected/src/messages/broker-protection/types/actions/extract.json
+++ b/injected/src/messages/broker-protection/types/actions/extract.json
@@ -1,0 +1,22 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "ExtractAction",
+    "type": "object",
+    "description": "Scrape candidate profiles from the page and match them against the user's data.",
+    "required": ["id", "actionType", "selector", "profile"],
+    "properties": {
+        "id": { "type": "string" },
+        "actionType": { "const": "extract" },
+        "selector": {
+            "type": "string",
+            "description": "selector matching each result row / profile element"
+        },
+        "noResultsSelector": {
+            "type": "string",
+            "description": "selector for a 'no results' element; when set, its presence is treated as a successful empty extract"
+        },
+        "profile": { "$ref": "../profile-spec.json" },
+        "dataSource": { "type": "string" },
+        "retry": { "$ref": "../retry-config.json" }
+    }
+}

--- a/injected/src/messages/broker-protection/types/actions/fill-form.json
+++ b/injected/src/messages/broker-protection/types/actions/fill-form.json
@@ -1,0 +1,21 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "FillFormAction",
+    "type": "object",
+    "description": "Fill a form's fields from the extracted profile data (or generated values).",
+    "required": ["id", "actionType", "selector", "elements"],
+    "properties": {
+        "id": { "type": "string" },
+        "actionType": { "const": "fillForm" },
+        "selector": {
+            "type": "string",
+            "description": "selector for the form element"
+        },
+        "elements": {
+            "type": "array",
+            "items": { "$ref": "../form-element.json" }
+        },
+        "dataSource": { "type": "string" },
+        "retry": { "$ref": "../retry-config.json" }
+    }
+}

--- a/injected/src/messages/broker-protection/types/actions/get-captcha-info.json
+++ b/injected/src/messages/broker-protection/types/actions/get-captcha-info.json
@@ -13,11 +13,7 @@
         },
         "captchaType": {
             "type": "string",
-            "description": "captcha provider type (e.g. recaptcha, hcaptcha); when omitted the deprecated handler is used"
-        },
-        "injectCaptchaHandler": {
-            "type": "string",
-            "description": "captcha type whose supporting code should be injected"
+            "description": "selects the captcha handler. Supported values: \"image\", \"cloudFlareTurnstile\". When omitted, the deprecated handler runs and self-detects recaptcha2/recaptchaEnterprise from the DOM."
         },
         "dataSource": { "type": "string" },
         "retry": { "$ref": "../retry-config.json" }

--- a/injected/src/messages/broker-protection/types/actions/get-captcha-info.json
+++ b/injected/src/messages/broker-protection/types/actions/get-captcha-info.json
@@ -1,0 +1,25 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "GetCaptchaInfoAction",
+    "type": "object",
+    "description": "Locate a captcha on the page and return the information native needs to solve it (url, site key, type).",
+    "required": ["id", "actionType", "selector"],
+    "properties": {
+        "id": { "type": "string" },
+        "actionType": { "const": "getCaptchaInfo" },
+        "selector": {
+            "type": "string",
+            "description": "selector for the captcha container"
+        },
+        "captchaType": {
+            "type": "string",
+            "description": "captcha provider type (e.g. recaptcha, hcaptcha); when omitted the deprecated handler is used"
+        },
+        "injectCaptchaHandler": {
+            "type": "string",
+            "description": "captcha type whose supporting code should be injected"
+        },
+        "dataSource": { "type": "string" },
+        "retry": { "$ref": "../retry-config.json" }
+    }
+}

--- a/injected/src/messages/broker-protection/types/actions/navigate.json
+++ b/injected/src/messages/broker-protection/types/actions/navigate.json
@@ -1,0 +1,26 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "NavigateAction",
+    "type": "object",
+    "description": "Build a URL from a template + the user's data and report it back for native to navigate to.",
+    "required": ["id", "actionType", "url"],
+    "properties": {
+        "id": { "type": "string" },
+        "actionType": { "const": "navigate" },
+        "url": {
+            "type": "string",
+            "description": "URL template; ${field} and ${field|transform} tokens are filled from the user profile"
+        },
+        "ageRange": {
+            "type": "array",
+            "items": { "type": "string" },
+            "description": "age buckets like \"18-30\" used by the ageRange URL transform"
+        },
+        "injectCaptchaHandler": {
+            "type": "string",
+            "description": "captcha type whose supporting code should be injected before navigation"
+        },
+        "dataSource": { "type": "string" },
+        "retry": { "$ref": "../retry-config.json" }
+    }
+}

--- a/injected/src/messages/broker-protection/types/actions/scroll.json
+++ b/injected/src/messages/broker-protection/types/actions/scroll.json
@@ -11,7 +11,6 @@
             "type": "string",
             "description": "selector for the element to scroll into view"
         },
-        "dataSource": { "type": "string" },
         "retry": { "$ref": "../retry-config.json" }
     }
 }

--- a/injected/src/messages/broker-protection/types/actions/scroll.json
+++ b/injected/src/messages/broker-protection/types/actions/scroll.json
@@ -1,0 +1,17 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "ScrollAction",
+    "type": "object",
+    "description": "Scroll a matching element into view.",
+    "required": ["id", "actionType", "selector"],
+    "properties": {
+        "id": { "type": "string" },
+        "actionType": { "const": "scroll" },
+        "selector": {
+            "type": "string",
+            "description": "selector for the element to scroll into view"
+        },
+        "dataSource": { "type": "string" },
+        "retry": { "$ref": "../retry-config.json" }
+    }
+}

--- a/injected/src/messages/broker-protection/types/actions/solve-captcha.json
+++ b/injected/src/messages/broker-protection/types/actions/solve-captcha.json
@@ -1,0 +1,25 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "SolveCaptchaAction",
+    "type": "object",
+    "description": "Inject a solved captcha token into the page.",
+    "required": ["id", "actionType", "selector"],
+    "properties": {
+        "id": { "type": "string" },
+        "actionType": { "const": "solveCaptcha" },
+        "selector": {
+            "type": "string",
+            "description": "selector for the captcha container"
+        },
+        "captchaType": {
+            "type": "string",
+            "description": "captcha provider type; when omitted the deprecated handler is used"
+        },
+        "injectCaptchaHandler": {
+            "type": "string",
+            "description": "captcha type whose supporting code should be injected"
+        },
+        "dataSource": { "type": "string" },
+        "retry": { "$ref": "../retry-config.json" }
+    }
+}

--- a/injected/src/messages/broker-protection/types/actions/solve-captcha.json
+++ b/injected/src/messages/broker-protection/types/actions/solve-captcha.json
@@ -13,11 +13,7 @@
         },
         "captchaType": {
             "type": "string",
-            "description": "captcha provider type; when omitted the deprecated handler is used"
-        },
-        "injectCaptchaHandler": {
-            "type": "string",
-            "description": "captcha type whose supporting code should be injected"
+            "description": "selects the captcha handler. Supported values: \"image\", \"cloudFlareTurnstile\". When omitted, the deprecated handler runs and self-detects recaptcha2/recaptchaEnterprise from the DOM."
         },
         "dataSource": { "type": "string" },
         "retry": { "$ref": "../retry-config.json" }

--- a/injected/src/messages/broker-protection/types/address.json
+++ b/injected/src/messages/broker-protection/types/address.json
@@ -1,0 +1,14 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "Address",
+    "type": "object",
+    "additionalProperties": true,
+    "description": "A single address belonging to the user profile. Extra broker-specific keys are allowed.",
+    "properties": {
+        "addressLine1": { "type": "string" },
+        "addressLine2": { "type": "string" },
+        "city": { "type": "string" },
+        "state": { "type": "string", "description": "two-letter state abbreviation" },
+        "zip": { "type": "string" }
+    }
+}

--- a/injected/src/messages/broker-protection/types/choice.json
+++ b/injected/src/messages/broker-protection/types/choice.json
@@ -1,0 +1,31 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "Choice",
+    "type": "object",
+    "description": "A conditional branch of a `click` action: when `condition` evaluates true, `elements` are clicked.",
+    "required": ["condition", "elements"],
+    "properties": {
+        "condition": {
+            "type": "object",
+            "required": ["operation", "left", "right"],
+            "properties": {
+                "operation": {
+                    "type": "string",
+                    "description": "comparison operator: =, ==, ===, !=, !==, <, <=, >, >="
+                },
+                "left": {
+                    "type": "string",
+                    "description": "left operand; may contain ${field} templates resolved from the data"
+                },
+                "right": {
+                    "type": "string",
+                    "description": "right operand; may contain ${field} templates resolved from the data"
+                }
+            }
+        },
+        "elements": {
+            "type": "array",
+            "items": { "$ref": "./click-element.json" }
+        }
+    }
+}

--- a/injected/src/messages/broker-protection/types/click-element.json
+++ b/injected/src/messages/broker-protection/types/click-element.json
@@ -24,6 +24,7 @@
         "parent": {
             "type": "object",
             "description": "scope the click to a matched profile element instead of the document",
+            "required": ["profileMatch"],
             "properties": {
                 "profileMatch": {
                     "type": "object",

--- a/injected/src/messages/broker-protection/types/click-element.json
+++ b/injected/src/messages/broker-protection/types/click-element.json
@@ -1,0 +1,40 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "ClickElement",
+    "type": "object",
+    "description": "A single element to click. When `parent.profileMatch` is present, the click is scoped to the best-matching profile element rather than the document.",
+    "required": ["selector"],
+    "properties": {
+        "type": {
+            "type": "string",
+            "description": "informational element type, e.g. \"button\""
+        },
+        "selector": {
+            "type": "string",
+            "description": "selector for the element to click"
+        },
+        "multiple": {
+            "type": "boolean",
+            "description": "click every match rather than just the first"
+        },
+        "failSilently": {
+            "type": "boolean",
+            "description": "treat a missing/disabled element as a non-error skip"
+        },
+        "parent": {
+            "type": "object",
+            "description": "scope the click to a matched profile element instead of the document",
+            "properties": {
+                "profileMatch": {
+                    "type": "object",
+                    "description": "an extract-style spec; the highest-scoring matching element becomes the click root",
+                    "required": ["selector", "profile"],
+                    "properties": {
+                        "selector": { "type": "string" },
+                        "profile": { "$ref": "./profile-spec.json" }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/injected/src/messages/broker-protection/types/error-response.json
+++ b/injected/src/messages/broker-protection/types/error-response.json
@@ -1,0 +1,17 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "ErrorResponse",
+    "type": "object",
+    "description": "The wire shape of a failed action result.",
+    "required": ["error"],
+    "properties": {
+        "error": {
+            "type": "object",
+            "required": ["actionID", "message"],
+            "properties": {
+                "actionID": { "type": "string" },
+                "message": { "type": "string" }
+            }
+        }
+    }
+}

--- a/injected/src/messages/broker-protection/types/expectation.json
+++ b/injected/src/messages/broker-protection/types/expectation.json
@@ -1,0 +1,30 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "Expectation",
+    "type": "object",
+    "description": "A single condition checked by `expectation`/`condition` actions: that an element exists, that an element contains text, or that the current URL contains a string.",
+    "required": ["type", "selector"],
+    "properties": {
+        "type": {
+            "type": "string",
+            "enum": ["element", "text", "url"],
+            "description": "what to check"
+        },
+        "selector": {
+            "type": "string",
+            "description": "target element selector (unused for `url`)"
+        },
+        "parent": {
+            "type": "string",
+            "description": "optional parent selector to scroll into view first (element checks)"
+        },
+        "expect": {
+            "type": "string",
+            "description": "expected substring for `text`/`url` checks"
+        },
+        "failSilently": {
+            "type": "boolean",
+            "description": "treat a failed check as a non-error skip"
+        }
+    }
+}

--- a/injected/src/messages/broker-protection/types/extracted-profile.json
+++ b/injected/src/messages/broker-protection/types/extracted-profile.json
@@ -1,0 +1,16 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "ExtractedProfile",
+    "type": "object",
+    "additionalProperties": true,
+    "description": "The broker-specific profile data submitted by `fillForm` actions, keyed by the field names a FormElement `type` references (e.g. firstName, lastName, city, state, email). Native owns the exact shape, so extra properties are allowed.",
+    "properties": {
+        "firstName": { "type": "string" },
+        "middleName": { "type": "string" },
+        "lastName": { "type": "string" },
+        "city": { "type": "string" },
+        "state": { "type": "string" },
+        "phone": { "type": "string" },
+        "email": { "type": "string" }
+    }
+}

--- a/injected/src/messages/broker-protection/types/extracted-profile.json
+++ b/injected/src/messages/broker-protection/types/extracted-profile.json
@@ -3,7 +3,7 @@
     "title": "ExtractedProfile",
     "type": "object",
     "additionalProperties": true,
-    "description": "The broker-specific profile data submitted by `fillForm` actions, keyed by the field names a FormElement `type` references (e.g. firstName, lastName, city, state, email). Native owns the exact shape, so extra properties are allowed.",
+    "description": "The profile data a `fillForm` action draws from, keyed by the field names a FormElement `type` references (e.g. firstName, lastName, city, state, email). The exact shape is caller-defined, so extra properties are allowed.",
     "properties": {
         "firstName": { "type": "string" },
         "middleName": { "type": "string" },
@@ -11,6 +11,9 @@
         "city": { "type": "string" },
         "state": { "type": "string" },
         "phone": { "type": "string" },
-        "email": { "type": "string" }
+        "email": { "type": "string" },
+        "age": { "type": ["string", "number"] },
+        "birthYear": { "type": ["string", "number"] },
+        "profileUrl": { "type": "string" }
     }
 }

--- a/injected/src/messages/broker-protection/types/form-element.json
+++ b/injected/src/messages/broker-protection/types/form-element.json
@@ -1,0 +1,25 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "FormElement",
+    "type": "object",
+    "description": "A single field to fill within a form. `type` is either a key to read from the data, or a special generator/composite token.",
+    "required": ["selector", "type"],
+    "properties": {
+        "selector": {
+            "type": "string",
+            "description": "selector for the input/select element"
+        },
+        "type": {
+            "type": "string",
+            "description": "a data key to fill (e.g. \"firstName\"), or a special token: $file_id$, $generated_phone_number$, $generated_zip_code$, $generated_random_number$, $generated_street_address$, cityState, fullState"
+        },
+        "min": {
+            "type": "string",
+            "description": "lower bound for $generated_random_number$"
+        },
+        "max": {
+            "type": "string",
+            "description": "upper bound for $generated_random_number$"
+        }
+    }
+}

--- a/injected/src/messages/broker-protection/types/input-data.json
+++ b/injected/src/messages/broker-protection/types/input-data.json
@@ -3,13 +3,26 @@
     "title": "ActionData",
     "type": "object",
     "additionalProperties": true,
-    "description": "The data bundle that accompanies an action. Which key an action reads is chosen by its `dataSource` (defaults: extract/navigate/click -> userProfile, fillForm -> extractedProfile, solveCaptcha -> token).",
+    "description": "The data bundle that accompanies an action. Which key an action reads is chosen by its `dataSource`; when an action omits `dataSource` the executor applies a fallback default (extract/navigate/click -> userProfile, fillForm -> extractedProfile, solveCaptcha -> token). An action may set `dataSource` explicitly to read a different bundle (e.g. a fillForm reading userProfile). `fetchedEmail`/`emailData` are also supported, for email-confirmation flows.",
     "properties": {
         "userProfile": { "$ref": "./user-profile.json" },
         "extractedProfile": { "$ref": "./extracted-profile.json" },
         "token": {
             "type": "string",
             "description": "a solved captcha token (used by solveCaptcha)"
+        },
+        "fetchedEmail": {
+            "type": "object",
+            "additionalProperties": true,
+            "description": "a fetched email address (read when an action sets dataSource: fetchedEmail)",
+            "properties": {
+                "email": { "type": "string" }
+            }
+        },
+        "emailData": {
+            "type": "object",
+            "additionalProperties": { "type": "string" },
+            "description": "email-derived values such as a verification code (read when an action sets dataSource: emailData)"
         }
     }
 }

--- a/injected/src/messages/broker-protection/types/input-data.json
+++ b/injected/src/messages/broker-protection/types/input-data.json
@@ -1,0 +1,15 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "ActionData",
+    "type": "object",
+    "additionalProperties": true,
+    "description": "The data bundle that accompanies an action. Which key an action reads is chosen by its `dataSource` (defaults: extract/navigate/click -> userProfile, fillForm -> extractedProfile, solveCaptcha -> token).",
+    "properties": {
+        "userProfile": { "$ref": "./user-profile.json" },
+        "extractedProfile": { "$ref": "./extracted-profile.json" },
+        "token": {
+            "type": "string",
+            "description": "a solved captcha token (used by solveCaptcha)"
+        }
+    }
+}

--- a/injected/src/messages/broker-protection/types/profile-spec.json
+++ b/injected/src/messages/broker-protection/types/profile-spec.json
@@ -1,0 +1,41 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "ProfileSpec",
+    "type": "object",
+    "description": "The `profile` block of an `extract` action: a map of output field name -> how to locate that field. `null` disables a field. This is the per-broker config the native layer sends; the field keys are a contract with that config.",
+    "properties": {
+        "name": {
+            "oneOf": [{ "$ref": "./specs/text-field-spec.json" }, { "type": "null" }]
+        },
+        "age": {
+            "oneOf": [{ "$ref": "./specs/text-field-spec.json" }, { "type": "null" }]
+        },
+        "alternativeNamesList": {
+            "oneOf": [{ "$ref": "./specs/text-field-spec.json" }, { "type": "null" }]
+        },
+        "relativesList": {
+            "oneOf": [{ "$ref": "./specs/text-field-spec.json" }, { "type": "null" }]
+        },
+        "phone": {
+            "oneOf": [{ "$ref": "./specs/text-field-spec.json" }, { "type": "null" }]
+        },
+        "phoneList": {
+            "oneOf": [{ "$ref": "./specs/text-field-spec.json" }, { "type": "null" }]
+        },
+        "addressFull": {
+            "oneOf": [{ "$ref": "./specs/text-field-spec.json" }, { "type": "null" }]
+        },
+        "addressFullList": {
+            "oneOf": [{ "$ref": "./specs/text-field-spec.json" }, { "type": "null" }]
+        },
+        "addressCityState": {
+            "oneOf": [{ "$ref": "./specs/city-state-spec.json" }, { "type": "null" }]
+        },
+        "addressCityStateList": {
+            "oneOf": [{ "$ref": "./specs/city-state-spec.json" }, { "type": "null" }]
+        },
+        "profileUrl": {
+            "oneOf": [{ "$ref": "./specs/profile-url-spec.json" }, { "type": "null" }]
+        }
+    }
+}

--- a/injected/src/messages/broker-protection/types/retry-config.json
+++ b/injected/src/messages/broker-protection/types/retry-config.json
@@ -2,11 +2,13 @@
     "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "RetryConfig",
     "type": "object",
-    "description": "Optional per-action retry policy. Honoured web-side only when `environment` is \"web\"; otherwise the native scheduler owns retries.",
+    "description": "Optional per-action retry policy honoured by the web executor. Retries run web-side only when `environment` is \"web\"; otherwise retrying is left to the caller's scheduler. When present, both `interval` and `maxAttempts` are required: the executor uses `interval.ms` as the inter-attempt delay and `maxAttempts` as the loop bound, with no defaults.",
+    "required": ["interval", "maxAttempts"],
     "properties": {
         "environment": {
             "type": "string",
-            "description": "where the retry runs; \"web\" enables web-side retry for this action"
+            "enum": ["web"],
+            "description": "where the retry runs; \"web\" is the only supported value and enables web-side retry for this action"
         },
         "interval": {
             "type": "object",

--- a/injected/src/messages/broker-protection/types/retry-config.json
+++ b/injected/src/messages/broker-protection/types/retry-config.json
@@ -1,0 +1,23 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "RetryConfig",
+    "type": "object",
+    "description": "Optional per-action retry policy. Honoured web-side only when `environment` is \"web\"; otherwise the native scheduler owns retries.",
+    "properties": {
+        "environment": {
+            "type": "string",
+            "description": "where the retry runs; \"web\" enables web-side retry for this action"
+        },
+        "interval": {
+            "type": "object",
+            "required": ["ms"],
+            "properties": {
+                "ms": { "type": "number", "description": "delay between attempts, in milliseconds" }
+            }
+        },
+        "maxAttempts": {
+            "type": "number",
+            "description": "maximum number of attempts before giving up"
+        }
+    }
+}

--- a/injected/src/messages/broker-protection/types/specs/city-state-spec.json
+++ b/injected/src/messages/broker-protection/types/specs/city-state-spec.json
@@ -1,0 +1,13 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "CityStateSpec",
+    "description": "Where a city/state field lives. A union of two shapes, discriminated on whether the spec carries its own `city` sub-selector: combined (a single `selector` whose text is \"City, ST\" — a plain TextFieldSpec) or nested (per-row `city`/`state` sub-selectors — a NestedCityStateSpec).",
+    "oneOf": [
+        {
+            "$ref": "./text-field-spec.json"
+        },
+        {
+            "$ref": "./nested-city-state-spec.json"
+        }
+    ]
+}

--- a/injected/src/messages/broker-protection/types/specs/identifier-type.json
+++ b/injected/src/messages/broker-protection/types/specs/identifier-type.json
@@ -1,0 +1,7 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "IdentifierType",
+    "description": "How a profile-URL identifier is located: a query `param`, a `path` segment, or the URL `hash`.",
+    "type": "string",
+    "enum": ["param", "path", "hash"]
+}

--- a/injected/src/messages/broker-protection/types/specs/nested-city-state-spec.json
+++ b/injected/src/messages/broker-protection/types/specs/nested-city-state-spec.json
@@ -1,0 +1,22 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "NestedCityStateSpec",
+    "description": "The nested city/state shape: the `selector` matches each result row, and `city` (plus optional `state`) sub-selectors are read relative to that row. Two variants: with state (both sub-selectors present, the `state` selector may even reach outside the row, e.g. a shared `<h1>`), or city only (`state` omitted, so the state comes out as `null`).",
+    "allOf": [
+        {
+            "$ref": "./text-field-spec.json"
+        },
+        {
+            "type": "object",
+            "required": ["city"],
+            "properties": {
+                "city": {
+                    "$ref": "./text-field-spec.json"
+                },
+                "state": {
+                    "$ref": "./text-field-spec.json"
+                }
+            }
+        }
+    ]
+}

--- a/injected/src/messages/broker-protection/types/specs/profile-url-spec.json
+++ b/injected/src/messages/broker-protection/types/specs/profile-url-spec.json
@@ -1,0 +1,27 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "ProfileUrlSpec",
+    "description": "Extends TextFieldSpec with the knobs unique to profileUrl: `source: 'pageUrl'` reads the value from the current page URL (globalThis.location.href) instead of from a `selector`; `identifier` is the identifier itself (a param name, or a templated URI) and `identifierType` says where to find it within the resolved URL.",
+    "allOf": [
+        {
+            "$ref": "./text-field-spec.json"
+        },
+        {
+            "type": "object",
+            "properties": {
+                "source": {
+                    "type": "string",
+                    "enum": ["pageUrl"],
+                    "description": "read the value from the current page URL instead of a `selector`"
+                },
+                "identifier": {
+                    "type": "string",
+                    "description": "the identifier itself: a param name, or a templated URI"
+                },
+                "identifierType": {
+                    "$ref": "./identifier-type.json"
+                }
+            }
+        }
+    ]
+}

--- a/injected/src/messages/broker-protection/types/specs/text-field-spec.json
+++ b/injected/src/messages/broker-protection/types/specs/text-field-spec.json
@@ -1,0 +1,32 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "TextFieldSpec",
+    "type": "object",
+    "description": "The text-shaping knobs every selector-based field shares: where the value lives and how to clean the text once read. This is the spec for the majority of fields (name, age, phone, …); city/state and profileUrl extend it (see CityStateSpec, ProfileUrlSpec). For example: { \"selector\": \".//div[@class='relatives']//li\" }",
+    "properties": {
+        "selector": {
+            "type": "string",
+            "description": "xpath or css selector"
+        },
+        "findElements": {
+            "type": "boolean",
+            "description": "whether to get all occurrences of the selector"
+        },
+        "afterText": {
+            "type": "string",
+            "description": "get all text after this string"
+        },
+        "beforeText": {
+            "type": "string",
+            "description": "get all text before this string"
+        },
+        "separator": {
+            "type": "string",
+            "description": "split the text on this string, or use a regex by passing \"/pattern/\" (e.g. \"/(?<=, [A-Z]{2}), /\")"
+        },
+        "attribute": {
+            "type": "string",
+            "description": "read this attribute (e.g. \"data-profile-id\") instead of the element's text. The raw attribute value is used (e.g. \"href\" is not resolved to an absolute URL)"
+        }
+    }
+}

--- a/injected/src/messages/broker-protection/types/success-response.json
+++ b/injected/src/messages/broker-protection/types/success-response.json
@@ -16,13 +16,13 @@
                 },
                 "next": {
                     "type": "array",
-                    "items": {},
-                    "description": "follow-up actions to run with the same data (e.g. from an expectation action)"
+                    "items": { "$ref": "./action.json" },
+                    "description": "follow-up actions the executor runs locally after this one (e.g. produced by an `expectation` action); each is executed with the same data and reports its own result"
                 },
                 "meta": {
                     "type": "object",
                     "additionalProperties": true,
-                    "description": "optional debugging metadata"
+                    "description": "optional action-specific metadata attached to the result (e.g. `extract` attaches the `{ userData }` it matched against)"
                 }
             }
         }

--- a/injected/src/messages/broker-protection/types/success-response.json
+++ b/injected/src/messages/broker-protection/types/success-response.json
@@ -1,0 +1,30 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "SuccessResponse",
+    "type": "object",
+    "description": "The wire shape of a successful action result. `response` is action-specific (e.g. { url } for navigate, an array of matched profiles for extract).",
+    "required": ["success"],
+    "properties": {
+        "success": {
+            "type": "object",
+            "required": ["actionID", "actionType", "response"],
+            "properties": {
+                "actionID": { "type": "string" },
+                "actionType": { "type": "string" },
+                "response": {
+                    "description": "action-specific result payload"
+                },
+                "next": {
+                    "type": "array",
+                    "items": {},
+                    "description": "follow-up actions to run with the same data (e.g. from an expectation action)"
+                },
+                "meta": {
+                    "type": "object",
+                    "additionalProperties": true,
+                    "description": "optional debugging metadata"
+                }
+            }
+        }
+    }
+}

--- a/injected/src/messages/broker-protection/types/user-profile.json
+++ b/injected/src/messages/broker-protection/types/user-profile.json
@@ -5,11 +5,19 @@
     "additionalProperties": true,
     "description": "The person whose records we're searching for. Used to build search URLs and to match scraped profiles. Brokers may reference additional flat keys (e.g. city, state) in URL templates, so extra properties are allowed.",
     "properties": {
+        "id": { "type": "string" },
         "firstName": { "type": "string" },
         "middleName": { "type": "string" },
         "lastName": { "type": "string" },
+        "fullName": { "type": "string" },
+        "suffix": { "type": "string" },
         "age": { "type": ["string", "number"] },
+        "birthYear": { "type": ["string", "number"] },
         "phone": { "type": "string" },
+        "city": { "type": "string" },
+        "state": { "type": "string", "description": "two-letter state abbreviation" },
+        "street": { "type": "string" },
+        "zip": { "type": "string" },
         "addresses": {
             "type": "array",
             "items": { "$ref": "./address.json" }

--- a/injected/src/messages/broker-protection/types/user-profile.json
+++ b/injected/src/messages/broker-protection/types/user-profile.json
@@ -1,0 +1,18 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "UserProfile",
+    "type": "object",
+    "additionalProperties": true,
+    "description": "The person whose records we're searching for. Used to build search URLs and to match scraped profiles. Brokers may reference additional flat keys (e.g. city, state) in URL templates, so extra properties are allowed.",
+    "properties": {
+        "firstName": { "type": "string" },
+        "middleName": { "type": "string" },
+        "lastName": { "type": "string" },
+        "age": { "type": ["string", "number"] },
+        "phone": { "type": "string" },
+        "addresses": {
+            "type": "array",
+            "items": { "$ref": "./address.json" }
+        }
+    }
+}

--- a/injected/src/types/broker-protection.ts
+++ b/injected/src/types/broker-protection.ts
@@ -1,0 +1,521 @@
+/**
+ * These types are auto-generated from schema files.
+ * scripts/build-types.mjs is responsible for type generation.
+ * **DO NOT** edit this file directly as your changes will be lost.
+ *
+ * @module BrokerProtection Messages
+ */
+
+/**
+ * The result of executing a single action: success or error.
+ */
+export type ActionResponse = SuccessResponse | ErrorResponse;
+/**
+ * A single instruction sent by native for the broker-protection executor to run on the page. Discriminated on `actionType`.
+ */
+export type PirAction =
+  | ExtractAction
+  | NavigateAction
+  | ClickAction
+  | FillFormAction
+  | ExpectationAction
+  | ConditionAction
+  | ScrollAction
+  | GetCaptchaInfoAction
+  | SolveCaptchaAction;
+/**
+ * Where a city/state field lives. A union of two shapes, discriminated on whether the spec carries its own `city` sub-selector: combined (a single `selector` whose text is "City, ST" — a plain TextFieldSpec) or nested (per-row `city`/`state` sub-selectors — a NestedCityStateSpec).
+ */
+export type CityStateSpec = TextFieldSpec | NestedCityStateSpec;
+/**
+ * The nested city/state shape: the `selector` matches each result row, and `city` (plus optional `state`) sub-selectors are read relative to that row. Two variants: with state (both sub-selectors present, the `state` selector may even reach outside the row, e.g. a shared `<h1>`), or city only (`state` omitted, so the state comes out as `null`).
+ */
+export type NestedCityStateSpec = TextFieldSpec & {
+  city: TextFieldSpec;
+  state?: TextFieldSpec;
+};
+/**
+ * Extends TextFieldSpec with the knobs unique to profileUrl: `source: 'pageUrl'` reads the value from the current page URL (globalThis.location.href) instead of from a `selector`; `identifier` is the identifier itself (a param name, or a templated URI) and `identifierType` says where to find it within the resolved URL.
+ */
+export type ProfileUrlSpec = TextFieldSpec & {
+  /**
+   * read the value from the current page URL instead of a `selector`
+   */
+  source?: "pageUrl";
+  /**
+   * the identifier itself: a param name, or a templated URI
+   */
+  identifier?: string;
+  identifierType?: IdentifierType;
+};
+/**
+ * How a profile-URL identifier is located: a query `param`, a `path` segment, or the URL `hash`.
+ */
+export type IdentifierType = "param" | "path" | "hash";
+
+/**
+ * Requests, Notifications and Subscriptions from the BrokerProtection feature
+ */
+export interface BrokerProtectionMessages {
+  notifications: ActionCompletedNotification | ActionErrorNotification;
+  subscriptions: OnActionReceivedSubscription;
+}
+/**
+ * Generated from @see "../messages/broker-protection/actionCompleted.notify.json"
+ */
+export interface ActionCompletedNotification {
+  method: "actionCompleted";
+  params: ActionCompletedNotify;
+}
+/**
+ * Sent back to native when an action finishes (successfully, or with an error captured in the result).
+ */
+export interface ActionCompletedNotify {
+  result: ActionResponse;
+}
+/**
+ * The wire shape of a successful action result. `response` is action-specific (e.g. { url } for navigate, an array of matched profiles for extract).
+ */
+export interface SuccessResponse {
+  success: {
+    actionID: string;
+    actionType: string;
+    /**
+     * action-specific result payload
+     */
+    response: {
+      [k: string]: unknown;
+    };
+    /**
+     * follow-up actions to run with the same data (e.g. from an expectation action)
+     */
+    next?: unknown[];
+    /**
+     * optional debugging metadata
+     */
+    meta?: {
+      [k: string]: unknown;
+    };
+  };
+}
+/**
+ * The wire shape of a failed action result.
+ */
+export interface ErrorResponse {
+  error: {
+    actionID: string;
+    message: string;
+  };
+}
+/**
+ * Generated from @see "../messages/broker-protection/actionError.notify.json"
+ */
+export interface ActionErrorNotification {
+  method: "actionError";
+  params: ActionErrorNotify;
+}
+/**
+ * Sent back to native when an action could not be run at all (no action, unhandled exception, or no response).
+ */
+export interface ActionErrorNotify {
+  /**
+   * human-readable error message
+   */
+  error: string;
+}
+/**
+ * Generated from @see "../messages/broker-protection/onActionReceived.subscribe.json"
+ */
+export interface OnActionReceivedSubscription {
+  subscriptionEvent: "onActionReceived";
+  params: OnActionReceivedSubscribe;
+}
+/**
+ * Native pushes the next action (plus its data) for the executor to run on the current page.
+ */
+export interface OnActionReceivedSubscribe {
+  state: {
+    action: PirAction;
+    data: ActionData;
+  };
+}
+/**
+ * Scrape candidate profiles from the page and match them against the user's data.
+ */
+export interface ExtractAction {
+  id: string;
+  actionType: "extract";
+  /**
+   * selector matching each result row / profile element
+   */
+  selector: string;
+  /**
+   * selector for a 'no results' element; when set, its presence is treated as a successful empty extract
+   */
+  noResultsSelector?: string;
+  profile: ProfileSpec;
+  dataSource?: string;
+  retry?: RetryConfig;
+}
+/**
+ * The `profile` block of an `extract` action: a map of output field name -> how to locate that field. `null` disables a field. This is the per-broker config the native layer sends; the field keys are a contract with that config.
+ */
+export interface ProfileSpec {
+  name?: TextFieldSpec | null;
+  age?: TextFieldSpec | null;
+  alternativeNamesList?: TextFieldSpec | null;
+  relativesList?: TextFieldSpec | null;
+  phone?: TextFieldSpec | null;
+  phoneList?: TextFieldSpec | null;
+  addressFull?: TextFieldSpec | null;
+  addressFullList?: TextFieldSpec | null;
+  addressCityState?: CityStateSpec | null;
+  addressCityStateList?: CityStateSpec | null;
+  profileUrl?: ProfileUrlSpec | null;
+}
+/**
+ * The text-shaping knobs every selector-based field shares: where the value lives and how to clean the text once read. This is the spec for the majority of fields (name, age, phone, …); city/state and profileUrl extend it (see CityStateSpec, ProfileUrlSpec). For example: { "selector": ".//div[@class='relatives']//li" }
+ */
+export interface TextFieldSpec {
+  /**
+   * xpath or css selector
+   */
+  selector?: string;
+  /**
+   * whether to get all occurrences of the selector
+   */
+  findElements?: boolean;
+  /**
+   * get all text after this string
+   */
+  afterText?: string;
+  /**
+   * get all text before this string
+   */
+  beforeText?: string;
+  /**
+   * split the text on this string, or use a regex by passing "/pattern/" (e.g. "/(?<=, [A-Z]{2}), /")
+   */
+  separator?: string;
+  /**
+   * read this attribute (e.g. "data-profile-id") instead of the element's text. The raw attribute value is used (e.g. "href" is not resolved to an absolute URL)
+   */
+  attribute?: string;
+}
+/**
+ * Optional per-action retry policy. Honoured web-side only when `environment` is "web"; otherwise the native scheduler owns retries.
+ */
+export interface RetryConfig {
+  /**
+   * where the retry runs; "web" enables web-side retry for this action
+   */
+  environment?: string;
+  interval?: {
+    /**
+     * delay between attempts, in milliseconds
+     */
+    ms: number;
+  };
+  /**
+   * maximum number of attempts before giving up
+   */
+  maxAttempts?: number;
+}
+/**
+ * Build a URL from a template + the user's data and report it back for native to navigate to.
+ */
+export interface NavigateAction {
+  id: string;
+  actionType: "navigate";
+  /**
+   * URL template; ${field} and ${field|transform} tokens are filled from the user profile
+   */
+  url: string;
+  /**
+   * age buckets like "18-30" used by the ageRange URL transform
+   */
+  ageRange?: string[];
+  /**
+   * captcha type whose supporting code should be injected before navigation
+   */
+  injectCaptchaHandler?: string;
+  dataSource?: string;
+  retry?: RetryConfig;
+}
+/**
+ * Click one or more elements. Either provide `elements` directly, or `choices` (with an optional `default`) to pick elements conditionally.
+ */
+export interface ClickAction {
+  id: string;
+  actionType: "click";
+  /**
+   * elements to click; mutually exclusive with `choices`
+   */
+  elements?: ClickElement[];
+  /**
+   * conditional branches; the first matching choice's elements are clicked
+   */
+  choices?: Choice[];
+  /**
+   * fallback used when no choice matches; `null` means skip without error
+   */
+  default?: {
+    elements: ClickElement[];
+  } | null;
+  dataSource?: string;
+  retry?: RetryConfig;
+}
+/**
+ * A single element to click. When `parent.profileMatch` is present, the click is scoped to the best-matching profile element rather than the document.
+ */
+export interface ClickElement {
+  /**
+   * informational element type, e.g. "button"
+   */
+  type?: string;
+  /**
+   * selector for the element to click
+   */
+  selector: string;
+  /**
+   * click every match rather than just the first
+   */
+  multiple?: boolean;
+  /**
+   * treat a missing/disabled element as a non-error skip
+   */
+  failSilently?: boolean;
+  /**
+   * scope the click to a matched profile element instead of the document
+   */
+  parent?: {
+    /**
+     * an extract-style spec; the highest-scoring matching element becomes the click root
+     */
+    profileMatch?: {
+      selector: string;
+      profile: ProfileSpec;
+    };
+  };
+}
+/**
+ * A conditional branch of a `click` action: when `condition` evaluates true, `elements` are clicked.
+ */
+export interface Choice {
+  condition: {
+    /**
+     * comparison operator: =, ==, ===, !=, !==, <, <=, >, >=
+     */
+    operation: string;
+    /**
+     * left operand; may contain ${field} templates resolved from the data
+     */
+    left: string;
+    /**
+     * right operand; may contain ${field} templates resolved from the data
+     */
+    right: string;
+  };
+  elements: ClickElement[];
+}
+/**
+ * Fill a form's fields from the extracted profile data (or generated values).
+ */
+export interface FillFormAction {
+  id: string;
+  actionType: "fillForm";
+  /**
+   * selector for the form element
+   */
+  selector: string;
+  elements: FormElement[];
+  dataSource?: string;
+  retry?: RetryConfig;
+}
+/**
+ * A single field to fill within a form. `type` is either a key to read from the data, or a special generator/composite token.
+ */
+export interface FormElement {
+  /**
+   * selector for the input/select element
+   */
+  selector: string;
+  /**
+   * a data key to fill (e.g. "firstName"), or a special token: $file_id$, $generated_phone_number$, $generated_zip_code$, $generated_random_number$, $generated_street_address$, cityState, fullState
+   */
+  type: string;
+  /**
+   * lower bound for $generated_random_number$
+   */
+  min?: string;
+  /**
+   * upper bound for $generated_random_number$
+   */
+  max?: string;
+}
+/**
+ * Assert a set of expectations about the page. When they all pass, optionally run further `actions`.
+ */
+export interface ExpectationAction {
+  id: string;
+  actionType: "expectation";
+  expectations: Expectation[];
+  /**
+   * actions to run next when all expectations pass
+   */
+  actions?: PirAction[];
+  dataSource?: string;
+  retry?: RetryConfig;
+}
+/**
+ * A single condition checked by `expectation`/`condition` actions: that an element exists, that an element contains text, or that the current URL contains a string.
+ */
+export interface Expectation {
+  /**
+   * what to check
+   */
+  type: "element" | "text" | "url";
+  /**
+   * target element selector (unused for `url`)
+   */
+  selector: string;
+  /**
+   * optional parent selector to scroll into view first (element checks)
+   */
+  parent?: string;
+  /**
+   * expected substring for `text`/`url` checks
+   */
+  expect?: string;
+  /**
+   * treat a failed check as a non-error skip
+   */
+  failSilently?: boolean;
+}
+/**
+ * Evaluate a set of expectations and report back the `actions` to run when they pass (the caller decides whether to execute them).
+ */
+export interface ConditionAction {
+  id: string;
+  actionType: "condition";
+  expectations: Expectation[];
+  /**
+   * actions returned for execution when all expectations pass
+   */
+  actions?: PirAction[];
+  dataSource?: string;
+  retry?: RetryConfig;
+}
+/**
+ * Scroll a matching element into view.
+ */
+export interface ScrollAction {
+  id: string;
+  actionType: "scroll";
+  /**
+   * selector for the element to scroll into view
+   */
+  selector: string;
+  dataSource?: string;
+  retry?: RetryConfig;
+}
+/**
+ * Locate a captcha on the page and return the information native needs to solve it (url, site key, type).
+ */
+export interface GetCaptchaInfoAction {
+  id: string;
+  actionType: "getCaptchaInfo";
+  /**
+   * selector for the captcha container
+   */
+  selector: string;
+  /**
+   * captcha provider type (e.g. recaptcha, hcaptcha); when omitted the deprecated handler is used
+   */
+  captchaType?: string;
+  /**
+   * captcha type whose supporting code should be injected
+   */
+  injectCaptchaHandler?: string;
+  dataSource?: string;
+  retry?: RetryConfig;
+}
+/**
+ * Inject a solved captcha token into the page.
+ */
+export interface SolveCaptchaAction {
+  id: string;
+  actionType: "solveCaptcha";
+  /**
+   * selector for the captcha container
+   */
+  selector: string;
+  /**
+   * captcha provider type; when omitted the deprecated handler is used
+   */
+  captchaType?: string;
+  /**
+   * captcha type whose supporting code should be injected
+   */
+  injectCaptchaHandler?: string;
+  dataSource?: string;
+  retry?: RetryConfig;
+}
+/**
+ * The data bundle that accompanies an action. Which key an action reads is chosen by its `dataSource` (defaults: extract/navigate/click -> userProfile, fillForm -> extractedProfile, solveCaptcha -> token).
+ */
+export interface ActionData {
+  userProfile?: UserProfile;
+  extractedProfile?: ExtractedProfile;
+  /**
+   * a solved captcha token (used by solveCaptcha)
+   */
+  token?: string;
+  [k: string]: unknown;
+}
+/**
+ * The person whose records we're searching for. Used to build search URLs and to match scraped profiles. Brokers may reference additional flat keys (e.g. city, state) in URL templates, so extra properties are allowed.
+ */
+export interface UserProfile {
+  firstName?: string;
+  middleName?: string;
+  lastName?: string;
+  age?: string | number;
+  phone?: string;
+  addresses?: Address[];
+  [k: string]: unknown;
+}
+/**
+ * A single address belonging to the user profile. Extra broker-specific keys are allowed.
+ */
+export interface Address {
+  addressLine1?: string;
+  addressLine2?: string;
+  city?: string;
+  /**
+   * two-letter state abbreviation
+   */
+  state?: string;
+  zip?: string;
+  [k: string]: unknown;
+}
+/**
+ * The broker-specific profile data submitted by `fillForm` actions, keyed by the field names a FormElement `type` references (e.g. firstName, lastName, city, state, email). Native owns the exact shape, so extra properties are allowed.
+ */
+export interface ExtractedProfile {
+  firstName?: string;
+  middleName?: string;
+  lastName?: string;
+  city?: string;
+  state?: string;
+  phone?: string;
+  email?: string;
+  [k: string]: unknown;
+}
+
+declare module "../features/broker-protection.js" {
+  export interface BrokerProtection {
+    notify: import("@duckduckgo/messaging/lib/shared-types").MessagingBase<BrokerProtectionMessages>['notify'],
+    subscribe: import("@duckduckgo/messaging/lib/shared-types").MessagingBase<BrokerProtectionMessages>['subscribe']
+  }
+}

--- a/injected/src/types/broker-protection.ts
+++ b/injected/src/types/broker-protection.ts
@@ -11,7 +11,7 @@
  */
 export type ActionResponse = SuccessResponse | ErrorResponse;
 /**
- * A single instruction sent by native for the broker-protection executor to run on the page. Discriminated on `actionType`.
+ * A single instruction for the broker-protection executor to run on the page, discriminated on `actionType`.
  */
 export type PirAction =
   | ExtractAction
@@ -68,7 +68,7 @@ export interface ActionCompletedNotification {
   params: ActionCompletedNotify;
 }
 /**
- * Sent back to native when an action finishes (successfully, or with an error captured in the result).
+ * Emitted when an action finishes (successfully, or with an error captured in the result).
  */
 export interface ActionCompletedNotify {
   result: ActionResponse;
@@ -87,56 +87,15 @@ export interface SuccessResponse {
       [k: string]: unknown;
     };
     /**
-     * follow-up actions to run with the same data (e.g. from an expectation action)
+     * follow-up actions the executor runs locally after this one (e.g. produced by an `expectation` action); each is executed with the same data and reports its own result
      */
-    next?: unknown[];
+    next?: PirAction[];
     /**
-     * optional debugging metadata
+     * optional action-specific metadata attached to the result (e.g. `extract` attaches the `{ userData }` it matched against)
      */
     meta?: {
       [k: string]: unknown;
     };
-  };
-}
-/**
- * The wire shape of a failed action result.
- */
-export interface ErrorResponse {
-  error: {
-    actionID: string;
-    message: string;
-  };
-}
-/**
- * Generated from @see "../messages/broker-protection/actionError.notify.json"
- */
-export interface ActionErrorNotification {
-  method: "actionError";
-  params: ActionErrorNotify;
-}
-/**
- * Sent back to native when an action could not be run at all (no action, unhandled exception, or no response).
- */
-export interface ActionErrorNotify {
-  /**
-   * human-readable error message
-   */
-  error: string;
-}
-/**
- * Generated from @see "../messages/broker-protection/onActionReceived.subscribe.json"
- */
-export interface OnActionReceivedSubscription {
-  subscriptionEvent: "onActionReceived";
-  params: OnActionReceivedSubscribe;
-}
-/**
- * Native pushes the next action (plus its data) for the executor to run on the current page.
- */
-export interface OnActionReceivedSubscribe {
-  state: {
-    action: PirAction;
-    data: ActionData;
   };
 }
 /**
@@ -203,14 +162,14 @@ export interface TextFieldSpec {
   attribute?: string;
 }
 /**
- * Optional per-action retry policy. Honoured web-side only when `environment` is "web"; otherwise the native scheduler owns retries.
+ * Optional per-action retry policy honoured by the web executor. Retries run web-side only when `environment` is "web"; otherwise retrying is left to the caller's scheduler. When present, both `interval` and `maxAttempts` are required: the executor uses `interval.ms` as the inter-attempt delay and `maxAttempts` as the loop bound, with no defaults.
  */
 export interface RetryConfig {
   /**
-   * where the retry runs; "web" enables web-side retry for this action
+   * where the retry runs; "web" is the only supported value and enables web-side retry for this action
    */
-  environment?: string;
-  interval?: {
+  environment?: "web";
+  interval: {
     /**
      * delay between attempts, in milliseconds
      */
@@ -219,7 +178,7 @@ export interface RetryConfig {
   /**
    * maximum number of attempts before giving up
    */
-  maxAttempts?: number;
+  maxAttempts: number;
 }
 /**
  * Build a URL from a template + the user's data and report it back for native to navigate to.
@@ -292,7 +251,7 @@ export interface ClickElement {
     /**
      * an extract-style spec; the highest-scoring matching element becomes the click root
      */
-    profileMatch?: {
+    profileMatch: {
       selector: string;
       profile: ProfileSpec;
     };
@@ -402,7 +361,7 @@ export interface ConditionAction {
   /**
    * actions returned for execution when all expectations pass
    */
-  actions?: PirAction[];
+  actions: PirAction[];
   dataSource?: string;
   retry?: RetryConfig;
 }
@@ -416,7 +375,6 @@ export interface ScrollAction {
    * selector for the element to scroll into view
    */
   selector: string;
-  dataSource?: string;
   retry?: RetryConfig;
 }
 /**
@@ -430,13 +388,9 @@ export interface GetCaptchaInfoAction {
    */
   selector: string;
   /**
-   * captcha provider type (e.g. recaptcha, hcaptcha); when omitted the deprecated handler is used
+   * selects the captcha handler. Supported values: "image", "cloudFlareTurnstile". When omitted, the deprecated handler runs and self-detects recaptcha2/recaptchaEnterprise from the DOM.
    */
   captchaType?: string;
-  /**
-   * captcha type whose supporting code should be injected
-   */
-  injectCaptchaHandler?: string;
   dataSource?: string;
   retry?: RetryConfig;
 }
@@ -451,18 +405,55 @@ export interface SolveCaptchaAction {
    */
   selector: string;
   /**
-   * captcha provider type; when omitted the deprecated handler is used
+   * selects the captcha handler. Supported values: "image", "cloudFlareTurnstile". When omitted, the deprecated handler runs and self-detects recaptcha2/recaptchaEnterprise from the DOM.
    */
   captchaType?: string;
-  /**
-   * captcha type whose supporting code should be injected
-   */
-  injectCaptchaHandler?: string;
   dataSource?: string;
   retry?: RetryConfig;
 }
 /**
- * The data bundle that accompanies an action. Which key an action reads is chosen by its `dataSource` (defaults: extract/navigate/click -> userProfile, fillForm -> extractedProfile, solveCaptcha -> token).
+ * The wire shape of a failed action result.
+ */
+export interface ErrorResponse {
+  error: {
+    actionID: string;
+    message: string;
+  };
+}
+/**
+ * Generated from @see "../messages/broker-protection/actionError.notify.json"
+ */
+export interface ActionErrorNotification {
+  method: "actionError";
+  params: ActionErrorNotify;
+}
+/**
+ * Emitted when an action could not be run at all (no action, unhandled exception, or no response).
+ */
+export interface ActionErrorNotify {
+  /**
+   * human-readable error message
+   */
+  error: string;
+}
+/**
+ * Generated from @see "../messages/broker-protection/onActionReceived.subscribe.json"
+ */
+export interface OnActionReceivedSubscription {
+  subscriptionEvent: "onActionReceived";
+  params: OnActionReceivedSubscribe;
+}
+/**
+ * Delivers the next action (plus its data) for the executor to run on the current page.
+ */
+export interface OnActionReceivedSubscribe {
+  state: {
+    action: PirAction;
+    data: ActionData;
+  };
+}
+/**
+ * The data bundle that accompanies an action. Which key an action reads is chosen by its `dataSource`; when an action omits `dataSource` the executor applies a fallback default (extract/navigate/click -> userProfile, fillForm -> extractedProfile, solveCaptcha -> token). An action may set `dataSource` explicitly to read a different bundle (e.g. a fillForm reading userProfile). `fetchedEmail`/`emailData` are also supported, for email-confirmation flows.
  */
 export interface ActionData {
   userProfile?: UserProfile;
@@ -471,17 +462,41 @@ export interface ActionData {
    * a solved captcha token (used by solveCaptcha)
    */
   token?: string;
+  /**
+   * a fetched email address (read when an action sets dataSource: fetchedEmail)
+   */
+  fetchedEmail?: {
+    email?: string;
+    [k: string]: unknown;
+  };
+  /**
+   * email-derived values such as a verification code (read when an action sets dataSource: emailData)
+   */
+  emailData?: {
+    [k: string]: string;
+  };
   [k: string]: unknown;
 }
 /**
  * The person whose records we're searching for. Used to build search URLs and to match scraped profiles. Brokers may reference additional flat keys (e.g. city, state) in URL templates, so extra properties are allowed.
  */
 export interface UserProfile {
+  id?: string;
   firstName?: string;
   middleName?: string;
   lastName?: string;
+  fullName?: string;
+  suffix?: string;
   age?: string | number;
+  birthYear?: string | number;
   phone?: string;
+  city?: string;
+  /**
+   * two-letter state abbreviation
+   */
+  state?: string;
+  street?: string;
+  zip?: string;
   addresses?: Address[];
   [k: string]: unknown;
 }
@@ -500,7 +515,7 @@ export interface Address {
   [k: string]: unknown;
 }
 /**
- * The broker-specific profile data submitted by `fillForm` actions, keyed by the field names a FormElement `type` references (e.g. firstName, lastName, city, state, email). Native owns the exact shape, so extra properties are allowed.
+ * The profile data a `fillForm` action draws from, keyed by the field names a FormElement `type` references (e.g. firstName, lastName, city, state, email). The exact shape is caller-defined, so extra properties are allowed.
  */
 export interface ExtractedProfile {
   firstName?: string;
@@ -510,6 +525,9 @@ export interface ExtractedProfile {
   state?: string;
   phone?: string;
   email?: string;
+  age?: string | number;
+  birthYear?: string | number;
+  profileUrl?: string;
   [k: string]: unknown;
 }
 

--- a/scripts/check-strict-core.js
+++ b/scripts/check-strict-core.js
@@ -111,6 +111,7 @@ const CORE_FILES = new Set([
     'injected/src/features/performance-metrics.js',
     'injected/src/features/autofill-passkeys.js',
     'injected/src/locales/duckplayer/en/native.json',
+    'injected/src/types/broker-protection.ts',
     'injected/src/types/context-menu.ts',
     'injected/src/types/favicon.ts',
     'injected/src/types/feature-map.ts',


### PR DESCRIPTION
**Asana Task/Github Issue:** N/A

## Description

Stacked on #2778.

Adds JSON Schema types to PIR. Two reasons:

- **Docs eventually.** Same as special-pages and web-compat, the native↔web contract lives in JSON Schema now, so we can generate HTML docs off the schemas later.
- **Precise types now.** They generate `broker-protection.ts`, replacing the `Record<string, any>` / `any` typedefs scattered through the feature with real action types (`PirAction`, `ExtractAction`, `ActionData`, …).

### How this was built

I used Claude Code's [dynamic workflows](https://code.claude.com/docs/en/workflows) for the audit: fan agents out over the native PIR implementations (Apple, Android, Windows) and the real broker JSON to work out what each action actually carries, cross-check every schema against both that and our executor, then run an adversarial pass to bin the false positives.

The run, as it looked in `/workflows` (31 agents, each phase fanning out in parallel):

```
broker-protection-schema-audit
│
├─ Ground truth
│  ├─ ground-truth:apple
│  ├─ ground-truth:android
│  └─ ground-truth:windows
├─ Schema audit
│  ├─ audit:action-union-and-dispatch
│  ├─ audit:extract-action
│  ├─ audit:extract-specs
│  ├─ audit:navigate-action
│  ├─ audit:click-action
│  ├─ audit:fillform-action
│  ├─ audit:expectation-condition
│  ├─ audit:scroll-action
│  ├─ audit:captcha-actions
│  ├─ audit:responses
│  ├─ audit:input-data-and-profiles
│  ├─ audit:retry-config
│  └─ audit:messages-envelope
├─ Verify
│  ├─ verify:extract-specs
│  ├─ verify:captcha-actions
│  ├─ verify:responses
│  └─ … one per area with findings
├─ Loose types
│  ├─ loose:actions
│  ├─ loose:captcha-services
│  ├─ loose:extractors+comparisons
│  └─ loose:core
└─ Synthesize
   └─ synthesize
```

### Schema corrections applied (now reflect native reality)

Each one checked against the native implementations and the executor:

- **`condition.json`** – `actions` now required (native always sends it: 29/29 broker JSON, Android models it non-null).
- **`input-data.json`** – added `fetchedEmail` + `emailData` (Apple sends both, `execute.js` resolves them via `dataSource`); clarified the `dataSource` defaults are fallbacks.
- **`success-response.json`** – `next` typed as `PirAction[]` (was `unknown[]`), the follow-up actions the executor runs locally and that no native `ActionResult` model decodes; `meta` re-described as an action-specific bag (Android decodes `extract`'s `meta.userData`), not "debug".
- **`retry-config.json`** – `interval` + `maxAttempts` now required (the web retry helper dereferences both with no fallback); `environment` → `enum: ["web"]`; a web-only field, since no native model or broker JSON carries a per-action retry.
- **`get-captcha-info.json` / `solve-captcha.json`** – fixed the `captchaType` description (real values are `image`/`cloudFlareTurnstile`, not the cited `recaptcha`/`hcaptcha`, which a broker-JSON census found 0 of); removed `injectCaptchaHandler` (only `navigate` reads it, never the captcha actions).
- **`scroll.json`** – dropped dead `dataSource` (the handler never reads it and `execute.js` passes no data bag to scroll).
- **`user-profile.json`** – added `id`, `city`, `state`, `street`, `zip`, `birthYear`, `fullName`, `suffix` (heavily template-referenced ProfileQuery keys); **`extracted-profile.json`** – added `age`, `birthYear`, `profileUrl` (FormElement `type` keys the fill-form reads).
- **`click-element.json`** – `parent.profileMatch` now required (`selectRootElement` throws if `parent` is present without it).

## Testing Steps

- `cd injected && npm run build-types` – regenerates `broker-protection.ts` with no diff.
- `npm run tsc-strict-core` + `npm run tsc` – clean.
- `cd injected && npm run test-unit` – broker-protection specs green (114).

## Checklist

*Please tick all that apply:*

- [x] I have tested this change locally
- [ ] I have tested this change locally in all supported browsers
- [ ] This change will be visible to users
- [ ] I have added automated tests that cover this change
- [ ] I have ensured the change is gated by config
- [ ] This change was covered by a ship review
- [ ] This change was covered by a tech design
- [ ] Any dependent config has been merged

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the native↔web PIR contract and action dispatch typing across many broker-protection paths; schema mismatches could surface at compile time or reject valid broker JSON if schemas are too strict.
> 
> **Overview**
> Introduces a **JSON Schema contract** for broker-protection (PIR): per-action shapes, profile/extract specs, `ActionData`, and messaging envelopes (`onActionReceived`, `actionCompleted`, `actionError`). Schemas generate **`injected/src/types/broker-protection.ts`**, which becomes the source of truth for `PirAction`, discriminated action types, and native↔web message typing.
> 
> The executor and action handlers are **rewired to those types**: inline `PirAction` / extract typedefs are removed in favor of imports from the generated module; JSDoc on `execute`, actions, captcha code, and integration mocks now references concrete types like `ExtractAction`, `UserProfile`, and `GetCaptchaInfoAction`. **`BrokerProtection`** uses typed `notify` / `subscribe` instead of generic messaging helpers.
> 
> Small **runtime/type-alignment tweaks**: `execute` narrows `ActionData` per action with explicit casts; click choice evaluation guards empty `choices` and uses `default === undefined`; some captcha test helpers require an explicit `selector`. **`check-strict-core`** whitelists the generated TS file.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit de9d056c448686d458cba858b6256b8478731822. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->