### PR TITLE
Drop loose types in broker-protection (hand-written @typedefs)

### DIFF
--- a/injected/integration-test/mocks/broker-protection/captcha.js
+++ b/injected/integration-test/mocks/broker-protection/captcha.js
@@ -1,6 +1,6 @@
 import { createPirState, getBrokerProtectionTestPageUrl } from './utils';
 /**
- * @import { PirAction } from '../../../src/features/broker-protection/types.js'
+ * @import { GetCaptchaInfoAction, SolveCaptchaAction } from '../../../src/features/broker-protection/types.js'
  */
 
 const MOCK_SITE_KEY = '6LeCl8UUAAAAAGssOpatU5nzFXH2D7UZEYelSLTn';
@@ -9,7 +9,7 @@ const MOCK_SITE_KEY = '6LeCl8UUAAAAAGssOpatU5nzFXH2D7UZEYelSLTn';
 
 /**
  * @param {object} params
- * @param {Omit<PirAction, 'id' | 'actionType'>} params.action
+ * @param {Omit<GetCaptchaInfoAction, 'id' | 'actionType'>} params.action
  */
 export function createGetCaptchaInfoAction({ action }) {
     return createPirState({
@@ -22,7 +22,7 @@ export function createGetCaptchaInfoAction({ action }) {
 }
 
 /**
- * @param {Partial<PirAction>} [actionOverrides]
+ * @param {Partial<GetCaptchaInfoAction>} [actionOverrides]
  */
 export function createGetRecaptchaInfoAction(actionOverrides = {}) {
     return createGetCaptchaInfoAction({
@@ -35,9 +35,9 @@ export function createGetRecaptchaInfoAction(actionOverrides = {}) {
 }
 
 /**
- * @param {Partial<PirAction>} [actionOverrides]
+ * @param {Partial<GetCaptchaInfoAction> & Pick<GetCaptchaInfoAction, 'selector'>} actionOverrides
  */
-export function createGetImageCaptchaInfoAction(actionOverrides = {}) {
+export function createGetImageCaptchaInfoAction(actionOverrides) {
     return createGetCaptchaInfoAction({
         action: {
             captchaType: 'image',
@@ -47,9 +47,9 @@ export function createGetImageCaptchaInfoAction(actionOverrides = {}) {
 }
 
 /**
- * @param {Partial<PirAction>} [actionOverrides]
+ * @param {Partial<GetCaptchaInfoAction> & Pick<GetCaptchaInfoAction, 'selector'>} actionOverrides
  */
-export function createGetCloudFlareCaptchaInfoAction(actionOverrides = {}) {
+export function createGetCloudFlareCaptchaInfoAction(actionOverrides) {
     return createGetCaptchaInfoAction({
         action: {
             captchaType: 'cloudFlareTurnstile',
@@ -60,7 +60,7 @@ export function createGetCloudFlareCaptchaInfoAction(actionOverrides = {}) {
 
 /**
  * @param {object} params
- * @param {Omit<PirAction, 'id' | 'actionType'>} params.action
+ * @param {Omit<SolveCaptchaAction, 'id' | 'actionType'>} params.action
  * @param {Record<string, any>} [params.data]
  */
 export function createSolveCaptchaAction({ action, data }) {
@@ -78,7 +78,7 @@ export function createSolveCaptchaAction({ action, data }) {
 }
 
 /**
- * @param {Partial<PirAction>} [actionOverrides]
+ * @param {Partial<SolveCaptchaAction>} [actionOverrides]
  */
 export function createSolveRecaptchaAction(actionOverrides = {}) {
     return createSolveCaptchaAction({
@@ -91,9 +91,9 @@ export function createSolveRecaptchaAction(actionOverrides = {}) {
 }
 
 /**
- * @param {Partial<PirAction>} [actionOverrides]
+ * @param {Partial<SolveCaptchaAction> & Pick<SolveCaptchaAction, 'selector'>} actionOverrides
  */
-export function createSolveImageCaptchaAction(actionOverrides = {}) {
+export function createSolveImageCaptchaAction(actionOverrides) {
     return createSolveCaptchaAction({
         action: {
             captchaType: 'image',
@@ -103,9 +103,9 @@ export function createSolveImageCaptchaAction(actionOverrides = {}) {
 }
 
 /**
- * @param {Partial<PirAction>} [actionOverrides]
+ * @param {Partial<SolveCaptchaAction> & Pick<SolveCaptchaAction, 'selector'>} actionOverrides
  */
-export function createSolveCloudFlareCaptchaAction(actionOverrides = {}) {
+export function createSolveCloudFlareCaptchaAction(actionOverrides) {
     return createSolveCaptchaAction({
         action: {
             captchaType: 'cloudFlareTurnstile',

--- a/injected/src/features/broker-protection.js
+++ b/injected/src/features/broker-protection.js
@@ -3,10 +3,16 @@ import { execute } from './broker-protection/execute.js';
 import { retry } from '../timer-utils.js';
 import { ErrorResponse } from './broker-protection/types.js';
 
+/**
+ * @typedef {import('./broker-protection/types.js').PirAction} PirAction
+ * @typedef {import('./broker-protection/types.js').ActionData} ActionData
+ * @typedef {import('./broker-protection/types.js').ActionResponse} ActionResponse
+ */
+
 export class ActionExecutorBase extends ContentFeature {
     /**
-     * @param {any} action
-     * @param {Record<string, any>} data
+     * @param {PirAction} action
+     * @param {ActionData} data
      */
     async processActionAndNotify(action, data) {
         try {
@@ -48,8 +54,8 @@ export class ActionExecutorBase extends ContentFeature {
     /**
      * Recursively execute actions with the same dataset, collecting all results/exceptions for
      * later analysis
-     * @param {any} action
-     * @param {Record<string, any>} data
+     * @param {PirAction} action
+     * @param {ActionData} data
      * @return {Promise<{results: ActionResponse[], exceptions: string[]}>}
      */
     async exec(action, data) {
@@ -75,6 +81,7 @@ export class ActionExecutorBase extends ContentFeature {
     }
 
     /**
+     * @param {PirAction} action
      * @returns {any}
      */
     retryConfigFor(action) {
@@ -82,12 +89,9 @@ export class ActionExecutorBase extends ContentFeature {
     }
 }
 
-/**
- * @typedef {import("./broker-protection/types.js").ActionResponse} ActionResponse
- */
 export default class BrokerProtection extends ActionExecutorBase {
     init() {
-        this.messaging.subscribe('onActionReceived', async (/** @type {any} */ params) => {
+        this.messaging.subscribe('onActionReceived', async (/** @type {{ state: { action: PirAction, data: ActionData } }} */ params) => {
             const { action, data } = params.state;
             return await this.processActionAndNotify(action, data);
         });
@@ -96,7 +100,7 @@ export default class BrokerProtection extends ActionExecutorBase {
     /**
      * Define default retry configurations for certain actions
      *
-     * @param {any} action
+     * @param {PirAction} action
      * @returns
      */
     retryConfigFor(action) {

--- a/injected/src/features/broker-protection/actions/captcha-deprecated.js
+++ b/injected/src/features/broker-protection/actions/captcha-deprecated.js
@@ -3,11 +3,17 @@ import { getElement } from '../utils/utils.js';
 import { ErrorResponse, SuccessResponse } from '../types.js';
 
 /**
+ * @typedef {import('../types.js').GetCaptchaInfoAction} GetCaptchaInfoAction
+ * @typedef {import('../types.js').SolveCaptchaAction} SolveCaptchaAction
+ * @typedef {import('../types.js').ActionResponse} ActionResponse
+ */
+
+/**
  * Gets the captcha information to send to the backend
  *
- * @param {import('../types.js').PirAction} action
+ * @param {GetCaptchaInfoAction} action
  * @param {Document | HTMLElement} root
- * @return {import('../types.js').ActionResponse}
+ * @return {ActionResponse}
  */
 export function getCaptchaInfo(action, root = document) {
     const pageUrl = window.location.href;
@@ -87,10 +93,10 @@ export function getCaptchaInfo(action, root = document) {
 /**
  * Takes the solved captcha token and injects it into the page to solve the captcha
  *
- * @param action
+ * @param {SolveCaptchaAction} action
  * @param {string} token
  * @param {Document} root
- * @return {import('../types.js').ActionResponse}
+ * @return {ActionResponse}
  */
 export function solveCaptcha(action, token, root = document) {
     const selectors = ['h-captcha-response', 'g-recaptcha-response'];

--- a/injected/src/features/broker-protection/actions/click.js
+++ b/injected/src/features/broker-protection/actions/click.js
@@ -4,13 +4,20 @@ import { extractProfiles } from './extract.js';
 import { processTemplateStringWithUserData } from './build-url-transforms.js';
 
 /**
- * @param {Record<string, any>} action
+ * @typedef {import('../types.js').ClickAction} ClickAction
+ * @typedef {import('../types.js').ClickElement} ClickElement
+ * @typedef {import('../types.js').Choice} Choice
+ * @typedef {import('../types.js').ActionResponse} ActionResponse
+ */
+
+/**
+ * @param {ClickAction} action
  * @param {Record<string, any>} userData
  * @param {Document | HTMLElement} root
- * @return {import('../types.js').ActionResponse}
+ * @return {ActionResponse}
  */
 export function click(action, userData, root = document) {
-    /** @type {Array<any> | null} */
+    /** @type {ClickElement[] | undefined} */
     let elements = [];
 
     if (action.choices?.length) {
@@ -81,7 +88,7 @@ export function click(action, userData, root = document) {
 }
 
 /**
- * @param {{parent?: {profileMatch?: Record<string, any>}}} clickElement
+ * @param {ClickElement} clickElement
  * @param {Record<string, any>} userData
  * @param {Document | HTMLElement} root
  * @return {Node}
@@ -135,13 +142,17 @@ export function getComparisonFunction(operator) {
 /**
  * Evaluates the defined choices (and/or the default) and returns an array of the elements to be clicked
  *
- * @param {Record<string, any>} action
+ * @param {ClickAction} action
  * @param {Record<string, any>} userData
- * @returns {{ elements: [Record<string, any>] } | { error: String } | null}
+ * @returns {{ elements: ClickElement[] } | { error: string } | null}
  */
 function evaluateChoices(action, userData) {
     if ('elements' in action) {
         return { error: 'Elements should be nested inside of choices' };
+    }
+
+    if (!action.choices?.length) {
+        throw new Error('evaluateChoices requires a non-empty `choices` array');
     }
 
     for (const choice of action.choices) {
@@ -159,7 +170,7 @@ function evaluateChoices(action, userData) {
     }
 
     // If there's no default defined, return an error.
-    if (!('default' in action)) {
+    if (action.default === undefined) {
         return { error: 'All conditions failed and no default action was provided' };
     }
 
@@ -180,10 +191,10 @@ function evaluateChoices(action, userData) {
 /**
  * Attempts to turn a choice definition into an executable comparison and returns the result
  *
- * @param {Record<string, any>} choice
- * @param {Record<string, any>} action
+ * @param {Choice} choice
+ * @param {ClickAction} action
  * @param {Record<string, any>} userData
- * @returns {{ result: Boolean } | { error: String }}
+ * @returns {{ result: boolean } | { error: string }}
  */
 function runComparison(choice, action, userData) {
     let compare;

--- a/injected/src/features/broker-protection/actions/condition.js
+++ b/injected/src/features/broker-protection/actions/condition.js
@@ -2,9 +2,14 @@ import { ErrorResponse, SuccessResponse } from '../types.js';
 import { expectMany } from '../utils/expectations.js';
 
 /**
- * @param {Record<string, any>} action
+ * @typedef {import('../types.js').ConditionAction} ConditionAction
+ * @typedef {import('../types.js').ActionResponse} ActionResponse
+ */
+
+/**
+ * @param {ConditionAction} action
  * @param {Document} root
- * @return {import('../types.js').ActionResponse}
+ * @return {ActionResponse}
  */
 export function condition(action, root = document) {
     const results = expectMany(action.expectations, root);

--- a/injected/src/features/broker-protection/actions/expectation.js
+++ b/injected/src/features/broker-protection/actions/expectation.js
@@ -2,9 +2,14 @@ import { ErrorResponse, SuccessResponse } from '../types.js';
 import { expectMany } from '../utils/expectations.js';
 
 /**
- * @param {Record<string, any>} action
+ * @typedef {import('../types.js').ExpectationAction} ExpectationAction
+ * @typedef {import('../types.js').ActionResponse} ActionResponse
+ */
+
+/**
+ * @param {ExpectationAction} action
  * @param {Document} root
- * @return {import('../types.js').ActionResponse}
+ * @return {ActionResponse}
  */
 export function expectation(action, root = document) {
     const results = expectMany(action.expectations, root);

--- a/injected/src/features/broker-protection/actions/extract.js
+++ b/injected/src/features/broker-protection/actions/extract.js
@@ -11,8 +11,16 @@ import { extractRelatives } from '../extractors/relatives.js';
 import { extractProfileUrl, ProfileHashTransformer } from '../extractors/profile-url.js';
 
 /**
- * Adding these types here so that we can switch to generated ones later
- * @typedef {Record<string, any>} Action
+ * @typedef {import('../types.js').ExtractAction} ExtractAction
+ * @typedef {import('../types.js').UserProfile} UserProfile
+ * @typedef {import('../types.js').ActionResponse} ActionResponse
+ * @typedef {import('../types.js').AsyncProfileTransform} AsyncProfileTransform
+ */
+
+/**
+ * The subset of an `extract` action that `extractProfiles` reads; satisfied both by a full
+ * {@link ExtractAction} and by a click action's `parent.profileMatch`.
+ * @typedef {{ selector: string, profile: ProfileSpec, noResultsSelector?: string }} ExtractSpec
  */
 
 /**
@@ -102,10 +110,10 @@ import { extractProfileUrl, ProfileHashTransformer } from '../extractors/profile
  */
 
 /**
- * @param {Action} action
- * @param {Record<string, any>} userData
+ * @param {ExtractAction} action
+ * @param {UserProfile} userData
  * @param {Document | HTMLElement} root
- * @return {Promise<import('../types.js').ActionResponse>}
+ * @return {Promise<ActionResponse>}
  */
 export async function extract(action, userData, root = document) {
     const extractResult = extractProfiles(action, userData, root);
@@ -155,8 +163,8 @@ function select(root, selector, all = false) {
 }
 
 /**
- * @param {Action} action
- * @param {Record<string, any>} userData
+ * @param {ExtractSpec} action
+ * @param {UserProfile} userData
  * @param {Element | Document} [root]
  * @return {{error: string} | {results: ProfileResult[]}}
  */
@@ -418,7 +426,7 @@ export function aggregateFields(profile) {
  * @return {Promise<Record<string, any>>}
  */
 async function applyPostTransforms(profile, profileSpec) {
-    /** @type {import("../types.js").AsyncProfileTransform[]} */
+    /** @type {AsyncProfileTransform[]} */
     const transforms = [
         // creates a hash if needed
         new ProfileHashTransformer(),

--- a/injected/src/features/broker-protection/actions/fill-form.js
+++ b/injected/src/features/broker-protection/actions/fill-form.js
@@ -4,10 +4,16 @@ import { generatePhoneNumber, generateZipCode, generateStreetAddress } from './g
 import { states } from '../comparisons/constants.js';
 
 /**
- * @param {Record<string, any>} action
+ * @typedef {import('../types.js').FillFormAction} FillFormAction
+ * @typedef {import('../types.js').FormElement} FormElement
+ * @typedef {import('../types.js').ActionResponse} ActionResponse
+ */
+
+/**
+ * @param {FillFormAction} action
  * @param {Record<string, any>} userData
  * @param {Document | HTMLElement} root
- * @return {import('../types.js').ActionResponse}
+ * @return {ActionResponse}
  */
 export function fillForm(action, userData, root = document) {
     const form = getElement(root, action.selector);
@@ -36,7 +42,7 @@ export function fillForm(action, userData, root = document) {
 /**
  * Try to fill form elements. Collecting results + warnings for reporting.
  * @param {HTMLElement} root
- * @param {{selector: string; type: string; min?: string; max?: string;}[]} elements
+ * @param {FormElement[]} elements
  * @param {Record<string, any>} data
  * @return {({result: true} | {result: false; error: string})[]}
  */

--- a/injected/src/features/broker-protection/actions/navigate.js
+++ b/injected/src/features/broker-protection/actions/navigate.js
@@ -3,12 +3,17 @@ import { ErrorResponse, SuccessResponse } from '../types';
 import { buildUrl } from './build-url';
 
 /**
+ * @typedef {import('../types.js').NavigateAction} NavigateAction
+ * @typedef {import('../types.js').ActionResponse} ActionResponse
+ */
+
+/**
  * This builds the proper URL given the URL template and userData.
  * Also, if the action requires a captcha handler, it will inject the necessary code.
  *
- * @param {import('../types.js').PirAction} action
+ * @param {NavigateAction} action
  * @param {Record<string, any>} userData
- * @return {import('../types.js').ActionResponse}
+ * @return {ActionResponse}
  */
 export function navigate(action, userData) {
     const { id: actionID, actionType } = action;

--- a/injected/src/features/broker-protection/actions/scroll.js
+++ b/injected/src/features/broker-protection/actions/scroll.js
@@ -2,9 +2,14 @@ import { ErrorResponse, SuccessResponse } from '../types';
 import { getElement } from '../utils/utils';
 
 /**
- * @param {Record<string, any>} action
+ * @typedef {import('../types.js').ScrollAction} ScrollAction
+ * @typedef {import('../types.js').ActionResponse} ActionResponse
+ */
+
+/**
+ * @param {ScrollAction} action
  * @param {Document} root
- * @return {import('../types.js').ActionResponse}
+ * @return {ActionResponse}
  */
 // eslint-disable-next-line no-redeclare
 export function scroll(action, root = document) {

--- a/injected/src/features/broker-protection/captcha-services/captcha.service.js
+++ b/injected/src/features/broker-protection/captcha-services/captcha.service.js
@@ -6,10 +6,17 @@ import { captchaFactory } from './providers/registry.js';
 import { getCaptchaInfo as getCaptchaInfoDeprecated, solveCaptcha as solveCaptchaDeprecated } from '../actions/captcha-deprecated';
 
 /**
+ * @typedef {import('../types.js').NavigateAction} NavigateAction
+ * @typedef {import('../types.js').GetCaptchaInfoAction} GetCaptchaInfoAction
+ * @typedef {import('../types.js').SolveCaptchaAction} SolveCaptchaAction
+ * @typedef {import('../types.js').ActionResponse} ActionResponse
+ */
+
+/**
  *
  * @param {Document | HTMLElement} root
- * @param {import('../types.js').PirAction['selector']} [selector]
- * @returns {HTMLElement | import('../types.js').PirError}
+ * @param {string} [selector]
+ * @returns {HTMLElement | PirError}
  */
 const getCaptchaContainer = (root, selector) => {
     if (!selector) {
@@ -27,8 +34,8 @@ const getCaptchaContainer = (root, selector) => {
 /**
  * Returns the supporting code to inject for the given captcha type
  *
- * @param {import('../types.js').PirAction} action
- * @return {import('../types.js').ActionResponse}
+ * @param {NavigateAction} action
+ * @return {ActionResponse}
  */
 export function getSupportingCodeToInject(action) {
     const { id: actionID, actionType, injectCaptchaHandler: captchaType } = action;
@@ -49,9 +56,9 @@ export function getSupportingCodeToInject(action) {
 /**
  * Gets the captcha information to send to the backend
  *
- * @param {import('../types.js').PirAction} action
+ * @param {GetCaptchaInfoAction} action
  * @param {Document | HTMLElement} root
- * @return {Promise<import('../types.js').ActionResponse>}
+ * @return {Promise<ActionResponse>}
  */
 export async function getCaptchaInfo(action, root = document) {
     const { id: actionID, actionType, captchaType, selector } = action;
@@ -93,10 +100,10 @@ export async function getCaptchaInfo(action, root = document) {
 /**
  * Takes the solved captcha token and injects it into the page to solve the captcha
  *
- * @param {import('../types.js').PirAction} action
+ * @param {SolveCaptchaAction} action
  * @param {string} token
  * @param {Document} root
- * @return {import('../types.js').ActionResponse}
+ * @return {ActionResponse}
  */
 export function solveCaptcha(action, token, root = document) {
     const { id: actionID, actionType, captchaType, selector } = action;

--- a/injected/src/features/broker-protection/captcha-services/get-captcha-container.js
+++ b/injected/src/features/broker-protection/captcha-services/get-captcha-container.js
@@ -4,7 +4,7 @@ import { PirError } from '../types';
 /**
  *
  * @param {Document | HTMLElement} root
- * @param {import('../types.js').PirAction['selector']} [selector]
+ * @param {string} [selector]
  * @returns {HTMLElement | PirError}
  */
 export function getCaptchaContainer(root, selector) {

--- a/injected/src/features/broker-protection/execute.js
+++ b/injected/src/features/broker-protection/execute.js
@@ -3,36 +3,56 @@ import { navigate, extract, click, scroll, expectation, fillForm, getCaptchaInfo
 import { ErrorResponse } from './types';
 
 /**
- * @param {import('./types.js').PirAction} action
- * @param {Record<string, any>} inputData
+ * @typedef {import('./types.js').PirAction} PirAction
+ * @typedef {import('./types.js').ActionResponse} ActionResponse
+ * @typedef {import('./types.js').ActionData} ActionData
+ * @typedef {import('./types.js').UserProfile} UserProfile
+ * @typedef {import('./types.js').ExtractedProfile} ExtractedProfile
+ */
+
+/**
+ * @param {PirAction} action
+ * @param {ActionData} inputData
  * @param {Document} [root] - optional root element
- * @return {Promise<import('./types.js').ActionResponse>}
+ * @return {Promise<ActionResponse>}
  */
 export async function execute(action, inputData, root = document) {
     try {
         switch (action.actionType) {
-            case 'navigate':
-                return navigate(action, data(action, inputData, 'userProfile'));
-            case 'extract':
-                return await extract(action, data(action, inputData, 'userProfile'), root);
-            case 'click':
-                return click(action, data(action, inputData, 'userProfile'), root);
+            case 'navigate': {
+                const userProfile = /** @type {UserProfile} */ (data(action, inputData, 'userProfile'));
+                return navigate(action, userProfile);
+            }
+            case 'extract': {
+                const userProfile = /** @type {UserProfile} */ (data(action, inputData, 'userProfile'));
+                return await extract(action, userProfile, root);
+            }
+            case 'click': {
+                const userProfile = /** @type {UserProfile} */ (data(action, inputData, 'userProfile'));
+                return click(action, userProfile, root);
+            }
             case 'expectation':
                 return expectation(action, root);
-            case 'fillForm':
-                return fillForm(action, data(action, inputData, 'extractedProfile'), root);
+            case 'fillForm': {
+                const extractedProfile = /** @type {ExtractedProfile} */ (data(action, inputData, 'extractedProfile'));
+                return fillForm(action, extractedProfile, root);
+            }
             case 'getCaptchaInfo':
                 return await getCaptchaInfo(action, root);
-            case 'solveCaptcha':
-                return solveCaptcha(action, data(action, inputData, 'token'), root);
+            case 'solveCaptcha': {
+                const token = /** @type {string} */ (data(action, inputData, 'token'));
+                return solveCaptcha(action, token, root);
+            }
             case 'condition':
                 return condition(action, root);
             case 'scroll':
                 return scroll(action, root);
             default: {
+                // exhaustive switch ⇒ `action` is `never` here; cast to report an unimplemented actionType
+                const unknownAction = /** @type {{ id: string; actionType: string }} */ (action);
                 return new ErrorResponse({
-                    actionID: action.id,
-                    message: `unimplemented actionType: ${action.actionType}`,
+                    actionID: unknownAction.id,
+                    message: `unimplemented actionType: ${unknownAction.actionType}`,
                 });
             }
         }
@@ -47,8 +67,9 @@ export async function execute(action, inputData, root = document) {
 
 /**
  * @param {{dataSource?: string}} action
- * @param {Record<string, any>} data
+ * @param {ActionData} data
  * @param {string} defaultSource
+ * @return {ActionData[keyof ActionData]} the selected bundle value, looked up by the dynamic `dataSource` key (or null when absent). `valueof ActionData` is `unknown` because the bundle allows extra keys, so each call site asserts the concrete bundle it expects.
  */
 function data(action, data, defaultSource) {
     if (!data) return null;

--- a/injected/src/features/broker-protection/extractors/profile-url.js
+++ b/injected/src/features/broker-protection/extractors/profile-url.js
@@ -109,12 +109,12 @@ function getIdFromProfileUrl(url, identifierType, identifier) {
  */
 export class ProfileHashTransformer {
     /**
-     * @param {Record<string, any>} profile
-     * @param {Record<string, any> } params
+     * @param {Record<string, any>} profile - the extracted/aggregated profile data to transform
+     * @param {import('../actions/extract.js').ProfileSpec} profileSpec - the action's `profile` block
      * @return {Promise<Record<string, any>>}
      */
-    async transform(profile, params) {
-        if (params?.profileUrl?.identifierType !== 'hash') {
+    async transform(profile, profileSpec) {
+        if (profileSpec?.profileUrl?.identifierType !== 'hash') {
             return profile;
         }
 

--- a/injected/src/features/broker-protection/types.js
+++ b/injected/src/features/broker-protection/types.js
@@ -1,18 +1,191 @@
 /**
+ * Hand-written types for the native↔web broker-protection (PIR) contract. These replace the loose
+ * `any` / `Record<string, any>` typedefs that used to be scattered across the feature. They are
+ * intended as a stepping stone: when the JSON-schema-generated types land, these `@typedef`s can be
+ * swapped for re-exports of the generated module without touching the call sites.
+ *
+ * The per-field extraction specs (`ProfileSpec`, `TextFieldSpec`, …) continue to live in
+ * `./actions/extract.js`; this module imports `ProfileSpec` for the action shapes that embed it.
+ *
+ * @typedef {import('./actions/extract.js').ProfileSpec} ProfileSpec
+ */
+
+/**
  * @typedef {SuccessResponse | ErrorResponse} ActionResponse
  * @typedef {{ result: true } | { result: false; error: string }} BooleanResult
  * @typedef {{type: "element" | "text" | "url"; selector: string; parent?: string; expect?: string; failSilently?: boolean}} Expectation
  */
 
 /**
- * @typedef {object} PirAction
+ * A single instruction for the broker-protection executor to run on the page, discriminated on `actionType`.
+ * @typedef {ExtractAction | NavigateAction | ClickAction | FillFormAction | ExpectationAction | ConditionAction | ScrollAction | GetCaptchaInfoAction | SolveCaptchaAction} PirAction
+ */
+
+/**
+ * Optional per-action retry policy honoured by the web executor. Retries run web-side only when
+ * `environment` is "web"; when present, both `interval` and `maxAttempts` are required (the executor
+ * uses `interval.ms` as the inter-attempt delay and `maxAttempts` as the loop bound, with no defaults).
+ * @typedef {object} RetryConfig
+ * @property {"web"} [environment] - "web" is the only supported value and enables web-side retry for this action
+ * @property {{ ms: number }} interval - delay between attempts, in milliseconds
+ * @property {number} maxAttempts - maximum number of attempts before giving up
+ */
+
+/**
+ * Scrape candidate profiles from the page and match them against the user's data.
+ * @typedef {object} ExtractAction
  * @property {string} id
- * @property {"extract" | "fillForm" | "click" | "expectation" | "getCaptchaInfo" | "solveCaptcha" | "navigate" | "condition" | "scroll"} actionType
- * @property {string} [selector]
- * @property {string} [captchaType]
- * @property {string} [injectCaptchaHandler]
+ * @property {"extract"} actionType
+ * @property {string} selector - selector matching each result row / profile element
+ * @property {string} [noResultsSelector] - when set, its presence is treated as a successful empty extract
+ * @property {ProfileSpec} profile
  * @property {string} [dataSource]
- * @property {string} [url]
+ * @property {RetryConfig} [retry]
+ */
+
+/**
+ * Build a URL from a template + the user's data and report it back for native to navigate to.
+ * @typedef {object} NavigateAction
+ * @property {string} id
+ * @property {"navigate"} actionType
+ * @property {string} url - URL template; ${field} and ${field|transform} tokens are filled from the user profile
+ * @property {string[]} [ageRange] - age buckets like "18-30" used by the ageRange URL transform
+ * @property {string} [injectCaptchaHandler] - captcha type whose supporting code should be injected before navigation
+ * @property {string} [dataSource]
+ * @property {RetryConfig} [retry]
+ */
+
+/**
+ * A single element to click. When `parent.profileMatch` is present, the click is scoped to the
+ * best-matching profile element rather than the document.
+ * @typedef {object} ClickElement
+ * @property {string} [type] - informational element type, e.g. "button"
+ * @property {string} selector - selector for the element to click
+ * @property {boolean} [multiple] - click every match rather than just the first
+ * @property {boolean} [failSilently] - treat a missing/disabled element as a non-error skip
+ * @property {{ profileMatch: { selector: string, profile: ProfileSpec } }} [parent] - scope the click to a matched profile element
+ */
+
+/**
+ * A conditional branch of a `click` action: when `condition` evaluates true, `elements` are clicked.
+ * @typedef {object} Choice
+ * @property {{ operation: string, left: string, right: string }} condition
+ * @property {ClickElement[]} elements
+ */
+
+/**
+ * Click one or more elements. Either provide `elements` directly, or `choices` (with an optional
+ * `default`) to pick elements conditionally.
+ * @typedef {object} ClickAction
+ * @property {string} id
+ * @property {"click"} actionType
+ * @property {ClickElement[]} [elements] - elements to click; mutually exclusive with `choices`
+ * @property {Choice[]} [choices] - conditional branches; the first matching choice's elements are clicked
+ * @property {{ elements: ClickElement[] } | null} [default] - fallback used when no choice matches; `null` means skip without error
+ * @property {string} [dataSource]
+ * @property {RetryConfig} [retry]
+ */
+
+/**
+ * A single field to fill within a form. `type` is either a key to read from the data, or a special
+ * generator/composite token.
+ * @typedef {object} FormElement
+ * @property {string} selector - selector for the input/select element
+ * @property {string} type - a data key to fill, or a special token ($generated_phone_number$, cityState, …)
+ * @property {string} [min] - lower bound for $generated_random_number$
+ * @property {string} [max] - upper bound for $generated_random_number$
+ */
+
+/**
+ * Fill a form's fields from the extracted profile data (or generated values).
+ * @typedef {object} FillFormAction
+ * @property {string} id
+ * @property {"fillForm"} actionType
+ * @property {string} selector - selector for the form element
+ * @property {FormElement[]} elements
+ * @property {string} [dataSource]
+ * @property {RetryConfig} [retry]
+ */
+
+/**
+ * Assert a set of expectations about the page. When they all pass, optionally run further `actions`.
+ * @typedef {object} ExpectationAction
+ * @property {string} id
+ * @property {"expectation"} actionType
+ * @property {Expectation[]} expectations
+ * @property {PirAction[]} [actions] - actions to run next when all expectations pass
+ * @property {string} [dataSource]
+ * @property {RetryConfig} [retry]
+ */
+
+/**
+ * Evaluate a set of expectations and report back the `actions` to run when they pass (the caller
+ * decides whether to execute them).
+ * @typedef {object} ConditionAction
+ * @property {string} id
+ * @property {"condition"} actionType
+ * @property {Expectation[]} expectations
+ * @property {PirAction[]} actions - actions returned for execution when all expectations pass
+ * @property {string} [dataSource]
+ * @property {RetryConfig} [retry]
+ */
+
+/**
+ * Scroll a matching element into view.
+ * @typedef {object} ScrollAction
+ * @property {string} id
+ * @property {"scroll"} actionType
+ * @property {string} selector - selector for the element to scroll into view
+ * @property {RetryConfig} [retry]
+ */
+
+/**
+ * Locate a captcha on the page and return the information native needs to solve it (url, site key, type).
+ * @typedef {object} GetCaptchaInfoAction
+ * @property {string} id
+ * @property {"getCaptchaInfo"} actionType
+ * @property {string} selector - selector for the captcha container
+ * @property {string} [captchaType] - selects the captcha handler ("image", "cloudFlareTurnstile"); when omitted the deprecated handler self-detects
+ * @property {string} [dataSource]
+ * @property {RetryConfig} [retry]
+ */
+
+/**
+ * Inject a solved captcha token into the page.
+ * @typedef {object} SolveCaptchaAction
+ * @property {string} id
+ * @property {"solveCaptcha"} actionType
+ * @property {string} selector - selector for the captcha container
+ * @property {string} [captchaType] - selects the captcha handler ("image", "cloudFlareTurnstile"); when omitted the deprecated handler self-detects
+ * @property {string} [dataSource]
+ * @property {RetryConfig} [retry]
+ */
+
+/**
+ * A single address belonging to the user profile. Extra broker-specific keys are allowed.
+ * @typedef {{ addressLine1?: string, addressLine2?: string, city?: string, state?: string, zip?: string, [key: string]: unknown }} Address
+ */
+
+/**
+ * The person whose records we're searching for. Used to build search URLs and to match scraped
+ * profiles. Brokers may reference additional flat keys (e.g. city, state) in URL templates, so extra
+ * properties are allowed.
+ * @typedef {{ id?: string, firstName?: string, middleName?: string, lastName?: string, fullName?: string, suffix?: string, age?: string | number, birthYear?: string | number, phone?: string, city?: string, state?: string, street?: string, zip?: string, addresses?: Address[], [key: string]: unknown }} UserProfile
+ */
+
+/**
+ * The profile data a `fillForm` action draws from, keyed by the field names a FormElement `type`
+ * references (e.g. firstName, lastName, city, state, email). The exact shape is caller-defined, so
+ * extra properties are allowed.
+ * @typedef {{ firstName?: string, middleName?: string, lastName?: string, city?: string, state?: string, phone?: string, email?: string, age?: string | number, birthYear?: string | number, profileUrl?: string, [key: string]: unknown }} ExtractedProfile
+ */
+
+/**
+ * The data bundle that accompanies an action. Which key an action reads is chosen by its
+ * `dataSource`; when an action omits `dataSource` the executor applies a fallback default
+ * (extract/navigate/click -> userProfile, fillForm -> extractedProfile, solveCaptcha -> token).
+ * `fetchedEmail`/`emailData` are also supported, for email-confirmation flows.
+ * @typedef {{ userProfile?: UserProfile, extractedProfile?: ExtractedProfile, token?: string, fetchedEmail?: { email?: string, [key: string]: unknown }, emailData?: { [key: string]: string }, [key: string]: unknown }} ActionData
  */
 
 /**
@@ -135,8 +308,8 @@ export class ErrorResponse {
  * @property {PirAction['id']} actionID
  * @property {PirAction['actionType']} actionType
  * @property {any} response
- * @property {import("./actions/extract").Action[]} [next]
- * @property {Record<string, any>} [meta] - optional meta data
+ * @property {PirAction[]} [next] - follow-up actions the executor runs locally after this one
+ * @property {Record<string, any>} [meta] - optional action-specific metadata attached to the result
  */
 
 /**


### PR DESCRIPTION
> [!WARNING]
> **AI-generated, not yet reviewed by a human.** This PR was produced by Claude Code and the author has not reviewed the changes yet. Treat with appropriate scepticism.

**Asana Task/Github Issue:** N/A

## Description

The loose-type-removal slice of #2789, **without** the JSON Schema pipeline.

Replaces the `any` / `Record<string, any>` action typedefs scattered through broker-protection with precise, discriminated `@typedef`s for each PIR action and the data bundles they read. The new types are hand-written in `broker-protection/types.js` (`PirAction` union, per-action shapes, `ClickElement`/`Choice`/`FormElement`, `RetryConfig`, `ActionData`, `UserProfile`, `ExtractedProfile`, `Address`); the per-field extraction specs (`ProfileSpec`, `TextFieldSpec`, …) stay where they are in `actions/extract.js`. Call sites import the typedefs from `types.js` rather than any generated module, so this stands alone — when the schema-generated types land later, the typedefs can be swapped for re-exports of the generated module without touching call sites.

**Deliberately excluded** (the "JSON schema stuff" from #2789): the `.json` schema files, the generated `broker-protection.ts`, the `check-strict-core.js` entry, and the typed `notify`/`subscribe` messaging refactor (coupled to the generated module's `declare module` augmentation — so `this.messaging.*` and `export default class` are kept as on `main`).

**Included** the type-soundness changes the precise types require:
- `click` `evaluateChoices` throws on an empty `choices` array and uses `default === undefined` instead of `'default' in action`
- `execute` narrows each `ActionData` bundle per action with explicit casts and casts the exhaustive-switch `default` case

## Testing Steps

- `cd injected && npx tsc` – no new broker-protection errors (only the pre-existing baseline noise).
- `cd injected && npm run test-unit` – broker-protection specs green (124).
- `npm run lint` – eslint + prettier clean on the changed files.

## Checklist

*Please tick all that apply:*

- [x] I have tested this change locally
- [ ] I have tested this change locally in all supported browsers
- [ ] This change will be visible to users
- [ ] I have added automated tests that cover this change
- [ ] I have ensured the change is gated by config
- [ ] This change was covered by a ship review
- [ ] This change was covered by a tech design
- [ ] Any dependent config has been merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)