### PR TITLE
NTP: use greyscale styling for voice icon button

### DIFF
--- a/special-pages/pages/new-tab/app/omnibar/components/AiChatForm.module.css
+++ b/special-pages/pages/new-tab/app/omnibar/components/AiChatForm.module.css
@@ -94,15 +94,27 @@
 /* When the input is empty AND voice-chat access is enabled, the submit button is repurposed
    as a 1-click voice-chat entry point. Use greyscale styling to match other icons. */
 .submitButton:has(.voiceIcon) {
-    background: none;
+    background: #f0f0f0;
     color: var(--ds-color-theme-icons-primary);
 
     &:hover:not([disabled]) {
-        background: color-mix(in srgb, var(--ds-color-theme-icons-primary) 12%, transparent);
+        background: #e9e9e9;
     }
 
     &:active:not([disabled]) {
-        background: color-mix(in srgb, var(--ds-color-theme-icons-primary) 20%, transparent);
+        background: #e9e9e9;
+    }
+
+    [data-theme="dark"] & {
+        background: #545454;
+
+        &:hover:not([disabled]) {
+            background: #5f5f5f;
+        }
+
+        &:active:not([disabled]) {
+            background: #5f5f5f;
+        }
     }
 }
 


### PR DESCRIPTION
## Description

This is a follow-up PR to https://github.com/duckduckgo/content-scope-scripts/pull/2781.

The original PR correctly updated the button to use greyscale styling. However, it should retain the default background color to match the native address bar. I've also adjust the bg color value to match the native address bar (used HEX since we don't have a matching design token)

Before: 
<img width="635" height="103" alt="Screenshot 2026-06-22 at 3 00 40 PM" src="https://github.com/user-attachments/assets/4f143eb3-a15b-4639-b096-29d2d7566ffc" />

After:
<img width="654" height="120" alt="Screenshot 2026-06-22 at 3 00 51 PM" src="https://github.com/user-attachments/assets/4c80da1c-4290-4eb7-9260-93b1daa3cb05" />


Video:


https://github.com/user-attachments/assets/a50389c3-4750-4897-95da-95134a927761



<!--
  Provide a terse summary of what the change is, detailed descriptions should belong in ship reviews or tech designs
-->

## Testing Steps

1. Checkout this branch.
2. Cd to `special-pages`
3. Run `npm run watch -- --page=new-tab`
4. Navigate to http://localhost:8000/?omnibar.enableAi=true&omnibar.enableVoiceChatAccess=true&omnibar.enableAiChatTools=true&omnibar.enableAttachTabs=true&omnibar.mode=ai
5. Confirm the voice icon changes.

## Checklist

<!--
  These questions are a friendly reminder to shipping code, if you're uncertain ask the AoR owners.
  It's also totally appropriate to not check some of these boxes, if they don't apply to your change.
-->
*Please tick all that apply:*

- [ ] I have tested this change locally
- [ ] I have tested this change locally in all supported browsers
- [ ] This change will be visible to users
- [ ] I have added automated tests that cover this change
- [ ] I have ensured the change is gated by config
- [ ] This change was covered by a ship review
- [ ] This change was covered by a tech design
- [ ] Any dependent config has been merged


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS-only NTP omnibar visual tweak with no logic, config, or data-handling changes.
> 
> **Overview**
> Updates the **empty-input voice-chat** submit button on the NTP AI omnibar so it keeps a **filled circular background** like the native address bar, while still using **greyscale icon** styling instead of the accent submit look.
> 
> **Light mode** uses `#f0f0f0` default and `#e9e9e9` on hover/active (replacing `background: none` and semi-transparent `color-mix` overlays). **Dark mode** adds matching rules with `#545454` and `#5f5f5f`. Icon color remains `var(--ds-color-theme-icons-primary)`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d6d65d75ada8cfeb228691271742569f2b83e217. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->