### PR TITLE
Onboarding: advance makeDefaultSingle step on native's onSetAsDefaultComplete

### DIFF
--- a/special-pages/pages/onboarding/app/global.js
+++ b/special-pages/pages/onboarding/app/global.js
@@ -1,5 +1,5 @@
 import { createContext, h } from 'preact';
-import { useCallback, useContext, useEffect, useReducer } from 'preact/hooks';
+import { useCallback, useContext, useEffect, useReducer, useRef } from 'preact/hooks';
 import { usePlatformName } from './shared/components/SettingsProvider.js';
 
 /**
@@ -44,6 +44,24 @@ export function reducer(state, action) {
             stepDefinitions: nextStepDefs,
             order: nextOrder,
             step: nextStepDefs[state.activeStep] ?? state.step,
+        };
+    }
+    if (action.kind === 'auto-advance') {
+        // Only meaningful while the make-default step is showing
+        if (state.activeStep !== 'makeDefaultSingle') return state;
+        const currentPageIndex = state.order.indexOf(state.activeStep);
+        const nextPageIndex = currentPageIndex + 1;
+        if (nextPageIndex >= state.order.length) return state;
+        return {
+            ...state,
+            status: { kind: 'idle' },
+            activeStep: state.order[nextPageIndex],
+            nextStep: state.order[nextPageIndex + 1],
+            activeRow: 0,
+            activeStepVisible: false,
+            exiting: false,
+            overlay: null,
+            step: state.stepDefinitions[state.order[nextPageIndex]],
         };
     }
     switch (state.status.kind) {
@@ -178,6 +196,25 @@ export function reducer(state, action) {
 }
 
 /**
+ * Notifies native that the current step has completed, and fires a `row_shown` telemetry
+ * event for the first row of the incoming settings step, if any.
+ *
+ * @param {GlobalState} state
+ * @param {import("./messages.js").OnboardingMessages} messaging
+ */
+function notifyStepAdvanced(state, messaging) {
+    const currentIndex = state.order.indexOf(state.activeStep);
+    const next = state.order[currentIndex + 1] ?? null;
+    messaging.stepCompleted({ id: state.activeStep, next });
+    if (next) {
+        const nextStepDef = state.stepDefinitions[next];
+        if (nextStepDef?.kind === 'settings' && nextStepDef.rows[0]) {
+            messaging.telemetryEvent({ attributes: { name: 'row_shown', value: nextStepDef.rows[0] } });
+        }
+    }
+}
+
+/**
  * Provides navigation functionality for the application.
  * @param {Object} props - The properties for the NavigationProvider component.
  * @param {import('./types').Step['id'][]} props.order - The order of screens to display
@@ -226,16 +263,10 @@ export function GlobalProvider({ order, children, stepDefinitions, messaging, fi
              * Side effects that don't impact global state (advance to non-customize step, or other message kinds).
              */
             if (msg.kind === 'advance') {
-                const currentIndex = state.order.indexOf(state.activeStep);
-                const next = state.order[currentIndex + 1] ?? null;
-                messaging.stepCompleted({ id: state.activeStep, next });
-                // Fire row_shown for the first row of the incoming settings step
-                if (next) {
-                    const nextStepDef = state.stepDefinitions[next];
-                    if (nextStepDef?.kind === 'settings' && nextStepDef.rows[0]) {
-                        messaging.telemetryEvent({ attributes: { name: 'row_shown', value: nextStepDef.rows[0] } });
-                    }
-                }
+                notifyStepAdvanced(state, messaging);
+            }
+            if (msg.kind === 'auto-advance' && state.activeStep === 'makeDefaultSingle') {
+                notifyStepAdvanced(state, messaging);
             }
             if (msg.kind === 'show-overlay' && msg.overlay === 'dock-instructions') {
                 messaging.telemetryEvent({ attributes: { name: 'dock_instructions_shown' } });
@@ -263,6 +294,17 @@ export function GlobalProvider({ order, children, stepDefinitions, messaging, fi
                 stepDefinitions: data.stepDefinitions,
                 exclude: /** @type {import('./types.js').ConfigUpdateEvent['exclude']} */ (data.exclude),
             });
+        });
+        return unsubscribe;
+    }, [messaging]);
+
+    // `proxy` is recreated whenever `state` changes; route through a ref so the
+    // subscription callback below always sees the latest `state` without re-subscribing.
+    const proxyRef = useRef(proxy);
+    proxyRef.current = proxy;
+    useEffect(() => {
+        const unsubscribe = messaging.onSetAsDefaultComplete(() => {
+            proxyRef.current({ kind: 'auto-advance' });
         });
         return unsubscribe;
     }, [messaging]);

--- a/special-pages/pages/onboarding/app/messages.js
+++ b/special-pages/pages/onboarding/app/messages.js
@@ -179,6 +179,16 @@ export class OnboardingMessages {
     }
 
     /**
+     * Subscribe to native's signal that the user has finished the Set Default OS flow.
+     * Sent at most once per requestSetAsDefault, when the browser returns to the foreground.
+     * @param {() => void} callback
+     * @returns {() => void} unsubscribe
+     */
+    onSetAsDefaultComplete(callback) {
+        return this.messaging.subscribe('onSetAsDefaultComplete', callback);
+    }
+
+    /**
      * Sent when the user wants to enable or disable ad blocking.
      *
      * @param {import('./types').BooleanSystemValue} params

--- a/special-pages/pages/onboarding/app/types.js
+++ b/special-pages/pages/onboarding/app/types.js
@@ -36,7 +36,7 @@ import { useContext } from 'preact/hooks';
  * @typedef {{ kind: 'info'; id: 'getStarted' }} GetStartedStep
  * @typedef {{ kind: 'settings'; id: 'systemSettings'; rows: SystemValueId[]; }} SystemSettingsStep
  * @typedef {{ kind: 'settings'; id: 'customize'; rows: SystemValueId[]; }} CustomizeStep
- * @typedef {{ kind: 'settings'; id: 'makeDefaultSingle'; rows: SystemValueId[]; }} MakeDefaultSingleStep
+ * @typedef {{ kind: 'settings'; id: 'makeDefaultSingle'; rows: SystemValueId[]; autoAdvance?: boolean }} MakeDefaultSingleStep
  * @typedef {{ kind: 'info'; id: 'duckPlayerSingle'; variant?: 'ad-free' }} DuckPlayerSingleStep
  * @typedef {{ kind: 'info'; id: 'addressBarMode' }} AddressBarModeStep
  */
@@ -100,6 +100,7 @@ export const ORDER_V4 = ['welcome', 'getStarted', 'makeDefaultSingle', 'systemSe
  *   | ShowOverlayEvent
  *   | DismissOverlayEvent
  *   | ConfigUpdateEvent
+ *   | AutoAdvanceEvent
  *   | TelemetryEvent} GlobalEvents
  *  All the events that the UI can dispatch
  * @typedef {{ kind: "enqueue-next"; }} NextEvent
@@ -114,6 +115,7 @@ export const ORDER_V4 = ['welcome', 'getStarted', 'makeDefaultSingle', 'systemSe
  * @typedef {{ kind: "show-overlay"; overlay: OverlayId }} ShowOverlayEvent
  * @typedef {{ kind: "dismiss-overlay" }} DismissOverlayEvent
  * @typedef {{ kind: "config-update"; stepDefinitions?: Record<string, any>; exclude?: Step['id'][] }} ConfigUpdateEvent
+ * @typedef {{ kind: "auto-advance" }} AutoAdvanceEvent
  * @typedef {{ kind: "telemetry"; attributes: import('../types/onboarding.ts').TelemetryEvent['attributes'] }} TelemetryEvent
  */
 

--- a/special-pages/pages/onboarding/app/v3/data/data.js
+++ b/special-pages/pages/onboarding/app/v3/data/data.js
@@ -38,30 +38,35 @@ export const stepsConfig = {
         };
     },
     makeDefaultSingle: ({ t, globalState, advance, enableSystemValue }) => {
-        const { UIValues } = globalState;
+        const { UIValues, stepDefinitions } = globalState;
+        const autoAdvance = Boolean(
+            /** @type {import('../../types').MakeDefaultSingleStep} */ (stepDefinitions.makeDefaultSingle)?.autoAdvance,
+        );
         const isIdle = UIValues['default-browser'] === 'idle';
 
         return {
             variant: 'box',
             heading: {
-                title: isIdle ? t('protectionsActivated_title') : t('makeDefaultAccept_title'),
+                title: autoAdvance || isIdle ? t('protectionsActivated_title') : t('makeDefaultAccept_title'),
                 speechBubble: true,
             },
-            dismissButton: isIdle
-                ? {
-                      text: t('skipButton'),
-                      handler: advance,
-                  }
-                : null,
-            acceptButton: isIdle
-                ? {
-                      text: t('makeDefaultButton'),
-                      handler: () => enableSystemValue('default-browser'),
-                  }
-                : {
-                      text: t('nextButton'),
-                      handler: advance,
-                  },
+            dismissButton:
+                isIdle || autoAdvance
+                    ? {
+                          text: t('skipButton'),
+                          handler: advance,
+                      }
+                    : null,
+            acceptButton:
+                autoAdvance || isIdle
+                    ? {
+                          text: t('makeDefaultButton'),
+                          handler: () => enableSystemValue('default-browser'),
+                      }
+                    : {
+                          text: t('nextButton'),
+                          handler: advance,
+                      },
             content: <MakeDefaultStep />,
         };
     },

--- a/special-pages/pages/onboarding/app/v4/components/MakeDefaultContent.js
+++ b/special-pages/pages/onboarding/app/v4/components/MakeDefaultContent.js
@@ -32,12 +32,19 @@ export function MakeDefaultContent({ advance, onTitleComplete, updateSystemValue
     const globalState = useGlobalState();
     const hasTypingEffect = !!useTypingEffect();
 
+    // Gate all auto-advance behaviour behind the flag native supplies in the init response
+    const autoAdvance = Boolean(
+        /** @type {import('../../types').MakeDefaultSingleStep} */ (globalState.stepDefinitions.makeDefaultSingle)?.autoAdvance,
+    );
+
     // Skip button visibility: hidden while the native call is in flight or after it succeeds
     const isPending =
         globalState.status.kind === 'executing' &&
         globalState.status.action.kind === 'update-system-value' &&
         globalState.status.action.id === 'default-browser';
-    const showSkipButton = !isPending && globalState.UIValues['default-browser'] === 'idle';
+    const showSkipButton = !isPending && (autoAdvance || globalState.UIValues['default-browser'] === 'idle');
+    // Primary button never shows "Next" when auto-advancing - native's push message drives navigation.
+    const showMakeDefaultButton = autoAdvance || showSkipButton;
 
     // Title text swaps mid-bounce so it can't be derived from global state
     const [showSuccess, setShowSuccess] = useState(false);
@@ -69,6 +76,10 @@ export function MakeDefaultContent({ advance, onTitleComplete, updateSystemValue
         }
 
         updateSystemValue('default-browser', { enabled: true }, true);
+
+        // We don't know the outcome yet (waiting for onSetAsDefaultComplete), so skip the
+        // success bounce/title swap entirely - the title stays on protectionsActivated_title.
+        if (autoAdvance) return;
 
         // Fire-and-forget sequential title bounce (text swaps at midpoint)
         (async () => {
@@ -139,8 +150,12 @@ export function MakeDefaultContent({ advance, onTitleComplete, updateSystemValue
                             {t('skipButton')}
                         </Button>
                     )}
-                    <Button buttonRef={primaryButtonRef} disabled={isPending} onClick={showSkipButton ? enableDefaultBrowser : advance}>
-                        {showSkipButton ? t('makeDefaultButton') : t('nextButton')}
+                    <Button
+                        buttonRef={primaryButtonRef}
+                        disabled={isPending}
+                        onClick={showMakeDefaultButton ? enableDefaultBrowser : advance}
+                    >
+                        {showMakeDefaultButton ? t('makeDefaultButton') : t('nextButton')}
                     </Button>
                 </div>
             </div>

--- a/special-pages/pages/onboarding/integration-tests/onboarding.page.js
+++ b/special-pages/pages/onboarding/integration-tests/onboarding.page.js
@@ -62,6 +62,14 @@ export class OnboardingPage {
     }
 
     /**
+     * Push an onSetAsDefaultComplete subscription event, simulating native returning to the
+     * foreground after the OS "set as default" flow.
+     */
+    async pushSetAsDefaultComplete() {
+        await this.mocks.simulateSubscriptionMessage('onSetAsDefaultComplete', {});
+    }
+
+    /**
      * Opens a page with optional parameters.
      * This method ensures that mocks are installed and routes are set up before navigating to the page.
      *

--- a/special-pages/pages/onboarding/integration-tests/onboarding.v3.spec.js
+++ b/special-pages/pages/onboarding/integration-tests/onboarding.v3.spec.js
@@ -65,6 +65,81 @@ test.describe('onboarding v3', () => {
         });
     });
 
+    test.describe('Given autoAdvance is enabled on the make default step', () => {
+        test('Then Next never appears while waiting, and Skip remains visible', async ({ page }, workerInfo) => {
+            const onboarding = OnboardingV3Page.create(page, workerInfo);
+            onboarding.withInitData({
+                stepDefinitions: {
+                    makeDefaultSingle: { autoAdvance: true },
+                },
+                order: 'v3',
+            });
+            await onboarding.reducedMotion();
+            await onboarding.openPage({ env: 'app', page: 'makeDefaultSingle' });
+
+            await page.getByRole('button', { name: 'Make DuckDuckGo Your Default' }).click();
+            await onboarding.mocks.waitForCallCount({ method: 'requestSetAsDefault', count: 1 });
+
+            await expect(page.getByRole('button', { name: 'Make DuckDuckGo Your Default' })).toBeVisible();
+            await expect(page.getByRole('button', { name: 'Next' })).not.toBeVisible();
+            await expect(page.getByRole('button', { name: 'Skip' })).toBeVisible();
+        });
+
+        test('Then onSetAsDefaultComplete advances to the next step and fires stepCompleted', async ({ page }, workerInfo) => {
+            const onboarding = OnboardingV3Page.create(page, workerInfo);
+            onboarding.withInitData({
+                stepDefinitions: {
+                    makeDefaultSingle: { autoAdvance: true },
+                },
+                order: 'v3',
+            });
+            await onboarding.reducedMotion();
+            await onboarding.openPage({ env: 'app', page: 'makeDefaultSingle' });
+
+            await page.getByRole('button', { name: 'Make DuckDuckGo Your Default' }).click();
+            await onboarding.mocks.waitForCallCount({ method: 'requestSetAsDefault', count: 1 });
+
+            await onboarding.pushSetAsDefaultComplete();
+
+            await page.getByText('Let’s get you set up!').nth(1).waitFor({ timeout: 1000 });
+            await onboarding.didFireStepCompleted({ id: 'makeDefaultSingle', next: 'systemSettings' });
+        });
+
+        test('Then onSetAsDefaultComplete is a no-op on other steps', async ({ page }, workerInfo) => {
+            const onboarding = OnboardingV3Page.create(page, workerInfo);
+            onboarding.withInitData({
+                stepDefinitions: {
+                    makeDefaultSingle: { autoAdvance: true },
+                },
+                order: 'v3',
+            });
+            await onboarding.reducedMotion();
+            await onboarding.openPage({ env: 'app', page: 'systemSettings' });
+            await page.getByText('Let’s get you set up!').nth(1).waitFor({ timeout: 1000 });
+
+            await onboarding.pushSetAsDefaultComplete();
+
+            await expect(page.getByText('Let’s get you set up!').nth(1)).toBeVisible();
+        });
+
+        test('Then Skip still advances to the next step', async ({ page }, workerInfo) => {
+            const onboarding = OnboardingV3Page.create(page, workerInfo);
+            onboarding.withInitData({
+                stepDefinitions: {
+                    makeDefaultSingle: { autoAdvance: true },
+                },
+                order: 'v3',
+            });
+            await onboarding.reducedMotion();
+            await onboarding.openPage({ env: 'app', page: 'makeDefaultSingle' });
+
+            await onboarding.skippedCurrent();
+
+            await page.getByText('Let’s get you set up!').nth(1).waitFor({ timeout: 1000 });
+            await onboarding.didFireStepCompleted({ id: 'makeDefaultSingle', next: 'systemSettings' });
+        });
+    });
+
     test.describe('Given I am on the system settings step', () => {
         test('Then I can turn on ad blocking (placebo variant)', async ({ page }, workerInfo) => {
             const onboarding = OnboardingV3Page.create(page, workerInfo);

--- a/special-pages/pages/onboarding/integration-tests/onboarding.v4.spec.js
+++ b/special-pages/pages/onboarding/integration-tests/onboarding.v4.spec.js
@@ -65,6 +65,81 @@ test.describe('onboarding v4', () => {
         });
     });
 
+    test.describe('Given autoAdvance is enabled on the make default step', () => {
+        test('Then Next never appears while waiting, and Skip remains visible', async ({ page }, workerInfo) => {
+            const onboarding = OnboardingV4Page.create(page, workerInfo);
+            onboarding.withInitData({
+                stepDefinitions: {
+                    makeDefaultSingle: { autoAdvance: true },
+                },
+                order: 'v4',
+            });
+            await onboarding.reducedMotion();
+            await onboarding.openPage({ env: 'app', page: 'makeDefaultSingle' });
+
+            await page.getByRole('button', { name: 'Make DuckDuckGo Your Default' }).click();
+            await onboarding.mocks.waitForCallCount({ method: 'requestSetAsDefault', count: 1 });
+
+            await expect(page.getByRole('button', { name: 'Make DuckDuckGo Your Default' })).toBeVisible();
+            await expect(page.getByRole('button', { name: 'Next' })).not.toBeVisible();
+            await expect(page.getByRole('button', { name: 'Skip' })).toBeVisible();
+        });
+
+        test('Then onSetAsDefaultComplete advances to the next step and fires stepCompleted', async ({ page }, workerInfo) => {
+            const onboarding = OnboardingV4Page.create(page, workerInfo);
+            onboarding.withInitData({
+                stepDefinitions: {
+                    makeDefaultSingle: { autoAdvance: true },
+                },
+                order: 'v4',
+            });
+            await onboarding.reducedMotion();
+            await onboarding.openPage({ env: 'app', page: 'makeDefaultSingle' });
+
+            await page.getByRole('button', { name: 'Make DuckDuckGo Your Default' }).click();
+            await onboarding.mocks.waitForCallCount({ method: 'requestSetAsDefault', count: 1 });
+
+            await onboarding.pushSetAsDefaultComplete();
+
+            await page.getByRole('heading', { name: 'Let\u2019s get you set up!' }).waitFor({ timeout: 1000 });
+            await onboarding.didFireStepCompleted({ id: 'makeDefaultSingle', next: 'systemSettings' });
+        });
+
+        test('Then onSetAsDefaultComplete is a no-op on other steps', async ({ page }, workerInfo) => {
+            const onboarding = OnboardingV4Page.create(page, workerInfo);
+            onboarding.withInitData({
+                stepDefinitions: {
+                    makeDefaultSingle: { autoAdvance: true },
+                },
+                order: 'v4',
+            });
+            await onboarding.reducedMotion();
+            await onboarding.openPage({ env: 'app', page: 'systemSettings' });
+            await page.getByRole('heading', { name: 'Let\u2019s get you set up!' }).waitFor({ timeout: 1000 });
+
+            await onboarding.pushSetAsDefaultComplete();
+
+            await expect(page.getByRole('heading', { name: 'Let\u2019s get you set up!' })).toBeVisible();
+        });
+
+        test('Then Skip still advances to the next step', async ({ page }, workerInfo) => {
+            const onboarding = OnboardingV4Page.create(page, workerInfo);
+            onboarding.withInitData({
+                stepDefinitions: {
+                    makeDefaultSingle: { autoAdvance: true },
+                },
+                order: 'v4',
+            });
+            await onboarding.reducedMotion();
+            await onboarding.openPage({ env: 'app', page: 'makeDefaultSingle' });
+
+            await onboarding.skippedCurrent();
+
+            await page.getByRole('heading', { name: 'Let\u2019s get you set up!' }).waitFor({ timeout: 1000 });
+            await onboarding.didFireStepCompleted({ id: 'makeDefaultSingle', next: 'systemSettings' });
+        });
+    });
+
     test.describe('Given I am on the system settings step', () => {
         test('Then I can turn on ad blocking (placebo variant)', async ({ page }, workerInfo) => {
             const onboarding = OnboardingV4Page.create(page, workerInfo);

--- a/special-pages/pages/onboarding/src/mock-transport.js
+++ b/special-pages/pages/onboarding/src/mock-transport.js
@@ -65,6 +65,15 @@ export function mockTransport() {
                         };
                     }
 
+                    if (url.searchParams.get('autoAdvance') === 'true') {
+                        stepDefinitions.makeDefaultSingle = {
+                            id: 'makeDefaultSingle',
+                            kind: 'settings',
+                            rows: ['default-browser'],
+                            autoAdvance: true,
+                        };
+                    }
+
                     return Promise.resolve({
                         stepDefinitions,
                         exclude: [],


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/task/1216255190183430 (parent: 1215435204288345)

## Description

On the onboarding `makeDefaultSingle` step (Comparison Chart / "Make DuckDuckGo Your Default" screen), the frontend now advances to the next step automatically when native pushes a new `onSetAsDefaultComplete` subscription message — equivalent to clicking "Next" today. While waiting for that message, the screen keeps showing "Make DuckDuckGo Your Default" and "Skip"; the "Next" button never appears on this step.

All new behaviour is gated behind an `autoAdvance` flag that native supplies per-step in the `init` response (`stepDefinitions.makeDefaultSingle.autoAdvance`), so nothing changes for native builds that don't opt in.

Changes:
- `app/messages.js` — new `onSetAsDefaultComplete(callback)` subscription (no JSON schema needed, same as `onConfigUpdate`).
- `app/types.js` — `MakeDefaultSingleStep.autoAdvance?: boolean`, new `AutoAdvanceEvent` added to `GlobalEvents`.
- `app/global.js` — reducer handles `auto-advance` at the top level (before the `status.kind` switch) so it works even mid-request; `GlobalProvider` subscribes to `onSetAsDefaultComplete` and dispatches `auto-advance` via a ref-backed proxy call (mirrors `advance`'s side effects — `stepCompleted` + `row_shown` telemetry — via a shared `notifyStepAdvanced` helper).
- `app/v3/data/data.js` / `app/v4/components/MakeDefaultContent.js` — when `autoAdvance` is on, the step never renders "Next": Skip + "Make Default" stay visible, and (v4) the success-title bounce animation is skipped since the outcome isn't known until the push arrives.
- `src/mock-transport.js` — `?autoAdvance=true` URL param for local dev/manual testing via `npm run serve-special-pages`.
- Integration tests + a `pushSetAsDefaultComplete()` page-object helper covering: no "Next" while waiting, advance-on-push (+ `stepCompleted`), no-op on other steps, and Skip still works — for both v3 and v4.

## Testing Steps

- `npm run build`, `npm run lint`, `npm run test-unit` all pass.
- `npm run test-int -- pages/onboarding --reporter list` — all onboarding v3/v4 integration tests pass (macOS + Windows projects), including the new `autoAdvance` cases.
- Manual: `npm run serve-special-pages`, open onboarding with `?env=app&page=makeDefaultSingle&autoAdvance=true`, then drive `window.__playwright_01.publishSubscriptionEvent({ subscriptionName: 'onSetAsDefaultComplete', params: {} })` from the console.

## Checklist

- [x] I have tested this change locally
- [ ] I have tested this change locally in all supported browsers
- [x] This change will be visible to users
- [x] I have added automated tests that cover this change
- [x] I have ensured the change is gated by config
- [ ] This change was covered by a ship review
- [x] This change was covered by a tech design
- [ ] Any dependent config has been merged

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8ffeeeac-eee1-44a0-b085-c70a6c43bb92"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8ffeeeac-eee1-44a0-b085-c70a6c43bb92"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

