### PR TITLE
Fix changelog generation dropping merge-queue commits

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -140,3 +140,14 @@ jobs:
                   prerelease: false
                   tag_name: ${{ steps.version.outputs.version }}
                   target_commitish: 'releases'
+
+            - name: Anchor released main commit
+              run: |
+                  # Record the exact `main` commit that was released so the next
+                  # release computes its changelog by ancestry (main-anchored
+                  # range) instead of by the release build commit's date. See
+                  # scripts/changelog.sh for why the date-based boundary is unsafe.
+                  MAIN_SHA=$(git rev-parse main)
+                  echo "Anchoring release ${{ steps.version.outputs.version }} at main $MAIN_SHA"
+                  git tag "released/${{ steps.version.outputs.version }}" "$MAIN_SHA"
+                  git push origin "released/${{ steps.version.outputs.version }}"

--- a/scripts/changelog.sh
+++ b/scripts/changelog.sh
@@ -1,42 +1,26 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Produce the changelog for the release currently being built: every commit on
-# `main` that was NOT part of the previous release.
+# Changelog for the release being built: commits on `main` since the previous
+# release. Anchored by ancestry, not dates — release tags live on the
+# `releases` branch with build-time timestamps that drift later than the `main`
+# commits they package, so a date-based `--since` drops merge-queue commits.
 #
-# We anchor on commit *ancestry*, not on dates. Release tags point at build
-# commits on the `releases` branch, whose timestamps are set at build time and
-# therefore drift *later* than the `main` commits they package. Combined with
-# merge-queue commits (whose committer date can predate when they land on
-# `main`), a date-based `--since` boundary silently drops legitimately
-# unreleased commits. Anchoring on the `main` commit that was last released
-# avoids this entirely.
-#
-# The anchor is a lightweight `released/<version>` tag placed on the released
-# `main` commit by the release workflow (see .github/workflows/build.yml).
-#
-# The boundary MUST be the anchor paired with the *latest* semver release, not
-# merely the highest `released/*` tag that happens to exist. If a release tag
-# were shipped without its paired anchor, picking the highest existing anchor
-# would start the range from an older release and repeat already-shipped
-# commits. So we resolve the latest release version first, then require its
-# matching anchor; if it is absent we fall back to the (less precise)
-# date-based boundary rather than trust a mismatched older anchor.
+# The anchor is a lightweight `released/<version>` tag on the released `main`
+# commit, pushed by the release workflow (see .github/workflows/build.yml).
 
-# Latest semver release tag (same selection as the release workflow).
-# `|| true` keeps `set -o pipefail` from aborting the script when `grep` finds
-# no semver tags (exit 1); in that case LATEST_RELEASE is empty and we fall
-# through to the date-based branch below.
+# Latest semver release; `|| true` avoids a pipefail abort when grep matches
+# nothing (LATEST_RELEASE stays empty and we use the date-based fallback).
 LATEST_RELEASE=$(git tag -l | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -1 || true)
 
+# Require the anchor paired with the *latest* release, not just the highest
+# `released/*` tag — otherwise a release missing its anchor would replay
+# already-shipped commits from an older one.
 if [ -n "$LATEST_RELEASE" ] && git rev-parse -q --verify "refs/tags/released/${LATEST_RELEASE}" >/dev/null; then
     git log "released/${LATEST_RELEASE}..main" --pretty='format:- %s'
 else
-    # No anchor paired with the latest release (bootstrap before anchors
-    # existed, or a missing pairing). Fall back to the commit date of the
-    # newest release tag. This is anchored to the correct (latest) release, so
-    # it will not replay commits from an older release; it can still drop
-    # commits whose committer date precedes the release build commit.
+    # No paired anchor (bootstrap, or missing pairing): fall back to the newest
+    # release tag's commit date. Less precise, but tied to the latest release.
     if [ -n "$LATEST_RELEASE" ]; then
         echo "changelog.sh: no 'released/${LATEST_RELEASE}' anchor found; using date-based fallback" >&2
     fi

--- a/scripts/changelog.sh
+++ b/scripts/changelog.sh
@@ -1,1 +1,29 @@
-git log main --since "$(git show -s --format=%ci $(git rev-list --tags --max-count=1))" --pretty='format:- %s'
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Produce the changelog for the release currently being built: every commit on
+# `main` that was NOT part of the previous release.
+#
+# We anchor on commit *ancestry*, not on dates. Release tags point at build
+# commits on the `releases` branch, whose timestamps are set at build time and
+# therefore drift *later* than the `main` commits they package. Combined with
+# merge-queue commits (whose committer date can predate when they land on
+# `main`), a date-based `--since` boundary silently drops legitimately
+# unreleased commits. Anchoring on the `main` commit that was last released
+# avoids this entirely.
+#
+# The anchor is a lightweight `released/<version>` tag placed on the released
+# `main` commit by the release workflow (see .github/workflows/build.yml).
+
+PREV_MAIN_ANCHOR=$(git tag -l 'released/*' | sort -V | tail -1)
+
+if [ -n "$PREV_MAIN_ANCHOR" ]; then
+    git log "${PREV_MAIN_ANCHOR}..main" --pretty='format:- %s'
+else
+    # Fallback for the first anchored release (no `released/*` tag exists yet).
+    # Uses the commit date of the newest release tag. NOTE: this is the legacy
+    # behaviour and can drop commits whose committer date precedes the release
+    # build commit; it is only a bootstrap path until the first anchor exists.
+    LAST_RELEASE_COMMIT=$(git rev-list --tags --max-count=1)
+    git log main --since "$(git show -s --format=%ci "$LAST_RELEASE_COMMIT")" --pretty='format:- %s'
+fi

--- a/scripts/changelog.sh
+++ b/scripts/changelog.sh
@@ -24,7 +24,10 @@ set -euo pipefail
 # date-based boundary rather than trust a mismatched older anchor.
 
 # Latest semver release tag (same selection as the release workflow).
-LATEST_RELEASE=$(git tag -l | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -1)
+# `|| true` keeps `set -o pipefail` from aborting the script when `grep` finds
+# no semver tags (exit 1); in that case LATEST_RELEASE is empty and we fall
+# through to the date-based branch below.
+LATEST_RELEASE=$(git tag -l | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -1 || true)
 
 if [ -n "$LATEST_RELEASE" ] && git rev-parse -q --verify "refs/tags/released/${LATEST_RELEASE}" >/dev/null; then
     git log "released/${LATEST_RELEASE}..main" --pretty='format:- %s'

--- a/scripts/changelog.sh
+++ b/scripts/changelog.sh
@@ -14,16 +14,29 @@ set -euo pipefail
 #
 # The anchor is a lightweight `released/<version>` tag placed on the released
 # `main` commit by the release workflow (see .github/workflows/build.yml).
+#
+# The boundary MUST be the anchor paired with the *latest* semver release, not
+# merely the highest `released/*` tag that happens to exist. If a release tag
+# were shipped without its paired anchor, picking the highest existing anchor
+# would start the range from an older release and repeat already-shipped
+# commits. So we resolve the latest release version first, then require its
+# matching anchor; if it is absent we fall back to the (less precise)
+# date-based boundary rather than trust a mismatched older anchor.
 
-PREV_MAIN_ANCHOR=$(git tag -l 'released/*' | sort -V | tail -1)
+# Latest semver release tag (same selection as the release workflow).
+LATEST_RELEASE=$(git tag -l | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -1)
 
-if [ -n "$PREV_MAIN_ANCHOR" ]; then
-    git log "${PREV_MAIN_ANCHOR}..main" --pretty='format:- %s'
+if [ -n "$LATEST_RELEASE" ] && git rev-parse -q --verify "refs/tags/released/${LATEST_RELEASE}" >/dev/null; then
+    git log "released/${LATEST_RELEASE}..main" --pretty='format:- %s'
 else
-    # Fallback for the first anchored release (no `released/*` tag exists yet).
-    # Uses the commit date of the newest release tag. NOTE: this is the legacy
-    # behaviour and can drop commits whose committer date precedes the release
-    # build commit; it is only a bootstrap path until the first anchor exists.
+    # No anchor paired with the latest release (bootstrap before anchors
+    # existed, or a missing pairing). Fall back to the commit date of the
+    # newest release tag. This is anchored to the correct (latest) release, so
+    # it will not replay commits from an older release; it can still drop
+    # commits whose committer date precedes the release build commit.
+    if [ -n "$LATEST_RELEASE" ]; then
+        echo "changelog.sh: no 'released/${LATEST_RELEASE}' anchor found; using date-based fallback" >&2
+    fi
     LAST_RELEASE_COMMIT=$(git rev-list --tags --max-count=1)
     git log main --since "$(git show -s --format=%ci "$LAST_RELEASE_COMMIT")" --pretty='format:- %s'
 fi


### PR DESCRIPTION
**Asana Task/Github Issue:** N/A

## Description

### The problem

The release workflow aborts with `Changelog is empty — no commits found since the last release tag` even when there are genuinely unreleased commits on `main`.

Root cause is in `scripts/changelog.sh`, which computes the changelog using a **date** boundary derived from the latest release tag:

```
git log main --since "$(git show -s --format=%ci $(git rev-list --tags --max-count=1))" ...
```

Two facts combine to break this:

1. **Release tags live on the `releases` branch.** Each release tag points at a build commit on `releases` (built via `git checkout main -- .`), whose commit timestamp is set at *build time* — always *later* than the `main` commits it packages, and with no ancestry link back to `main`.
2. **Merge-queue commits can be dated before they land on `main`.** A merge commit's committer date is set when the queue *creates* it, but it only becomes reachable on `main` when the queue *finishes*.

Concretely, this happened with PR #2847:

- `15.13.0` build commit (on `releases`) is dated `22:23:11`.
- #2847's merge commit is dated `22:19:21` but only landed on `main` at `22:26` — correctly *not* in `15.13.0`.
- `git log main --since 22:23:11` excludes `22:19:21`, so #2847 is dropped from the changelog **permanently** (not just transiently), producing an empty changelog and aborting the release.

Because the boundary is a date taken from a build commit that is always newer than the `main` commits it ships, any commit merged shortly before a release can be silently lost from all future changelogs.

### The fix

Anchor the changelog on **commit ancestry** instead of dates.

- **`scripts/changelog.sh`** now computes `git log <prev-anchor>..main`, where `<prev-anchor>` is a lightweight `released/<version>` tag placed on the exact `main` commit that the previous release shipped. It keeps the old date-based logic only as a one-time bootstrap fallback (used until the first `released/*` tag exists).
- **`.github/workflows/build.yml`** gains an `Anchor released main commit` step that runs *after* `Create Release` and pushes `released/<version>` pointing at the released `main` SHA.

Notes:
- This does **not** modify or rename existing version tags (`15.13.0`, etc.); they still point at the `releases` branch build commits. Consumers (SPM/npm/submodule) are unaffected.
- `released/*` tags do not interfere with version calculation (that step filters tags to `^[0-9]+\.[0-9]+\.[0-9]+$`).

### One-time bootstrap

No `released/*` anchor exists yet, so a maintainer should create the first one so the next release uses the ancestry path immediately:

```
git tag released/15.13.0 af2da2586b054e9584c7a0909a428c79fe3d0ce7
git push origin released/15.13.0
```

(`af2da258` is the `main` tip that `15.13.0` shipped — PR #2868.)

## Testing Steps

- With a bootstrap anchor at `af2da258`, `bash ./scripts/changelog.sh` against current `main` correctly outputs `- Delete Chats and Search Suggestions from NTP Omnibar (#2847)` instead of an empty changelog.

## Checklist

*Please tick all that apply:*

- [x] I have tested this change locally
- [ ] I have tested this change locally in all supported browsers
- [ ] This change will be visible to users
- [ ] I have added automated tests that cover this change
- [ ] I have ensured the change is gated by config
- [ ] This change was covered by a ship review
- [ ] This change was covered by a tech design
- [ ] Any dependent config has been merged

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes release automation and changelog boundaries; mistakes could omit or duplicate changelog entries until anchors are correct, but consumer version tags and packaging are unchanged.
> 
> **Overview**
> Fixes release failures from **empty changelogs** when merge-queue commits are excluded by a date boundary taken from the latest semver tag on `releases`.
> 
> **`scripts/changelog.sh`** is now a proper script that lists commits on `main` since the previous release using **`git log released/<latest>..main`**, where `released/<version>` points at the `main` SHA that release shipped. It still falls back to the old **`--since` last-release-date** path when no paired anchor exists (bootstrap or missing tag), with a stderr warning.
> 
> **`.github/workflows/build.yml`** adds an **Anchor released main commit** step after **Create Release** that tags and pushes **`released/<version>`** at the current `main` tip so the next run uses the ancestry range.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e80285ad1944c319ce2d9d0669fbf94e07ca4067. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->