### PR TITLE
feat(ntp): omnibar picker impression + upsell source telemetry (FE)

### DIFF
--- a/special-pages/pages/new-tab/app/omnibar/components/OmnibarProvider.js
+++ b/special-pages/pages/new-tab/app/omnibar/components/OmnibarProvider.js
@@ -79,8 +79,8 @@ export const OmnibarContext = createContext({
     viewAllAiChats: () => {
         throw new Error('must implement');
     },
-    /** @type {() => void} */
-    showSubscriptionUpsell: () => {
+    /** @type {(type?: 'subscribe' | 'upgrade') => void} */
+    showUpsell: () => {
         throw new Error('must implement');
     },
     /** @type {() => Promise<GetOpenTabsResponse>} */
@@ -235,10 +235,13 @@ export function OmnibarProvider(props) {
         [service],
     );
 
-    /** @type {() => void} */
-    const showSubscriptionUpsell = useCallback(() => {
-        service.current?.showSubscriptionUpsell();
-    }, [service]);
+    /** @type {(type?: 'subscribe' | 'upgrade') => void} */
+    const showUpsell = useCallback(
+        (type) => {
+            service.current?.showUpsell(type);
+        },
+        [service],
+    );
 
     /** @type {() => Promise<GetOpenTabsResponse>} */
     const getOpenTabs = useCallback(() => {
@@ -273,7 +276,7 @@ export function OmnibarProvider(props) {
                 onAiChats,
                 openAiChat,
                 viewAllAiChats,
-                showSubscriptionUpsell,
+                showUpsell,
                 getOpenTabs,
                 getTabContent,
             }}

--- a/special-pages/pages/new-tab/app/omnibar/components/OmnibarProvider.js
+++ b/special-pages/pages/new-tab/app/omnibar/components/OmnibarProvider.js
@@ -79,6 +79,10 @@ export const OmnibarContext = createContext({
     viewAllAiChats: () => {
         throw new Error('must implement');
     },
+    /** @type {() => void} */
+    showSubscriptionUpsell: () => {
+        throw new Error('must implement');
+    },
     /** @type {() => Promise<GetOpenTabsResponse>} */
     getOpenTabs: () => {
         throw new Error('must implement');
@@ -231,6 +235,11 @@ export function OmnibarProvider(props) {
         [service],
     );
 
+    /** @type {() => void} */
+    const showSubscriptionUpsell = useCallback(() => {
+        service.current?.showSubscriptionUpsell();
+    }, [service]);
+
     /** @type {() => Promise<GetOpenTabsResponse>} */
     const getOpenTabs = useCallback(() => {
         if (!service.current) throw new Error('Service not available');
@@ -264,6 +273,7 @@ export function OmnibarProvider(props) {
                 onAiChats,
                 openAiChat,
                 viewAllAiChats,
+                showSubscriptionUpsell,
                 getOpenTabs,
                 getTabContent,
             }}

--- a/special-pages/pages/new-tab/app/omnibar/components/OmnibarProvider.js
+++ b/special-pages/pages/new-tab/app/omnibar/components/OmnibarProvider.js
@@ -14,6 +14,7 @@ import { OmnibarService } from '../omnibar.service.js';
  * @typedef {import('../../../types/new-tab.js').SubmitChatAction} SubmitChatAction
  * @typedef {import('../../../types/new-tab.js').GetOpenTabsResponse} GetOpenTabsResponse
  * @typedef {import('../../../types/new-tab.js').PageContext} PageContext
+ * @typedef {import('../../../types/new-tab.js').OmnibarPickerSource} OmnibarPickerSource
  * @typedef {import('../../service.hooks.js').State<null, OmnibarConfig>} State
  */
 
@@ -79,7 +80,15 @@ export const OmnibarContext = createContext({
     viewAllAiChats: () => {
         throw new Error('must implement');
     },
-    /** @type {(type?: 'subscribe' | 'upgrade') => void} */
+    /** @type {(picker: OmnibarPickerSource) => void} */
+    pickerShown: () => {
+        throw new Error('must implement');
+    },
+    /** @type {(picker: OmnibarPickerSource) => void} */
+    upsellShown: () => {
+        throw new Error('must implement');
+    },
+    /** @type {(type: 'subscribe' | 'upgrade' | undefined, source: OmnibarPickerSource) => void} */
     showUpsell: () => {
         throw new Error('must implement');
     },
@@ -235,10 +244,26 @@ export function OmnibarProvider(props) {
         [service],
     );
 
-    /** @type {(type?: 'subscribe' | 'upgrade') => void} */
+    /** @type {(picker: OmnibarPickerSource) => void} */
+    const pickerShown = useCallback(
+        (picker) => {
+            service.current?.pickerShown(picker);
+        },
+        [service],
+    );
+
+    /** @type {(picker: OmnibarPickerSource) => void} */
+    const upsellShown = useCallback(
+        (picker) => {
+            service.current?.upsellShown(picker);
+        },
+        [service],
+    );
+
+    /** @type {(type: 'subscribe' | 'upgrade' | undefined, source: OmnibarPickerSource) => void} */
     const showUpsell = useCallback(
-        (type) => {
-            service.current?.showUpsell(type);
+        (type, source) => {
+            service.current?.showUpsell(type, source);
         },
         [service],
     );
@@ -276,6 +301,8 @@ export function OmnibarProvider(props) {
                 onAiChats,
                 openAiChat,
                 viewAllAiChats,
+                pickerShown,
+                upsellShown,
                 showUpsell,
                 getOpenTabs,
                 getTabContent,

--- a/special-pages/pages/new-tab/app/omnibar/components/chat-tools/dropdown/Dropdown.module.css
+++ b/special-pages/pages/new-tab/app/omnibar/components/chat-tools/dropdown/Dropdown.module.css
@@ -58,6 +58,13 @@
     margin-left: auto;
 }
 
+/* Gated options (e.g. "Upgrade"): gray out the icon and label to signal they aren't selectable,
+   while keeping the trailing badge at full opacity. */
+.itemDimmed > svg,
+.itemDimmed .itemLabel {
+    opacity: 0.4;
+}
+
 .itemActive {
     background: var(--ds-color-theme-control-fill-primary);
     color: var(--ds-color-theme-text-primary);

--- a/special-pages/pages/new-tab/app/omnibar/components/chat-tools/dropdown/DropdownItem.js
+++ b/special-pages/pages/new-tab/app/omnibar/components/chat-tools/dropdown/DropdownItem.js
@@ -17,6 +17,7 @@ import styles from './Dropdown.module.css';
  * @param {string} props.name
  * @param {string} [props.description]
  * @param {boolean} [props.isSelected]
+ * @param {boolean} [props.isDimmed] - Grays the icon and label (e.g. gated options) while keeping the trailing badge legible
  * @param {'option' | 'menuitemcheckbox' | 'menuitemradio' | 'menuitem'} props.role
  * @param {() => void} props.onSelect
  * @param {boolean} [props.ariaChecked]
@@ -36,6 +37,7 @@ export function DropdownItem({
     name,
     description,
     isSelected = false,
+    isDimmed = false,
     role,
     ariaChecked,
     ariaSelected,
@@ -69,7 +71,7 @@ export function DropdownItem({
             aria-selected={ariaSelected}
             aria-haspopup={ariaHasPopup}
             aria-expanded={ariaExpanded}
-            class={cn(styles.item, isActive && styles.itemActive, isSelected && styles.itemSelected)}
+            class={cn(styles.item, isActive && styles.itemActive, isSelected && styles.itemSelected, isDimmed && styles.itemDimmed)}
             onMouseOver={onMouseOver}
             onMouseEnter={onHover}
             onClick={onClick}

--- a/special-pages/pages/new-tab/app/omnibar/components/chat-tools/dropdown/DropdownItem.js
+++ b/special-pages/pages/new-tab/app/omnibar/components/chat-tools/dropdown/DropdownItem.js
@@ -13,7 +13,7 @@ import styles from './Dropdown.module.css';
  *
  * @param {object} props
  * @param {import('preact').ComponentChildren} [props.icon]
- * @param {import('preact').ComponentChildren} [props.trailingIcon]
+ * @param {import('preact').ComponentChildren} [props.trailingIcon] - Rendered after the label. Callers own its accessibility (mark decorative icons `aria-hidden`; leave meaningful ones, e.g. an "Upgrade" badge, exposed).
  * @param {string} props.name
  * @param {string} [props.description]
  * @param {boolean} [props.isSelected]
@@ -82,11 +82,7 @@ export function DropdownItem({
                 <span class={styles.itemName}>{name}</span>
                 {description && <span class={styles.itemDescription}>{description}</span>}
             </div>
-            {trailingIcon && (
-                <span class={styles.trailingIcon} aria-hidden="true">
-                    {trailingIcon}
-                </span>
-            )}
+            {trailingIcon && <span class={styles.trailingIcon}>{trailingIcon}</span>}
         </li>
     );
 }

--- a/special-pages/pages/new-tab/app/omnibar/components/chat-tools/model-selector/ModelDropdown.js
+++ b/special-pages/pages/new-tab/app/omnibar/components/chat-tools/model-selector/ModelDropdown.js
@@ -34,7 +34,7 @@ function getRowBadgeLabel(model, t) {
  * @param {import('../useDropdown.js').DropdownPosition} props.dropdownPos
  * @param {(options: {restoreFocus: boolean}) => void} props.onClose
  * @param {(id: string) => void} props.onSelect
- * @param {() => void} props.onUpsell
+ * @param {(type?: 'subscribe' | 'upgrade') => void} props.onUpsell
  * @param {string} props.ariaLabel
  * @param {import('preact').RefObject<HTMLUListElement>} [props.dropdownRef]
  */
@@ -144,6 +144,7 @@ export function ModelDropdown({ sections, selectedModelId, dropdownPos, onClose,
         >
             {sections.map((section, sectionIndex) => {
                 const isUpsellSection = section.items.length > 0 && section.items.every((model) => !model.isEnabled);
+                const sectionUpsell = section.items.find((model) => model.upsell)?.upsell ?? 'subscribe';
                 return (
                     <Fragment key={sectionIndex}>
                         {isUpsellSection ? (
@@ -156,10 +157,10 @@ export function ModelDropdown({ sections, selectedModelId, dropdownPos, onClose,
                                         class={styles.modelUpsellCta}
                                         onClick={(e) => {
                                             e.stopPropagation();
-                                            onUpsell();
+                                            onUpsell(sectionUpsell);
                                         }}
                                     >
-                                        {t('omnibar_tryForFree')}
+                                        {sectionUpsell === 'upgrade' ? t('omnibar_upgrade') : t('omnibar_tryForFree')}
                                     </button>
                                 </li>
                             </Fragment>

--- a/special-pages/pages/new-tab/app/omnibar/components/chat-tools/model-selector/ModelDropdown.js
+++ b/special-pages/pages/new-tab/app/omnibar/components/chat-tools/model-selector/ModelDropdown.js
@@ -1,8 +1,31 @@
 import { Fragment, h } from 'preact';
 import { useEffect, useState } from 'preact/hooks';
 import cn from 'classnames';
+import { useTypedTranslationWith } from '../../../../types';
 import styles from './ModelSelector.module.css';
 import { getModelIcon } from './Icons';
+
+/**
+ * @typedef {import('../../../strings.json')} Strings
+ * @typedef {import('../../../../../types/new-tab.js').AIModelItem} AIModelItem
+ */
+
+/**
+ * Returns the badge label for a model row, or null when no badge should show.
+ *
+ * @param {AIModelItem} model
+ * @param {ReturnType<typeof useTypedTranslationWith<Strings>>['t']} t
+ * @returns {string | null}
+ */
+function getRowBadgeLabel(model, t) {
+    const tiers = model.accessTier ?? [];
+    if (tiers.length === 1 && tiers[0] === 'internal') return t('omnibar_modelBadgeInternal');
+    if (model.isBeta) return t('omnibar_modelBadgeBeta');
+    if (tiers.includes('free')) return null;
+    if (tiers.includes('plus')) return t('omnibar_modelBadgePlus');
+    if (tiers.includes('pro')) return t('omnibar_modelBadgePro');
+    return null;
+}
 
 /**
  * @param {object} props
@@ -11,10 +34,12 @@ import { getModelIcon } from './Icons';
  * @param {import('../useDropdown.js').DropdownPosition} props.dropdownPos
  * @param {(options: {restoreFocus: boolean}) => void} props.onClose
  * @param {(id: string) => void} props.onSelect
+ * @param {() => void} props.onUpsell
  * @param {string} props.ariaLabel
  * @param {import('preact').RefObject<HTMLUListElement>} [props.dropdownRef]
  */
-export function ModelDropdown({ sections, selectedModelId, dropdownPos, onClose, onSelect, ariaLabel, dropdownRef }) {
+export function ModelDropdown({ sections, selectedModelId, dropdownPos, onClose, onSelect, onUpsell, ariaLabel, dropdownRef }) {
+    const { t } = useTypedTranslationWith(/** @type {Strings} */ ({}));
     const allModels = sections.flatMap((section) => section.items);
     const optionIndexById = new Map(allModels.map((model, index) => [model.id, index]));
     const enabledModelIndices = allModels.reduce(
@@ -117,49 +142,76 @@ export function ModelDropdown({ sections, selectedModelId, dropdownPos, onClose,
             onKeyDown={handleKeyDown}
             onMouseLeave={clearActiveIndex}
         >
-            {sections.map((section, sectionIndex) => (
-                <Fragment key={sectionIndex}>
-                    {section.header && (
-                        <Fragment>
-                            <li role="separator" class={styles.modelSectionDivider} />
-                            <li role="presentation" class={styles.modelSectionHeader}>
-                                {section.header}
-                            </li>
-                        </Fragment>
-                    )}
-                    {section.items.map((model) => {
-                        const Icon = getModelIcon(model.id);
-                        const optionIndex = optionIndexById.get(model.id) ?? -1;
-                        return (
-                            <li
-                                key={model.id}
-                                id={getOptionId(optionIndex)}
-                                role="option"
-                                aria-selected={model.isEnabled ? model.id === selectedModelId : undefined}
-                                aria-disabled={!model.isEnabled || undefined}
-                                class={cn(
-                                    styles.modelOption,
-                                    model.isEnabled && activeIndex === optionIndex && styles.modelOptionActive,
-                                    !model.isEnabled && styles.modelOptionDisabled,
-                                    model.isEnabled && model.id === selectedModelId && styles.modelOptionSelected,
-                                )}
-                                onMouseOver={model.isEnabled ? () => setActiveIndex(optionIndex) : undefined}
-                                onClick={
-                                    model.isEnabled
-                                        ? (e) => {
-                                              e.stopPropagation();
-                                              onSelect(model.id);
-                                          }
-                                        : undefined
-                                }
-                            >
-                                {Icon && <Icon />}
-                                <span>{model.name}</span>
-                            </li>
-                        );
-                    })}
-                </Fragment>
-            ))}
+            {sections.map((section, sectionIndex) => {
+                const isUpsellSection = section.items.length > 0 && section.items.every((model) => !model.isEnabled);
+                return (
+                    <Fragment key={sectionIndex}>
+                        {isUpsellSection ? (
+                            <Fragment>
+                                <li role="separator" class={styles.modelSectionDivider} />
+                                <li role="presentation" class={styles.modelUpsellHeader}>
+                                    <span class={styles.modelUpsellText}>{t('omnibar_subscriberExclusive')}</span>
+                                    <button
+                                        type="button"
+                                        class={styles.modelUpsellCta}
+                                        onClick={(e) => {
+                                            e.stopPropagation();
+                                            onUpsell();
+                                        }}
+                                    >
+                                        {t('omnibar_tryForFree')}
+                                    </button>
+                                </li>
+                            </Fragment>
+                        ) : (
+                            section.header && (
+                                <Fragment>
+                                    <li role="separator" class={styles.modelSectionDivider} />
+                                    <li role="presentation" class={styles.modelSectionHeader}>
+                                        {section.header}
+                                    </li>
+                                </Fragment>
+                            )
+                        )}
+                        {section.items.map((model) => {
+                            const Icon = getModelIcon(model.id);
+                            const optionIndex = optionIndexById.get(model.id) ?? -1;
+                            const badgeLabel = getRowBadgeLabel(model, t);
+                            return (
+                                <li
+                                    key={model.id}
+                                    id={getOptionId(optionIndex)}
+                                    role="option"
+                                    aria-selected={model.isEnabled ? model.id === selectedModelId : undefined}
+                                    aria-disabled={!model.isEnabled || undefined}
+                                    class={cn(
+                                        styles.modelOption,
+                                        model.isEnabled && activeIndex === optionIndex && styles.modelOptionActive,
+                                        !model.isEnabled && styles.modelOptionDisabled,
+                                        model.isEnabled && model.id === selectedModelId && styles.modelOptionSelected,
+                                    )}
+                                    onMouseOver={model.isEnabled ? () => setActiveIndex(optionIndex) : undefined}
+                                    onClick={
+                                        model.isEnabled
+                                            ? (e) => {
+                                                  e.stopPropagation();
+                                                  onSelect(model.id);
+                                              }
+                                            : undefined
+                                    }
+                                >
+                                    {Icon && <Icon />}
+                                    <div class={styles.modelOptionLabel}>
+                                        <span class={styles.modelOptionName}>{model.name}</span>
+                                        {model.description && <span class={styles.modelOptionDescription}>{model.description}</span>}
+                                    </div>
+                                    {badgeLabel && <span class={styles.modelOptionBadge}>{badgeLabel}</span>}
+                                </li>
+                            );
+                        })}
+                    </Fragment>
+                );
+            })}
         </ul>
     );
 }

--- a/special-pages/pages/new-tab/app/omnibar/components/chat-tools/model-selector/ModelSelector.js
+++ b/special-pages/pages/new-tab/app/omnibar/components/chat-tools/model-selector/ModelSelector.js
@@ -9,7 +9,7 @@ import styles from './ModelSelector.module.css';
  * @param {import('./useModelSelector').ModelSelectorState} props.selector
  * @param {import('../../../../../types/new-tab.js').AIModelItem|null} props.selectedModel
  * @param {import('../../../../../types/new-tab.js').AIModelSections} props.aiModelSections
- * @param {() => void} props.onUpsell
+ * @param {(type?: 'subscribe' | 'upgrade') => void} props.onUpsell
  * @param {string} props.ariaLabel
  */
 export function ModelSelector({ selector, selectedModel, aiModelSections, onUpsell, ariaLabel }) {

--- a/special-pages/pages/new-tab/app/omnibar/components/chat-tools/model-selector/ModelSelector.js
+++ b/special-pages/pages/new-tab/app/omnibar/components/chat-tools/model-selector/ModelSelector.js
@@ -9,9 +9,10 @@ import styles from './ModelSelector.module.css';
  * @param {import('./useModelSelector').ModelSelectorState} props.selector
  * @param {import('../../../../../types/new-tab.js').AIModelItem|null} props.selectedModel
  * @param {import('../../../../../types/new-tab.js').AIModelSections} props.aiModelSections
+ * @param {() => void} props.onUpsell
  * @param {string} props.ariaLabel
  */
-export function ModelSelector({ selector, selectedModel, aiModelSections, ariaLabel }) {
+export function ModelSelector({ selector, selectedModel, aiModelSections, onUpsell, ariaLabel }) {
     const { modelButtonRef, modelDropdownOpen, dropdownPos, dropdownRef, toggleDropdown, closeDropdown, selectModel } = selector;
     /** @param {{ restoreFocus: boolean }} options */
     const handleClose = ({ restoreFocus }) => {
@@ -45,6 +46,7 @@ export function ModelSelector({ selector, selectedModel, aiModelSections, ariaLa
                     dropdownPos={dropdownPos}
                     onClose={handleClose}
                     onSelect={selectModel}
+                    onUpsell={onUpsell}
                     ariaLabel={ariaLabel}
                 />
             )}

--- a/special-pages/pages/new-tab/app/omnibar/components/chat-tools/model-selector/ModelSelector.module.css
+++ b/special-pages/pages/new-tab/app/omnibar/components/chat-tools/model-selector/ModelSelector.module.css
@@ -81,15 +81,57 @@
     white-space: nowrap;
 
     &::before {
+        align-self: flex-start;
         color: transparent;
         content: '\2713';
         flex-shrink: 0;
         font-size: 13px;
         margin-right: -5px;
 		font-weight: 700;
+        margin-top: 2px;
         width: var(--sp-4);
     }
 
+    & > svg {
+        align-self: flex-start;
+        flex-shrink: 0;
+        margin-top: 2px;
+    }
+}
+
+.modelOptionLabel {
+    display: flex;
+    flex: 1;
+    flex-direction: column;
+    gap: 1px;
+    min-width: 0;
+}
+
+.modelOptionName {
+    line-height: 16px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.modelOptionDescription {
+    color: var(--ds-color-theme-text-secondary);
+    font-size: 12px;
+    line-height: 16px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.modelOptionBadge {
+    align-self: center;
+    color: var(--ds-color-theme-text-tertiary);
+    flex-shrink: 0;
+    font-size: 11px;
+    font-weight: 600;
+    letter-spacing: 0.12px;
+    margin-left: auto;
+    padding-left: var(--sp-2);
+    text-transform: uppercase;
+    white-space: nowrap;
 }
 
 .modelOptionActive {
@@ -138,5 +180,39 @@
         content: '';
         flex-shrink: 0;
         width: var(--sp-4);
+    }
+}
+
+.modelUpsellHeader {
+    align-items: center;
+    color: var(--ds-color-theme-text-primary);
+    cursor: default;
+    display: flex;
+    font-size: 13px;
+    gap: var(--sp-1);
+    padding: var(--sp-1) var(--sp-4) var(--sp-1) var(--sp-4);
+    white-space: nowrap;
+}
+
+.modelUpsellCta {
+    align-items: center;
+    background: var(--ds-color-pollen-30, #ffd885);
+    border: none;
+    border-radius: 24px;
+    color: var(--ds-color-black-at-84, rgba(0, 0, 0, 0.84));
+    cursor: pointer;
+    display: inline-flex;
+    font-size: 11px;
+    font-weight: 700;
+    height: 20px;
+    letter-spacing: -0.2px;
+    margin-left: auto;
+    padding: 0 var(--sp-2);
+    text-transform: uppercase;
+    white-space: nowrap;
+
+    &:focus-visible {
+        box-shadow: var(--focus-ring);
+        outline: none;
     }
 }

--- a/special-pages/pages/new-tab/app/omnibar/components/chat-tools/model-selector/ModelSelectorTool.js
+++ b/special-pages/pages/new-tab/app/omnibar/components/chat-tools/model-selector/ModelSelectorTool.js
@@ -1,5 +1,7 @@
 import { h } from 'preact';
+import { useContext } from 'preact/hooks';
 import { useTypedTranslationWith } from '../../../../types';
+import { OmnibarContext } from '../../OmnibarProvider';
 import { useSelectedModel } from '../../useSelectedModel';
 import { useModelSelector } from './useModelSelector';
 import { ModelSelector } from './ModelSelector';
@@ -10,6 +12,7 @@ import { ModelSelector } from './ModelSelector';
 
 export function ModelSelectorTool() {
     const { t } = useTypedTranslationWith(/** @type {Strings} */ ({}));
+    const { showSubscriptionUpsell } = useContext(OmnibarContext);
     const { selectedModel, aiModelSections, allModels, setSelectedModelId } = useSelectedModel();
 
     const selector = useModelSelector({
@@ -24,6 +27,7 @@ export function ModelSelectorTool() {
             selector={selector}
             selectedModel={selectedModel}
             aiModelSections={aiModelSections}
+            onUpsell={showSubscriptionUpsell}
             ariaLabel={t('omnibar_modelSelectorLabel')}
         />
     );

--- a/special-pages/pages/new-tab/app/omnibar/components/chat-tools/model-selector/ModelSelectorTool.js
+++ b/special-pages/pages/new-tab/app/omnibar/components/chat-tools/model-selector/ModelSelectorTool.js
@@ -12,7 +12,7 @@ import { ModelSelector } from './ModelSelector';
 
 export function ModelSelectorTool() {
     const { t } = useTypedTranslationWith(/** @type {Strings} */ ({}));
-    const { showSubscriptionUpsell } = useContext(OmnibarContext);
+    const { showUpsell } = useContext(OmnibarContext);
     const { selectedModel, aiModelSections, allModels, setSelectedModelId } = useSelectedModel();
 
     const selector = useModelSelector({
@@ -27,7 +27,7 @@ export function ModelSelectorTool() {
             selector={selector}
             selectedModel={selectedModel}
             aiModelSections={aiModelSections}
-            onUpsell={showSubscriptionUpsell}
+            onUpsell={showUpsell}
             ariaLabel={t('omnibar_modelSelectorLabel')}
         />
     );

--- a/special-pages/pages/new-tab/app/omnibar/components/chat-tools/model-selector/ModelSelectorTool.js
+++ b/special-pages/pages/new-tab/app/omnibar/components/chat-tools/model-selector/ModelSelectorTool.js
@@ -12,12 +12,19 @@ import { ModelSelector } from './ModelSelector';
 
 export function ModelSelectorTool() {
     const { t } = useTypedTranslationWith(/** @type {Strings} */ ({}));
-    const { showUpsell } = useContext(OmnibarContext);
+    const { showUpsell, pickerShown, upsellShown } = useContext(OmnibarContext);
     const { selectedModel, aiModelSections, allModels, setSelectedModelId } = useSelectedModel();
+
+    // The upsell CTA renders only for a fully-gated section (mirrors ModelDropdown's `isUpsellSection`).
+    const hasUpsell = aiModelSections.some((section) => section.items.length > 0 && section.items.every((model) => !model.isEnabled));
 
     const selector = useModelSelector({
         allModels,
         onModelChange: setSelectedModelId,
+        onOpen: () => {
+            pickerShown('model');
+            if (hasUpsell) upsellShown('model');
+        },
     });
 
     if (aiModelSections.length === 0) return null;
@@ -27,7 +34,7 @@ export function ModelSelectorTool() {
             selector={selector}
             selectedModel={selectedModel}
             aiModelSections={aiModelSections}
-            onUpsell={showUpsell}
+            onUpsell={(type) => showUpsell(type, 'model')}
             ariaLabel={t('omnibar_modelSelectorLabel')}
         />
     );

--- a/special-pages/pages/new-tab/app/omnibar/components/chat-tools/model-selector/useModelSelector.js
+++ b/special-pages/pages/new-tab/app/omnibar/components/chat-tools/model-selector/useModelSelector.js
@@ -10,9 +10,10 @@ import { useDropdown } from '../useDropdown';
  * @param {object} options
  * @param {AIModelItem[]} options.allModels
  * @param {(id: string) => void} [options.onModelChange] - Called when the user selects a model, to persist the choice
+ * @param {() => void} [options.onOpen] - Called when the dropdown opens, to report a picker impression
  */
-export function useModelSelector({ allModels, onModelChange }) {
-    const dropdown = useDropdown({ align: 'right' });
+export function useModelSelector({ allModels, onModelChange, onOpen }) {
+    const dropdown = useDropdown({ align: 'right', onOpen });
 
     /** @param {string} id */
     const selectModel = (id) => {

--- a/special-pages/pages/new-tab/app/omnibar/components/chat-tools/reasoning-picker/ReasoningPicker.js
+++ b/special-pages/pages/new-tab/app/omnibar/components/chat-tools/reasoning-picker/ReasoningPicker.js
@@ -25,13 +25,24 @@ import styles from './ReasoningPicker.module.css';
  * @param {ReasoningEffort|null} props.selectedEffort
  * @param {(effort: ReasoningEffort) => void} props.onSelect
  * @param {(type?: 'subscribe' | 'upgrade') => void} props.onUpsell
+ * @param {() => void} [props.onOpen] - Called when the dropdown opens, to report a picker impression
  * @param {string} props.ariaLabel
  * @param {string} props.buttonLabel
  * @param {string} props.tryForFreeLabel
  * @param {string} props.upgradeLabel
  */
-export function ReasoningPicker({ options, selectedEffort, onSelect, onUpsell, ariaLabel, buttonLabel, tryForFreeLabel, upgradeLabel }) {
-    const { isOpen, dropdownPos, buttonRef, dropdownRef, toggle, close } = useDropdown({ align: 'right' });
+export function ReasoningPicker({
+    options,
+    selectedEffort,
+    onSelect,
+    onUpsell,
+    onOpen,
+    ariaLabel,
+    buttonLabel,
+    tryForFreeLabel,
+    upgradeLabel,
+}) {
+    const { isOpen, dropdownPos, buttonRef, dropdownRef, toggle, close } = useDropdown({ align: 'right', onOpen });
 
     /** @param {{ restoreFocus: boolean }} opts */
     const handleClose = ({ restoreFocus }) => {

--- a/special-pages/pages/new-tab/app/omnibar/components/chat-tools/reasoning-picker/ReasoningPicker.js
+++ b/special-pages/pages/new-tab/app/omnibar/components/chat-tools/reasoning-picker/ReasoningPicker.js
@@ -16,6 +16,7 @@ import styles from './ReasoningPicker.module.css';
  * @property {string} name - Localized label
  * @property {string} [description] - Localized description
  * @property {'available' | 'unavailable'} status - Whether the option is selectable or gated behind an upsell
+ * @property {'subscribe' | 'upgrade'} [upsell] - For a gated option, which upsell flow to trigger
  */
 
 /**
@@ -23,12 +24,13 @@ import styles from './ReasoningPicker.module.css';
  * @param {ReasoningEffortOptionView[]} props.options
  * @param {ReasoningEffort|null} props.selectedEffort
  * @param {(effort: ReasoningEffort) => void} props.onSelect
- * @param {() => void} props.onUpsell
+ * @param {(type?: 'subscribe' | 'upgrade') => void} props.onUpsell
  * @param {string} props.ariaLabel
  * @param {string} props.buttonLabel
  * @param {string} props.tryForFreeLabel
+ * @param {string} props.upgradeLabel
  */
-export function ReasoningPicker({ options, selectedEffort, onSelect, onUpsell, ariaLabel, buttonLabel, tryForFreeLabel }) {
+export function ReasoningPicker({ options, selectedEffort, onSelect, onUpsell, ariaLabel, buttonLabel, tryForFreeLabel, upgradeLabel }) {
     const { isOpen, dropdownPos, buttonRef, dropdownRef, toggle, close } = useDropdown({ align: 'right' });
 
     /** @param {{ restoreFocus: boolean }} opts */
@@ -76,6 +78,7 @@ export function ReasoningPicker({ options, selectedEffort, onSelect, onUpsell, a
                     {options.map((option) => {
                         const OptionIcon = option.icon;
                         const isUnavailable = option.status === 'unavailable';
+                        const badgeLabel = option.upsell === 'upgrade' ? upgradeLabel : tryForFreeLabel;
                         return (
                             <DropdownItem
                                 key={option.id}
@@ -85,8 +88,9 @@ export function ReasoningPicker({ options, selectedEffort, onSelect, onUpsell, a
                                 description={option.description}
                                 isSelected={!isUnavailable && option.id === selectedEffort}
                                 ariaSelected={!isUnavailable && option.id === selectedEffort}
-                                trailingIcon={isUnavailable ? <span class={styles.tryForFreeBadge}>{tryForFreeLabel}</span> : undefined}
-                                onSelect={() => (isUnavailable ? onUpsell() : handleSelect(option.id))}
+                                isDimmed={isUnavailable && option.upsell === 'upgrade'}
+                                trailingIcon={isUnavailable ? <span class={styles.tryForFreeBadge}>{badgeLabel}</span> : undefined}
+                                onSelect={() => (isUnavailable ? onUpsell(option.upsell) : handleSelect(option.id))}
                             />
                         );
                     })}

--- a/special-pages/pages/new-tab/app/omnibar/components/chat-tools/reasoning-picker/ReasoningPicker.js
+++ b/special-pages/pages/new-tab/app/omnibar/components/chat-tools/reasoning-picker/ReasoningPicker.js
@@ -8,27 +8,27 @@ import styles from './ReasoningPicker.module.css';
 /**
  * @typedef {import('../../../../../types/new-tab.js').ReasoningEffort} ReasoningEffort
  *
- * @typedef {'fast' | 'reasoning' | 'extendedReasoning'} ReasoningMode
- *
  * @typedef {import('preact').ComponentType<import('preact').JSX.SVGAttributes<SVGSVGElement>>} ReasoningEffortIconComponent
  *
- * @typedef {object} ReasoningEffortOption
+ * @typedef {object} ReasoningEffortOptionView
  * @property {ReasoningEffort} id - Server key; round-tripped on submit
- * @property {ReasoningMode} reasoningMode - Stable UX identity; used for deduping
  * @property {ReasoningEffortIconComponent} icon - Icon component rendered in the button and dropdown
- * @property {string} label - Localized label
- * @property {string} description - Localized description
+ * @property {string} name - Localized label
+ * @property {string} [description] - Localized description
+ * @property {'available' | 'unavailable'} status - Whether the option is selectable or gated behind an upsell
  */
 
 /**
  * @param {object} props
- * @param {ReasoningEffortOption[]} props.options
+ * @param {ReasoningEffortOptionView[]} props.options
  * @param {ReasoningEffort|null} props.selectedEffort
  * @param {(effort: ReasoningEffort) => void} props.onSelect
+ * @param {() => void} props.onUpsell
  * @param {string} props.ariaLabel
  * @param {string} props.buttonLabel
+ * @param {string} props.tryForFreeLabel
  */
-export function ReasoningPicker({ options, selectedEffort, onSelect, ariaLabel, buttonLabel }) {
+export function ReasoningPicker({ options, selectedEffort, onSelect, onUpsell, ariaLabel, buttonLabel, tryForFreeLabel }) {
     const { isOpen, dropdownPos, buttonRef, dropdownRef, toggle, close } = useDropdown({ align: 'right' });
 
     /** @param {{ restoreFocus: boolean }} opts */
@@ -39,7 +39,7 @@ export function ReasoningPicker({ options, selectedEffort, onSelect, ariaLabel, 
 
     /** @param {ReasoningEffort} effort */
     const handleSelect = (effort) => {
-        const isSupported = options.some((option) => option.id === effort);
+        const isSupported = options.some((option) => option.id === effort && option.status === 'available');
         if (!isSupported) return;
         onSelect(effort);
     };
@@ -75,16 +75,18 @@ export function ReasoningPicker({ options, selectedEffort, onSelect, ariaLabel, 
                 >
                     {options.map((option) => {
                         const OptionIcon = option.icon;
+                        const isUnavailable = option.status === 'unavailable';
                         return (
                             <DropdownItem
                                 key={option.id}
                                 role="option"
                                 icon={<OptionIcon />}
-                                name={option.label}
+                                name={option.name}
                                 description={option.description}
-                                isSelected={option.id === selectedEffort}
-                                ariaSelected={option.id === selectedEffort}
-                                onSelect={() => handleSelect(option.id)}
+                                isSelected={!isUnavailable && option.id === selectedEffort}
+                                ariaSelected={!isUnavailable && option.id === selectedEffort}
+                                trailingIcon={isUnavailable ? <span class={styles.tryForFreeBadge}>{tryForFreeLabel}</span> : undefined}
+                                onSelect={() => (isUnavailable ? onUpsell() : handleSelect(option.id))}
                             />
                         );
                     })}

--- a/special-pages/pages/new-tab/app/omnibar/components/chat-tools/reasoning-picker/ReasoningPicker.module.css
+++ b/special-pages/pages/new-tab/app/omnibar/components/chat-tools/reasoning-picker/ReasoningPicker.module.css
@@ -52,3 +52,18 @@
     text-overflow: ellipsis;
     white-space: nowrap;
 }
+
+.tryForFreeBadge {
+    align-items: center;
+    background: var(--ds-color-pollen-30, #ffd885);
+    border-radius: 24px;
+    color: var(--ds-color-black-at-84, rgba(0, 0, 0, 0.84));
+    display: inline-flex;
+    font-size: 11px;
+    font-weight: 700;
+    height: 20px;
+    letter-spacing: -0.2px;
+    padding: 0 var(--sp-2);
+    text-transform: uppercase;
+    white-space: nowrap;
+}

--- a/special-pages/pages/new-tab/app/omnibar/components/chat-tools/reasoning-picker/ReasoningPickerTool.js
+++ b/special-pages/pages/new-tab/app/omnibar/components/chat-tools/reasoning-picker/ReasoningPickerTool.js
@@ -37,7 +37,7 @@ function getReasoningIcon(id) {
 
 export function ReasoningPickerTool() {
     const { t } = useTypedTranslationWith(/** @type {Strings} */ ({}));
-    const { showUpsell } = useContext(OmnibarContext);
+    const { showUpsell, pickerShown, upsellShown } = useContext(OmnibarContext);
     const { reasoningEfforts, selectedEffort, setSelectedReasoningEffort } = useSelectedReasoningEffort();
 
     const options = reasoningEfforts.map((effort) => ({
@@ -53,6 +53,9 @@ export function ReasoningPickerTool() {
         return null;
     }
 
+    // The upsell badge renders for any gated (unavailable) option.
+    const hasUpsell = options.some((option) => option.status === 'unavailable');
+
     const selectedOption = options.find((option) => option.id === selectedEffort);
 
     return (
@@ -60,7 +63,11 @@ export function ReasoningPickerTool() {
             options={options}
             selectedEffort={selectedEffort}
             onSelect={setSelectedReasoningEffort}
-            onUpsell={showUpsell}
+            onUpsell={(type) => showUpsell(type, 'reasoning')}
+            onOpen={() => {
+                pickerShown('reasoning');
+                if (hasUpsell) upsellShown('reasoning');
+            }}
             ariaLabel={t('omnibar_reasoningPickerLabel')}
             buttonLabel={selectedOption?.name ?? t('omnibar_reasoningPickerLabel')}
             tryForFreeLabel={t('omnibar_reasoningTryForFree')}

--- a/special-pages/pages/new-tab/app/omnibar/components/chat-tools/reasoning-picker/ReasoningPickerTool.js
+++ b/special-pages/pages/new-tab/app/omnibar/components/chat-tools/reasoning-picker/ReasoningPickerTool.js
@@ -1,5 +1,7 @@
 import { h } from 'preact';
+import { useContext } from 'preact/hooks';
 import { useTypedTranslationWith } from '../../../../types';
+import { OmnibarContext } from '../../OmnibarProvider';
 import { useSelectedReasoningEffort } from '../../useSelectedReasoningEffort';
 import { ExtendedReasoningIcon, FastReasoningIcon, ReasoningEffortIcon } from './Icons';
 import { ReasoningPicker } from './ReasoningPicker';
@@ -7,82 +9,46 @@ import { ReasoningPicker } from './ReasoningPicker';
 /**
  * @typedef {import('../../../strings.json')} Strings
  * @typedef {import('../../../../../types/new-tab.js').ReasoningEffort} ReasoningEffort
- * @typedef {import('./ReasoningPicker').ReasoningEffortOption} ReasoningEffortOption
+ * @typedef {import('./ReasoningPicker').ReasoningEffortIconComponent} ReasoningEffortIconComponent
  */
 
 /**
- * Builds the full display option (icon, label, description) for a given effort key.
+ * Maps a server-provided reasoning-effort id to its icon. Native controls the id set, so unknown
+ * ids fall back to the generic reasoning icon rather than dropping the option.
  *
- * Returns null for unknown keys: the type narrows to the schema's current values, but at runtime
- * native may introduce a new key before the web app has strings for it. Dropping it is safer than
- * rendering with the raw server string.
- *
- * @param {ReasoningEffort} key
- * @param {ReturnType<typeof useTypedTranslationWith<Strings>>['t']} t
- * @returns {ReasoningEffortOption|null}
+ * @param {ReasoningEffort} id
+ * @returns {ReasoningEffortIconComponent}
  */
-function getEffortOption(key, t) {
-    switch (key) {
+function getReasoningIcon(id) {
+    switch (id) {
         case 'none':
         case 'minimal':
-            return {
-                id: key,
-                reasoningMode: 'fast',
-                icon: FastReasoningIcon,
-                label: t('omnibar_reasoningEffortFastLabel'),
-                description: t('omnibar_reasoningEffortFastDescription'),
-            };
-        case 'low':
-            return {
-                id: key,
-                reasoningMode: 'reasoning',
-                icon: ReasoningEffortIcon,
-                label: t('omnibar_reasoningEffortReasoningLabel'),
-                description: t('omnibar_reasoningEffortReasoningDescription'),
-            };
-        case 'medium':
+            return FastReasoningIcon;
+        case 'extended':
         case 'high':
-            return {
-                id: key,
-                reasoningMode: 'extendedReasoning',
-                icon: ExtendedReasoningIcon,
-                label: t('omnibar_reasoningEffortExtendedReasoningLabel'),
-                description: t('omnibar_reasoningEffortExtendedReasoningDescription'),
-            };
-        default: {
-            /**
-             * Exhaustiveness check — `never` means all ReasoningEffort cases are handled;
-             * adding a new one without a case will cause a type error here.
-             * @type {never}
-             */
-            const _exhaustiveCheck = key;
-            console.error(`Unknown reasoning effort: ${_exhaustiveCheck}`);
-            return null;
-        }
+            return ExtendedReasoningIcon;
+        case 'low':
+        case 'medium':
+            return ReasoningEffortIcon;
+        default:
+            return ReasoningEffortIcon;
     }
 }
 
 export function ReasoningPickerTool() {
     const { t } = useTypedTranslationWith(/** @type {Strings} */ ({}));
-    const { supportedEfforts, selectedEffort, setSelectedReasoningEffort } = useSelectedReasoningEffort();
+    const { showSubscriptionUpsell } = useContext(OmnibarContext);
+    const { reasoningEfforts, selectedEffort, setSelectedReasoningEffort } = useSelectedReasoningEffort();
 
-    const getOptions = () => {
-        const mapped = /** @type {ReasoningEffortOption[]} */ (supportedEfforts.map((key) => getEffortOption(key, t)).filter(Boolean));
-        const usedModes = new Set();
+    const options = reasoningEfforts.map((effort) => ({
+        id: effort.id,
+        name: effort.name,
+        description: effort.description,
+        status: effort.status,
+        icon: getReasoningIcon(effort.id),
+    }));
 
-        return mapped.filter((option) => {
-            if (usedModes.has(option.reasoningMode)) {
-                return false;
-            }
-            usedModes.add(option.reasoningMode);
-            return true;
-        });
-    };
-
-    const options = getOptions();
-    const hasMultipleOptions = options.length >= 2;
-
-    if (!hasMultipleOptions) {
+    if (options.length < 2) {
         return null;
     }
 
@@ -93,8 +59,10 @@ export function ReasoningPickerTool() {
             options={options}
             selectedEffort={selectedEffort}
             onSelect={setSelectedReasoningEffort}
+            onUpsell={showSubscriptionUpsell}
             ariaLabel={t('omnibar_reasoningPickerLabel')}
-            buttonLabel={selectedOption?.label ?? t('omnibar_reasoningPickerLabel')}
+            buttonLabel={selectedOption?.name ?? t('omnibar_reasoningPickerLabel')}
+            tryForFreeLabel={t('omnibar_reasoningTryForFree')}
         />
     );
 }

--- a/special-pages/pages/new-tab/app/omnibar/components/chat-tools/reasoning-picker/ReasoningPickerTool.js
+++ b/special-pages/pages/new-tab/app/omnibar/components/chat-tools/reasoning-picker/ReasoningPickerTool.js
@@ -37,7 +37,7 @@ function getReasoningIcon(id) {
 
 export function ReasoningPickerTool() {
     const { t } = useTypedTranslationWith(/** @type {Strings} */ ({}));
-    const { showSubscriptionUpsell } = useContext(OmnibarContext);
+    const { showUpsell } = useContext(OmnibarContext);
     const { reasoningEfforts, selectedEffort, setSelectedReasoningEffort } = useSelectedReasoningEffort();
 
     const options = reasoningEfforts.map((effort) => ({
@@ -45,6 +45,7 @@ export function ReasoningPickerTool() {
         name: effort.name,
         description: effort.description,
         status: effort.status,
+        upsell: effort.upsell,
         icon: getReasoningIcon(effort.id),
     }));
 
@@ -59,10 +60,11 @@ export function ReasoningPickerTool() {
             options={options}
             selectedEffort={selectedEffort}
             onSelect={setSelectedReasoningEffort}
-            onUpsell={showSubscriptionUpsell}
+            onUpsell={showUpsell}
             ariaLabel={t('omnibar_reasoningPickerLabel')}
             buttonLabel={selectedOption?.name ?? t('omnibar_reasoningPickerLabel')}
             tryForFreeLabel={t('omnibar_reasoningTryForFree')}
+            upgradeLabel={t('omnibar_upgrade')}
         />
     );
 }

--- a/special-pages/pages/new-tab/app/omnibar/components/chat-tools/tab-attachment/AttachMenu.js
+++ b/special-pages/pages/new-tab/app/omnibar/components/chat-tools/tab-attachment/AttachMenu.js
@@ -238,7 +238,7 @@ function OpenDropdownBody({ attachEnabled, fileLabel, dropdownPos, dropdownRef, 
                     icon={<PageContentIcon />}
                     name={t('omnibar_attachPageContentLabel')}
                     trailingIcon={
-                        <span class={styles.submenuChevron}>
+                        <span class={styles.submenuChevron} aria-hidden="true">
                             <ChevronSmall />
                         </span>
                     }

--- a/special-pages/pages/new-tab/app/omnibar/components/chat-tools/useDropdown.js
+++ b/special-pages/pages/new-tab/app/omnibar/components/chat-tools/useDropdown.js
@@ -53,8 +53,9 @@ function computePosition(buttonRect, cbRect, align) {
  *
  * @param {object} [options]
  * @param {'left' | 'right'} [options.align] - Horizontal alignment of the dropdown relative to the button. Defaults to 'left'.
+ * @param {() => void} [options.onOpen] - Invoked once each time the dropdown transitions from closed to open. Used to report picker-impression telemetry.
  */
-export function useDropdown({ align = 'left' } = {}) {
+export function useDropdown({ align = 'left', onOpen } = {}) {
     const [isOpen, setIsOpen] = useState(false);
     const [dropdownPos, setDropdownPos] = useState(/** @type {DropdownPosition|null} */ (null));
     const buttonRef = useRef(/** @type {HTMLButtonElement|null} */ (null));
@@ -78,6 +79,7 @@ export function useDropdown({ align = 'left' } = {}) {
         const cbRect = cb?.getBoundingClientRect() ?? null;
         setDropdownPos(computePosition(rect, cbRect, align));
         setIsOpen(true);
+        onOpen?.();
 
         /** @param {MouseEvent} e */
         const handleClickOutside = (e) => {

--- a/special-pages/pages/new-tab/app/omnibar/components/useSelectedReasoningEffort.js
+++ b/special-pages/pages/new-tab/app/omnibar/components/useSelectedReasoningEffort.js
@@ -3,25 +3,23 @@ import { OmnibarContext } from './OmnibarProvider';
 import { useSelectedModel } from './useSelectedModel';
 
 /**
- * Runtime allowlist of reasoning-effort keys the web app knows how to render and submit.
- * Native may advertise new keys before web has strings/icons for them; filter them out so
- * unknown keys never surface in the UI or leak into `omnibar_submitChat` payloads.
- *
- * @type {ReadonlySet<import('../../../types/new-tab.js').ReasoningEffort>}
+ * @typedef {import('../../../types/new-tab.js').ReasoningEffortOption} ReasoningEffortOption
  */
-const KNOWN_REASONING_EFFORTS = new Set(['none', 'minimal', 'low', 'medium', 'high']);
 
 export function useSelectedReasoningEffort() {
     const { state, setSelectedReasoningEffort } = useContext(OmnibarContext);
     const { selectedModel } = useSelectedModel();
 
-    const supportedEfforts = (selectedModel?.supportedReasoningEffort ?? []).filter((effort) => KNOWN_REASONING_EFFORTS.has(effort));
+    /** @type {ReasoningEffortOption[]} */
+    const reasoningEfforts = selectedModel?.reasoningEfforts ?? [];
+    const availableEffortIds = reasoningEfforts.filter((effort) => effort.status === 'available').map((effort) => effort.id);
+
     const persisted = state.config?.selectedReasoningEffort;
-    const isPersistedSupported = persisted && supportedEfforts.includes(persisted);
+    const isPersistedAvailable = persisted != null && availableEffortIds.includes(persisted);
 
     /** @type {import('../../../types/new-tab.js').ReasoningEffort | null} */
-    const fallbackEffort = supportedEfforts[0] ?? null;
-    const selectedEffort = isPersistedSupported ? persisted : fallbackEffort;
+    const fallbackEffort = availableEffortIds[0] ?? null;
+    const selectedEffort = isPersistedAvailable ? persisted : fallbackEffort;
 
-    return { selectedEffort, supportedEfforts, setSelectedReasoningEffort };
+    return { selectedEffort, reasoningEfforts, setSelectedReasoningEffort };
 }

--- a/special-pages/pages/new-tab/app/omnibar/integration-tests/omnibar.page.js
+++ b/special-pages/pages/new-tab/app/omnibar/integration-tests/omnibar.page.js
@@ -332,6 +332,11 @@ export class OmnibarPage {
         return this.modelDropdown().getByRole('option', { name: modelName });
     }
 
+    /** The "Try for free" upsell link shown above subscription-only models in the model selector. */
+    modelUpsellButton() {
+        return this.modelDropdown().getByRole('button', { name: 'Try for free' });
+    }
+
     toolsMenuButton() {
         return this.context().getByRole('button', { name: 'Tools' });
     }

--- a/special-pages/pages/new-tab/app/omnibar/integration-tests/omnibar.spec.js
+++ b/special-pages/pages/new-tab/app/omnibar/integration-tests/omnibar.spec.js
@@ -2044,6 +2044,35 @@ test.describe('omnibar widget', () => {
 
             await ntp.mocks.waitForCallCount({ method: 'omnibar_showSubscriptionUpsell', count: 1 });
         });
+
+        test('an upgrade-gated reasoning-effort option shows "Upgrade" and opens the subscription upgrade', async ({
+            page,
+        }, workerInfo) => {
+            const ntp = NewtabPage.create(page, workerInfo);
+            const omnibar = new OmnibarPage(ntp);
+            await ntp.reducedMotion();
+
+            // Mistral Small 3 has an 'extended' reasoning effort with status 'unavailable' and upsell 'upgrade' in the mock
+            await ntp.openPage({
+                additional: {
+                    omnibar: true,
+                    'omnibar.enableAiChatTools': 'true',
+                    'omnibar.selectedModelId': 'mistralai_Mistral-Small-24B-Instruct-2501',
+                },
+            });
+            await omnibar.ready();
+
+            await omnibar.aiTab().click();
+            await omnibar.expectMode('ai');
+
+            await omnibar.reasoningPickerButton().click();
+            const gatedOption = omnibar.reasoningOption('Extended Reasoning Researches before responding');
+            await expect(gatedOption).toContainText('Upgrade');
+
+            await gatedOption.click();
+
+            await ntp.mocks.waitForCallCount({ method: 'omnibar_showSubscriptionUpgrade', count: 1 });
+        });
     });
 
     test.describe('AI chat image attachments', () => {

--- a/special-pages/pages/new-tab/app/omnibar/integration-tests/omnibar.spec.js
+++ b/special-pages/pages/new-tab/app/omnibar/integration-tests/omnibar.spec.js
@@ -1719,13 +1719,74 @@ test.describe('omnibar widget', () => {
         });
     });
 
-    test.describe('AI chat reasoning picker', () => {
-        test('picker is hidden when the selected model has no supportedReasoningEffort', async ({ page }, workerInfo) => {
+    test.describe('AI chat model selector', () => {
+        test('renders model descriptions and tier/beta badges', async ({ page }, workerInfo) => {
             const ntp = NewtabPage.create(page, workerInfo);
             const omnibar = new OmnibarPage(ntp);
             await ntp.reducedMotion();
 
-            // gpt-4o-mini in the mock has no supportedReasoningEffort
+            await ntp.openPage({ additional: { omnibar: true, 'omnibar.enableAiChatTools': 'true' } });
+            await omnibar.ready();
+
+            await omnibar.aiTab().click();
+            await omnibar.expectMode('ai');
+
+            await omnibar.modelSelectorButton().click();
+
+            // description under the model name
+            await expect(omnibar.modelOption('GPT-5 mini')).toContainText('Best for everyday use');
+            // beta badge (claude-3-5-haiku-latest has isBeta in the mock)
+            await expect(omnibar.modelOption('Claude 3.5 Haiku')).toContainText('Beta');
+            // tier badges on gated models
+            await expect(omnibar.modelOption('Claude Sonnet 4.5')).toContainText('Plus');
+            await expect(omnibar.modelOption('Claude Opus 4.6')).toContainText('Pro');
+        });
+
+        test('shows the subscriber-exclusive upsell and opens the subscription upsell on "Try for free"', async ({ page }, workerInfo) => {
+            const ntp = NewtabPage.create(page, workerInfo);
+            const omnibar = new OmnibarPage(ntp);
+            await ntp.reducedMotion();
+
+            // Default mock: the advanced section is entirely disabled, so it renders as an upsell section
+            await ntp.openPage({ additional: { omnibar: true, 'omnibar.enableAiChatTools': 'true' } });
+            await omnibar.ready();
+
+            await omnibar.aiTab().click();
+            await omnibar.expectMode('ai');
+
+            await omnibar.modelSelectorButton().click();
+            await expect(omnibar.modelDropdown()).toContainText('Subscriber exclusive.');
+
+            await omnibar.modelUpsellButton().click();
+
+            await ntp.mocks.waitForCallCount({ method: 'omnibar_showSubscriptionUpsell', count: 1 });
+        });
+
+        test('does not show the upsell when all models are available', async ({ page }, workerInfo) => {
+            const ntp = NewtabPage.create(page, workerInfo);
+            const omnibar = new OmnibarPage(ntp);
+            await ntp.reducedMotion();
+
+            await ntp.openPage({
+                additional: { omnibar: true, 'omnibar.enableAiChatTools': 'true', 'omnibar.subscription': 'true' },
+            });
+            await omnibar.ready();
+
+            await omnibar.aiTab().click();
+            await omnibar.expectMode('ai');
+
+            await omnibar.modelSelectorButton().click();
+            await expect(omnibar.modelUpsellButton()).toHaveCount(0);
+        });
+    });
+
+    test.describe('AI chat reasoning picker', () => {
+        test('picker is hidden when the selected model has no reasoningEfforts', async ({ page }, workerInfo) => {
+            const ntp = NewtabPage.create(page, workerInfo);
+            const omnibar = new OmnibarPage(ntp);
+            await ntp.reducedMotion();
+
+            // gpt-4o-mini in the mock has no reasoningEfforts
             await ntp.openPage({
                 additional: {
                     omnibar: true,
@@ -1783,7 +1844,7 @@ test.describe('omnibar widget', () => {
 
             const calls = await ntp.mocks.waitForCallCount({ method: 'omnibar_setConfig', count: 1 });
             const last = calls[calls.length - 1];
-            expect(last?.payload?.params?.selectedReasoningEffort).toBe('low');
+            expect(last?.payload?.params?.selectedReasoningEffort).toBe('medium');
         });
 
         test('submit includes reasoningEffort for models that support it', async ({ page }, workerInfo) => {
@@ -1796,7 +1857,7 @@ test.describe('omnibar widget', () => {
                     omnibar: true,
                     'omnibar.enableAiChatTools': 'true',
                     'omnibar.selectedModelId': 'gpt-5-mini',
-                    'omnibar.selectedReasoningEffort': 'low',
+                    'omnibar.selectedReasoningEffort': 'medium',
                 },
             });
             await omnibar.ready();
@@ -1811,11 +1872,11 @@ test.describe('omnibar widget', () => {
                 chat: 'hello',
                 target: 'same-tab',
                 modelId: 'gpt-5-mini',
-                reasoningEffort: 'low',
+                reasoningEffort: 'medium',
             });
         });
 
-        test('submit omits reasoningEffort when the model has no supportedReasoningEffort', async ({ page }, workerInfo) => {
+        test('submit omits reasoningEffort when the model has no reasoningEfforts', async ({ page }, workerInfo) => {
             const ntp = NewtabPage.create(page, workerInfo);
             const omnibar = new OmnibarPage(ntp);
             await ntp.reducedMotion();
@@ -1825,7 +1886,7 @@ test.describe('omnibar widget', () => {
                     omnibar: true,
                     'omnibar.enableAiChatTools': 'true',
                     'omnibar.selectedModelId': 'gpt-4o-mini',
-                    'omnibar.selectedReasoningEffort': 'low',
+                    'omnibar.selectedReasoningEffort': 'medium',
                 },
             });
             await omnibar.ready();
@@ -1841,21 +1902,19 @@ test.describe('omnibar widget', () => {
             expect(last?.payload?.params?.reasoningEffort).toBeUndefined();
         });
 
-        test('switching to a model with a different supportedReasoningEffort falls back to a valid default', async ({
-            page,
-        }, workerInfo) => {
+        test('switching to a model with different reasoningEfforts falls back to a valid default', async ({ page }, workerInfo) => {
             const ntp = NewtabPage.create(page, workerInfo);
             const omnibar = new OmnibarPage(ntp);
             await ntp.reducedMotion();
 
-            // claude-opus-4-6 supports ['none', 'low', 'medium']; claude-haiku-4-5 only ['none', 'low']
+            // claude-opus-4-6 supports ['none', 'medium', 'extended']; gpt-5-mini only ['none', 'medium']
             await ntp.openPage({
                 additional: {
                     omnibar: true,
                     'omnibar.enableAiChatTools': 'true',
                     'omnibar.subscription': 'true',
                     'omnibar.selectedModelId': 'claude-opus-4-6',
-                    'omnibar.selectedReasoningEffort': 'medium',
+                    'omnibar.selectedReasoningEffort': 'extended',
                 },
             });
             await omnibar.ready();
@@ -1864,16 +1923,16 @@ test.describe('omnibar widget', () => {
             await omnibar.expectMode('ai');
 
             await omnibar.modelSelectorButton().click();
-            await omnibar.modelOption('Claude Haiku 4.5').click();
+            await omnibar.modelOption('GPT-5 mini').click();
 
             await omnibar.chatInput().fill('hello');
             await omnibar.chatInput().press('Enter');
 
-            // 'medium' isn't in claude-haiku-4-5's list; effective value falls back to the first supported one
+            // 'extended' isn't in gpt-5-mini's list; effective value falls back to the first supported one
             await omnibar.expectMethodCalledWith('omnibar_submitChat', {
                 chat: 'hello',
                 target: 'same-tab',
-                modelId: 'claude-haiku-4-5',
+                modelId: 'gpt-5-mini',
                 reasoningEffort: 'none',
             });
         });
@@ -1883,14 +1942,14 @@ test.describe('omnibar widget', () => {
             const omnibar = new OmnibarPage(ntp);
             await ntp.reducedMotion();
 
-            // claude-opus-4-6 supports 'medium'; claude-haiku-4-5 does not
+            // claude-opus-4-6 supports 'extended'; gpt-5-mini does not
             await ntp.openPage({
                 additional: {
                     omnibar: true,
                     'omnibar.enableAiChatTools': 'true',
                     'omnibar.subscription': 'true',
                     'omnibar.selectedModelId': 'claude-opus-4-6',
-                    'omnibar.selectedReasoningEffort': 'medium',
+                    'omnibar.selectedReasoningEffort': 'extended',
                 },
             });
             await omnibar.ready();
@@ -1899,12 +1958,12 @@ test.describe('omnibar widget', () => {
             await omnibar.expectMode('ai');
 
             await omnibar.modelSelectorButton().click();
-            await omnibar.modelOption('Claude Haiku 4.5').click();
+            await omnibar.modelOption('GPT-5 mini').click();
 
             // Model change should carry a reconciled selectedReasoningEffort in the same config write
             const calls = await ntp.mocks.waitForCallCount({ method: 'omnibar_setConfig', count: 1 });
             const last = calls[calls.length - 1];
-            expect(last?.payload?.params?.selectedModelId).toBe('claude-haiku-4-5');
+            expect(last?.payload?.params?.selectedModelId).toBe('gpt-5-mini');
             expect(last?.payload?.params?.selectedReasoningEffort).toBe('none');
         });
 
@@ -1933,6 +1992,57 @@ test.describe('omnibar widget', () => {
             const calls = await ntp.mocks.waitForCallCount({ method: 'omnibar_setConfig', count: 1 });
             const last = calls[calls.length - 1];
             expect(last?.payload?.params?.selectedReasoningEffort).toBe('none');
+        });
+
+        test('renders a description under each reasoning-effort option', async ({ page }, workerInfo) => {
+            const ntp = NewtabPage.create(page, workerInfo);
+            const omnibar = new OmnibarPage(ntp);
+            await ntp.reducedMotion();
+
+            await ntp.openPage({
+                additional: {
+                    omnibar: true,
+                    'omnibar.enableAiChatTools': 'true',
+                    'omnibar.selectedModelId': 'gpt-5-mini',
+                },
+            });
+            await omnibar.ready();
+
+            await omnibar.aiTab().click();
+            await omnibar.expectMode('ai');
+
+            await omnibar.reasoningPickerButton().click();
+            await expect(omnibar.reasoningOption('Fast Answers right away')).toBeVisible();
+            await expect(omnibar.reasoningOption('Reasoning Takes a moment to respond')).toBeVisible();
+        });
+
+        test('an unavailable reasoning-effort option shows "Try for Free" and opens the subscription upsell', async ({
+            page,
+        }, workerInfo) => {
+            const ntp = NewtabPage.create(page, workerInfo);
+            const omnibar = new OmnibarPage(ntp);
+            await ntp.reducedMotion();
+
+            // claude-haiku-4-5 has an 'extended' reasoning effort with status 'unavailable' in the mock
+            await ntp.openPage({
+                additional: {
+                    omnibar: true,
+                    'omnibar.enableAiChatTools': 'true',
+                    'omnibar.selectedModelId': 'claude-haiku-4-5',
+                },
+            });
+            await omnibar.ready();
+
+            await omnibar.aiTab().click();
+            await omnibar.expectMode('ai');
+
+            await omnibar.reasoningPickerButton().click();
+            const gatedOption = omnibar.reasoningOption('Extended Reasoning Researches before responding');
+            await expect(gatedOption).toContainText('Try for Free');
+
+            await gatedOption.click();
+
+            await ntp.mocks.waitForCallCount({ method: 'omnibar_showSubscriptionUpsell', count: 1 });
         });
     });
 

--- a/special-pages/pages/new-tab/app/omnibar/integration-tests/omnibar.spec.js
+++ b/special-pages/pages/new-tab/app/omnibar/integration-tests/omnibar.spec.js
@@ -1759,7 +1759,27 @@ test.describe('omnibar widget', () => {
 
             await omnibar.modelUpsellButton().click();
 
-            await ntp.mocks.waitForCallCount({ method: 'omnibar_showSubscriptionUpsell', count: 1 });
+            await omnibar.expectMethodCalledWith('omnibar_showSubscriptionUpsell', { source: 'model' });
+        });
+
+        test('fires model-picker and upsell impressions when the model selector is opened', async ({ page }, workerInfo) => {
+            const ntp = NewtabPage.create(page, workerInfo);
+            const omnibar = new OmnibarPage(ntp);
+            await ntp.reducedMotion();
+
+            // Default mock: the advanced section is entirely gated, so the upsell CTA is visible on open.
+            await ntp.openPage({ additional: { omnibar: true, 'omnibar.enableAiChatTools': 'true' } });
+            await omnibar.ready();
+
+            await omnibar.aiTab().click();
+            await omnibar.expectMode('ai');
+
+            await omnibar.modelSelectorButton().click();
+
+            const calls = await ntp.mocks.waitForCallCount({ method: 'telemetryEvent', count: 2 });
+            const params = calls.map((call) => call.payload.params);
+            expect(params).toContainEqual({ attributes: { name: 'omnibar_picker', value: { picker: 'model' } } });
+            expect(params).toContainEqual({ attributes: { name: 'omnibar_upsell', value: { picker: 'model' } } });
         });
 
         test('does not show the upsell when all models are available', async ({ page }, workerInfo) => {
@@ -1777,6 +1797,12 @@ test.describe('omnibar widget', () => {
 
             await omnibar.modelSelectorButton().click();
             await expect(omnibar.modelUpsellButton()).toHaveCount(0);
+
+            // Picker impression still fires, but the upsell impression must not (no gated option visible).
+            const calls = await ntp.mocks.waitForCallCount({ method: 'telemetryEvent', count: 1 });
+            const params = calls.map((call) => call.payload.params);
+            expect(params).toContainEqual({ attributes: { name: 'omnibar_picker', value: { picker: 'model' } } });
+            expect(params).not.toContainEqual({ attributes: { name: 'omnibar_upsell', value: { picker: 'model' } } });
         });
     });
 
@@ -2042,7 +2068,7 @@ test.describe('omnibar widget', () => {
 
             await gatedOption.click();
 
-            await ntp.mocks.waitForCallCount({ method: 'omnibar_showSubscriptionUpsell', count: 1 });
+            await omnibar.expectMethodCalledWith('omnibar_showSubscriptionUpsell', { source: 'reasoning' });
         });
 
         test('an upgrade-gated reasoning-effort option shows "Upgrade" and opens the subscription upgrade', async ({
@@ -2071,7 +2097,33 @@ test.describe('omnibar widget', () => {
 
             await gatedOption.click();
 
-            await ntp.mocks.waitForCallCount({ method: 'omnibar_showSubscriptionUpgrade', count: 1 });
+            await omnibar.expectMethodCalledWith('omnibar_showSubscriptionUpgrade', { source: 'reasoning' });
+        });
+
+        test('fires reasoning-picker and upsell impressions when the reasoning picker is opened', async ({ page }, workerInfo) => {
+            const ntp = NewtabPage.create(page, workerInfo);
+            const omnibar = new OmnibarPage(ntp);
+            await ntp.reducedMotion();
+
+            // claude-haiku-4-5 has a gated 'extended' effort, so the upsell CTA is visible on open.
+            await ntp.openPage({
+                additional: {
+                    omnibar: true,
+                    'omnibar.enableAiChatTools': 'true',
+                    'omnibar.selectedModelId': 'claude-haiku-4-5',
+                },
+            });
+            await omnibar.ready();
+
+            await omnibar.aiTab().click();
+            await omnibar.expectMode('ai');
+
+            await omnibar.reasoningPickerButton().click();
+
+            const calls = await ntp.mocks.waitForCallCount({ method: 'telemetryEvent', count: 2 });
+            const params = calls.map((call) => call.payload.params);
+            expect(params).toContainEqual({ attributes: { name: 'omnibar_picker', value: { picker: 'reasoning' } } });
+            expect(params).toContainEqual({ attributes: { name: 'omnibar_upsell', value: { picker: 'reasoning' } } });
         });
     });
 

--- a/special-pages/pages/new-tab/app/omnibar/mocks/omnibar.mock-transport.js
+++ b/special-pages/pages/new-tab/app/omnibar/mocks/omnibar.mock-transport.js
@@ -38,9 +38,12 @@ const EXTENDED_EFFORT_UNAVAILABLE = {
     name: 'Extended Reasoning',
     description: 'Researches before responding',
     status: 'unavailable',
+    upsell: 'subscribe',
 };
 /** @type {import('../../../types/new-tab.ts').ReasoningEffortOption} */
-const EXTENDED_EFFORT_AVAILABLE = { ...EXTENDED_EFFORT_UNAVAILABLE, status: 'available' };
+const EXTENDED_EFFORT_UPGRADE = { ...EXTENDED_EFFORT_UNAVAILABLE, upsell: 'upgrade' };
+/** @type {import('../../../types/new-tab.ts').ReasoningEffortOption} */
+const EXTENDED_EFFORT_AVAILABLE = { ...EXTENDED_EFFORT_UNAVAILABLE, status: 'available', upsell: undefined };
 
 export function omnibarMockTransport() {
     /** @type {import('../../../types/new-tab.ts').OmnibarConfig} */
@@ -113,6 +116,8 @@ export function omnibarMockTransport() {
                         accessTier: ['free'],
                         supportsImageUpload: false,
                         supportedTools: [],
+                        // Demonstrates the 'upgrade' upsell (existing subscriber gated behind a higher tier).
+                        reasoningEfforts: [FAST_EFFORT, REASONING_EFFORT, EXTENDED_EFFORT_UPGRADE],
                     },
                     {
                         id: 'claude-3-5-haiku-latest',
@@ -214,8 +219,15 @@ export function omnibarMockTransport() {
                 case 'omnibar_openSuggestion':
                 case 'omnibar_submitSearch':
                 case 'omnibar_submitChat':
-                case 'omnibar_showSubscriptionUpsell':
                     console.warn('notification (no-op in mock)', msg.method, msg.params);
+                    break;
+                case 'omnibar_showSubscriptionUpsell':
+                    // Placeholder until native ships the real flow.
+                    globalThis.alert?.('Show subscription upsell (Try for free)');
+                    break;
+                case 'omnibar_showSubscriptionUpgrade':
+                    // Placeholder until native ships the real flow.
+                    globalThis.alert?.('Show subscription upgrade (Upgrade)');
                     break;
                 default: {
                     console.warn('unhandled notification', msg);

--- a/special-pages/pages/new-tab/app/omnibar/mocks/omnibar.mock-transport.js
+++ b/special-pages/pages/new-tab/app/omnibar/mocks/omnibar.mock-transport.js
@@ -219,6 +219,7 @@ export function omnibarMockTransport() {
                 case 'omnibar_openSuggestion':
                 case 'omnibar_submitSearch':
                 case 'omnibar_submitChat':
+                case 'telemetryEvent':
                     console.warn('notification (no-op in mock)', msg.method, msg.params);
                     break;
                 case 'omnibar_showSubscriptionUpsell':

--- a/special-pages/pages/new-tab/app/omnibar/mocks/omnibar.mock-transport.js
+++ b/special-pages/pages/new-tab/app/omnibar/mocks/omnibar.mock-transport.js
@@ -16,7 +16,7 @@ function parseBooleanQueryParam(param) {
 }
 
 /** @type {ReadonlyArray<import('../../../types/new-tab.ts').ReasoningEffort>} */
-const REASONING_EFFORTS = ['none', 'low', 'medium'];
+const REASONING_EFFORTS = ['none', 'medium', 'extended'];
 
 /**
  * Reads a URL query param as a ReasoningEffort. Returns null if absent or invalid.
@@ -27,6 +27,20 @@ function parseReasoningEffortQueryParam(param) {
     const value = url.searchParams.get(param);
     return REASONING_EFFORTS.find((effort) => effort === value) ?? null;
 }
+
+/** @type {import('../../../types/new-tab.ts').ReasoningEffortOption} */
+const FAST_EFFORT = { id: 'none', name: 'Fast', description: 'Answers right away', status: 'available' };
+/** @type {import('../../../types/new-tab.ts').ReasoningEffortOption} */
+const REASONING_EFFORT = { id: 'medium', name: 'Reasoning', description: 'Takes a moment to respond', status: 'available' };
+/** @type {import('../../../types/new-tab.ts').ReasoningEffortOption} */
+const EXTENDED_EFFORT_UNAVAILABLE = {
+    id: 'extended',
+    name: 'Extended Reasoning',
+    description: 'Researches before responding',
+    status: 'unavailable',
+};
+/** @type {import('../../../types/new-tab.ts').ReasoningEffortOption} */
+const EXTENDED_EFFORT_AVAILABLE = { ...EXTENDED_EFFORT_UNAVAILABLE, status: 'available' };
 
 export function omnibarMockTransport() {
     /** @type {import('../../../types/new-tab.ts').OmnibarConfig} */
@@ -44,7 +58,9 @@ export function omnibarMockTransport() {
                         id: 'gpt-4o-mini',
                         name: 'GPT-4o mini',
                         shortName: '4o-mini',
+                        description: 'Solid but uses limits faster',
                         isEnabled: true,
+                        accessTier: ['free'],
                         supportsImageUpload: true,
                         supportedTools: ['WebSearch'],
                     },
@@ -52,16 +68,19 @@ export function omnibarMockTransport() {
                         id: 'gpt-5-mini',
                         name: 'GPT-5 mini',
                         shortName: 'GPT-5',
+                        description: 'Best for everyday use',
                         isEnabled: true,
+                        accessTier: ['free'],
                         supportsImageUpload: true,
                         supportedTools: ['WebSearch'],
-                        supportedReasoningEffort: ['none', 'low'],
+                        reasoningEfforts: [FAST_EFFORT, REASONING_EFFORT],
                     },
                     {
                         id: 'openai_gpt-oss-120b',
                         name: 'GPT-OSS 120B',
                         shortName: 'GPT-OSS',
                         isEnabled: true,
+                        accessTier: ['free'],
                         supportsImageUpload: false,
                         supportedTools: [],
                     },
@@ -70,6 +89,7 @@ export function omnibarMockTransport() {
                         name: 'Llama 4 Scout',
                         shortName: 'Scout',
                         isEnabled: true,
+                        accessTier: ['free'],
                         supportsImageUpload: false,
                         supportedTools: [],
                     },
@@ -77,17 +97,20 @@ export function omnibarMockTransport() {
                         id: 'claude-haiku-4-5',
                         name: 'Claude Haiku 4.5',
                         shortName: 'Haiku 4.5',
+                        description: 'Solid but uses limits faster',
                         isEnabled: true,
+                        accessTier: ['free'],
                         supportsImageUpload: true,
                         supportedFileTypes: ['application/pdf'],
                         supportedTools: ['WebSearch'],
-                        supportedReasoningEffort: ['none', 'low'],
+                        reasoningEfforts: [FAST_EFFORT, REASONING_EFFORT, EXTENDED_EFFORT_UNAVAILABLE],
                     },
                     {
                         id: 'mistralai_Mistral-Small-24B-Instruct-2501',
                         name: 'Mistral Small 3',
                         shortName: 'Mistral',
                         isEnabled: true,
+                        accessTier: ['free'],
                         supportsImageUpload: false,
                         supportedTools: [],
                     },
@@ -96,6 +119,8 @@ export function omnibarMockTransport() {
                         name: 'Claude 3.5 Haiku',
                         shortName: 'Claude 3.5 Haiku',
                         isEnabled: true,
+                        isBeta: true,
+                        accessTier: ['free'],
                         supportsImageUpload: true,
                         supportedTools: ['WebSearch'],
                     },
@@ -109,6 +134,7 @@ export function omnibarMockTransport() {
                         name: 'GPT-4o',
                         shortName: 'GPT-4o',
                         isEnabled: false,
+                        accessTier: ['plus'],
                         supportsImageUpload: true,
                         supportedTools: ['WebSearch'],
                     },
@@ -117,25 +143,28 @@ export function omnibarMockTransport() {
                         name: 'GPT-5.2',
                         shortName: 'GPT-5.2',
                         isEnabled: false,
+                        accessTier: ['plus'],
                         supportsImageUpload: true,
                         supportedTools: ['WebSearch'],
-                        supportedReasoningEffort: ['none', 'low', 'medium'],
+                        reasoningEfforts: [FAST_EFFORT, REASONING_EFFORT, EXTENDED_EFFORT_AVAILABLE],
                     },
                     {
                         id: 'claude-sonnet-4-5',
                         name: 'Claude Sonnet 4.5',
                         shortName: 'Sonnet 4.5',
                         isEnabled: false,
+                        accessTier: ['plus'],
                         supportsImageUpload: true,
                         supportedFileTypes: ['application/pdf'],
                         supportedTools: ['WebSearch'],
-                        supportedReasoningEffort: ['none', 'low'],
+                        reasoningEfforts: [FAST_EFFORT, REASONING_EFFORT],
                     },
                     {
                         id: 'meta-llama_Llama-4-Maverick-17B-128E-Instruct-FP8',
                         name: 'Llama 4 Maverick',
                         shortName: 'Maverick',
                         isEnabled: false,
+                        accessTier: ['plus'],
                         supportsImageUpload: false,
                         supportedTools: [],
                     },
@@ -144,15 +173,17 @@ export function omnibarMockTransport() {
                         name: 'Claude Opus 4.6',
                         shortName: 'Opus 4.6',
                         isEnabled: false,
+                        accessTier: ['pro'],
                         supportsImageUpload: true,
                         supportedTools: ['WebSearch'],
-                        supportedReasoningEffort: ['none', 'low', 'medium'],
+                        reasoningEfforts: [FAST_EFFORT, REASONING_EFFORT, EXTENDED_EFFORT_AVAILABLE],
                     },
                     {
                         id: 'claude-sonnet-4',
                         name: 'Claude 4 Sonnet',
                         shortName: 'Claude 4 Sonnet',
                         isEnabled: false,
+                        accessTier: ['pro'],
                         supportsImageUpload: true,
                         supportedTools: ['WebSearch'],
                     },
@@ -183,6 +214,7 @@ export function omnibarMockTransport() {
                 case 'omnibar_openSuggestion':
                 case 'omnibar_submitSearch':
                 case 'omnibar_submitChat':
+                case 'omnibar_showSubscriptionUpsell':
                     console.warn('notification (no-op in mock)', msg.method, msg.params);
                     break;
                 default: {
@@ -224,7 +256,11 @@ export function omnibarMockTransport() {
                     if (parseBooleanQueryParam('omnibar.subscription') === true) {
                         config.aiModelSections = config.aiModelSections?.map((section) => ({
                             ...section,
-                            items: section.items.map((item) => ({ ...item, isEnabled: true })),
+                            items: section.items.map((item) => ({
+                                ...item,
+                                isEnabled: true,
+                                reasoningEfforts: item.reasoningEfforts?.map((effort) => ({ ...effort, status: 'available' })),
+                            })),
                         }));
                     }
                     config.selectedReasoningEffort =

--- a/special-pages/pages/new-tab/app/omnibar/omnibar.md
+++ b/special-pages/pages/new-tab/app/omnibar/omnibar.md
@@ -257,6 +257,41 @@ title: Omnibar Widget
 }
 ```
 
+### Picker impressions — `telemetryEvent`
+Impression telemetry is sent via the shared `telemetryEvent` notification (not a bespoke message), so native only needs to add a name case + pixel mapping. Fired once per open (closed→open transition). Native maps `value.picker` to the platform-specific subscription funnel origin and fires the impression pixel.
+
+- **Picker shown** — `{ attributes: { name: "omnibar_picker", value: { picker: "model" | "reasoning" } } }`, sent when the model or reasoning picker opens.
+- **Upsell shown** — `{ attributes: { name: "omnibar_upsell", value: { picker: "model" | "reasoning" } } }`, sent when the conditional subscription upsell CTA is visible on open (only when a gated option exists).
+
+Example payload:
+```json
+{
+   "attributes": { "name": "omnibar_picker", "value": { "picker": "model" } }
+}
+```
+
+### `omnibar_showSubscriptionUpsell`
+- {@link "NewTab Messages".OmnibarShowSubscriptionUpsellNotification}
+- Sent when the user taps "Try for free" on a subscription-gated model or reasoning-effort option.
+- requires `source` — `"model"` or `"reasoning"`, identifying the picker the upsell was triggered from. Native maps `source` to the subscription funnel origin (and infers `flow_type`); the frontend does not send origin or flow information.
+- example payload:
+```json
+{
+   "source": "model"
+}
+```
+
+### `omnibar_showSubscriptionUpgrade`
+- {@link "NewTab Messages".OmnibarShowSubscriptionUpgradeNotification}
+- Sent when a subscriber taps "Upgrade" on a model or reasoning-effort option gated behind a higher tier.
+- requires `source` — `"model"` or `"reasoning"`, identifying the picker the upgrade was triggered from. Native maps `source` to the subscription funnel origin; the frontend does not send origin or flow information.
+- example payload:
+```json
+{
+   "source": "reasoning"
+}
+```
+
 ## Suggestion Types
 
 The omnibar supports various types of suggestions:

--- a/special-pages/pages/new-tab/app/omnibar/omnibar.service.js
+++ b/special-pages/pages/new-tab/app/omnibar/omnibar.service.js
@@ -12,6 +12,7 @@ import { OmnibarAiChatsService } from './omnibar.ai-chats.service.js';
  * @typedef {import("../../types/new-tab.js").SubmitChatAction} SubmitChatAction
  * @typedef {import("../../types/new-tab.js").GetOpenTabsResponse} GetOpenTabsResponse
  * @typedef {import("../../types/new-tab.js").PageContext} PageContext
+ * @typedef {import("../../types/new-tab.js").OmnibarPickerSource} OmnibarPickerSource
  */
 
 export class OmnibarService {
@@ -214,30 +215,52 @@ export class OmnibarService {
     }
 
     /**
+     * Report that the user opened a chat-tool picker (impression), via the shared
+     * `telemetryEvent` message. Native maps `picker` to the platform-specific
+     * subscription funnel origin and fires the picker-impression pixel.
+     * @param {OmnibarPickerSource} picker
+     */
+    pickerShown(picker) {
+        this.ntp.telemetryEvent({ attributes: { name: 'omnibar_picker', value: { picker } } });
+    }
+
+    /**
+     * Report that the conditional subscription upsell CTA became visible inside a picker
+     * (impression), via the shared `telemetryEvent` message.
+     * @param {OmnibarPickerSource} picker
+     */
+    upsellShown(picker) {
+        this.ntp.telemetryEvent({ attributes: { name: 'omnibar_upsell', value: { picker } } });
+    }
+
+    /**
      * Ask native to present the subscription upsell (e.g. when the user taps
      * "Try for free" on a gated model or reasoning-effort option).
+     * @param {OmnibarPickerSource} source - The picker the upsell was triggered from.
      */
-    showSubscriptionUpsell() {
-        this.ntp.messaging.notify('omnibar_showSubscriptionUpsell', {});
+    showSubscriptionUpsell(source) {
+        this.ntp.messaging.notify('omnibar_showSubscriptionUpsell', { source });
     }
 
     /**
      * Ask native to present the subscription upgrade flow (e.g. when a subscriber
      * taps "Upgrade" on a model or reasoning-effort option gated behind a higher tier).
+     * @param {OmnibarPickerSource} source - The picker the upgrade was triggered from.
      */
-    showSubscriptionUpgrade() {
-        this.ntp.messaging.notify('omnibar_showSubscriptionUpgrade', {});
+    showSubscriptionUpgrade(source) {
+        this.ntp.messaging.notify('omnibar_showSubscriptionUpgrade', { source });
     }
 
     /**
      * Route a gated item's upsell to the correct native flow.
-     * @param {'subscribe' | 'upgrade'} [type]
+     * @param {'subscribe' | 'upgrade' | undefined} type
+     * @param {OmnibarPickerSource} source - The picker the upsell was triggered from.
      */
-    showUpsell(type) {
+    showUpsell(type, source) {
         if (type === 'upgrade') {
-            this.showSubscriptionUpgrade();
+            this.showSubscriptionUpgrade(source);
         } else {
-            this.showSubscriptionUpsell();
+            this.showSubscriptionUpsell(source);
         }
     }
 

--- a/special-pages/pages/new-tab/app/omnibar/omnibar.service.js
+++ b/special-pages/pages/new-tab/app/omnibar/omnibar.service.js
@@ -222,6 +222,26 @@ export class OmnibarService {
     }
 
     /**
+     * Ask native to present the subscription upgrade flow (e.g. when a subscriber
+     * taps "Upgrade" on a model or reasoning-effort option gated behind a higher tier).
+     */
+    showSubscriptionUpgrade() {
+        this.ntp.messaging.notify('omnibar_showSubscriptionUpgrade', {});
+    }
+
+    /**
+     * Route a gated item's upsell to the correct native flow.
+     * @param {'subscribe' | 'upgrade'} [type]
+     */
+    showUpsell(type) {
+        if (type === 'upgrade') {
+            this.showSubscriptionUpgrade();
+        } else {
+            this.showSubscriptionUpsell();
+        }
+    }
+
+    /**
      * Requests the list of open tabs available for attachment.
      * @returns {Promise<GetOpenTabsResponse>}
      */

--- a/special-pages/pages/new-tab/app/omnibar/omnibar.service.js
+++ b/special-pages/pages/new-tab/app/omnibar/omnibar.service.js
@@ -105,11 +105,13 @@ export class OmnibarService {
     setSelectedModelId(selectedModelId) {
         this.configService.update((old) => {
             const nextModel = (old.aiModelSections ?? []).flatMap((section) => section.items).find((model) => model.id === selectedModelId);
-            const supportedEfforts = nextModel?.supportedReasoningEffort ?? [];
+            const availableEffortIds = (nextModel?.reasoningEfforts ?? [])
+                .filter((effort) => effort.status === 'available')
+                .map((effort) => effort.id);
 
             const currentEffort = old.selectedReasoningEffort;
             const nextEffort =
-                currentEffort && supportedEfforts.includes(currentEffort) ? currentEffort : (supportedEfforts[0] ?? undefined);
+                currentEffort && availableEffortIds.includes(currentEffort) ? currentEffort : (availableEffortIds[0] ?? undefined);
 
             return {
                 ...old,
@@ -209,6 +211,14 @@ export class OmnibarService {
      */
     viewAllAiChats(params) {
         this.ntp.messaging.notify('omnibar_viewAllAIChats', params);
+    }
+
+    /**
+     * Ask native to present the subscription upsell (e.g. when the user taps
+     * "Try for free" on a gated model or reasoning-effort option).
+     */
+    showSubscriptionUpsell() {
+        this.ntp.messaging.notify('omnibar_showSubscriptionUpsell', {});
     }
 
     /**

--- a/special-pages/pages/new-tab/app/omnibar/strings.json
+++ b/special-pages/pages/new-tab/app/omnibar/strings.json
@@ -215,6 +215,10 @@
     "title": "Try for free",
     "description": "Link text next to the 'Subscriber exclusive.' label that opens the subscription upsell when tapped."
   },
+  "omnibar_upgrade": {
+    "title": "Upgrade",
+    "description": "CTA shown on a model or reasoning-effort option gated behind a higher subscription tier; opens the upgrade flow when tapped."
+  },
   "omnibar_reasoningTryForFree": {
     "title": "Try for Free",
     "description": "Badge text on a gated reasoning-effort option in the reasoning picker; tapping it opens the subscription upsell."

--- a/special-pages/pages/new-tab/app/omnibar/strings.json
+++ b/special-pages/pages/new-tab/app/omnibar/strings.json
@@ -206,5 +206,33 @@
   "omnibar_removeAttachedTabLabel": {
     "title": "Remove {title}",
     "description": "Accessible label for the close button on an attached-tab chip. {title} is the tab title."
+  },
+  "omnibar_subscriberExclusive": {
+    "title": "Subscriber exclusive.",
+    "description": "Label shown above subscription-only AI models in the model selector, next to the 'Try for free' link."
+  },
+  "omnibar_tryForFree": {
+    "title": "Try for free",
+    "description": "Link text next to the 'Subscriber exclusive.' label that opens the subscription upsell when tapped."
+  },
+  "omnibar_reasoningTryForFree": {
+    "title": "Try for Free",
+    "description": "Badge text on a gated reasoning-effort option in the reasoning picker; tapping it opens the subscription upsell."
+  },
+  "omnibar_modelBadgeBeta": {
+    "title": "Beta",
+    "description": "Badge shown next to an AI model in the model selector that is in beta."
+  },
+  "omnibar_modelBadgePlus": {
+    "title": "Plus",
+    "description": "Badge shown next to an AI model in the model selector that requires a Plus subscription tier."
+  },
+  "omnibar_modelBadgePro": {
+    "title": "Pro",
+    "description": "Badge shown next to an AI model in the model selector that requires a Pro subscription tier."
+  },
+  "omnibar_modelBadgeInternal": {
+    "title": "Internal",
+    "description": "Badge shown next to an AI model in the model selector that is only available to internal users."
   }
 }

--- a/special-pages/pages/new-tab/messages/omnibar_showSubscriptionUpgrade.notify.json
+++ b/special-pages/pages/new-tab/messages/omnibar_showSubscriptionUpgrade.notify.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Show Subscription Upgrade Action",
+  "description": "Ask native to present the subscription upgrade flow (e.g. when a subscriber taps 'Upgrade' on a model or reasoning-effort option gated behind a higher tier).",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {}
+}

--- a/special-pages/pages/new-tab/messages/omnibar_showSubscriptionUpgrade.notify.json
+++ b/special-pages/pages/new-tab/messages/omnibar_showSubscriptionUpgrade.notify.json
@@ -1,8 +1,13 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "Show Subscription Upgrade Action",
-  "description": "Ask native to present the subscription upgrade flow (e.g. when a subscriber taps 'Upgrade' on a model or reasoning-effort option gated behind a higher tier).",
+  "description": "Ask native to present the subscription upgrade flow (e.g. when a subscriber taps 'Upgrade' on a model or reasoning-effort option gated behind a higher tier). `source` identifies the originating picker so native can attribute the subscription funnel origin.",
   "type": "object",
   "additionalProperties": false,
-  "properties": {}
+  "required": ["source"],
+  "properties": {
+    "source": {
+      "$ref": "./types/omnibar-picker-source.json"
+    }
+  }
 }

--- a/special-pages/pages/new-tab/messages/omnibar_showSubscriptionUpsell.notify.json
+++ b/special-pages/pages/new-tab/messages/omnibar_showSubscriptionUpsell.notify.json
@@ -1,8 +1,13 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "Show Subscription Upsell Action",
-  "description": "Ask native to present the subscription upsell (e.g. when the user taps 'Try for free' on a gated model or reasoning-effort option).",
+  "description": "Ask native to present the subscription upsell (e.g. when the user taps 'Try for free' on a gated model or reasoning-effort option). `source` identifies the originating picker so native can attribute the subscription funnel origin.",
   "type": "object",
   "additionalProperties": false,
-  "properties": {}
+  "required": ["source"],
+  "properties": {
+    "source": {
+      "$ref": "./types/omnibar-picker-source.json"
+    }
+  }
 }

--- a/special-pages/pages/new-tab/messages/omnibar_showSubscriptionUpsell.notify.json
+++ b/special-pages/pages/new-tab/messages/omnibar_showSubscriptionUpsell.notify.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Show Subscription Upsell Action",
+  "description": "Ask native to present the subscription upsell (e.g. when the user taps 'Try for free' on a gated model or reasoning-effort option).",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {}
+}

--- a/special-pages/pages/new-tab/messages/telemetryEvent.notify.json
+++ b/special-pages/pages/new-tab/messages/telemetryEvent.notify.json
@@ -53,6 +53,48 @@
               }
             }
           }
+        },
+        {
+          "type": "object",
+          "title": "Omnibar Picker Shown",
+          "description": "Fired once when the user opens an omnibar chat-tool picker (impression). `picker` identifies which picker; native maps it to the platform-specific subscription funnel origin.",
+          "required": ["name", "value"],
+          "properties": {
+            "name": {
+              "const": "omnibar_picker"
+            },
+            "value": {
+              "type": "object",
+              "required": ["picker"],
+              "properties": {
+                "picker": {
+                  "type": "string",
+                  "enum": ["model", "reasoning"]
+                }
+              }
+            }
+          }
+        },
+        {
+          "type": "object",
+          "title": "Omnibar Upsell Shown",
+          "description": "Fired once when the conditional subscription upsell CTA becomes visible inside an omnibar picker (impression). `picker` identifies which picker surfaced the upsell.",
+          "required": ["name", "value"],
+          "properties": {
+            "name": {
+              "const": "omnibar_upsell"
+            },
+            "value": {
+              "type": "object",
+              "required": ["picker"],
+              "properties": {
+                "picker": {
+                  "type": "string",
+                  "enum": ["model", "reasoning"]
+                }
+              }
+            }
+          }
         }
       ]
     }

--- a/special-pages/pages/new-tab/messages/types/omnibar-config.json
+++ b/special-pages/pages/new-tab/messages/types/omnibar-config.json
@@ -22,6 +22,30 @@
         }
       }
     },
+    "ReasoningEffortOption": {
+      "type": "object",
+      "description": "A reasoning-effort option for a reasoning-capable model, including its localized display copy and availability.",
+      "required": ["id", "name", "status"],
+      "properties": {
+        "id": {
+          "description": "Stable server key for this reasoning-effort option; round-tripped on submit.",
+          "$ref": "./reasoning-effort.json"
+        },
+        "name": {
+          "description": "Localized display name for this reasoning-effort option.",
+          "type": "string"
+        },
+        "description": {
+          "description": "Optional localized subtitle shown beneath the name.",
+          "type": "string"
+        },
+        "status": {
+          "description": "Whether this option is selectable ('available') or gated behind a subscription upsell ('unavailable').",
+          "type": "string",
+          "enum": ["available", "unavailable"]
+        }
+      }
+    },
     "AIModelItem": {
       "type": "object",
       "description": "An individual AI model available for selection.",
@@ -39,9 +63,22 @@
           "description": "Short display name for the model selector button",
           "type": "string"
         },
+        "description": {
+          "description": "Optional short description shown beneath the model name in the selector.",
+          "type": "string"
+        },
         "isEnabled": {
           "description": "Whether the model is enabled and selectable",
           "type": "boolean"
+        },
+        "isBeta": {
+          "description": "Whether this model is in beta; drives a 'Beta' badge in the model selector.",
+          "type": "boolean"
+        },
+        "accessTier": {
+          "description": "Access tiers that grant this model (e.g. 'internal', 'free', 'plus', 'pro'). Drives the tier badge (Plus/Pro/Internal) in the model selector.",
+          "type": "array",
+          "items": { "type": "string" }
         },
         "supportsImageUpload": {
           "description": "Whether this model supports image attachments",
@@ -57,10 +94,10 @@
           "type": "array",
           "items": { "$ref": "./tool-id.json" }
         },
-        "supportedReasoningEffort": {
-          "description": "Reasoning-effort keys this model supports. Empty or omitted means the reasoning picker is hidden for this model.",
+        "reasoningEfforts": {
+          "description": "Reasoning-effort options this model supports, each with localized copy and availability. Empty or omitted means the reasoning picker is hidden for this model.",
           "type": "array",
-          "items": { "$ref": "./reasoning-effort.json" }
+          "items": { "$ref": "#/$defs/ReasoningEffortOption" }
         }
       }
     }

--- a/special-pages/pages/new-tab/messages/types/omnibar-config.json
+++ b/special-pages/pages/new-tab/messages/types/omnibar-config.json
@@ -6,6 +6,11 @@
     "mode"
   ],
   "$defs": {
+    "UpsellType": {
+      "type": "string",
+      "description": "Which upsell flow a gated item leads to: 'subscribe' (non-subscribers, shown as 'Try for free') or 'upgrade' (existing subscribers who need a higher tier, shown as 'Upgrade').",
+      "enum": ["subscribe", "upgrade"]
+    },
     "AIModelSection": {
       "type": "object",
       "description": "A section of AI models with an optional header and a list of model items.",
@@ -43,6 +48,10 @@
           "description": "Whether this option is selectable ('available') or gated behind a subscription upsell ('unavailable').",
           "type": "string",
           "enum": ["available", "unavailable"]
+        },
+        "upsell": {
+          "description": "For a gated ('unavailable') option, which upsell flow it leads to. Absent for available options.",
+          "$ref": "#/$defs/UpsellType"
         }
       }
     },
@@ -98,6 +107,10 @@
           "description": "Reasoning-effort options this model supports, each with localized copy and availability. Empty or omitted means the reasoning picker is hidden for this model.",
           "type": "array",
           "items": { "$ref": "#/$defs/ReasoningEffortOption" }
+        },
+        "upsell": {
+          "description": "For a gated (disabled) model, which upsell flow it leads to. Absent for enabled models.",
+          "$ref": "#/$defs/UpsellType"
         }
       }
     }

--- a/special-pages/pages/new-tab/messages/types/omnibar-picker-source.json
+++ b/special-pages/pages/new-tab/messages/types/omnibar-picker-source.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Omnibar Picker Source",
+  "description": "Identifies which omnibar chat-tool picker triggered a telemetry event. Native maps this lightweight identifier to a platform-specific subscription funnel origin.",
+  "type": "string",
+  "enum": ["model", "reasoning"]
+}

--- a/special-pages/pages/new-tab/messages/types/reasoning-effort.json
+++ b/special-pages/pages/new-tab/messages/types/reasoning-effort.json
@@ -1,7 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "ReasoningEffort",
-  "description": "Stable server key for a reasoning-effort option on a reasoning-capable model.",
-  "type": "string",
-  "enum": ["none", "minimal", "low", "medium", "high"]
+  "description": "Stable server key for a reasoning-effort option on a reasoning-capable model (e.g. 'none', 'medium', 'extended'). Server-controlled and round-tripped on submit.",
+  "type": "string"
 }

--- a/special-pages/pages/new-tab/public/locales/en/new-tab.json
+++ b/special-pages/pages/new-tab/public/locales/en/new-tab.json
@@ -377,6 +377,10 @@
     "title": "Try for free",
     "description": "Link text next to the 'Subscriber exclusive.' label that opens the subscription upsell when tapped."
   },
+  "omnibar_upgrade": {
+    "title": "Upgrade",
+    "description": "CTA shown on a model or reasoning-effort option gated behind a higher subscription tier; opens the upgrade flow when tapped."
+  },
   "omnibar_reasoningTryForFree": {
     "title": "Try for Free",
     "description": "Badge text on a gated reasoning-effort option in the reasoning picker; tapping it opens the subscription upsell."

--- a/special-pages/pages/new-tab/public/locales/en/new-tab.json
+++ b/special-pages/pages/new-tab/public/locales/en/new-tab.json
@@ -369,6 +369,34 @@
     "title": "Remove {title}",
     "description": "Accessible label for the close button on an attached-tab chip. {title} is the tab title."
   },
+  "omnibar_subscriberExclusive": {
+    "title": "Subscriber exclusive.",
+    "description": "Label shown above subscription-only AI models in the model selector, next to the 'Try for free' link."
+  },
+  "omnibar_tryForFree": {
+    "title": "Try for free",
+    "description": "Link text next to the 'Subscriber exclusive.' label that opens the subscription upsell when tapped."
+  },
+  "omnibar_reasoningTryForFree": {
+    "title": "Try for Free",
+    "description": "Badge text on a gated reasoning-effort option in the reasoning picker; tapping it opens the subscription upsell."
+  },
+  "omnibar_modelBadgeBeta": {
+    "title": "Beta",
+    "description": "Badge shown next to an AI model in the model selector that is in beta."
+  },
+  "omnibar_modelBadgePlus": {
+    "title": "Plus",
+    "description": "Badge shown next to an AI model in the model selector that requires a Plus subscription tier."
+  },
+  "omnibar_modelBadgePro": {
+    "title": "Pro",
+    "description": "Badge shown next to an AI model in the model selector that requires a Pro subscription tier."
+  },
+  "omnibar_modelBadgeInternal": {
+    "title": "Internal",
+    "description": "Badge shown next to an AI model in the model selector that is only available to internal users."
+  },
   "nextStepsList_sectionTitle": {
     "title": "Next Steps",
     "note": "Text that goes in the Next Steps bubble label above the card"

--- a/special-pages/pages/new-tab/types/new-tab.ts
+++ b/special-pages/pages/new-tab/types/new-tab.ts
@@ -83,13 +83,17 @@ export type EnableAIChatTools = boolean;
  */
 export type SelectedModelID = string;
 /**
- * Stable server key for a reasoning-effort option on a reasoning-capable model.
+ * Stable server key for a reasoning-effort option on a reasoning-capable model (e.g. 'none', 'medium', 'extended'). Server-controlled and round-tripped on submit.
  */
-export type ReasoningEffort = "none" | "minimal" | "low" | "medium" | "high";
+export type ReasoningEffort = string;
 /**
  * Identifier for an AI chat tool.
  */
 export type ToolId = "WebSearch";
+/**
+ * Stable server key for this reasoning-effort option; round-tripped on submit.
+ */
+export type ReasoningEffort1 = string;
 /**
  * Sections of AI models for the model selector.
  */
@@ -201,6 +205,7 @@ export interface NewTabMessages {
     | OmnibarOpenAiChatNotification
     | OmnibarOpenSuggestionNotification
     | OmnibarSetConfigNotification
+    | OmnibarShowSubscriptionUpsellNotification
     | OmnibarSubmitChatNotification
     | OmnibarSubmitSearchNotification
     | OmnibarViewAllAIChatsNotification
@@ -674,9 +679,21 @@ export interface AIModelItem {
    */
   shortName: string;
   /**
+   * Optional short description shown beneath the model name in the selector.
+   */
+  description?: string;
+  /**
    * Whether the model is enabled and selectable
    */
   isEnabled: boolean;
+  /**
+   * Whether this model is in beta; drives a 'Beta' badge in the model selector.
+   */
+  isBeta?: boolean;
+  /**
+   * Access tiers that grant this model (e.g. 'internal', 'free', 'plus', 'pro'). Drives the tier badge (Plus/Pro/Internal) in the model selector.
+   */
+  accessTier?: string[];
   /**
    * Whether this model supports image attachments
    */
@@ -690,10 +707,39 @@ export interface AIModelItem {
    */
   supportedTools?: ToolId[];
   /**
-   * Reasoning-effort keys this model supports. Empty or omitted means the reasoning picker is hidden for this model.
+   * Reasoning-effort options this model supports, each with localized copy and availability. Empty or omitted means the reasoning picker is hidden for this model.
    */
-  supportedReasoningEffort?: ReasoningEffort[];
+  reasoningEfforts?: ReasoningEffortOption[];
 }
+/**
+ * A reasoning-effort option for a reasoning-capable model, including its localized display copy and availability.
+ */
+export interface ReasoningEffortOption {
+  id: ReasoningEffort1;
+  /**
+   * Localized display name for this reasoning-effort option.
+   */
+  name: string;
+  /**
+   * Optional localized subtitle shown beneath the name.
+   */
+  description?: string;
+  /**
+   * Whether this option is selectable ('available') or gated behind a subscription upsell ('unavailable').
+   */
+  status: "available" | "unavailable";
+}
+/**
+ * Generated from @see "../messages/omnibar_showSubscriptionUpsell.notify.json"
+ */
+export interface OmnibarShowSubscriptionUpsellNotification {
+  method: "omnibar_showSubscriptionUpsell";
+  params: ShowSubscriptionUpsellAction;
+}
+/**
+ * Ask native to present the subscription upsell (e.g. when the user taps 'Try for free' on a gated model or reasoning-effort option).
+ */
+export interface ShowSubscriptionUpsellAction {}
 /**
  * Generated from @see "../messages/omnibar_submitChat.notify.json"
  */

--- a/special-pages/pages/new-tab/types/new-tab.ts
+++ b/special-pages/pages/new-tab/types/new-tab.ts
@@ -122,6 +122,10 @@ export type EnableAskDuckAiSuggestion = boolean;
  * Show the paperclip entry point and accept `@` mentions for attaching open tabs as context to a Duck.ai submission. When true, the omnibar can call `omnibar_getOpenTabs` and `omnibar_getTabContent`.
  */
 export type EnableAttachTabs = boolean;
+/**
+ * Identifies which omnibar chat-tool picker triggered a telemetry event. Native maps this lightweight identifier to a platform-specific subscription funnel origin.
+ */
+export type OmnibarPickerSource = "model" | "reasoning";
 export type Favicon = null | {
   src: string;
   maxAvailableSize?: number;
@@ -746,9 +750,11 @@ export interface OmnibarShowSubscriptionUpgradeNotification {
   params: ShowSubscriptionUpgradeAction;
 }
 /**
- * Ask native to present the subscription upgrade flow (e.g. when a subscriber taps 'Upgrade' on a model or reasoning-effort option gated behind a higher tier).
+ * Ask native to present the subscription upgrade flow (e.g. when a subscriber taps 'Upgrade' on a model or reasoning-effort option gated behind a higher tier). `source` identifies the originating picker so native can attribute the subscription funnel origin.
  */
-export interface ShowSubscriptionUpgradeAction {}
+export interface ShowSubscriptionUpgradeAction {
+  source: OmnibarPickerSource;
+}
 /**
  * Generated from @see "../messages/omnibar_showSubscriptionUpsell.notify.json"
  */
@@ -757,9 +763,11 @@ export interface OmnibarShowSubscriptionUpsellNotification {
   params: ShowSubscriptionUpsellAction;
 }
 /**
- * Ask native to present the subscription upsell (e.g. when the user taps 'Try for free' on a gated model or reasoning-effort option).
+ * Ask native to present the subscription upsell (e.g. when the user taps 'Try for free' on a gated model or reasoning-effort option). `source` identifies the originating picker so native can attribute the subscription funnel origin.
  */
-export interface ShowSubscriptionUpsellAction {}
+export interface ShowSubscriptionUpsellAction {
+  source: OmnibarPickerSource;
+}
 /**
  * Generated from @see "../messages/omnibar_submitChat.notify.json"
  */
@@ -978,7 +986,7 @@ export interface TelemetryEventNotification {
   params: NTPTelemetryEvent;
 }
 export interface NTPTelemetryEvent {
-  attributes: StatsShowMore | ExampleTelemetryEvent | CustomizerDrawerState;
+  attributes: StatsShowMore | ExampleTelemetryEvent | CustomizerDrawerState | OmnibarPickerShown | OmnibarUpsellShown;
 }
 export interface StatsShowMore {
   name: "stats_toggle";
@@ -995,6 +1003,24 @@ export interface CustomizerDrawerState {
      * True if the theme variant popover was visible when the drawer was opened
      */
     themeVariantPopoverWasOpen?: boolean;
+  };
+}
+/**
+ * Fired once when the user opens an omnibar chat-tool picker (impression). `picker` identifies which picker; native maps it to the platform-specific subscription funnel origin.
+ */
+export interface OmnibarPickerShown {
+  name: "omnibar_picker";
+  value: {
+    picker: "model" | "reasoning";
+  };
+}
+/**
+ * Fired once when the conditional subscription upsell CTA becomes visible inside an omnibar picker (impression). `picker` identifies which picker surfaced the upsell.
+ */
+export interface OmnibarUpsellShown {
+  name: "omnibar_upsell";
+  value: {
+    picker: "model" | "reasoning";
   };
 }
 /**

--- a/special-pages/pages/new-tab/types/new-tab.ts
+++ b/special-pages/pages/new-tab/types/new-tab.ts
@@ -205,6 +205,7 @@ export interface NewTabMessages {
     | OmnibarOpenAiChatNotification
     | OmnibarOpenSuggestionNotification
     | OmnibarSetConfigNotification
+    | OmnibarShowSubscriptionUpgradeNotification
     | OmnibarShowSubscriptionUpsellNotification
     | OmnibarSubmitChatNotification
     | OmnibarSubmitSearchNotification
@@ -710,6 +711,10 @@ export interface AIModelItem {
    * Reasoning-effort options this model supports, each with localized copy and availability. Empty or omitted means the reasoning picker is hidden for this model.
    */
   reasoningEfforts?: ReasoningEffortOption[];
+  /**
+   * For a gated (disabled) model, which upsell flow it leads to. Absent for enabled models.
+   */
+  upsell?: "subscribe" | "upgrade";
 }
 /**
  * A reasoning-effort option for a reasoning-capable model, including its localized display copy and availability.
@@ -728,7 +733,22 @@ export interface ReasoningEffortOption {
    * Whether this option is selectable ('available') or gated behind a subscription upsell ('unavailable').
    */
   status: "available" | "unavailable";
+  /**
+   * For a gated ('unavailable') option, which upsell flow it leads to. Absent for available options.
+   */
+  upsell?: "subscribe" | "upgrade";
 }
+/**
+ * Generated from @see "../messages/omnibar_showSubscriptionUpgrade.notify.json"
+ */
+export interface OmnibarShowSubscriptionUpgradeNotification {
+  method: "omnibar_showSubscriptionUpgrade";
+  params: ShowSubscriptionUpgradeAction;
+}
+/**
+ * Ask native to present the subscription upgrade flow (e.g. when a subscriber taps 'Upgrade' on a model or reasoning-effort option gated behind a higher tier).
+ */
+export interface ShowSubscriptionUpgradeAction {}
 /**
  * Generated from @see "../messages/omnibar_showSubscriptionUpsell.notify.json"
  */


### PR DESCRIPTION
Add omnibar_modelPickerShown / omnibar_reasoningPickerShown notifications, fired once when the user opens the model selector or reasoning-effort picker (picker impressions). Add a `source` param ("model" | "reasoning") to the existing omnibar_showSubscriptionUpsell / omnibar_showSubscriptionUpgrade notifications so native can attribute the subscription funnel origin.

Frontend only. Native (macOS/Windows) must add the corresponding handlers before this is shipped, so this lands on a dedicated branch pending native coordination.

**Asana Task/Github Issue:** <!-- Link to Asana Task/Github Issue -->

## Description

<!--
  Provide a terse summary of what the change is, detailed descriptions should belong in ship reviews or tech designs
-->

## Testing Steps

- <!-- Include simple steps on how to check this change is working. Write "N/A" if not applicable. -->

## Checklist

<!--
  These questions are a friendly reminder to shipping code, if you're uncertain ask the AoR owners.
  It's also totally appropriate to not check some of these boxes, if they don't apply to your change.
-->
*Please tick all that apply:*

- [ ] I have tested this change locally
- [ ] I have tested this change locally in all supported browsers
- [ ] This change will be visible to users
- [ ] I have added automated tests that cover this change
- [ ] I have ensured the change is gated by config
- [ ] This change was covered by a ship review
- [ ] This change was covered by a tech design
- [ ] Any dependent config has been merged

