### PR TITLE
Add aliases for captcha providers

### DIFF
--- a/injected/integration-test/broker-protection-tests/broker-protection-captcha.spec.js
+++ b/injected/integration-test/broker-protection-tests/broker-protection-captcha.spec.js
@@ -1,4 +1,4 @@
-import { test as base } from '@playwright/test';
+import { test as base, expect } from '@playwright/test';
 import { createConfiguredDbpTest } from './fixtures';
 import {
     createGetRecaptchaInfoAction,
@@ -126,6 +126,22 @@ test.describe('Broker Protection Captcha', () => {
                 await dbp.receivesInlineAction(createGetImageCaptchaInfoAction({ selector: '#svg-captcha-rendering' }));
 
                 await dbp.isCaptchaError();
+            });
+
+            test('reports the requested alias type to the backend for an aliased image captcha', async ({ createConfiguredDbp }) => {
+                const dbp = await createConfiguredDbp(BROKER_PROTECTION_CONFIGS.default);
+                await dbp.navigatesTo(imageCaptchaTargetPage);
+                // 'red-circle' is registered as an alias of the image provider, so it is resolved and
+                // extracted via the same DOM mechanisms...
+                await dbp.receivesInlineAction(
+                    createGetImageCaptchaInfoAction({ captchaType: 'red-circle', selector: '#svg-captcha-rendering svg' }),
+                );
+                const successResponse = await dbp.getSuccessResponse();
+
+                // ...but the response echoes the alias type that dbp-api expects, not the provider's
+                // canonical 'image' type.
+                expect(successResponse.type).toBe('red-circle');
+                expect(successResponse.siteKey).toMatch(/^data:image\/jpeg;base64,/);
             });
         });
 

--- a/injected/src/features/broker-protection/captcha-services/captcha.service.js
+++ b/injected/src/features/broker-protection/captcha-services/captcha.service.js
@@ -81,10 +81,17 @@ export async function getCaptchaInfo(action, root = document) {
         return createError(captchaIdentifier.error.message);
     }
 
+    // Determine the type to report to dbp-api. When the requested captchaType resolved to its
+    // provider (including via an alias such as 'red-circle' → ImageProvider), echo the requested
+    // type back so aliased captchas are reported under the distinct type the backend expects. If
+    // we instead fell back to detection because the requested type didn't match the element, report
+    // the detected provider's canonical type.
+    const reportedType = captchaFactory.getProviderByType(captchaType) === captchaProvider ? captchaType : captchaProvider.getType();
+
     const response = {
         url: removeUrlQueryParams(window.location.href), // query params (which may include PII)
         siteKey: captchaIdentifier,
-        type: captchaProvider.getType(),
+        type: reportedType,
     };
 
     return SuccessResponse.create({ actionID, actionType, response });

--- a/injected/src/features/broker-protection/captcha-services/factory.js
+++ b/injected/src/features/broker-protection/captcha-services/factory.js
@@ -58,6 +58,8 @@ export class CaptchaFactory {
      * @returns {Array<import('./providers/provider.interface').CaptchaProvider>}
      */
     _getAllProviders() {
-        return Array.from(this.providers.values());
+        // Aliases register the same provider instance under multiple keys, so deduplicate to
+        // avoid running a provider's detection methods once per alias on the detection miss path.
+        return Array.from(new Set(this.providers.values()));
     }
 }

--- a/injected/src/features/broker-protection/captcha-services/factory.js
+++ b/injected/src/features/broker-protection/captcha-services/factory.js
@@ -9,9 +9,19 @@ export class CaptchaFactory {
     /**
      * Register a captcha provider
      * @param {import('./providers/provider.interface').CaptchaProvider} provider - The provider to register
+     * @param {Object} [options] - The optional provider options
+     * @param {Array<string>} [options.aliases] - An optional list of aliases for that provider
      */
-    registerProvider(provider) {
+    registerProvider(provider, options) {
         this.providers.set(provider.getType(), provider);
+
+        // Some captchas use the same DOM mechanisms to get the relevant captcha information, but
+        // need to call dbp-api with a distinct captcha type.
+        if (options?.aliases) {
+            options?.aliases.forEach((alias) => {
+                this.providers.set(alias, provider);
+            });
+        }
     }
 
     /**

--- a/injected/src/features/broker-protection/captcha-services/providers/registry.js
+++ b/injected/src/features/broker-protection/captcha-services/providers/registry.js
@@ -22,6 +22,6 @@ captchaFactory.registerProvider(
 );
 
 captchaFactory.registerProvider(new CloudFlareTurnstileProvider());
-captchaFactory.registerProvider(new ImageProvider());
+captchaFactory.registerProvider(new ImageProvider(), { aliases: ['red-circle', 'local-llm'] });
 
 export { captchaFactory };

--- a/injected/src/features/broker-protection/captcha-services/providers/registry.js
+++ b/injected/src/features/broker-protection/captcha-services/providers/registry.js
@@ -22,6 +22,6 @@ captchaFactory.registerProvider(
 );
 
 captchaFactory.registerProvider(new CloudFlareTurnstileProvider());
-captchaFactory.registerProvider(new ImageProvider(), { aliases: ['red-circle', 'local-llm'] });
+captchaFactory.registerProvider(new ImageProvider(), { aliases: ['red-circle', 'basic-math'] });
 
 export { captchaFactory };

--- a/injected/unit-test/broker-protection-captcha-factory.js
+++ b/injected/unit-test/broker-protection-captcha-factory.js
@@ -80,5 +80,20 @@ describe('CaptchaFactory', () => {
             expect(detected).toBe(provider);
             expect(provider.isSupportedForElement).toHaveBeenCalledTimes(1);
         });
+
+        it('does not probe an aliased provider once per alias on the detection miss path', () => {
+            const factory = new CaptchaFactory();
+            const provider = createStubProvider('image');
+            // Nothing matches, so detection iterates every distinct provider rather than
+            // short-circuiting. Without deduplication the aliased provider would be probed
+            // once per registered key.
+            spyOn(provider, 'isSupportedForElement').and.returnValue(false);
+
+            factory.registerProvider(provider, { aliases: ['red-circle', 'local-llm'] });
+
+            const detected = factory.detectProvider(/** @type {any} */ ({}), /** @type {any} */ ({}));
+            expect(detected).toBe(null);
+            expect(provider.isSupportedForElement).toHaveBeenCalledTimes(1);
+        });
     });
 });

--- a/injected/unit-test/broker-protection-captcha-factory.js
+++ b/injected/unit-test/broker-protection-captcha-factory.js
@@ -1,0 +1,84 @@
+import { CaptchaFactory } from '../src/features/broker-protection/captcha-services/factory.js';
+
+/**
+ * Minimal stand-in provider so these tests exercise the factory's
+ * registration/alias logic without depending on real provider DOM mechanisms.
+ * @param {string} type
+ */
+function createStubProvider(type) {
+    return /** @type {import('../src/features/broker-protection/captcha-services/providers/provider.interface').CaptchaProvider} */ (
+        /** @type {unknown} */ ({
+            getType: () => type,
+            isSupportedForElement: () => false,
+            canSolve: () => false,
+        })
+    );
+}
+
+describe('CaptchaFactory', () => {
+    describe('registerProvider', () => {
+        it('registers a provider under its own type', () => {
+            const factory = new CaptchaFactory();
+            const provider = createStubProvider('image');
+
+            factory.registerProvider(provider);
+
+            expect(factory.getProviderByType('image')).toBe(provider);
+        });
+
+        it('returns null for an unknown type', () => {
+            const factory = new CaptchaFactory();
+
+            expect(factory.getProviderByType('does-not-exist')).toBe(null);
+        });
+
+        it('registers a provider under each of its aliases', () => {
+            const factory = new CaptchaFactory();
+            const provider = createStubProvider('image');
+
+            factory.registerProvider(provider, { aliases: ['red-circle', 'local-llm'] });
+
+            // The canonical type still resolves to the provider...
+            expect(factory.getProviderByType('image')).toBe(provider);
+            // ...and so does each alias, returning the same instance.
+            expect(factory.getProviderByType('red-circle')).toBe(provider);
+            expect(factory.getProviderByType('local-llm')).toBe(provider);
+        });
+
+        it('does not register any aliases when none are provided', () => {
+            const factory = new CaptchaFactory();
+            const provider = createStubProvider('image');
+
+            factory.registerProvider(provider, {});
+
+            expect(factory.getProviderByType('image')).toBe(provider);
+            expect(factory.getProviderByType('red-circle')).toBe(null);
+        });
+
+        it('handles an empty aliases array without registering extras', () => {
+            const factory = new CaptchaFactory();
+            const provider = createStubProvider('image');
+
+            factory.registerProvider(provider, { aliases: [] });
+
+            expect(factory.getProviderByType('image')).toBe(provider);
+        });
+
+        it('does not expose aliases as additional providers during detection', () => {
+            const factory = new CaptchaFactory();
+            const provider = createStubProvider('image');
+            spyOn(provider, 'isSupportedForElement').and.returnValue(true);
+
+            factory.registerProvider(provider, { aliases: ['red-circle', 'local-llm'] });
+
+            // Even though the provider is registered under three keys, detection
+            // should consider it once (find returns the first match) and never
+            // double-count aliased entries.
+            const root = /** @type {any} */ ({});
+            const element = /** @type {any} */ ({});
+            const detected = factory.detectProvider(root, element);
+            expect(detected).toBe(provider);
+            expect(provider.isSupportedForElement).toHaveBeenCalledTimes(1);
+        });
+    });
+});


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/task/1213642859971038?focus=true

## Description
This PR allows aliases to be defined for captcha services. This allows for captchas which are solved the same (e.g. an image captcha) but need to pass a distinct type to the backend.

## Testing Steps

- `npm run test-unit`
- `npm run test-int`

## Checklist

<!--
  These questions are a friendly reminder to shipping code, if you're uncertain ask the AoR owners.
  It's also totally appropriate to not check some of these boxes, if they don't apply to your change.
-->
*Please tick all that apply:*

- [x] I have tested this change locally
- [x] I have tested this change locally in all supported browsers
- [ ] This change will be visible to users
- [x] I have added automated tests that cover this change
- [ ] I have ensured the change is gated by config
- [ ] This change was covered by a ship review
- [ ] This change was covered by a tech design
- [ ] Any dependent config has been merged



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the captcha type sent to dbp-api for aliased flows; incorrect reporting logic could misroute backend solving, but scope is limited to broker-protection captcha handling with new tests.
> 
> **Overview**
> **Captcha providers can register optional type aliases** so multiple backend captcha types (e.g. `red-circle`, `basic-math`) reuse the same DOM extraction logic as `image` while still calling dbp-api with the requested type.
> 
> `CaptchaFactory.registerProvider` accepts `{ aliases }`, maps each alias to the same provider instance, and **deduplicates providers** in detection paths so alias keys do not run `isSupportedForElement` multiple times. The image provider is wired with aliases `red-circle` and `basic-math`.
> 
> **`getCaptchaInfo` changes the reported `type` in the success payload**: when the action’s `captchaType` resolves directly to a provider (including via alias), the response echoes that requested type; if the code fell back to element detection, it uses the provider’s canonical type.
> 
> Coverage adds factory unit tests for alias registration and deduplication, plus an integration test asserting an aliased image captcha returns `type: 'red-circle'` with a base64 `siteKey`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eb14a92abb590a4cf88e0b48645675cf27c1f37c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->