### PR TITLE
[TEST — DO NOT MERGE] Exercise web-detection Bugbot rule

### DIFF
--- a/injected/src/features/web-detection/BUGBOT.md
+++ b/injected/src/features/web-detection/BUGBOT.md
@@ -1,0 +1,34 @@
+# Web-detection: keep captcha/anti-bot matching layout-free
+
+web-detection runs its detector selectors on live pages, including
+Cloudflare/Turnstile/hCaptcha/reCAPTCHA challenge pages. Forcing synchronous
+layout on challenge elements perturbs their anti-bot heuristics and can cause
+challenge **reload loops**. The `visibility: 'content'` mode (`hasContent`)
+exists to detect presence WITHOUT forcing layout — it inspects a detached
+`DOMParser` copy of the element. This risk is invisible to the hermetic test
+suite, so it must be caught in review.
+
+## Flag when a change in this directory
+
+- Introduces `getBoundingClientRect`, `getClientRects`, `getComputedStyle`,
+  `offset*` / `scroll*` / `client*` dimension reads, or `elementFromPoint` into
+  the `content` / `hasContent` code path. That path must stay layout-free (it
+  operates on a detached copy).
+- Adds a new visibility mode or captcha/anti-bot detector that measures live
+  element geometry/style instead of using the layout-free `content` path.
+- Routes captcha/challenge detectors through a path that forces layout on matched
+  elements (e.g. the `visible` path, which calls `isVisible`).
+
+## Require
+
+For captcha/anti-bot detection, keep element/visibility checks layout-free
+(prefer `visibility: 'content'`). Any change that must read live layout in a
+challenge-detection path should be justified, config-gated, and A/B / slow-rolled
+before wide enablement. Rate such changes at least Medium risk (never Low).
+
+## Don't flag
+
+- Layout reads in test code (`integration-test` / `unit-test`).
+- The existing `visible` / `hidden` modes themselves — they legitimately force
+  layout and are intended for non-challenge detectors. Only flag if a
+  captcha/anti-bot detector is newly routed through them.

--- a/injected/src/features/web-detection/matching.js
+++ b/injected/src/features/web-detection/matching.js
@@ -100,6 +100,12 @@ const CONTENT_TEXT_PARSE_LIMIT = 50000;
  * @returns {boolean}
  */
 function hasContent(element) {
+    // Fast path: skip the serialize+parse work for off-screen elements.
+    const rect = element.getBoundingClientRect();
+    if (rect.width === 0 && rect.height === 0) {
+        return false;
+    }
+
     // Only guard: never serialize+parse a pathologically large subtree on every
     // poll tick (reachable only via an overly broad selector). textContent is a
     // cheap, layout-free proxy for the serialized size; such a subtree clearly


### PR DESCRIPTION
## Purpose (test only)

Validates the nested Bugbot rule at `injected/src/features/web-detection/BUGBOT.md`. This PR intentionally introduces a **forced-layout read (`getBoundingClientRect`) into the layout-free `hasContent` path** — exactly the pattern the rule says to flag (it can perturb Cloudflare/captcha pages and cause reload loops).

Base is `jd/android-captcha` (which has `content` mode) so the diff stays small: just the rule file + the deliberate violation.

**Expected:** Bugbot flags the `hasContent` change, references the layout-free/reload-loop concern, and rates it >= Medium (so `cursor-review.yml` routes to manual review rather than auto-approving).

Do not merge — will be closed after confirming Bugbot behavior.

Made with [Cursor](https://cursor.com)