### PR TITLE
Fix New Tab Page horizontal drag-scroll in WebKit

### DIFF
--- a/special-pages/pages/new-tab/app/components/App.module.css
+++ b/special-pages/pages/new-tab/app/components/App.module.css
@@ -50,6 +50,10 @@ body[data-animate-background="true"] {
 .layout {
     position: relative;
     z-index: 1;
+    /* Prevent clicking on background and dragging from scrolling horizontally in
+       WebKit. Need overflow: clip and not overflow-x: clip to prevent Customize
+       button outline rendering issue. */
+    overflow: clip;
 }
 
 .main {


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1209121419454298/task/1215710466370635?focus=true

## Description

On WebKit only, clicking on the New Tab Page background and dragging to the right scrolls the whole page horizontally, even though there's nothing over there to scroll to.

The culprit is the customizer drawer. When it's closed we park it just off the right edge with `position: absolute` + `transform: translateX(100%)`. WebKit counts that parked drawer as horizontal scrollable overflow, and `overflow: hidden` on the body doesn't stop a background click-drag from autoscrolling into it, so the page slides left by exactly the drawer's width.

The fix is to `overflow: clip` the layout container so the parked drawer can't create a scrollable region in the first place. It has to be `overflow: clip` and not `overflow-x: clip` though – a single-axis clip leaves `overflow-y: visible`, and WebKit then intermittently mis-renders the Customize button's outline until you resize the window.

## Testing Steps

Best tested in Safari/WebKit. Open the hosted [**New Tab Page**](https://rawcdn.githack.com/duckduckgo/content-scope-scripts/aa8c0d06f05ba428a69d70d0919eb3f0b7d4c0b0/build/integration/pages/new-tab/index.html) (from the **Build Branch** comment below), then shrink the window until the vertical scrollbar appears.

Small viewport:
- Click on the page background and drag to the right, past where the scrollbar is. The page should **not** move horizontally.
- Check you can still scroll the page up and down.
- Open the customizer (Customize button) and check you can scroll the page and the customizer up and down independently.

Large viewport (no scrollbar):
- Same as above. Nothing should scroll horizontally or vertically.

## Checklist

*Please tick all that apply:*

- [x] I have tested this change locally
- [x] I have tested this change locally in all supported browsers
- [x] This change will be visible to users
- [ ] I have added automated tests that cover this change
- [ ] I have ensured the change is gated by config
- [ ] This change was covered by a ship review
- [ ] This change was covered by a tech design
- [ ] Any dependent config has been merged
