### PR TITLE
feat(pir): resolve navigate url from data source key

### DIFF
--- a/injected/src/features/broker-protection/actions/navigate.js
+++ b/injected/src/features/broker-protection/actions/navigate.js
@@ -1,6 +1,7 @@
-import { getSupportingCodeToInject } from '../captcha-services/captcha.service';
-import { ErrorResponse, SuccessResponse } from '../types';
-import { buildUrl } from './build-url';
+import { getSupportingCodeToInject } from '../captcha-services/captcha.service.js';
+import { ErrorResponse, SuccessResponse } from '../types.js';
+import { buildUrl } from './build-url.js';
+import { resolveUrlFromDataSource } from './resolve-url-from-data-source.js';
 
 /**
  * This builds the proper URL given the URL template and userData.
@@ -12,7 +13,7 @@ import { buildUrl } from './build-url';
  */
 export function navigate(action, userData) {
     const { id: actionID, actionType } = action;
-    const urlResult = buildUrl(action, userData);
+    const urlResult = resolveUrlFromDataSource(action, userData) ?? buildUrl(action, userData);
     if (urlResult instanceof ErrorResponse) {
         return urlResult;
     }

--- a/injected/src/features/broker-protection/actions/resolve-url-from-data-source.js
+++ b/injected/src/features/broker-protection/actions/resolve-url-from-data-source.js
@@ -6,8 +6,8 @@ import { ErrorResponse, SuccessResponse } from '../types.js';
  */
 const isValidUrl = (value) => {
     try {
-        new URL(value);
-        return true;
+        const { protocol } = new URL(value);
+        return protocol === 'http:' || protocol === 'https:';
     } catch (e) {
         return false;
     }

--- a/injected/src/features/broker-protection/actions/resolve-url-from-data-source.js
+++ b/injected/src/features/broker-protection/actions/resolve-url-from-data-source.js
@@ -1,0 +1,34 @@
+import { ErrorResponse, SuccessResponse } from '../types.js';
+
+/**
+ * @param {string} value
+ * @return {boolean}
+ */
+const isValidUrl = (value) => {
+    try {
+        new URL(value);
+        return true;
+    } catch (e) {
+        return false;
+    }
+};
+
+/**
+ * @param {import('../types.js').PirAction} action
+ * @param {Record<string, any> | null} userData
+ * @return {import('../types.js').ActionResponse | null}
+ */
+export const resolveUrlFromDataSource = (action, userData) => {
+    if (!action.dataSource || !action.url || isValidUrl(action.url)) {
+        return null;
+    }
+
+    const { id: actionID, actionType } = action;
+    const value = userData?.[action.url];
+
+    if (typeof value !== 'string' || !isValidUrl(value)) {
+        return new ErrorResponse({ actionID, message: `'${action.url}' did not resolve to a valid URL from '${action.dataSource}'` });
+    }
+
+    return new SuccessResponse({ actionID, actionType, response: { url: value } });
+};

--- a/injected/src/features/broker-protection/actions/resolve-url-from-data-source.js
+++ b/injected/src/features/broker-protection/actions/resolve-url-from-data-source.js
@@ -6,6 +6,20 @@ import { ErrorResponse, SuccessResponse } from '../types.js';
  */
 const isValidUrl = (value) => {
     try {
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        const _ = new URL(value);
+        return true;
+    } catch (e) {
+        return false;
+    }
+};
+
+/**
+ * @param {string} value
+ * @return {boolean}
+ */
+const canNavigateToUrl = (value) => {
+    try {
         const { protocol } = new URL(value);
         return protocol === 'http:' || protocol === 'https:';
     } catch (e) {
@@ -26,7 +40,7 @@ export const resolveUrlFromDataSource = (action, userData) => {
     const { id: actionID, actionType } = action;
     const value = userData?.[action.url];
 
-    if (typeof value !== 'string' || !isValidUrl(value)) {
+    if (typeof value !== 'string' || !canNavigateToUrl(value)) {
         return new ErrorResponse({ actionID, message: `'${action.url}' did not resolve to a valid URL from '${action.dataSource}'` });
     }
 

--- a/injected/unit-test/broker-protection.js
+++ b/injected/unit-test/broker-protection.js
@@ -666,6 +666,18 @@ describe('Actions', () => {
             const result = resolveUrlFromDataSource(action, { link: 'not-a-url' });
             expect(result instanceof ErrorResponse).toBe(true);
         });
+
+        it('returns error when dataSource value is a non-http(s) scheme', () => {
+            /** @type {PirAction} */
+            const action = {
+                id: 'n5',
+                actionType: 'navigate',
+                dataSource: 'emailData',
+                url: 'link',
+            };
+            const result = resolveUrlFromDataSource(action, { link: 'javascript:alert(1)' });
+            expect(result instanceof ErrorResponse).toBe(true);
+        });
     });
 
     describe('click', () => {

--- a/injected/unit-test/broker-protection.js
+++ b/injected/unit-test/broker-protection.js
@@ -632,6 +632,18 @@ describe('Actions', () => {
             expect(result).toBe(null);
         });
 
+        it('delegates to buildUrl when url is a non-http(s) absolute URL', () => {
+            /** @type {PirAction} */
+            const action = {
+                id: 'n2a',
+                actionType: 'navigate',
+                url: 'ftp://example.com/static',
+                dataSource: 'emailData',
+            };
+            const result = resolveUrlFromDataSource(action, {});
+            expect(result).toBe(null);
+        });
+
         it('delegates to buildUrl when dataSource is not set', () => {
             /** @type {PirAction} */
             const action = {

--- a/injected/unit-test/broker-protection.js
+++ b/injected/unit-test/broker-protection.js
@@ -5,6 +5,8 @@ import { stringToList } from '../src/features/broker-protection/actions/extract.
 import { extractName } from '../src/features/broker-protection/extractors/name.js';
 import { addressMatch } from '../src/features/broker-protection/comparisons/address.js';
 import { replaceTemplatedUrl } from '../src/features/broker-protection/actions/build-url.js';
+import { resolveUrlFromDataSource } from '../src/features/broker-protection/actions/resolve-url-from-data-source.js';
+import { ErrorResponse, SuccessResponse } from '../src/features/broker-protection/types.js';
 import { processTemplateStringWithUserData } from '../src/features/broker-protection/actions/build-url-transforms.js';
 import { names } from '../src/features/broker-protection/comparisons/constants.js';
 import { generateRandomInt, hashObject, sortAddressesByStateAndCity } from '../src/features/broker-protection/utils/utils.js';
@@ -12,6 +14,10 @@ import { generatePhoneNumber, generateZipCode, generateStreetAddress } from '../
 import { ProfileHashTransformer } from '../src/features/broker-protection/extractors/profile-url.js';
 import { getComparisonFunction } from '../src/features/broker-protection/actions/click.js';
 import { isElementType } from '../src/features/broker-protection/captcha-services/utils/element.js';
+
+/**
+ * @typedef {import('../src/features/broker-protection/types.js').PirAction} PirAction
+ */
 
 describe('Actions', () => {
     describe('extract', () => {
@@ -597,6 +603,68 @@ describe('Actions', () => {
                     },
                 ),
             );
+        });
+    });
+
+    describe('navigate', () => {
+        it('resolves url from dataSource when url is a key name', () => {
+            /** @type {PirAction} */
+            const action = {
+                id: 'n1',
+                actionType: 'navigate',
+                dataSource: 'emailData',
+                url: 'link',
+            };
+            const result = resolveUrlFromDataSource(action, { link: 'https://example.com/verify/abc' });
+            expect(result instanceof SuccessResponse).toBe(true);
+            expect(/** @type {SuccessResponse} */ (result).success.response.url).toBe('https://example.com/verify/abc');
+        });
+
+        it('delegates to buildUrl when url is already a full URL', () => {
+            /** @type {PirAction} */
+            const action = {
+                id: 'n2',
+                actionType: 'navigate',
+                url: 'https://example.com/static',
+                dataSource: 'emailData',
+            };
+            const result = resolveUrlFromDataSource(action, {});
+            expect(result).toBe(null);
+        });
+
+        it('delegates to buildUrl when dataSource is not set', () => {
+            /** @type {PirAction} */
+            const action = {
+                id: 'n2b',
+                actionType: 'navigate',
+                url: 'link',
+            };
+            const result = resolveUrlFromDataSource(action, { link: 'https://example.com' });
+            expect(result).toBe(null);
+        });
+
+        it('returns error when dataSource key is missing from userData', () => {
+            /** @type {PirAction} */
+            const action = {
+                id: 'n3',
+                actionType: 'navigate',
+                dataSource: 'emailData',
+                url: 'missing',
+            };
+            const result = resolveUrlFromDataSource(action, { link: 'https://example.com' });
+            expect(result instanceof ErrorResponse).toBe(true);
+        });
+
+        it('returns error when dataSource value is not a valid url', () => {
+            /** @type {PirAction} */
+            const action = {
+                id: 'n4',
+                actionType: 'navigate',
+                dataSource: 'emailData',
+                url: 'link',
+            };
+            const result = resolveUrlFromDataSource(action, { link: 'not-a-url' });
+            expect(result instanceof ErrorResponse).toBe(true);
         });
     });
 

--- a/scripts/check-strict-core.js
+++ b/scripts/check-strict-core.js
@@ -42,6 +42,7 @@ const CORE_FILES = new Set([
     'injected/src/features/broker-protection/actions/expectation.js',
     'injected/src/features/broker-protection/actions/generators.js',
     'injected/src/features/broker-protection/actions/navigate.js',
+    'injected/src/features/broker-protection/actions/resolve-url-from-data-source.js',
     'injected/src/features/broker-protection/actions/scroll.js',
     'injected/src/features/broker-protection/captcha-services/factory.js',
     'injected/src/features/broker-protection/captcha-services/get-captcha-container.js',


### PR DESCRIPTION
### Summary

Asana: https://app.asana.com/1/137249556945/project/1206873150423133/task/1213810234827719?focus=true

This PR:

* Adds `resolveUrlFromDataSource` so navigate can resolve a URL from a data bag key when `url` is a field name, not a template URL.
* Falls back to `buildUrl` when `dataSource` is missing, `url` is already a full URL, or the key lookup does not apply.
* Adds unit tests for the lookup path.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how navigation URLs are chosen from runtime user data, but http/https-only checks limit open-redirect and script-injection style URLs; behavior is localized to broker-protection navigate with tests.
> 
> **Overview**
> **Navigate** actions can now treat `url` as a **userData field name** when `dataSource` is set and `url` is not already a parseable absolute URL. A new `resolveUrlFromDataSource` helper looks up that key and returns the resolved `http`/`https` URL; otherwise `navigate` keeps using `buildUrl` as before.
> 
> Invalid or unsafe targets (missing key, non-string, bad URL, or non-http(s) schemes like `javascript:`) return an **ErrorResponse** instead of navigating. Unit tests cover success, fallback-to-`buildUrl`, and error paths; the new module is added to the strict-core allowlist. Related imports in `navigate.js` are updated to explicit `.js` paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1d4a9fcb8d2f4b8e20951c1e59b6c8aba485c0a6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->