### PR TITLE
NTP: Use attachmentLimits config for NTP omnibar attachments

### DIFF
--- a/special-pages/pages/new-tab/app/omnibar/components/Omnibar.js
+++ b/special-pages/pages/new-tab/app/omnibar/components/Omnibar.js
@@ -21,7 +21,7 @@ import { useDrawerControls, useDrawerEventListeners } from '../../components/Dra
 import { Trans } from '../../../../../shared/components/TranslationsProvider.js';
 import { ImageAttachmentContent } from './chat-tools/image-attachment/ImageAttachmentTool';
 import { useImageAttachments } from './chat-tools/image-attachment/useImageAttachments';
-import { MAX_FILES, useFileAttachments } from './chat-tools/file-attachment/useFileAttachments';
+import { useFileAttachments } from './chat-tools/file-attachment/useFileAttachments';
 import { AttachmentChips } from './chat-tools/attachments/AttachmentChips';
 import { ModelSelectorTool } from './chat-tools/model-selector/ModelSelectorTool';
 import { ReasoningPickerTool } from './chat-tools/reasoning-picker/ReasoningPickerTool';
@@ -210,6 +210,8 @@ function AiChatContent({
     const { t } = useTypedTranslationWith(/** @type {Strings} */ ({}));
     const platformName = usePlatformName();
     const { showChats, hideChats } = useAiChatsContext();
+    const { state } = useContext(OmnibarContext);
+    const attachmentLimits = state.config?.attachmentLimits;
     const { selectedModel } = useSelectedModel();
     const { selectedEffort } = useSelectedReasoningEffort();
     const { activeTool, availableTools, imageGenerationActive, webSearchActive, setActiveTool } = useActiveTools();
@@ -217,7 +219,7 @@ function AiChatContent({
     const hasVisibleImagesRef = useRef(false);
     const submittingRef = useRef(false);
     const [imageWarning, setImageWarning] = useState(false);
-    const imageState = useImageAttachments(tabId);
+    const imageState = useImageAttachments(tabId, attachmentLimits?.images.maxPerTurn);
 
     const hasAttachedImages = imageState.attachedImages.length > 0;
     const imageGenerationPlaceholder = hasAttachedImages
@@ -226,7 +228,12 @@ function AiChatContent({
     const selectedModelSupportsImages = selectedModel?.supportsImageUpload ?? false;
     const canAttachImages = selectedModelSupportsImages || imageGenerationActive;
 
-    const fileState = useFileAttachments(selectedModel?.supportedFileTypes, tabId);
+    const fileState = useFileAttachments(
+        selectedModel?.supportedFileTypes,
+        tabId,
+        attachmentLimits?.files.maxPerConversation,
+        attachmentLimits?.files.maxFileSizeMB,
+    );
     const canAttachFiles = !imageGenerationActive && (selectedModel?.supportedFileTypes?.length ?? 0) > 0;
 
     const canAttachTabs = enableAttachTabs && !imageGenerationActive;
@@ -322,9 +329,11 @@ function AiChatContent({
     };
 
     const fileWarning = canAttachFiles && fileState.fileLimitExceeded;
+    const fileError = canAttachFiles ? fileState.fileError : null;
 
     const imageMessageShowing = !!(canAttachImages && (imageState.imageLimitExceeded || imageState.imageError));
-    const showFileWarning = fileWarning && !imageMessageShowing;
+    const showFileError = !!fileError && !imageMessageShowing;
+    const showFileWarning = fileWarning && !imageMessageShowing && !showFileError;
     const disabled = !query || imageWarning || fileWarning;
 
     const isVoiceChatMode =
@@ -391,7 +400,11 @@ function AiChatContent({
                                 <AttachMenu
                                     image={
                                         canAttachImages
-                                            ? { processFiles: imageState.processFiles, disabled: imageState.imageUploadDisabled }
+                                            ? {
+                                                  processFiles: imageState.processFiles,
+                                                  disabled: imageState.imageUploadDisabled,
+                                                  maxImages: imageState.maxImages,
+                                              }
                                             : null
                                     }
                                     file={
@@ -456,9 +469,14 @@ function AiChatContent({
                         onRemoveFile={fileState.handleRemoveFile}
                         onRemoveImage={imageState.handleRemoveImage}
                     />
+                    {showFileError && (
+                        <p class={styles.attachmentWarning} role="alert">
+                            {t('omnibar_fileTooLargeError', { limit: String(fileState.maxFileSizeMB ?? '') })}
+                        </p>
+                    )}
                     {showFileWarning && (
                         <p class={styles.attachmentWarning} role="alert">
-                            {t('omnibar_fileAttachmentLimitWarning', { limit: String(MAX_FILES) })}
+                            {t('omnibar_fileAttachmentLimitWarning', { limit: String(fileState.maxFiles) })}
                         </p>
                     )}
                     <ImageAttachmentContent

--- a/special-pages/pages/new-tab/app/omnibar/components/Omnibar.js
+++ b/special-pages/pages/new-tab/app/omnibar/components/Omnibar.js
@@ -215,11 +215,12 @@ function AiChatContent({
     const { selectedModel } = useSelectedModel();
     const { selectedEffort } = useSelectedReasoningEffort();
     const { activeTool, availableTools, imageGenerationActive, webSearchActive, setActiveTool } = useActiveTools();
+
     const containerRef = useRef(/** @type {HTMLDivElement|null} */ (null));
     const hasVisibleImagesRef = useRef(false);
     const submittingRef = useRef(false);
     const [imageWarning, setImageWarning] = useState(false);
-    const imageState = useImageAttachments(tabId, attachmentLimits?.images.maxPerTurn);
+    const imageState = useImageAttachments(tabId, attachmentLimits?.images?.maxPerTurn);
 
     const hasAttachedImages = imageState.attachedImages.length > 0;
     const imageGenerationPlaceholder = hasAttachedImages
@@ -231,8 +232,8 @@ function AiChatContent({
     const fileState = useFileAttachments(
         selectedModel?.supportedFileTypes,
         tabId,
-        attachmentLimits?.files.maxPerConversation,
-        attachmentLimits?.files.maxFileSizeMB,
+        attachmentLimits?.files?.maxPerConversation,
+        attachmentLimits?.files?.maxFileSizeMB,
     );
     const canAttachFiles = !imageGenerationActive && (selectedModel?.supportedFileTypes?.length ?? 0) > 0;
 

--- a/special-pages/pages/new-tab/app/omnibar/components/Omnibar.js
+++ b/special-pages/pages/new-tab/app/omnibar/components/Omnibar.js
@@ -220,7 +220,7 @@ function AiChatContent({
     const hasVisibleImagesRef = useRef(false);
     const submittingRef = useRef(false);
     const [imageWarning, setImageWarning] = useState(false);
-    const imageState = useImageAttachments(tabId, attachmentLimits?.images?.maxPerTurn);
+    const imageState = useImageAttachments({ tabId, maxImages: attachmentLimits?.images?.maxPerTurn });
 
     const hasAttachedImages = imageState.attachedImages.length > 0;
     const imageGenerationPlaceholder = hasAttachedImages
@@ -229,12 +229,12 @@ function AiChatContent({
     const selectedModelSupportsImages = selectedModel?.supportsImageUpload ?? false;
     const canAttachImages = selectedModelSupportsImages || imageGenerationActive;
 
-    const fileState = useFileAttachments(
-        selectedModel?.supportedFileTypes,
+    const fileState = useFileAttachments({
+        supportedFileTypes: selectedModel?.supportedFileTypes,
         tabId,
-        attachmentLimits?.files?.maxPerConversation,
-        attachmentLimits?.files?.maxFileSizeMB,
-    );
+        maxFiles: attachmentLimits?.files?.maxPerConversation,
+        maxFileSizeMB: attachmentLimits?.files?.maxFileSizeMB,
+    });
     const canAttachFiles = !imageGenerationActive && (selectedModel?.supportedFileTypes?.length ?? 0) > 0;
 
     const canAttachTabs = enableAttachTabs && !imageGenerationActive;

--- a/special-pages/pages/new-tab/app/omnibar/components/chat-tools/file-attachment/useFileAttachments.js
+++ b/special-pages/pages/new-tab/app/omnibar/components/chat-tools/file-attachment/useFileAttachments.js
@@ -8,16 +8,23 @@ const { useStateWithLocalPersistence } = FileAttachments;
 /**
  * `addedAtRelative` is a `performance.now()` value used to sort attachments by attach order.
  * @typedef {{ data: string, fileName: string, mimeType: string, addedAtRelative: number }} AttachedFile
+ * @typedef {'fileTooLarge'} FileErrorType
+ * @typedef {{ type: FileErrorType, fileNames: string[] }} FileError
  */
 
 export const MAX_FILES = 3;
 
+const BYTES_PER_MB = 1024 * 1024;
+
 /**
  * @param {string[] | undefined} supportedFileTypes — MIME types the active model accepts.
  * @param {string|null|undefined} [tabId] - NTP tab the attachments are persisted under.
+ * @param {number} [maxFiles] - Max file attachments, from backend `attachmentLimits`. Defaults to {@link MAX_FILES}.
+ * @param {number} [maxFileSizeMB] - Max size of a single file in MB, from backend `attachmentLimits`. Omitted means no size cap.
  */
-export function useFileAttachments(supportedFileTypes, tabId) {
+export function useFileAttachments(supportedFileTypes, tabId, maxFiles = MAX_FILES, maxFileSizeMB) {
     const [attachedFiles, setAttachedFiles] = useStateWithLocalPersistence(tabId);
+    const [fileError, setFileError] = useState(/** @type {FileError|null} */ (null));
 
     const allowList = supportedFileTypes ?? [];
     const allowListKey = allowList.join('|');
@@ -28,20 +35,38 @@ export function useFileAttachments(supportedFileTypes, tabId) {
         setAttachedFiles((prev) => prev.filter((f) => allowList.includes(f.mimeType)));
     }
 
-    // No hard cap on adding files; exceeding MAX_FILES warns and blocks submit until removed.
+    // No hard cap on adding files; exceeding maxFiles warns and blocks submit until removed.
     const fileUploadDisabled = allowList.length === 0;
-    const fileLimitExceeded = attachedFiles.length > MAX_FILES;
+    const fileLimitExceeded = attachedFiles.length > maxFiles;
 
     const clearAttachedFiles = () => setAttachedFiles([]);
+    const clearFileError = () => setFileError(null);
 
     /** @type {(files: File[]) => Promise<void>} */
     const processFiles = async (files) => {
         if (files.length === 0) return;
+        setFileError(null);
 
         const existingNames = new Set(attachedFiles.map((file) => file.fileName));
-        const validFiles = files
+        const candidates = files
             .map((file) => ({ file, mimeType: resolveFileMimeType(file, allowList) }))
             .filter(({ file, mimeType }) => mimeType !== null && !existingNames.has(file.name));
+        if (candidates.length === 0) return;
+
+        // Reject files larger than the backend-configured per-file size cap (when present).
+        const maxBytes = maxFileSizeMB != null ? maxFileSizeMB * BYTES_PER_MB : null;
+        /** @type {string[]} */
+        const tooLargeNames = [];
+        const validFiles = candidates.filter(({ file }) => {
+            if (maxBytes != null && file.size > maxBytes) {
+                tooLargeNames.push(file.name);
+                return false;
+            }
+            return true;
+        });
+        if (tooLargeNames.length > 0) {
+            setFileError({ type: 'fileTooLarge', fileNames: tooLargeNames });
+        }
         if (validFiles.length === 0) return;
 
         const results = await Promise.allSettled(
@@ -76,6 +101,10 @@ export function useFileAttachments(supportedFileTypes, tabId) {
         fileUploadDisabled,
         fileLimitExceeded,
         getFilesForSubmission,
+        fileError,
+        clearFileError,
+        maxFiles,
+        maxFileSizeMB,
     };
 }
 

--- a/special-pages/pages/new-tab/app/omnibar/components/chat-tools/file-attachment/useFileAttachments.js
+++ b/special-pages/pages/new-tab/app/omnibar/components/chat-tools/file-attachment/useFileAttachments.js
@@ -17,12 +17,13 @@ export const MAX_FILES = 3;
 const BYTES_PER_MB = 1024 * 1024;
 
 /**
- * @param {string[] | undefined} supportedFileTypes — MIME types the active model accepts.
- * @param {string|null|undefined} [tabId] - NTP tab the attachments are persisted under.
- * @param {number} [maxFiles] - Max file attachments, from backend `attachmentLimits`. Defaults to {@link MAX_FILES}.
- * @param {number} [maxFileSizeMB] - Max size of a single file in MB, from backend `attachmentLimits`. Omitted means no size cap.
+ * @param {object} params
+ * @param {string[]} [params.supportedFileTypes] - MIME types the active model accepts.
+ * @param {string|null|undefined} [params.tabId] - NTP tab the attachments are persisted under.
+ * @param {number} [params.maxFiles] - Max file attachments, from backend `attachmentLimits`. Defaults to {@link MAX_FILES}.
+ * @param {number} [params.maxFileSizeMB] - Max size of a single file in MB, from backend `attachmentLimits`. Omitted means no size cap.
  */
-export function useFileAttachments(supportedFileTypes, tabId, maxFiles = MAX_FILES, maxFileSizeMB) {
+export function useFileAttachments({ supportedFileTypes, tabId, maxFiles = MAX_FILES, maxFileSizeMB } = {}) {
     const [attachedFiles, setAttachedFiles] = useStateWithLocalPersistence(tabId);
     const [fileError, setFileError] = useState(/** @type {FileError|null} */ (null));
 

--- a/special-pages/pages/new-tab/app/omnibar/components/chat-tools/image-attachment/ImageAttachmentTool.js
+++ b/special-pages/pages/new-tab/app/omnibar/components/chat-tools/image-attachment/ImageAttachmentTool.js
@@ -1,7 +1,7 @@
 import { Fragment, h } from 'preact';
 import { useLayoutEffect, useRef } from 'preact/hooks';
 import { useTypedTranslationWith } from '../../../../types';
-import { MAX_IMAGES, getImageErrorMessage } from './useImageAttachments';
+import { getImageErrorMessage } from './useImageAttachments';
 import styles from './ImageAttachment.module.css';
 
 /**
@@ -18,7 +18,7 @@ import styles from './ImageAttachment.module.css';
  */
 export function ImageAttachmentContent({ state, supportsImageUpload, onVisibleImagesChange, onImageWarningChange }) {
     const { t } = useTypedTranslationWith(/** @type {Strings} */ ({}));
-    const { attachedImages, imageLimitExceeded, imageError, clearImageError } = state;
+    const { attachedImages, imageLimitExceeded, imageError, clearImageError, maxImages } = state;
 
     const hasVisibleImages = !!(supportsImageUpload && attachedImages.length > 0);
     const showImageWarning = !!(supportsImageUpload && imageLimitExceeded);
@@ -44,7 +44,7 @@ export function ImageAttachmentContent({ state, supportsImageUpload, onVisibleIm
 
     if (!supportsImageUpload) return null;
 
-    const imageLimitWarning = t('omnibar_imageAttachmentLimitWarning', { limit: String(MAX_IMAGES) });
+    const imageLimitWarning = t('omnibar_imageAttachmentLimitWarning', { limit: String(maxImages) });
     const imageErrorMessage = getImageErrorMessage(imageError, {
         imageTooLarge: t('omnibar_imageTooLargeError'),
         processingFailed: t('omnibar_imageProcessingError'),

--- a/special-pages/pages/new-tab/app/omnibar/components/chat-tools/image-attachment/useImageAttachments.js
+++ b/special-pages/pages/new-tab/app/omnibar/components/chat-tools/image-attachment/useImageAttachments.js
@@ -83,10 +83,11 @@ function normaliseImage(srcDataUrl, targetMime) {
 }
 
 /**
- * @param {string|null|undefined} [tabId] - NTP tab the attachments are persisted under.
- * @param {number} [maxImages] - Max images per submission, from backend `attachmentLimits`. Defaults to {@link MAX_IMAGES}.
+ * @param {object} params
+ * @param {string|null|undefined} [params.tabId] - NTP tab the attachments are persisted under.
+ * @param {number} [params.maxImages] - Max images per submission, from backend `attachmentLimits`. Defaults to {@link MAX_IMAGES}.
  */
-export function useImageAttachments(tabId, maxImages = MAX_IMAGES) {
+export function useImageAttachments({ tabId, maxImages = MAX_IMAGES } = {}) {
     const [attachedImages, setAttachedImages] = useStateWithLocalPersistence(tabId);
     const [imageError, setImageError] = useState(/** @type {ImageError|null} */ (null));
 

--- a/special-pages/pages/new-tab/app/omnibar/components/chat-tools/image-attachment/useImageAttachments.js
+++ b/special-pages/pages/new-tab/app/omnibar/components/chat-tools/image-attachment/useImageAttachments.js
@@ -82,13 +82,16 @@ function normaliseImage(srcDataUrl, targetMime) {
     });
 }
 
-/** @param {string|null|undefined} [tabId] - NTP tab the attachments are persisted under. */
-export function useImageAttachments(tabId) {
+/**
+ * @param {string|null|undefined} [tabId] - NTP tab the attachments are persisted under.
+ * @param {number} [maxImages] - Max images per submission, from backend `attachmentLimits`. Defaults to {@link MAX_IMAGES}.
+ */
+export function useImageAttachments(tabId, maxImages = MAX_IMAGES) {
     const [attachedImages, setAttachedImages] = useStateWithLocalPersistence(tabId);
     const [imageError, setImageError] = useState(/** @type {ImageError|null} */ (null));
 
-    const imageLimitExceeded = attachedImages.length > MAX_IMAGES;
-    const imageUploadDisabled = attachedImages.length >= MAX_IMAGES;
+    const imageLimitExceeded = attachedImages.length > maxImages;
+    const imageUploadDisabled = attachedImages.length >= maxImages;
 
     const clearAttachedImages = () => setAttachedImages([]);
     const clearImageError = () => setImageError(null);
@@ -112,8 +115,8 @@ export function useImageAttachments(tabId) {
 
         if (validFiles.length === 0) return;
 
-        // Only process enough to reach MAX_IMAGES + 1 (to trigger the limit warning).
-        const processLimit = MAX_IMAGES + 1 - attachedImages.length;
+        // Only process enough to reach maxImages + 1 (to trigger the limit warning).
+        const processLimit = maxImages + 1 - attachedImages.length;
         const filesToProcess = processLimit > 0 ? validFiles.slice(0, processLimit) : [];
 
         if (filesToProcess.length === 0) return;
@@ -204,6 +207,7 @@ export function useImageAttachments(tabId) {
         imageError,
         clearImageError,
         getImagesForSubmission,
+        maxImages,
     };
 }
 

--- a/special-pages/pages/new-tab/app/omnibar/components/chat-tools/tab-attachment/AttachMenu.js
+++ b/special-pages/pages/new-tab/app/omnibar/components/chat-tools/tab-attachment/AttachMenu.js
@@ -9,7 +9,6 @@ import { DropdownItem } from '../dropdown/DropdownItem';
 import { resolveFileInput } from './fileChannels';
 import { TabPicker } from './TabPicker';
 import { Tooltip } from '../../Tooltip';
-import { MAX_IMAGES } from '../image-attachment/useImageAttachments';
 import imageStyles from '../image-attachment/ImageAttachment.module.css';
 import styles from './AttachMenu.module.css';
 
@@ -49,7 +48,7 @@ export function AttachMenu({ image, file, tabsEnabled, onToggleTab, isAttached }
         // Image-only: a disabled button means the image limit is reached — show its warning tooltip.
         if (image && !file && fileInput.disabled) {
             return (
-                <Tooltip content={t('omnibar_imageAttachmentLimitWarning', { limit: String(MAX_IMAGES) })} position="above">
+                <Tooltip content={t('omnibar_imageAttachmentLimitWarning', { limit: String(image.maxImages) })} position="above">
                     {button}
                 </Tooltip>
             );

--- a/special-pages/pages/new-tab/app/omnibar/components/chat-tools/tab-attachment/fileChannels.js
+++ b/special-pages/pages/new-tab/app/omnibar/components/chat-tools/tab-attachment/fileChannels.js
@@ -1,6 +1,6 @@
 /**
  * @typedef {typeof import('../../../strings.json')} Strings
- * @typedef {{ processFiles: (files: File[]) => Promise<void>, disabled: boolean }} ImageChannel
+ * @typedef {{ processFiles: (files: File[]) => Promise<void>, disabled: boolean, maxImages: number }} ImageChannel
  * @typedef {{ processFiles: (files: File[]) => Promise<void>, disabled: boolean, mimeTypes: string[] }} FileChannel
  * @typedef {{ label: string, accept: string, disabled: boolean, onChange: (event: Event) => Promise<void> }} ResolvedFileInput
  */

--- a/special-pages/pages/new-tab/app/omnibar/integration-tests/omnibar-attachments.spec.js
+++ b/special-pages/pages/new-tab/app/omnibar/integration-tests/omnibar-attachments.spec.js
@@ -362,6 +362,59 @@ test.describe('omnibar file attachment', () => {
         await expect(omnibar.chatSubmitButton()).toBeEnabled();
     });
 
+    test('the file cap follows the backend attachmentLimits config', async ({ page }, workerInfo) => {
+        const { ntp, omnibar } = setup(page, workerInfo);
+        await ntp.reducedMotion();
+        await ntp.openPage({
+            additional: {
+                'omnibar.mode': 'ai',
+                'omnibar.enableAiChatTools': 'true',
+                'omnibar.selectedModelId': 'claude-haiku-4-5',
+                // Backend-configured cap of two files (default is three).
+                'omnibar.fileMaxPerConversation': '2',
+            },
+        });
+        await omnibar.ready();
+
+        // Two files are within the configured cap — no warning.
+        await omnibar
+            .fileInput()
+            .setInputFiles(['a.pdf', 'b.pdf'].map((name) => ({ name, mimeType: 'application/pdf', buffer: PDF_BYTES })));
+        await expect(omnibar.fileChip()).toHaveCount(2);
+        await expect(omnibar.fileLimitWarning()).toHaveCount(0);
+
+        // A third file exceeds the configured cap of two → warning, and it names the configured limit.
+        await omnibar.fileInput().setInputFiles({ name: 'c.pdf', mimeType: 'application/pdf', buffer: PDF_BYTES });
+        await expect(omnibar.fileChip()).toHaveCount(3);
+        await expect(omnibar.context().getByText('You can only attach 2 files at a time.')).toBeVisible();
+    });
+
+    test('a file larger than the configured maxFileSizeMB is rejected with an error', async ({ page }, workerInfo) => {
+        const { ntp, omnibar } = setup(page, workerInfo);
+        await ntp.reducedMotion();
+        await ntp.openPage({
+            additional: {
+                'omnibar.mode': 'ai',
+                'omnibar.enableAiChatTools': 'true',
+                'omnibar.selectedModelId': 'claude-haiku-4-5',
+                // Backend-configured per-file cap of 1 MB.
+                'omnibar.fileMaxFileSizeMB': '1',
+            },
+        });
+        await omnibar.ready();
+
+        // A ~2 MB PDF exceeds the 1 MB cap → not attached, error shown.
+        const tooLarge = Buffer.alloc(2 * 1024 * 1024, 1);
+        await omnibar.fileInput().setInputFiles({ name: 'huge.pdf', mimeType: 'application/pdf', buffer: tooLarge });
+        await expect(omnibar.fileTooLargeWarning()).toBeVisible();
+        await expect(omnibar.fileChip()).toHaveCount(0);
+
+        // A small PDF under the cap still attaches and clears the error.
+        await omnibar.fileInput().setInputFiles({ name: 'small.pdf', mimeType: 'application/pdf', buffer: PDF_BYTES });
+        await expect(omnibar.fileChip()).toHaveCount(1);
+        await expect(omnibar.fileTooLargeWarning()).toHaveCount(0);
+    });
+
     test('switching to a model without file support clears attached files', async ({ page }, workerInfo) => {
         const { ntp, omnibar } = setup(page, workerInfo);
         await ntp.reducedMotion();

--- a/special-pages/pages/new-tab/app/omnibar/integration-tests/omnibar.page.js
+++ b/special-pages/pages/new-tab/app/omnibar/integration-tests/omnibar.page.js
@@ -451,6 +451,10 @@ export class OmnibarPage {
         return this.context().getByText(/You can only attach \d+ files at a time/);
     }
 
+    fileTooLargeWarning() {
+        return this.context().getByText(/File is too large/);
+    }
+
     imageLimitWarning() {
         return this.context().getByText(/You can only attach \d+ images at a time/);
     }

--- a/special-pages/pages/new-tab/app/omnibar/mocks/omnibar.mock-transport.js
+++ b/special-pages/pages/new-tab/app/omnibar/mocks/omnibar.mock-transport.js
@@ -166,7 +166,7 @@ export function omnibarMockTransport() {
         attachmentLimits: {
             files: {
                 maxPerConversation: 3,
-                maxFileSizeMB: 25,
+                maxFileSizeMB: 3,
                 maxTotalFileSizeBytes: 75 * 1024 * 1024,
                 maxPagesPerFile: 100,
             },

--- a/special-pages/pages/new-tab/app/omnibar/mocks/omnibar.mock-transport.js
+++ b/special-pages/pages/new-tab/app/omnibar/mocks/omnibar.mock-transport.js
@@ -163,6 +163,19 @@ export function omnibarMockTransport() {
         enableVoiceChatAccess: false,
         enableAskAiSuggestion: true,
         enableAttachTabs: false,
+        attachmentLimits: {
+            files: {
+                maxPerConversation: 3,
+                maxFileSizeMB: 25,
+                maxTotalFileSizeBytes: 75 * 1024 * 1024,
+                maxPagesPerFile: 100,
+            },
+            images: {
+                maxPerTurn: 3,
+                maxPerConversation: 10,
+                maxInputCharsWithAttachments: 30000,
+            },
+        },
     };
 
     /** @type {Map<string, (d: any) => void>} */
@@ -233,6 +246,14 @@ export function omnibarMockTransport() {
                     config.enableVoiceChatAccess = parseBooleanQueryParam('omnibar.enableVoiceChatAccess') ?? config.enableVoiceChatAccess;
                     config.enableAskAiSuggestion = parseBooleanQueryParam('omnibar.enableAskAiSuggestion') ?? config.enableAskAiSuggestion;
                     config.enableAttachTabs = parseBooleanQueryParam('omnibar.enableAttachTabs') ?? config.enableAttachTabs;
+                    if (config.attachmentLimits) {
+                        const imageMaxPerTurn = parseInt(url.searchParams.get('omnibar.imageMaxPerTurn') ?? '', 10);
+                        if (imageMaxPerTurn > 0) config.attachmentLimits.images.maxPerTurn = imageMaxPerTurn;
+                        const fileMaxPerConversation = parseInt(url.searchParams.get('omnibar.fileMaxPerConversation') ?? '', 10);
+                        if (fileMaxPerConversation > 0) config.attachmentLimits.files.maxPerConversation = fileMaxPerConversation;
+                        const fileMaxFileSizeMB = parseInt(url.searchParams.get('omnibar.fileMaxFileSizeMB') ?? '', 10);
+                        if (fileMaxFileSizeMB > 0) config.attachmentLimits.files.maxFileSizeMB = fileMaxFileSizeMB;
+                    }
                     return config;
                 }
                 case 'omnibar_getSuggestions': {

--- a/special-pages/pages/new-tab/app/omnibar/strings.json
+++ b/special-pages/pages/new-tab/app/omnibar/strings.json
@@ -95,6 +95,10 @@
     "title": "Image is too large. Please use an image smaller than 10000×10000 pixels.",
     "description": "Error shown when a user tries to attach an image that exceeds the maximum pixel dimensions."
   },
+  "omnibar_fileTooLargeError": {
+    "title": "File is too large. Please use a file smaller than {limit} MB.",
+    "description": "Error shown when a user tries to attach a file that exceeds the maximum allowed size. {limit} is the size limit in megabytes."
+  },
   "omnibar_imageProcessingError": {
     "title": "Failed to process image. Please try a different file.",
     "description": "Error shown when an attached image cannot be processed."

--- a/special-pages/pages/new-tab/messages/types/omnibar-config.json
+++ b/special-pages/pages/new-tab/messages/types/omnibar-config.json
@@ -6,6 +6,55 @@
     "mode"
   ],
   "$defs": {
+    "AttachmentLimits": {
+      "type": "object",
+      "description": "Attachment limits sourced from the Duck.ai backend (`/duckchat/v1/models`, field `attachmentLimits`), already resolved for the user's tier by native. Omitted on older native clients, in which case the web falls back to its built-in defaults.",
+      "required": ["files", "images"],
+      "properties": {
+        "files": {
+          "description": "Limits for file attachments (e.g. PDFs).",
+          "type": "object",
+          "required": ["maxPerConversation", "maxFileSizeMB", "maxTotalFileSizeBytes", "maxPagesPerFile"],
+          "properties": {
+            "maxPerConversation": {
+              "description": "Maximum number of file attachments allowed.",
+              "type": "integer"
+            },
+            "maxFileSizeMB": {
+              "description": "Maximum size of a single file attachment, in megabytes.",
+              "type": "integer"
+            },
+            "maxTotalFileSizeBytes": {
+              "description": "Maximum combined size of all file attachments, in bytes.",
+              "type": "integer"
+            },
+            "maxPagesPerFile": {
+              "description": "Maximum number of pages allowed in a single file (e.g. PDF). Not enforced web-side.",
+              "type": "integer"
+            }
+          }
+        },
+        "images": {
+          "description": "Limits for image attachments.",
+          "type": "object",
+          "required": ["maxPerTurn", "maxPerConversation", "maxInputCharsWithAttachments"],
+          "properties": {
+            "maxPerTurn": {
+              "description": "Maximum number of images allowed in a single submission.",
+              "type": "integer"
+            },
+            "maxPerConversation": {
+              "description": "Maximum number of images allowed across an entire conversation.",
+              "type": "integer"
+            },
+            "maxInputCharsWithAttachments": {
+              "description": "Maximum prompt length (characters) when attachments are present. Not enforced web-side.",
+              "type": "integer"
+            }
+          }
+        }
+      }
+    },
     "AIModelSection": {
       "type": "object",
       "description": "A section of AI models with an optional header and a list of model items.",
@@ -111,6 +160,10 @@
       "description": "Sections of AI models for the model selector.",
       "type": "array",
       "items": { "$ref": "#/$defs/AIModelSection" }
+    },
+    "attachmentLimits": {
+      "title": "Attachment Limits",
+      "$ref": "#/$defs/AttachmentLimits"
     },
     "showViewAllAiChats": {
       "title": "Show View All AI Chats",

--- a/special-pages/pages/new-tab/messages/types/omnibar-config.json
+++ b/special-pages/pages/new-tab/messages/types/omnibar-config.json
@@ -8,7 +8,7 @@
   "$defs": {
     "AttachmentLimits": {
       "type": "object",
-      "description": "Attachment limits sourced from the Duck.ai backend (`/duckchat/v1/models`, field `attachmentLimits`), already resolved for the user's tier by native. Omitted on older native clients, in which case the web falls back to its built-in defaults.",
+      "description": "Limits the omnibar applies to image and file attachments. When omitted, the omnibar uses its built-in defaults.",
       "required": ["files", "images"],
       "properties": {
         "files": {

--- a/special-pages/pages/new-tab/public/locales/en/new-tab.json
+++ b/special-pages/pages/new-tab/public/locales/en/new-tab.json
@@ -257,6 +257,10 @@
     "title": "Image is too large. Please use an image smaller than 10000×10000 pixels.",
     "description": "Error shown when a user tries to attach an image that exceeds the maximum pixel dimensions."
   },
+  "omnibar_fileTooLargeError": {
+    "title": "File is too large. Please use a file smaller than {limit} MB.",
+    "description": "Error shown when a user tries to attach a file that exceeds the maximum allowed size. {limit} is the size limit in megabytes."
+  },
   "omnibar_imageProcessingError": {
     "title": "Failed to process image. Please try a different file.",
     "description": "Error shown when an attached image cannot be processed."

--- a/special-pages/pages/new-tab/types/new-tab.ts
+++ b/special-pages/pages/new-tab/types/new-tab.ts
@@ -637,6 +637,7 @@ export interface OmnibarConfig {
   selectedModelId?: SelectedModelID;
   selectedReasoningEffort?: ReasoningEffort;
   aiModelSections?: AIModelSections;
+  attachmentLimits?: AttachmentLimits;
   showViewAllAiChats?: ShowViewAllAIChats;
   enableImageGeneration?: EnableImageGeneration;
   enableWebSearch?: EnableWebSearch;
@@ -693,6 +694,49 @@ export interface AIModelItem {
    * Reasoning-effort keys this model supports. Empty or omitted means the reasoning picker is hidden for this model.
    */
   supportedReasoningEffort?: ReasoningEffort[];
+}
+/**
+ * Attachment limits sourced from the Duck.ai backend (`/duckchat/v1/models`, field `attachmentLimits`), already resolved for the user's tier by native. Omitted on older native clients, in which case the web falls back to its built-in defaults.
+ */
+export interface AttachmentLimits {
+  /**
+   * Limits for file attachments (e.g. PDFs).
+   */
+  files: {
+    /**
+     * Maximum number of file attachments allowed.
+     */
+    maxPerConversation: number;
+    /**
+     * Maximum size of a single file attachment, in megabytes.
+     */
+    maxFileSizeMB: number;
+    /**
+     * Maximum combined size of all file attachments, in bytes.
+     */
+    maxTotalFileSizeBytes: number;
+    /**
+     * Maximum number of pages allowed in a single file (e.g. PDF). Not enforced web-side.
+     */
+    maxPagesPerFile: number;
+  };
+  /**
+   * Limits for image attachments.
+   */
+  images: {
+    /**
+     * Maximum number of images allowed in a single submission.
+     */
+    maxPerTurn: number;
+    /**
+     * Maximum number of images allowed across an entire conversation.
+     */
+    maxPerConversation: number;
+    /**
+     * Maximum prompt length (characters) when attachments are present. Not enforced web-side.
+     */
+    maxInputCharsWithAttachments: number;
+  };
 }
 /**
  * Generated from @see "../messages/omnibar_submitChat.notify.json"

--- a/special-pages/pages/new-tab/types/new-tab.ts
+++ b/special-pages/pages/new-tab/types/new-tab.ts
@@ -696,7 +696,7 @@ export interface AIModelItem {
   supportedReasoningEffort?: ReasoningEffort[];
 }
 /**
- * Attachment limits sourced from the Duck.ai backend (`/duckchat/v1/models`, field `attachmentLimits`), already resolved for the user's tier by native. Omitted on older native clients, in which case the web falls back to its built-in defaults.
+ * Limits the omnibar applies to image and file attachments. When omitted, the omnibar uses its built-in defaults.
  */
 export interface AttachmentLimits {
   /**


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1208671677432066/task/1215504742109018?focus=true

## Description

The NTP omnibar hardcoded image/file attachment counts (MAX_IMAGES=3, MAX_FILES=3) and had no PDF size check. Consume the new optional attachmentLimits field on the omnibar config (forwarded by native from /duckchat/v1/models) to drive these limits, falling back to the previous defaults when the field is absent.

- Add optional attachmentLimits to the omnibar-config schema (+ regenerated types)
- useImageAttachments: take maxImages (default 3)
- useFileAttachments: take maxFiles (default 3) and maxFileSizeMB; reject oversized files with an error
- Wire the config limits through Omnibar.js into both hooks
- Add omnibar_fileTooLargeError string and render it next to the file warning
- Seed attachmentLimits in the mock transport with query-param overrides
- Add integration tests for the config-driven cap and oversize-PDF rejection

<!--
  Provide a terse summary of what the change is, detailed descriptions should belong in ship reviews or tech designs
-->

## Testing Steps

Use [attachment-test-sample-files.zip](https://github.com/user-attachments/files/29483789/attachment-test-sample-files.zip) files for testing.

1. Navigate to https://rawcdn.githack.com/duckduckgo/content-scope-scripts/f15fbcc3bc7997768c96338b37f6d4faa8b1f9d1/build/integration/pages/new-tab/index.html?omnibar.mode=ai&omnibar.enableAiChatTools=true&omnibar.selectedModelId=claude-haiku-4-5
2. The mock allows files up to 3 MB and up to 3 images
3. Try uploading sample-3.5mb.pdf from the sample file.
4. Confirm that the validation fails and warning message is displayed.
5. Try uploading 4 files. You should see an error message.

If you want to test it with a real native build, try it with https://github.com/duckduckgo/apple-browsers/pull/5614


## Checklist

<!--
  These questions are a friendly reminder to shipping code, if you're uncertain ask the AoR owners.
  It's also totally appropriate to not check some of these boxes, if they don't apply to your change.
-->
*Please tick all that apply:*

- [ ] I have tested this change locally
- [ ] I have tested this change locally in all supported browsers
- [ ] This change will be visible to users
- [ ] I have added automated tests that cover this change
- [ ] I have ensured the change is gated by config
- [ ] This change was covered by a ship review
- [ ] This change was covered by a tech design
- [ ] Any dependent config has been merged



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> User-facing validation only in the NTP omnibar; optional config with safe defaults and integration test coverage.
> 
> **Overview**
> The NTP omnibar no longer relies only on fixed caps (3 images / 3 files) for attachment UX. It reads optional **`attachmentLimits`** on omnibar config (from native `/duckchat/v1/models`) and falls back to the old defaults when that field is missing.
> 
> **Image and file hooks** take config-driven limits: `maxImages` from `images.maxPerTurn`, `maxFiles` from `files.maxPerConversation`, and **`maxFileSizeMB`** for per-file size. Limit warnings and attach-menu tooltips use those values instead of hardcoded constants.
> 
> **File attachments** gain client-side rejection of oversized files with a new **`omnibar_fileTooLargeError`** alert (shown ahead of the existing “too many files” warning). Schema/types, mock transport query-param overrides, and integration tests cover the configurable file cap and oversize rejection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 89db3618471f4676a6759867efaf5b655e21cf48. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->