### PR TITLE
Migrate CI LLM judges to Claude Sonnet 5

### DIFF
--- a/.github/scripts/anthropic-config.mjs
+++ b/.github/scripts/anthropic-config.mjs
@@ -5,8 +5,14 @@
  * current — see https://platform.claude.com/docs/en/about-claude/model-deprecations
  */
 export const DEFAULT_ANTHROPIC_MODEL = 'claude-sonnet-4-6';
+export const DEFAULT_SEMVER_ANTHROPIC_MODEL = 'claude-sonnet-5';
 
 /** @param {NodeJS.ProcessEnv} [env] */
 export function resolveAnthropicModel(env = process.env) {
     return env.ANTHROPIC_MODEL || DEFAULT_ANTHROPIC_MODEL;
+}
+
+/** @param {NodeJS.ProcessEnv} [env] */
+export function resolveSemverAnthropicModel(env = process.env) {
+    return env.ANTHROPIC_MODEL || DEFAULT_SEMVER_ANTHROPIC_MODEL;
 }

--- a/.github/scripts/anthropic-config.mjs
+++ b/.github/scripts/anthropic-config.mjs
@@ -4,15 +4,9 @@
  * Override per workflow via the ANTHROPIC_MODEL env var. Keep the default
  * current — see https://platform.claude.com/docs/en/about-claude/model-deprecations
  */
-export const DEFAULT_ANTHROPIC_MODEL = 'claude-sonnet-4-6';
-export const DEFAULT_SEMVER_ANTHROPIC_MODEL = 'claude-sonnet-5';
+export const DEFAULT_ANTHROPIC_MODEL = 'claude-sonnet-5';
 
 /** @param {NodeJS.ProcessEnv} [env] */
 export function resolveAnthropicModel(env = process.env) {
     return env.ANTHROPIC_MODEL || DEFAULT_ANTHROPIC_MODEL;
-}
-
-/** @param {NodeJS.ProcessEnv} [env] */
-export function resolveSemverAnthropicModel(env = process.env) {
-    return env.ANTHROPIC_MODEL || DEFAULT_SEMVER_ANTHROPIC_MODEL;
 }

--- a/.github/scripts/anthropic-config.test.mjs
+++ b/.github/scripts/anthropic-config.test.mjs
@@ -1,9 +1,19 @@
 import assert from 'node:assert/strict';
 import { test } from 'node:test';
 
-import { DEFAULT_ANTHROPIC_MODEL, resolveAnthropicModel } from './anthropic-config.mjs';
+import {
+    DEFAULT_ANTHROPIC_MODEL,
+    DEFAULT_SEMVER_ANTHROPIC_MODEL,
+    resolveAnthropicModel,
+    resolveSemverAnthropicModel,
+} from './anthropic-config.mjs';
 
 test('resolveAnthropicModel prefers ANTHROPIC_MODEL env var', () => {
     assert.equal(resolveAnthropicModel({ ANTHROPIC_MODEL: 'claude-haiku-4-5-20251001' }), 'claude-haiku-4-5-20251001');
     assert.equal(resolveAnthropicModel({}), DEFAULT_ANTHROPIC_MODEL);
+});
+
+test('resolveSemverAnthropicModel defaults to Sonnet 5', () => {
+    assert.equal(resolveSemverAnthropicModel({ ANTHROPIC_MODEL: 'claude-haiku-4-5-20251001' }), 'claude-haiku-4-5-20251001');
+    assert.equal(resolveSemverAnthropicModel({}), DEFAULT_SEMVER_ANTHROPIC_MODEL);
 });

--- a/.github/scripts/anthropic-config.test.mjs
+++ b/.github/scripts/anthropic-config.test.mjs
@@ -1,19 +1,9 @@
 import assert from 'node:assert/strict';
 import { test } from 'node:test';
 
-import {
-    DEFAULT_ANTHROPIC_MODEL,
-    DEFAULT_SEMVER_ANTHROPIC_MODEL,
-    resolveAnthropicModel,
-    resolveSemverAnthropicModel,
-} from './anthropic-config.mjs';
+import { DEFAULT_ANTHROPIC_MODEL, resolveAnthropicModel } from './anthropic-config.mjs';
 
 test('resolveAnthropicModel prefers ANTHROPIC_MODEL env var', () => {
     assert.equal(resolveAnthropicModel({ ANTHROPIC_MODEL: 'claude-haiku-4-5-20251001' }), 'claude-haiku-4-5-20251001');
     assert.equal(resolveAnthropicModel({}), DEFAULT_ANTHROPIC_MODEL);
-});
-
-test('resolveSemverAnthropicModel defaults to Sonnet 5', () => {
-    assert.equal(resolveSemverAnthropicModel({ ANTHROPIC_MODEL: 'claude-haiku-4-5-20251001' }), 'claude-haiku-4-5-20251001');
-    assert.equal(resolveSemverAnthropicModel({}), DEFAULT_SEMVER_ANTHROPIC_MODEL);
 });

--- a/.github/scripts/dependabot-anthropic-gate.mjs
+++ b/.github/scripts/dependabot-anthropic-gate.mjs
@@ -860,7 +860,6 @@ async function askAnthropicForCommentRisk({ apiKey, model, thread, pullRequest }
     const body = JSON.stringify({
         model,
         max_tokens: 400,
-        temperature: 0,
         system,
         tools: [SUBMIT_COMMENT_DECISION_TOOL],
         tool_choice: { type: 'tool', name: SUBMIT_COMMENT_DECISION_TOOL_NAME, disable_parallel_tool_use: true },
@@ -967,7 +966,6 @@ async function askAnthropic({ apiKey, model, evidence }) {
     const body = JSON.stringify({
         model,
         max_tokens: 800,
-        temperature: 0,
         system,
         tools: [SUBMIT_DECISION_TOOL],
         tool_choice: { type: 'tool', name: SUBMIT_DECISION_TOOL_NAME, disable_parallel_tool_use: true },

--- a/.github/scripts/semver-analysis.mjs
+++ b/.github/scripts/semver-analysis.mjs
@@ -9,7 +9,7 @@
  *
  * Expects env vars:
  *   ANTHROPIC_API_KEY - Anthropic API key
- *   ANTHROPIC_MODEL   - Optional; defaults to semver model in anthropic-config.mjs
+ *   ANTHROPIC_MODEL   - Optional; defaults to shared CI model in anthropic-config.mjs
  *   BUILD_DIFF        - Build output diff from diff-directories.js
  *   PR_TITLE          - Pull request title
  *   PR_BODY           - Pull request body/description
@@ -18,7 +18,7 @@
  * Outputs to stdout a JSON object: { "severity": "major"|"minor"|"patch", "reasoning": "..." }
  */
 
-import { resolveSemverAnthropicModel } from './anthropic-config.mjs';
+import { resolveAnthropicModel } from './anthropic-config.mjs';
 
 const ANTHROPIC_API_URL = 'https://api.anthropic.com/v1/messages';
 const MAX_DIFF_CHARS = 80_000;
@@ -115,7 +115,7 @@ async function callAnthropic(systemPrompt, userPrompt, apiKey) {
             'anthropic-version': '2023-06-01',
         },
         body: JSON.stringify({
-            model: resolveSemverAnthropicModel(),
+            model: resolveAnthropicModel(),
             max_tokens: 512,
             system: systemPrompt,
             messages: [{ role: 'user', content: userPrompt }],

--- a/.github/scripts/semver-analysis.mjs
+++ b/.github/scripts/semver-analysis.mjs
@@ -9,7 +9,7 @@
  *
  * Expects env vars:
  *   ANTHROPIC_API_KEY - Anthropic API key
- *   ANTHROPIC_MODEL   - Optional; defaults to shared CI model in anthropic-config.mjs
+ *   ANTHROPIC_MODEL   - Optional; defaults to semver model in anthropic-config.mjs
  *   BUILD_DIFF        - Build output diff from diff-directories.js
  *   PR_TITLE          - Pull request title
  *   PR_BODY           - Pull request body/description
@@ -18,7 +18,7 @@
  * Outputs to stdout a JSON object: { "severity": "major"|"minor"|"patch", "reasoning": "..." }
  */
 
-import { resolveAnthropicModel } from './anthropic-config.mjs';
+import { resolveSemverAnthropicModel } from './anthropic-config.mjs';
 
 const ANTHROPIC_API_URL = 'https://api.anthropic.com/v1/messages';
 const MAX_DIFF_CHARS = 80_000;
@@ -115,9 +115,8 @@ async function callAnthropic(systemPrompt, userPrompt, apiKey) {
             'anthropic-version': '2023-06-01',
         },
         body: JSON.stringify({
-            model: resolveAnthropicModel(),
+            model: resolveSemverAnthropicModel(),
             max_tokens: 512,
-            temperature: 0,
             system: systemPrompt,
             messages: [{ role: 'user', content: userPrompt }],
         }),

--- a/.github/scripts/semver-analysis.mjs
+++ b/.github/scripts/semver-analysis.mjs
@@ -10,7 +10,8 @@
  * Expects env vars:
  *   ANTHROPIC_API_KEY - Anthropic API key
  *   ANTHROPIC_MODEL   - Optional; defaults to shared CI model in anthropic-config.mjs
- *   BUILD_DIFF        - Build output diff from diff-directories.js
+ *   BUILD_DIFF        - Build output diff from diff-directories.js (may be empty)
+ *   SOURCE_DIFF       - Git diff of source changes between base and PR (may be empty)
  *   PR_TITLE          - Pull request title
  *   PR_BODY           - Pull request body/description
  *   PR_FILES          - Newline-separated list of changed source file paths
@@ -18,10 +19,13 @@
  * Outputs to stdout a JSON object: { "severity": "major"|"minor"|"patch", "reasoning": "..." }
  */
 
+import { fileURLToPath } from 'node:url';
+
 import { resolveAnthropicModel } from './anthropic-config.mjs';
 
 const ANTHROPIC_API_URL = 'https://api.anthropic.com/v1/messages';
-const MAX_DIFF_CHARS = 80_000;
+const MAX_BUILD_DIFF_CHARS = 80_000;
+const MAX_SOURCE_DIFF_CHARS = 80_000;
 
 const SYSTEM_PROMPT = `You are a semver classification expert for the duckduckgo/content-scope-scripts repository.
 
@@ -34,7 +38,9 @@ You receive a **build output diff** comparing built artifacts between the base b
 - "New Files" — built artifacts only in the PR build (the PR adds them)
 - Named groups (e.g. "Apple", "Windows", "Integration") — artifacts that exist in both but whose content differs
 
-You also receive the list of changed **source files** and the PR title/description for context.
+When the build output diff is empty, built artifacts are identical between base and PR. Do not infer semver impact from that alone — use the **source diff** and changed file list to classify the PR.
+
+You also receive a **source diff** (unified git diff between base and PR) and the list of changed **source files**, plus the PR title/description for context. Use the source diff to inspect API, schema, feature-bundle, and messaging contract changes even when build output is unchanged.
 
 ## Public API surfaces (changes here are semver-sensitive):
 
@@ -78,18 +84,33 @@ You also receive the list of changed **source files** and the PR title/descripti
 - No new message schema files added under \`injected/src/messages/\`
 - No changes to message schema shapes (field additions/removals/renames in \`.notify.json\`, \`.request.json\`, \`.subscribe.json\` files)
 - No new entries in \`platformSupport\` or \`platformSpecificFeatures\`
-- OR no build artifacts changed at all (docs/test/CI-only PRs)
+- OR source changes are limited to docs, tests, CI/tooling, or dependency updates with no semver-sensitive API changes (even when build output is unchanged)
 
 Always respond with valid JSON: { "severity": "major"|"minor"|"patch", "reasoning": "..." }
 The reasoning should be 2-3 concise sentences explaining the classification.`;
 
-function truncateDiff(diff) {
-    if (diff.length <= MAX_DIFF_CHARS) return diff;
-    return diff.slice(0, MAX_DIFF_CHARS) + '\n\n... [diff truncated at 80k chars] ...';
+function truncateDiff(diff, maxChars) {
+    if (!diff) return diff;
+    if (diff.length <= maxChars) return diff;
+    return diff.slice(0, maxChars) + '\n\n... [diff truncated] ...';
 }
 
-function buildUserPrompt({ buildDiff, title, body, files }) {
-    return `Classify this PR's semver impact based on build output changes.
+function formatBuildDiffSection(buildDiff) {
+    if (!buildDiff.trim()) {
+        return '(no build output artifacts changed — built outputs are identical between base and PR)';
+    }
+    return truncateDiff(buildDiff, MAX_BUILD_DIFF_CHARS);
+}
+
+function formatSourceDiffSection(sourceDiff) {
+    if (!sourceDiff.trim()) {
+        return '(no source changes detected)';
+    }
+    return truncateDiff(sourceDiff, MAX_SOURCE_DIFF_CHARS);
+}
+
+function buildUserPrompt({ buildDiff, sourceDiff, title, body, files }) {
+    return `Classify this PR's semver impact using both build output changes and source changes.
 
 ## PR Title
 ${title}
@@ -101,10 +122,15 @@ ${body || '(no description)'}
 ${files || '(not available)'}
 
 ## Build Output Diff
-${truncateDiff(buildDiff)}
+${formatBuildDiffSection(buildDiff)}
+
+## Source Diff
+${formatSourceDiffSection(sourceDiff)}
 
 Respond with JSON only: { "severity": "major"|"minor"|"patch", "reasoning": "..." }`;
 }
+
+export { buildUserPrompt, formatBuildDiffSection, formatSourceDiffSection };
 
 async function callAnthropic(systemPrompt, userPrompt, apiKey) {
     const response = await fetch(ANTHROPIC_API_URL, {
@@ -156,25 +182,18 @@ async function main() {
     }
 
     const buildDiff = process.env.BUILD_DIFF || '';
+    const sourceDiff = process.env.SOURCE_DIFF || '';
     const title = process.env.PR_TITLE || '';
     const body = process.env.PR_BODY || '';
     const files = process.env.PR_FILES || '';
 
-    if (!buildDiff) {
-        console.log(
-            JSON.stringify({
-                severity: 'patch',
-                reasoning: 'No build output artifacts changed. PR only affects tests, documentation, CI, or other non-shipped files.',
-            }),
-        );
-        return;
-    }
-
-    const userPrompt = buildUserPrompt({ buildDiff, title, body, files });
+    const userPrompt = buildUserPrompt({ buildDiff, sourceDiff, title, body, files });
     const rawResponse = await callAnthropic(SYSTEM_PROMPT, userPrompt, apiKey);
     const result = parseResponse(rawResponse);
 
     console.log(JSON.stringify(result));
 }
 
-main();
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+    main();
+}

--- a/.github/scripts/semver-analysis.test.mjs
+++ b/.github/scripts/semver-analysis.test.mjs
@@ -1,0 +1,31 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import { buildUserPrompt, formatBuildDiffSection, formatSourceDiffSection } from './semver-analysis.mjs';
+
+test('formatBuildDiffSection explains when build output is unchanged', () => {
+    assert.match(formatBuildDiffSection(''), /no build output artifacts changed/);
+    assert.match(formatBuildDiffSection('   \n'), /no build output artifacts changed/);
+    assert.equal(formatBuildDiffSection('- changed.js'), '- changed.js');
+});
+
+test('formatSourceDiffSection explains when source diff is empty', () => {
+    assert.match(formatSourceDiffSection(''), /no source changes detected/);
+    assert.equal(formatSourceDiffSection('diff --git a/foo b/foo'), 'diff --git a/foo b/foo');
+});
+
+test('buildUserPrompt includes build and source diff sections', () => {
+    const prompt = buildUserPrompt({
+        buildDiff: '',
+        sourceDiff: 'diff --git a/.github/scripts/foo.mjs b/.github/scripts/foo.mjs',
+        title: 'CI-only change',
+        body: 'Updates semver workflow',
+        files: '.github/scripts/foo.mjs',
+    });
+
+    assert.match(prompt, /Build Output Diff/);
+    assert.match(prompt, /no build output artifacts changed/);
+    assert.match(prompt, /Source Diff/);
+    assert.match(prompt, /diff --git a\/\.github\/scripts\/foo\.mjs/);
+    assert.match(prompt, /Changed Source Files/);
+});

--- a/.github/workflows/semver-label.yml
+++ b/.github/workflows/semver-label.yml
@@ -51,18 +51,14 @@ jobs:
                   node base/.github/scripts/diff-directories.js base pr > /tmp/build_diff.txt
                   echo "Build diff size: $(wc -c < /tmp/build_diff.txt) bytes"
 
-            - name: Create source diff
-              run: |
-                  BASE_SHA=$(git -C base rev-parse HEAD)
-                  git -C pr diff "$BASE_SHA" > /tmp/source_diff.txt
-                  echo "Source diff size: $(wc -c < /tmp/source_diff.txt) bytes"
-
-            - name: Get PR source files
+            - name: Get PR source files and diff
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
                   PR_NUMBER: ${{ github.event.pull_request.number }}
               run: |
                   gh pr view "$PR_NUMBER" --json files --jq '.files[].path' > /tmp/pr_files.txt 2>/dev/null || true
+                  gh pr diff "$PR_NUMBER" > /tmp/source_diff.txt 2>/dev/null || true
+                  echo "Source diff size: $(wc -c < /tmp/source_diff.txt) bytes"
 
             - name: Run semver analysis
               id: analyse

--- a/.github/workflows/semver-label.yml
+++ b/.github/workflows/semver-label.yml
@@ -51,14 +51,27 @@ jobs:
                   node base/.github/scripts/diff-directories.js base pr > /tmp/build_diff.txt
                   echo "Build diff size: $(wc -c < /tmp/build_diff.txt) bytes"
 
-            - name: Get PR source files and diff
-              env:
-                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-                  PR_NUMBER: ${{ github.event.pull_request.number }}
+            - name: Create source diff
               run: |
-                  gh pr view "$PR_NUMBER" --json files --jq '.files[].path' > /tmp/pr_files.txt 2>/dev/null || true
-                  gh pr diff "$PR_NUMBER" > /tmp/source_diff.txt 2>/dev/null || true
+                  BASE_SHA=$(git -C base rev-parse HEAD)
+                  if ! git -C pr cat-file -e "$BASE_SHA^{commit}" 2>/dev/null; then
+                      git -C pr remote add base-checkout "$GITHUB_WORKSPACE/base" 2>/dev/null || \
+                        git -C pr remote set-url base-checkout "$GITHUB_WORKSPACE/base"
+                      git -C pr fetch --no-tags base-checkout "$BASE_SHA":refs/base-sha
+                      BASE_REF=refs/base-sha
+                  else
+                      BASE_REF="$BASE_SHA"
+                  fi
+
+                  git -C pr diff --name-only "$BASE_REF" > /tmp/pr_files.txt
+                  git -C pr diff "$BASE_REF" > /tmp/source_diff.txt
+                  echo "Changed files: $(wc -l < /tmp/pr_files.txt)"
                   echo "Source diff size: $(wc -c < /tmp/source_diff.txt) bytes"
+
+                  if [[ -s /tmp/pr_files.txt && ! -s /tmp/source_diff.txt ]]; then
+                      echo "Error: PR has changed files but source diff is empty"
+                      exit 1
+                  fi
 
             - name: Run semver analysis
               id: analyse

--- a/.github/workflows/semver-label.yml
+++ b/.github/workflows/semver-label.yml
@@ -51,6 +51,12 @@ jobs:
                   node base/.github/scripts/diff-directories.js base pr > /tmp/build_diff.txt
                   echo "Build diff size: $(wc -c < /tmp/build_diff.txt) bytes"
 
+            - name: Create source diff
+              run: |
+                  BASE_SHA=$(git -C base rev-parse HEAD)
+                  git -C pr diff "$BASE_SHA" > /tmp/source_diff.txt
+                  echo "Source diff size: $(wc -c < /tmp/source_diff.txt) bytes"
+
             - name: Get PR source files
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -66,6 +72,7 @@ jobs:
                   PR_BODY: ${{ github.event.pull_request.body }}
               run: |
                   export BUILD_DIFF="$(cat /tmp/build_diff.txt 2>/dev/null || echo '')"
+                  export SOURCE_DIFF="$(cat /tmp/source_diff.txt 2>/dev/null || echo '')"
                   export PR_FILES="$(cat /tmp/pr_files.txt 2>/dev/null || echo '')"
 
                   RESULT=$(node base/.github/scripts/semver-analysis.mjs)

--- a/.github/workflows/semver-label.yml
+++ b/.github/workflows/semver-label.yml
@@ -54,17 +54,17 @@ jobs:
             - name: Create source diff
               run: |
                   BASE_SHA=$(git -C base rev-parse HEAD)
-                  if ! git -C pr cat-file -e "$BASE_SHA^{commit}" 2>/dev/null; then
+                  if git -C pr cat-file -e "$BASE_SHA^{commit}" 2>/dev/null; then
+                      BASE_REF="$BASE_SHA"
+                  else
                       git -C pr remote add base-checkout "$GITHUB_WORKSPACE/base" 2>/dev/null || \
                         git -C pr remote set-url base-checkout "$GITHUB_WORKSPACE/base"
-                      git -C pr fetch --no-tags base-checkout "$BASE_SHA":refs/base-sha
-                      BASE_REF=refs/base-sha
-                  else
-                      BASE_REF="$BASE_SHA"
+                      git -C pr fetch --no-tags --depth=1 base-checkout "$BASE_SHA"
+                      BASE_REF=FETCH_HEAD
                   fi
 
-                  git -C pr diff --name-only "$BASE_REF" > /tmp/pr_files.txt
-                  git -C pr diff "$BASE_REF" > /tmp/source_diff.txt
+                  git -C pr diff --name-only "$BASE_REF" HEAD > /tmp/pr_files.txt
+                  git -C pr diff "$BASE_REF" HEAD > /tmp/source_diff.txt
                   echo "Changed files: $(wc -l < /tmp/pr_files.txt)"
                   echo "Source diff size: $(wc -c < /tmp/source_diff.txt) bytes"
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -56,7 +56,7 @@ jobs:
               with:
                   node-version-file: '.nvmrc'
             - name: Dependabot Anthropic gate helpers
-              run: node --test .github/scripts/dependabot-anthropic-gate.test.mjs .github/scripts/anthropic-config.test.mjs
+              run: node --test .github/scripts/dependabot-anthropic-gate.test.mjs .github/scripts/anthropic-config.test.mjs .github/scripts/semver-analysis.test.mjs
 
     unit:
         runs-on: ${{ matrix.os }}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**Asana Task/Github Issue:** N/A

## Description

CI-only changes across three areas:

### 1. Migrate CI LLM judges to Claude Sonnet 5
- Set `DEFAULT_ANTHROPIC_MODEL` to `claude-sonnet-5` in `anthropic-config.mjs`
- Remove `temperature: 0` from Anthropic API calls in `semver-analysis.mjs` and `dependabot-anthropic-gate.mjs` — Sonnet 5 returns HTTP 400 for non-default sampling parameters

### 2. Improve semver classification
- **Always consult Claude** — remove the patch early-exit when build output is unchanged
- **Include source diff** — send a unified git diff alongside the build output diff so CI-only and source-only changes are classified from actual code changes, not heuristics
- Update the system prompt to instruct the judge to use source diff when build artifacts are identical

### 3. Fix semver-label workflow source diff generation
The workflow builds from the PR merge ref; source diff now matches that:
- Diff `FETCH_HEAD..HEAD` in the `pr` checkout against the `base` checkout SHA
- Fetch the base commit into the shallow `pr` clone via a local `base-checkout` remote (named refs are rejected on shallow clones)
- Fail the job if changed files exist but the diff is empty (no silent error swallowing)

### Files changed
| File | Change |
|------|--------|
| `anthropic-config.mjs` | Default model → `claude-sonnet-5` |
| `dependabot-anthropic-gate.mjs` | Remove `temperature: 0` |
| `semver-analysis.mjs` | Source diff input, always call Claude, remove `temperature`, export prompt helpers |
| `semver-analysis.test.mjs` | Unit tests for prompt formatting |
| `semver-label.yml` | Generate aligned source diff in CI |
| `tests.yml` | Wire in semver-analysis tests |

## Testing Steps

```bash
node --test .github/scripts/anthropic-config.test.mjs .github/scripts/dependabot-anthropic-gate.test.mjs .github/scripts/semver-analysis.test.mjs
```

Verify **Semver Label** workflow passes on this PR after merge.

## Checklist

*Please tick all that apply:*

- [ ] I have tested this change locally
- [ ] I have tested this change locally in all supported browsers
- [ ] This change will be visible to users
- [x] I have added automated tests that cover this change
- [ ] I have ensured the change is gated by config
- [ ] This change was covered by a ship review
- [ ] This change was covered by a tech design
- [ ] Any dependent config has been merged

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-be1977ae-28f1-4650-9db4-e0f09f4b63fb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-be1977ae-28f1-4650-9db4-e0f09f4b63fb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

