### PR TITLE
fix(ci): auto-resolve Dependabot reviewer threads authored via GraphQL

### DIFF
--- a/.github/scripts/dependabot-anthropic-gate.mjs
+++ b/.github/scripts/dependabot-anthropic-gate.mjs
@@ -389,6 +389,28 @@ export function isTrustedAutomationActor(user) {
     return TRUSTED_AUTOMATION_AUTHORS.has(user.login);
 }
 
+/**
+ * Normalises a GraphQL `Actor.login` to the REST `[bot]` convention.
+ *
+ * The REST APIs (`/pulls/{pr}/reviews`, `/issues/{pr}/comments`,
+ * `/pulls/{pr}/comments`) report App authors as `cursor[bot]`, and the entire
+ * trust model — `TRUSTED_AUTOMATION_AUTHORS`, `isTrustedAutomationActor` — keys
+ * off that suffixed form. The GraphQL `reviewThreads` feed instead reports the
+ * same App as the bare app slug (`cursor`, typename `Bot`). Without this
+ * normalisation, `isDependabotReviewerThread` rejects every Cursor-authored
+ * thread, the classifier resolves nothing, and unresolved low-risk lockfile
+ * comments keep otherwise-green Dependabot PRs `BLOCKED` on
+ * conversation-resolution branch protection even though auto-merge is armed.
+ */
+export function normalizeGraphqlActorLogin(author) {
+    const login = author?.login ?? '';
+    if (!login) return '';
+    if (author?.__typename === 'Bot' && !login.endsWith('[bot]')) {
+        return `${login}[bot]`;
+    }
+    return login;
+}
+
 export function sourceFromReview(review) {
     if (!isTrustedAutomationActor(review.user)) return null;
     return {
@@ -779,7 +801,7 @@ query($owner: String!, $repo: String!, $prNumber: Int!, $after: String) {
           isResolved
           comments(first: 50) {
             nodes {
-              author { login }
+              author { login __typename }
               body
               path
             }
@@ -806,7 +828,7 @@ async function fetchReviewThreads(owner, repo, prNumber, token) {
                 id: node.id,
                 isResolved: node.isResolved,
                 comments: (node.comments?.nodes ?? []).map((comment) => ({
-                    author: comment.author?.login ?? '',
+                    author: normalizeGraphqlActorLogin(comment.author),
                     body: comment.body ?? '',
                     path: comment.path ?? null,
                 })),

--- a/.github/scripts/dependabot-anthropic-gate.test.mjs
+++ b/.github/scripts/dependabot-anthropic-gate.test.mjs
@@ -16,6 +16,7 @@ import {
     missingExpectedCheckNames,
     pendingExpectedCheckRuns,
     isTrustedAutomationActor,
+    normalizeGraphqlActorLogin,
     sourceFromReview,
     sourceFromComment,
     sourceFromInlineReviewComment,
@@ -353,6 +354,44 @@ describe('isTrustedAutomationActor', () => {
         assert.equal(isTrustedAutomationActor({ login: 'evil[bot]', type: 'Bot' }), false);
         assert.equal(isTrustedAutomationActor(null), false);
         assert.equal(isTrustedAutomationActor(undefined), false);
+    });
+});
+
+describe('normalizeGraphqlActorLogin', () => {
+    it('suffixes Bot actors with [bot] to match the REST convention', () => {
+        assert.equal(normalizeGraphqlActorLogin({ login: 'cursor', __typename: 'Bot' }), 'cursor[bot]');
+        assert.equal(normalizeGraphqlActorLogin({ login: 'dependabot', __typename: 'Bot' }), 'dependabot[bot]');
+    });
+
+    it('does not double-suffix logins already carrying [bot]', () => {
+        assert.equal(normalizeGraphqlActorLogin({ login: 'cursor[bot]', __typename: 'Bot' }), 'cursor[bot]');
+    });
+
+    it('leaves human (User) logins untouched', () => {
+        assert.equal(normalizeGraphqlActorLogin({ login: 'octocat', __typename: 'User' }), 'octocat');
+    });
+
+    it('returns empty string for missing authors', () => {
+        assert.equal(normalizeGraphqlActorLogin(null), '');
+        assert.equal(normalizeGraphqlActorLogin(undefined), '');
+        assert.equal(normalizeGraphqlActorLogin({ __typename: 'Bot' }), '');
+    });
+
+    it('keeps isDependabotReviewerThread matching for GraphQL-shaped Cursor threads', () => {
+        const dependabotRun = cursorAutomationRun('Cursor Automation: Review dependabot', 'bc-dep');
+        const webCompatRun = cursorAutomationRun('Cursor Automation: Web compat and sec', 'bc-sec');
+        const candidate = {
+            id: 'PRRT_graphql',
+            isResolved: false,
+            comments: [
+                {
+                    author: normalizeGraphqlActorLogin({ login: 'cursor', __typename: 'Bot' }),
+                    body: '<!-- CURSOR_AUTOMATION_ID: abc | RUN_ID: bc-dep -->\nUnrelated lockfile churn (low risk).',
+                    path: 'package-lock.json',
+                },
+            ],
+        };
+        assert.equal(isDependabotReviewerThread(candidate, { dependabotRun, webCompatRun }), true);
     });
 });
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**Asana Task/Github Issue:** N/A

## Description

Dependabot PRs were being auto-approved with auto-merge armed by `daxtheduck`, yet stayed `BLOCKED` and never merged. The auto-merge gate's `classify-threads` step is supposed to classify and auto-resolve low-risk Cursor reviewer comments, but it was resolving **none** of them.

Root cause: the step fetches review threads via the **GraphQL** `reviewThreads` API, which reports GitHub App authors as the bare app slug (e.g. `cursor`, typename `Bot`) rather than the **REST** `cursor[bot]` form that the entire trust model (`TRUSTED_AUTOMATION_AUTHORS` / `isTrustedAutomationActor`) keys off. Because of the login mismatch, `isDependabotReviewerThread()` rejected every Cursor-authored thread, so the classifier never resolved the low-risk informational lockfile/manifest comments, and the conversation-resolution branch-protection rule kept otherwise-green, approved PRs blocked.

Verified empirically against the open Dependabot PRs (#2811–#2814): auto-merge armed, all checks green, `reviewDecision=APPROVED`, but unresolved `cursor`-authored threads on `package-lock.json` / `package.json`. Resolving those threads flipped them `BLOCKED` → `CLEAN` and they merged via the queue.

### Fix

Select `__typename` in the `reviewThreads` query and normalise the GraphQL `Actor.login` to the REST `[bot]` convention (`cursor` → `cursor[bot]`) before the trust check, via a new `normalizeGraphqlActorLogin()` helper. With this in place the `classify-threads` step will recognise and auto-resolve low-risk Dependabot reviewer threads on future PRs, so they no longer stall on conversation resolution. The REST-sourced merge-gate evidence path is unchanged.

## Testing Steps

- `node --test .github/scripts/dependabot-anthropic-gate.test.mjs` (78 pass)
- Added unit coverage for `normalizeGraphqlActorLogin` (Bot suffixing, no double-suffix, User passthrough, missing author) and an `isDependabotReviewerThread` case using the GraphQL-shaped `cursor` author.

## Checklist

*Please tick all that apply:*

- [x] I have tested this change locally
- [ ] I have tested this change locally in all supported browsers
- [ ] This change will be visible to users
- [x] I have added automated tests that cover this change
- [ ] I have ensured the change is gated by config
- [ ] This change was covered by a ship review
- [ ] This change was covered by a tech design
- [ ] Any dependent config has been merged
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-baefe5a8-4a87-466d-93a4-ea2d44c283ab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-baefe5a8-4a87-466d-93a4-ea2d44c283ab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

