### PR TITLE
Add captcha detection test coverage for webDetection

### DIFF
--- a/injected/integration-test/test-pages/web-detection/pages/captcha-cloudflare.html
+++ b/injected/integration-test/test-pages/web-detection/pages/captcha-cloudflare.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Captcha - Cloudflare interstitial</title>
+</head>
+<body>
+    <!-- Current Cloudflare full-page interstitial / managed challenge. It embeds Turnstile via
+         <div id="turnstile-wrapper" class="cf-turnstile">, so it must fire ONLY captcha_cloudflare:
+         the turnstile detector excludes #turnstile-wrapper. -->
+    <div id="cf-wrapper" style="width: 100%; min-height: 400px;">
+        <div id="challenge-running" style="width: 320px; height: 40px;">Checking your browser before accessing the site.</div>
+        <div id="challenge-stage" style="width: 320px; height: 120px;">
+            <div id="turnstile-wrapper" class="cf-turnstile" style="width: 300px; height: 65px;"></div>
+        </div>
+    </div>
+</body>
+</html>

--- a/injected/integration-test/test-pages/web-detection/pages/captcha-hcaptcha.html
+++ b/injected/integration-test/test-pages/web-detection/pages/captcha-hcaptcha.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Captcha - hCaptcha</title>
+</head>
+<body>
+    <h1>Sign in</h1>
+    <p>Please complete the challenge below to continue.</p>
+    <!-- Visible hCaptcha widget container -->
+    <div class="h-captcha" style="width: 303px; height: 78px;" data-sitekey="test"></div>
+</body>
+</html>

--- a/injected/integration-test/test-pages/web-detection/pages/captcha-other.html
+++ b/injected/integration-test/test-pages/web-detection/pages/captcha-other.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Captcha - other / unknown vendor</title>
+</head>
+<body>
+    <h1>Security check</h1>
+    <!-- Generic challenge from a vendor without a dedicated detector -->
+    <div style="width: 320px; height: 120px;">
+        <p>Please press and hold to confirm you are human.</p>
+    </div>
+</body>
+</html>

--- a/injected/integration-test/test-pages/web-detection/pages/captcha-recaptcha-hidden.html
+++ b/injected/integration-test/test-pages/web-detection/pages/captcha-recaptcha-hidden.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Captcha - hidden reCAPTCHA</title>
+</head>
+<body>
+    <h1>Sign in</h1>
+    <p>No challenge is shown to the user on this page.</p>
+    <!-- reCAPTCHA present in the DOM but hidden — must NOT be counted as a visible challenge -->
+    <div class="g-recaptcha" style="display: none;" data-sitekey="test">
+        <iframe title="reCAPTCHA" src="about:blank#recaptcha"></iframe>
+    </div>
+</body>
+</html>

--- a/injected/integration-test/test-pages/web-detection/pages/captcha-recaptcha.html
+++ b/injected/integration-test/test-pages/web-detection/pages/captcha-recaptcha.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Captcha - reCAPTCHA</title>
+</head>
+<body>
+    <h1>Sign in</h1>
+    <p>Please complete the challenge below to continue.</p>
+    <!-- Visible reCAPTCHA v2 widget container -->
+    <div class="g-recaptcha" style="width: 304px; height: 78px;" data-sitekey="test"></div>
+</body>
+</html>

--- a/injected/integration-test/test-pages/web-detection/pages/captcha-turnstile.html
+++ b/injected/integration-test/test-pages/web-detection/pages/captcha-turnstile.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Captcha - Cloudflare Turnstile</title>
+</head>
+<body>
+    <h1>Sign in</h1>
+    <p>Please complete the challenge below to continue.</p>
+    <!-- Cloudflare Turnstile widget (the widget, NOT the full-page interstitial) -->
+    <div class="cf-turnstile" style="width: 300px; height: 65px;" data-sitekey="test"></div>
+</body>
+</html>

--- a/injected/integration-test/web-detection.spec.js
+++ b/injected/integration-test/web-detection.spec.js
@@ -5,6 +5,55 @@ import { readFileSync } from 'node:fs';
 const CONFIG = './integration-test/test-pages/web-detection/config/config.json';
 
 /**
+ * Captcha detectors mirroring privacy-configuration/features/web-detection.json (the `captcha`
+ * group) with the Windows conditionalChanges applied inline (auto trigger + per-provider
+ * fireEvent), so this test exercises the same auto-run → fireEvent path the product ships.
+ * Detection is element + visibility only (a *visible* challenge); keep selectors in sync with config.
+ */
+const CAPTCHA_DETECTORS = {
+    recaptcha: {
+        match: { element: { selector: ['.g-recaptcha', "iframe[src*='recaptcha']", "iframe[title*='recaptcha' i]"], visibility: 'visible' } },
+        triggers: { auto: { state: 'enabled', when: { intervalMs: [100] } } },
+        actions: { fireEvent: { type: 'captcha_recaptcha' } },
+    },
+    hcaptcha: {
+        match: { element: { selector: ['.h-captcha', "iframe[src*='hcaptcha.com']", "iframe[title*='hcaptcha' i]"], visibility: 'visible' } },
+        triggers: { auto: { state: 'enabled', when: { intervalMs: [100] } } },
+        actions: { fireEvent: { type: 'captcha_hcaptcha' } },
+    },
+    turnstile: {
+        // :not(#turnstile-wrapper) excludes the Cloudflare interstitial's own Turnstile wrapper, so an
+        // interstitial is counted as `cloudflare`, not `turnstile`.
+        match: { element: { selector: ['.cf-turnstile:not(#turnstile-wrapper)', '.cf-turnstile:not(#turnstile-wrapper) iframe'], visibility: 'visible' } },
+        triggers: { auto: { state: 'enabled', when: { intervalMs: [100] } } },
+        actions: { fireEvent: { type: 'captcha_turnstile' } },
+    },
+    cloudflare: {
+        match: {
+            element: {
+                selector: ['#challenge-form', '#cf-wrapper', '.cf-browser-verification', '#challenge-running', '#cf-challenge-running', '#challenge-stage'],
+                visibility: 'visible',
+            },
+        },
+        triggers: { auto: { state: 'enabled', when: { intervalMs: [100] } } },
+        actions: { fireEvent: { type: 'captcha_cloudflare' } },
+    },
+    other: {
+        match: {
+            text: {
+                pattern: [
+                    'press (and|&) hold to (confirm|verify)',
+                    'slide( right)? to (verify|complete)',
+                    'complete the security check to (access|continue)',
+                ],
+            },
+        },
+        triggers: { auto: { state: 'enabled', when: { intervalMs: [100] } } },
+        actions: { fireEvent: { type: 'captcha_other' } },
+    },
+};
+
+/**
  * Helper class for web-detection tests.
  */
 class WebDetectionTestHelper {
@@ -105,6 +154,28 @@ class WebDetectionTestHelper {
             fireEvent: { type: 'adwall' },
         };
         if (configModifier) configModifier(config);
+
+        const collector = ResultsCollector.create(page, projectUse);
+        collector.withMockResponse({ webDetectionAutoRun: null, webEvent: null });
+        await page.clock.install();
+        await collector.load('/web-detection/index.html', config);
+        const helper = new WebDetectionTestHelper(page, collector);
+
+        return { collector, helper };
+    }
+
+    /**
+     * Set up collector for captcha detection tests: enables webEvents and installs the captcha
+     * detector group (auto-run + per-provider fireEvent), with fake timers.
+     *
+     * @param {import('@playwright/test').Page} page
+     * @param {Record<string, any>} projectUse
+     * @returns {Promise<{collector: ResultsCollector, helper: WebDetectionTestHelper}>}
+     */
+    static async setupCaptchaTest(page, projectUse) {
+        const config = JSON.parse(readFileSync(CONFIG, 'utf8'));
+        config.features.webEvents = { state: 'enabled', hash: 'test', exceptions: [] };
+        config.features.webDetection.settings.detectors.captcha = CAPTCHA_DETECTORS;
 
         const collector = ResultsCollector.create(page, projectUse);
         collector.withMockResponse({ webDetectionAutoRun: null, webEvent: null });
@@ -575,6 +646,49 @@ test.describe('WebDetection Feature', () => {
             // First-success: only 1 webEvent despite 3 intervals
             expect(webEvents.length).toBe(1);
             expect(webEvents[0].type).toBe('adwall');
+        });
+    });
+
+    test.describe('captcha detection (per-provider events)', () => {
+        /** @type {Array<[string, string]>} */
+        const cases = [
+            ['captcha-recaptcha.html', 'captcha_recaptcha'],
+            ['captcha-hcaptcha.html', 'captcha_hcaptcha'],
+            ['captcha-turnstile.html', 'captcha_turnstile'],
+            ['captcha-cloudflare.html', 'captcha_cloudflare'],
+            ['captcha-other.html', 'captcha_other'],
+        ];
+
+        for (const [pageName, expectedType] of cases) {
+            test(`fires exactly ${expectedType} for a visible ${pageName}`, async ({ page }, testInfo) => {
+                const { helper } = await WebDetectionTestHelper.setupCaptchaTest(page, testInfo.project.use);
+                await helper.navigateTo(`/web-detection/pages/${pageName}`);
+
+                await page.clock.fastForward(100);
+
+                const events = await helper.getWebEventNotifications();
+                // Exactly one event, of the expected provider — proves per-provider firing and no
+                // cross-counting (e.g. the Turnstile widget must not also fire captcha_cloudflare).
+                expect(events.map((e) => e.type)).toEqual([expectedType]);
+            });
+        }
+
+        test('does not fire on a page without a captcha', async ({ page }, testInfo) => {
+            const { helper } = await WebDetectionTestHelper.setupCaptchaTest(page, testInfo.project.use);
+            await helper.navigateTo('/web-detection/pages/no-detection.html');
+
+            await page.clock.fastForward(100);
+
+            expect(await helper.getWebEventNotifications()).toEqual([]);
+        });
+
+        test('does not fire for a hidden (display:none) captcha', async ({ page }, testInfo) => {
+            const { helper } = await WebDetectionTestHelper.setupCaptchaTest(page, testInfo.project.use);
+            await helper.navigateTo('/web-detection/pages/captcha-recaptcha-hidden.html');
+
+            await page.clock.fastForward(100);
+
+            expect(await helper.getWebEventNotifications()).toEqual([]);
         });
     });
 });

--- a/injected/integration-test/web-detection.spec.js
+++ b/injected/integration-test/web-detection.spec.js
@@ -12,26 +12,42 @@ const CONFIG = './integration-test/test-pages/web-detection/config/config.json';
  */
 const CAPTCHA_DETECTORS = {
     recaptcha: {
-        match: { element: { selector: ['.g-recaptcha', "iframe[src*='recaptcha']", "iframe[title*='recaptcha' i]"], visibility: 'visible' } },
+        match: {
+            element: { selector: ['.g-recaptcha', "iframe[src*='recaptcha']", "iframe[title*='recaptcha' i]"], visibility: 'visible' },
+        },
         triggers: { auto: { state: 'enabled', when: { intervalMs: [100] } } },
         actions: { fireEvent: { type: 'captcha_recaptcha' } },
     },
     hcaptcha: {
-        match: { element: { selector: ['.h-captcha', "iframe[src*='hcaptcha.com']", "iframe[title*='hcaptcha' i]"], visibility: 'visible' } },
+        match: {
+            element: { selector: ['.h-captcha', "iframe[src*='hcaptcha.com']", "iframe[title*='hcaptcha' i]"], visibility: 'visible' },
+        },
         triggers: { auto: { state: 'enabled', when: { intervalMs: [100] } } },
         actions: { fireEvent: { type: 'captcha_hcaptcha' } },
     },
     turnstile: {
         // :not(#turnstile-wrapper) excludes the Cloudflare interstitial's own Turnstile wrapper, so an
         // interstitial is counted as `cloudflare`, not `turnstile`.
-        match: { element: { selector: ['.cf-turnstile:not(#turnstile-wrapper)', '.cf-turnstile:not(#turnstile-wrapper) iframe'], visibility: 'visible' } },
+        match: {
+            element: {
+                selector: ['.cf-turnstile:not(#turnstile-wrapper)', '.cf-turnstile:not(#turnstile-wrapper) iframe'],
+                visibility: 'visible',
+            },
+        },
         triggers: { auto: { state: 'enabled', when: { intervalMs: [100] } } },
         actions: { fireEvent: { type: 'captcha_turnstile' } },
     },
     cloudflare: {
         match: {
             element: {
-                selector: ['#challenge-form', '#cf-wrapper', '.cf-browser-verification', '#challenge-running', '#cf-challenge-running', '#challenge-stage'],
+                selector: [
+                    '#challenge-form',
+                    '#cf-wrapper',
+                    '.cf-browser-verification',
+                    '#challenge-running',
+                    '#cf-challenge-running',
+                    '#challenge-stage',
+                ],
                 visibility: 'visible',
             },
         },

--- a/injected/unit-test/web-detection.js
+++ b/injected/unit-test/web-detection.js
@@ -1193,5 +1193,115 @@ describe('WebDetection', () => {
                 expect(matchInDOM('<p>welcome</p>', condition)).toBe(false);
             });
         });
+
+        // Captcha vendor detectors. These mirror the per-provider `captcha` detectors in
+        // privacy-configuration/features/web-detection.json — keep the selectors in sync.
+        // The metric counts *visible* captcha challenges per navigation, so every detector
+        // uses visibility: 'visible'. Window-property signals (window.grecaptcha etc.) are
+        // intentionally NOT used: a loaded captcha library is not a visible challenge and
+        // would inflate the per-navigation ratio.
+        describe('captcha vendor detectors', () => {
+            const captcha = {
+                recaptcha: {
+                    element: {
+                        selector: ['.g-recaptcha', "iframe[src*='recaptcha']", "iframe[title*='recaptcha' i]"],
+                        visibility: 'visible',
+                    },
+                },
+                hcaptcha: {
+                    element: {
+                        selector: ['.h-captcha', "iframe[src*='hcaptcha.com']", "iframe[title*='hcaptcha' i]"],
+                        visibility: 'visible',
+                    },
+                },
+                turnstile: {
+                    element: {
+                        // :not(#turnstile-wrapper) excludes the Cloudflare interstitial's own Turnstile wrapper
+                        // (<div id="turnstile-wrapper" class="cf-turnstile">), so an interstitial counts as `cloudflare`, not `turnstile`.
+                        selector: ['.cf-turnstile:not(#turnstile-wrapper)', '.cf-turnstile:not(#turnstile-wrapper) iframe'],
+                        visibility: 'visible',
+                    },
+                },
+                cloudflare: {
+                    element: {
+                        selector: ['#challenge-form', '#cf-wrapper', '.cf-browser-verification', '#challenge-running', '#cf-challenge-running', '#challenge-stage'],
+                        visibility: 'visible',
+                    },
+                },
+                other: {
+                    text: {
+                        pattern: [
+                            'press (and|&) hold to (confirm|verify)',
+                            'slide( right)? to (verify|complete)',
+                            'complete the security check to (access|continue)',
+                        ],
+                    },
+                },
+            };
+
+            // Representative visible markup per vendor.
+            const fixtures = {
+                recaptcha:
+                    '<div class="g-recaptcha"></div><iframe src="https://www.google.com/recaptcha/api2/anchor" title="reCAPTCHA"></iframe>',
+                hcaptcha:
+                    '<div class="h-captcha"></div><iframe src="https://newassets.hcaptcha.com/captcha/v1/frame" title="hCaptcha"></iframe>',
+                turnstile:
+                    '<div class="cf-turnstile"><iframe src="https://challenges.cloudflare.com/cdn-cgi/challenge-platform/turnstile"></iframe></div>',
+                // The current Cloudflare interstitial embeds Turnstile via <div id="turnstile-wrapper" class="cf-turnstile">,
+                // so it carries a .cf-turnstile element. It must match `cloudflare` (via #cf-wrapper/#challenge-*) but NOT
+                // `turnstile` — which is why the turnstile selector excludes #turnstile-wrapper.
+                cloudflare:
+                    '<div id="cf-wrapper"><div id="challenge-running">Checking your browser before accessing the site.</div><div id="challenge-stage"><div id="turnstile-wrapper" class="cf-turnstile"><iframe src="https://challenges.cloudflare.com/cdn-cgi/challenge-platform/h/b/turnstile"></iframe></div></div></div>',
+                other: '<main><p>Please press and hold to confirm you are human.</p></main>',
+            };
+
+            const vendors = ['recaptcha', 'hcaptcha', 'turnstile', 'cloudflare', 'other'];
+
+            describe('matches its own visible fixture', () => {
+                for (const vendor of vendors) {
+                    it(`${vendor}`, () => {
+                        expect(matchInDOM(fixtures[vendor], captcha[vendor])).toBe(true);
+                    });
+                }
+            });
+
+            describe('does not match other vendors (no double counting)', () => {
+                for (const vendor of vendors) {
+                    for (const fixtureVendor of vendors) {
+                        if (vendor === fixtureVendor) continue;
+                        it(`${fixtureVendor} fixture does not match ${vendor}`, () => {
+                            expect(matchInDOM(fixtures[fixtureVendor], captcha[vendor])).toBe(false);
+                        });
+                    }
+                }
+            });
+
+            describe('does not match when absent', () => {
+                const clean = '<main><h1>Welcome</h1><p>Just an ordinary article with nothing to verify.</p></main>';
+                for (const vendor of vendors) {
+                    it(`${vendor}`, () => {
+                        expect(matchInDOM(clean, captcha[vendor])).toBe(false);
+                    });
+                }
+            });
+
+            describe('visibility gating (only visible challenges count)', () => {
+                it('hidden recaptcha (display:none) does not match', () => {
+                    expect(matchInDOM('<div class="g-recaptcha" style="display: none"></div>', captcha.recaptcha)).toBe(false);
+                });
+
+                it('zero-size hcaptcha does not match', () => {
+                    expect(matchInDOM('<div class="h-captcha"></div>', captcha.hcaptcha, { zeroSizeSelectors: ['.h-captcha'] })).toBe(false);
+                });
+
+                it('hidden turnstile widget (display:none) does not match', () => {
+                    expect(matchInDOM('<div class="cf-turnstile" style="display: none"></div>', captcha.turnstile)).toBe(false);
+                });
+            });
+
+            it('other does not fire on reCAPTCHA\'s "I\'m not a robot" label', () => {
+                expect(matchInDOM('<div class="g-recaptcha">I\'m not a robot</div>', captcha.other)).toBe(false);
+            });
+        });
     });
 });

--- a/injected/unit-test/web-detection.js
+++ b/injected/unit-test/web-detection.js
@@ -1201,6 +1201,7 @@ describe('WebDetection', () => {
         // intentionally NOT used: a loaded captcha library is not a visible challenge and
         // would inflate the per-navigation ratio.
         describe('captcha vendor detectors', () => {
+            /** @type {Record<string, import('../src/features/web-detection/parse.js').MatchCondition>} */
             const captcha = {
                 recaptcha: {
                     element: {
@@ -1224,7 +1225,14 @@ describe('WebDetection', () => {
                 },
                 cloudflare: {
                     element: {
-                        selector: ['#challenge-form', '#cf-wrapper', '.cf-browser-verification', '#challenge-running', '#cf-challenge-running', '#challenge-stage'],
+                        selector: [
+                            '#challenge-form',
+                            '#cf-wrapper',
+                            '.cf-browser-verification',
+                            '#challenge-running',
+                            '#cf-challenge-running',
+                            '#challenge-stage',
+                        ],
                         visibility: 'visible',
                     },
                 },
@@ -1291,7 +1299,9 @@ describe('WebDetection', () => {
                 });
 
                 it('zero-size hcaptcha does not match', () => {
-                    expect(matchInDOM('<div class="h-captcha"></div>', captcha.hcaptcha, { zeroSizeSelectors: ['.h-captcha'] })).toBe(false);
+                    expect(matchInDOM('<div class="h-captcha"></div>', captcha.hcaptcha, { zeroSizeSelectors: ['.h-captcha'] })).toBe(
+                        false,
+                    );
                 });
 
                 it('hidden turnstile widget (display:none) does not match', () => {


### PR DESCRIPTION
## What

Test coverage for per-provider captcha detection via the existing `webDetection` framework. The detectors themselves are config (see the paired privacy-configuration PR) — **no source change here**; this proves the element + visibility matching and the auto-run → `fireEvent` path behave correctly for captchas, and that providers don't cross-count.

- **Unit tests** (`injected/unit-test/web-detection.js`): per-vendor visible/hidden/absent matching for reCAPTCHA, hCaptcha, Cloudflare Turnstile, the Cloudflare interstitial, and a generic `other` fallback, plus a full no-cross-counting matrix.
- **Integration tests** (`injected/integration-test/web-detection.spec.js` + fixture pages): each vendor page fires exactly its own `captcha_<vendor>` webEvent and nothing else; clean and hidden pages fire nothing.

## Why the turnstile/cloudflare split matters

The current Cloudflare interstitial embeds Turnstile via `<div id="turnstile-wrapper" class="cf-turnstile">`, so a naive `.cf-turnstile` selector would match both the standalone widget and the full-page gate. The tests pin the intended behaviour: the interstitial is attributed to `cloudflare` only (the turnstile selector excludes `#turnstile-wrapper`), keeping the two surfaces separable.

## Validation

`npm run test-unit` (34 captcha specs green) and `npm run test-int` (7 captcha integration tests green, headless Chromium).

Part of the "visible captchas per million navigations" project; pairs with the privacy-configuration captcha PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to tests and static fixture pages; no production webDetection or runtime behavior is modified in this diff.
> 
> **Overview**
> Adds **test-only** coverage for per-provider captcha detection through the existing `webDetection` auto-run → `fireEvent` path. Production detector config lives in the paired privacy-configuration PR; this PR pins expected matching and event behavior.
> 
> **Unit tests** extend `web-detection.js` with a `captcha vendor detectors` suite that mirrors config selectors: each of reCAPTCHA, hCaptcha, Turnstile, Cloudflare interstitial, and generic `other` matches its fixture, fails cross-vendor double-counting, ignores clean pages, and gates on **visible** challenges (hidden/zero-size DOM does not match).
> 
> **Integration tests** add six HTML fixture pages plus `CAPTCHA_DETECTORS` and `setupCaptchaTest` in `web-detection.spec.js`. Each vendor page emits exactly one `captcha_<vendor>` `webEvent`; pages with no captcha or `display:none` reCAPTCHA emit none.
> 
> The **Turnstile vs Cloudflare** split is explicitly tested: interstitial markup uses `#turnstile-wrapper.cf-turnstile`, so Turnstile selectors exclude `#turnstile-wrapper` so the gate counts as `captcha_cloudflare` only, not `captcha_turnstile`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 985f38bb91e04be787b8725f375d23eede3393f5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->