### PR TITLE
Add nested Bugbot rule to keep web-detection captcha matching layout-free

### DIFF
--- a/injected/src/features/web-detection/BUGBOT.md
+++ b/injected/src/features/web-detection/BUGBOT.md
@@ -1,0 +1,34 @@
+# Web-detection: keep captcha/anti-bot matching layout-free
+
+web-detection runs its detector selectors on live pages, including
+Cloudflare/Turnstile/hCaptcha/reCAPTCHA challenge pages. Forcing synchronous
+layout on challenge elements perturbs their anti-bot heuristics and can cause
+challenge **reload loops**. The `visibility: 'content'` mode (`hasContent`)
+exists to detect presence WITHOUT forcing layout — it inspects a detached
+`DOMParser` copy of the element. This risk is invisible to the hermetic test
+suite, so it must be caught in review.
+
+## Flag when a change in this directory
+
+- Introduces `getBoundingClientRect`, `getClientRects`, `getComputedStyle`,
+  `offset*` / `scroll*` / `client*` dimension reads, or `elementFromPoint` into
+  the `content` / `hasContent` code path. That path must stay layout-free (it
+  operates on a detached copy).
+- Adds a new visibility mode or captcha/anti-bot detector that measures live
+  element geometry/style instead of using the layout-free `content` path.
+- Routes captcha/challenge detectors through a path that forces layout on matched
+  elements (e.g. the `visible` path, which calls `isVisible`).
+
+## Require
+
+For captcha/anti-bot detection, keep element/visibility checks layout-free
+(prefer `visibility: 'content'`). Any change that must read live layout in a
+challenge-detection path should be justified, config-gated, and A/B / slow-rolled
+before wide enablement. Rate such changes at least Medium risk (never Low).
+
+## Don't flag
+
+- Layout reads in test code (`integration-test` / `unit-test`).
+- The existing `visible` / `hidden` modes themselves — they legitimately force
+  layout and are intended for non-challenge detectors. Only flag if a
+  captcha/anti-bot detector is newly routed through them.


### PR DESCRIPTION
## Description

Adds a **nested** `BUGBOT.md` at `injected/src/features/web-detection/BUGBOT.md`. 

It guards the reason the `visibility: 'content'` mode exists: forcing synchronous layout (`getBoundingClientRect`/`getComputedStyle`) on Cloudflare/Turnstile/captcha challenge elements perturbs their anti-bot heuristics and can cause challenge **reload loops** 

The rule flags changes in this directory that:
- reintroduce forced-layout reads into the `content`/`hasContent` path (must stay layout-free),
- add a captcha/anti-bot detector that measures live geometry/style instead of the `content` path, or
- route captcha/challenge detectors through the layout-forcing `visible` path.

Includes a "don't flag" section so the existing `visible`/`hidden` modes and test code aren't flagged.


## Test plan

- [ ] Bugbot applies the rule on a PR that edits `injected/src/features/web-detection/**`.
- [ ] A PR adding `getBoundingClientRect` to `hasContent` is flagged >= Medium.
- [ ] A PR editing an unrelated feature (e.g. autofill) is NOT flagged by this rule.

Made with [Cursor](https://cursor.com)