### PR TITLE
fix(broker-protection): support filling textarea form fields

### DIFF
--- a/injected/integration-test/broker-protection-tests/broker-protection.spec.js
+++ b/injected/integration-test/broker-protection-tests/broker-protection.spec.js
@@ -486,6 +486,16 @@ test.describe('Broker Protection communications', () => {
             await dbp.doesInputValueEqual('#birthYearNoValue', '1992');
         });
 
+        test('fillForm with a textarea', async ({ page }, workerInfo) => {
+            const dbp = BrokerProtectionPage.create(page, workerInfo.project.use);
+            await dbp.enabled();
+            await dbp.navigatesTo('form.html');
+            await dbp.receivesAction('fill-form-textarea.json');
+            const response = await dbp.collector.waitForMessage('actionCompleted');
+            dbp.isSuccessMessage(response);
+            await dbp.doesInputValueEqual('#profile_url', 'https://www.veripages.com/profile/John-Smith-12345');
+        });
+
         test('fillForm with optional information', async ({ page }, workerInfo) => {
             const dbp = BrokerProtectionPage.create(page, workerInfo.project.use);
             await dbp.enabled();

--- a/injected/integration-test/test-pages/broker-protection/actions/fill-form-textarea.json
+++ b/injected/integration-test/test-pages/broker-protection/actions/fill-form-textarea.json
@@ -1,0 +1,25 @@
+{
+    "state": {
+        "action": {
+            "actionType": "fillForm",
+            "id": "3",
+            "selector": ".ahm",
+            "dataSource": "userProfile",
+            "elements": [
+                {
+                    "type": "profileUrl",
+                    "selector": "#profile_url"
+                }
+            ]
+        },
+        "data": {
+            "userProfile": {
+                "firstName": "John",
+                "lastName": "Smith",
+                "city": "Chicago",
+                "state": "IL",
+                "profileUrl": "https://www.veripages.com/profile/John-Smith-12345"
+            }
+        }
+    }
+}

--- a/injected/integration-test/test-pages/broker-protection/pages/form.html
+++ b/injected/integration-test/test-pages/broker-protection/pages/form.html
@@ -70,6 +70,10 @@
         <input type="text" name="city_state" id="city_state">
     </label>
     <label>
+        Profile URL:
+        <textarea name="profile_url" id="profile_url"></textarea>
+    </label>
+    <label>
         Age:
         <select name="age" id="age">
             <option value="30">30</option>

--- a/injected/src/features/broker-protection/actions/fill-form.js
+++ b/injected/src/features/broker-protection/actions/fill-form.js
@@ -165,6 +165,7 @@ function setValueForInput(el, val) {
     let target;
     if (el.tagName === 'INPUT') target = window.HTMLInputElement;
     if (el.tagName === 'SELECT') target = window.HTMLSelectElement;
+    if (el.tagName === 'TEXTAREA') target = window.HTMLTextAreaElement;
 
     // Bail early if we cannot fill this element
     if (!target) {
@@ -180,7 +181,7 @@ function setValueForInput(el, val) {
 
     try {
         // separate strategies for inputs vs selects
-        if (el.tagName === 'INPUT') {
+        if (el.tagName === 'INPUT' || el.tagName === 'TEXTAREA') {
             // set the input value
             el.dispatchEvent(new Event('keydown', { bubbles: true }));
             originalSet.call(el, val);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**Asana Task/Github Issue:** N/A

## Description

The broker-protection (PIR) form-filling helper `setValueForInput` in `injected/src/features/broker-protection/actions/fill-form.js` only supported `<input>` (`HTMLInputElement`) and `<select>` (`HTMLSelectElement`) elements. When the target element was a `<textarea>`, the `target` variable stayed `undefined` and the function returned an error: `input type was not supported: TEXTAREA`.

This surfaced with a Veripages opt-out form, which uses a `<textarea>` for a field (e.g. the profile URL), so those fields could not be filled.

### Fix
- In `setValueForInput`, also set `target = window.HTMLTextAreaElement` when `el.tagName === 'TEXTAREA'`.
- Treat `TEXTAREA` the same as `INPUT` in the value-setting strategy block (`if (el.tagName === 'INPUT' || el.tagName === 'TEXTAREA')`): dispatch `keydown`, call the original value setter, dispatch `input`/`keyup`/`change`, set again, dispatch again, then blur. The `SELECT` branch is unchanged.

The change is minimal and focused; no unrelated refactoring.

## Testing Steps

- Added a `<textarea id="profile_url">` to the broker-protection `form.html` test page.
- Added `fill-form-textarea.json` action that fills the textarea via a `profileUrl` field.
- Added a `fillForm with a textarea` integration test asserting the textarea value is set.
- `npm run lint` (ESLint + tsc + Prettier) passes.
- `npm run build` passes.
- Broker-protection integration tests pass on all platforms, including the new textarea case:
  `npx playwright test broker-protection-tests/broker-protection.spec.js -g "fillForm"`

## Checklist

*Please tick all that apply:*

- [ ] I have tested this change locally
- [ ] I have tested this change locally in all supported browsers
- [ ] This change will be visible to users
- [x] I have added automated tests that cover this change
- [ ] I have ensured the change is gated by config
- [ ] This change was covered by a ship review
- [ ] This change was covered by a tech design
- [ ] Any dependent config has been merged

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c80c9f04-a812-4411-85f9-0e31018fab74"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c80c9f04-a812-4411-85f9-0e31018fab74"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

