### PR TITLE
macOS: Release Notes Rebranding UX

### DIFF
--- a/special-pages/pages/release-notes/app/components/App.module.css
+++ b/special-pages/pages/release-notes/app/components/App.module.css
@@ -15,11 +15,10 @@ body {
     gap: var(--sp-8);
 }
 
-/* Release notes uses fully-rounded (pill) buttons on every platform. This
-   overrides the shared Button's per-platform radius (up to specificity 0-3-0,
-   e.g. macOS `.button.lg`), so !important is required to win reliably. */
-.main button {
-    border-radius: 999px !important;
+/* macOS: pill-shaped buttons. Attribute chain reaches specificity 0-3-1 to beat
+   the shared `.button.lg` rule (0-3-0) without !important. */
+[data-platform-name="macos"] .main[data-theme] button {
+    border-radius: var(--border-radius-pill);
 }
 
 .header {

--- a/special-pages/pages/release-notes/app/components/App.module.css
+++ b/special-pages/pages/release-notes/app/components/App.module.css
@@ -11,11 +11,11 @@ body {
 .main {
     /* Release Notes accent palette (this page only): links use
        accent-text-primary; buttons use accent-primary + accent-content-primary. */
-    --ds-color-theme-accent-primary: #1074cc;
-    --ds-color-theme-accent-secondary: #045eb2;
-    --ds-color-theme-accent-tertiary: #034180;
-    --ds-color-theme-accent-content-primary: #ffffff;
-    --ds-color-theme-accent-text-primary: #1074cc;
+    --theme-accent-primary: #1074cc;
+    --theme-accent-secondary: #045eb2;
+    --theme-accent-tertiary: #034180;
+    --theme-accent-content-primary: #ffffff;
+    --theme-accent-text-primary: #1074cc;
 
     padding: var(--sp-6) var(--sp-5);
     position: relative;
@@ -24,11 +24,11 @@ body {
 }
 
 .main[data-theme="dark"] {
-    --ds-color-theme-accent-primary: #75b6eb;
-    --ds-color-theme-accent-secondary: #4397e0;
-    --ds-color-theme-accent-tertiary: #1074cc;
-    --ds-color-theme-accent-content-primary: #242323;
-    --ds-color-theme-accent-text-primary: #75b6eb;
+    --theme-accent-primary: #75b6eb;
+    --theme-accent-secondary: #4397e0;
+    --theme-accent-tertiary: #1074cc;
+    --theme-accent-content-primary: #242323;
+    --theme-accent-text-primary: #75b6eb;
 }
 
 /* Pill radius + recolor accentBrand buttons to the palette above.
@@ -37,12 +37,12 @@ body {
 [data-platform-name="macos"] .main[data-theme] button[class] {
     border-radius: var(--border-radius-pill);
 
-    --button-text: var(--ds-color-theme-accent-content-primary);
-    --button-text--active: var(--ds-color-theme-accent-content-primary);
-    --button-bg: var(--ds-color-theme-accent-primary);
-    --button-bg--hover: var(--ds-color-theme-accent-secondary);
-    --button-bg--focus: var(--ds-color-theme-accent-primary);
-    --button-bg--active: var(--ds-color-theme-accent-tertiary);
+    --button-text: var(--theme-accent-content-primary);
+    --button-text--active: var(--theme-accent-content-primary);
+    --button-bg: var(--theme-accent-primary);
+    --button-bg--hover: var(--theme-accent-secondary);
+    --button-bg--focus: var(--theme-accent-primary);
+    --button-bg--active: var(--theme-accent-tertiary);
 }
 
 .header {

--- a/special-pages/pages/release-notes/app/components/App.module.css
+++ b/special-pages/pages/release-notes/app/components/App.module.css
@@ -9,16 +9,40 @@ body {
 }
 
 .main {
+    /* Release Notes accent palette (this page only): links use
+       accent-text-primary; buttons use accent-primary + accent-content-primary. */
+    --ds-color-theme-accent-primary: #1074cc;
+    --ds-color-theme-accent-secondary: #045eb2;
+    --ds-color-theme-accent-tertiary: #034180;
+    --ds-color-theme-accent-content-primary: #ffffff;
+    --ds-color-theme-accent-text-primary: #1074cc;
+
     padding: var(--sp-6) var(--sp-5);
     position: relative;
     display: grid;
     gap: var(--sp-8);
 }
 
-/* macOS: pill-shaped buttons. Attribute chain reaches specificity 0-3-1 to beat
-   the shared `.button.lg` rule (0-3-0) without !important. */
-[data-platform-name="macos"] .main[data-theme] button {
+.main[data-theme="dark"] {
+    --ds-color-theme-accent-primary: #75b6eb;
+    --ds-color-theme-accent-secondary: #4397e0;
+    --ds-color-theme-accent-tertiary: #1074cc;
+    --ds-color-theme-accent-content-primary: #242323;
+    --ds-color-theme-accent-text-primary: #75b6eb;
+}
+
+/* Pill radius + recolor accentBrand buttons to the palette above.
+   `button[class]` (0-4-1) beats the shared dark-mode --button-text override
+   (0-4-0), which would otherwise win over a plain 0-3-1 selector. */
+[data-platform-name="macos"] .main[data-theme] button[class] {
     border-radius: var(--border-radius-pill);
+
+    --button-text: var(--ds-color-theme-accent-content-primary);
+    --button-text--active: var(--ds-color-theme-accent-content-primary);
+    --button-bg: var(--ds-color-theme-accent-primary);
+    --button-bg--hover: var(--ds-color-theme-accent-secondary);
+    --button-bg--focus: var(--ds-color-theme-accent-primary);
+    --button-bg--active: var(--ds-color-theme-accent-tertiary);
 }
 
 .header {

--- a/special-pages/pages/release-notes/app/components/App.module.css
+++ b/special-pages/pages/release-notes/app/components/App.module.css
@@ -15,6 +15,13 @@ body {
     gap: var(--sp-8);
 }
 
+/* Release notes uses fully-rounded (pill) buttons on every platform. This
+   overrides the shared Button's per-platform radius (up to specificity 0-3-0,
+   e.g. macOS `.button.lg`), so !important is required to win reliably. */
+.main button {
+    border-radius: 999px !important;
+}
+
 .header {
     max-width: var(--sp-320);
     width: 100%;

--- a/special-pages/pages/release-notes/app/components/App.module.css
+++ b/special-pages/pages/release-notes/app/components/App.module.css
@@ -35,7 +35,7 @@ body {
    `button[class]` (0-4-1) beats the shared dark-mode --button-text override
    (0-4-0), which would otherwise win over a plain 0-3-1 selector. */
 [data-platform-name="macos"] .main[data-theme] button[class] {
-    border-radius: var(--border-radius-pill);
+    border-radius: var(--border-radius-full);
 
     --button-text: var(--theme-accent-content-primary);
     --button-text--active: var(--theme-accent-content-primary);

--- a/special-pages/pages/release-notes/app/components/ReleaseNotes.module.css
+++ b/special-pages/pages/release-notes/app/components/ReleaseNotes.module.css
@@ -201,6 +201,11 @@
     border-bottom: 1px solid transparent;
     width: fit-content;
     text-decoration: none;
+    color: var(--ds-color-theme-default-light-accent-text-primary);
+
+    [data-theme="dark"] & {
+        color: var(--ds-color-theme-default-dark-accent-text-primary);
+    }
 
     &:hover {
         border-bottom-color: currentColor;

--- a/special-pages/pages/release-notes/app/components/ReleaseNotes.module.css
+++ b/special-pages/pages/release-notes/app/components/ReleaseNotes.module.css
@@ -201,7 +201,7 @@
     border-bottom: 1px solid transparent;
     width: fit-content;
     text-decoration: none;
-    color: var(--ds-color-theme-accent-text-primary);
+    color: var(--theme-accent-text-primary);
 
     &:hover {
         border-bottom-color: currentColor;

--- a/special-pages/pages/release-notes/app/components/ReleaseNotes.module.css
+++ b/special-pages/pages/release-notes/app/components/ReleaseNotes.module.css
@@ -201,11 +201,7 @@
     border-bottom: 1px solid transparent;
     width: fit-content;
     text-decoration: none;
-    color: var(--ds-color-theme-default-light-accent-text-primary);
-
-    [data-theme="dark"] & {
-        color: var(--ds-color-theme-default-dark-accent-text-primary);
-    }
+    color: var(--ds-color-theme-accent-text-primary);
 
     &:hover {
         border-bottom-color: currentColor;

--- a/special-pages/shared/styles/variables.css
+++ b/special-pages/shared/styles/variables.css
@@ -137,7 +137,7 @@
     --border-radius-md: 8px;
     --border-radius-sm: 6px;
     --border-radius-xs: 4px;
-   --border-radius-full: 999px;
+    --border-radius-full: 999px;
 
     @media (prefers-color-scheme: dark) {
         --theme-background-color: var(--color-gray-95);

--- a/special-pages/shared/styles/variables.css
+++ b/special-pages/shared/styles/variables.css
@@ -137,7 +137,7 @@
     --border-radius-md: 8px;
     --border-radius-sm: 6px;
     --border-radius-xs: 4px;
-    --border-radius-pill: 9999px; /* fully rounded (pill/capsule) */
+   --border-radius-full: 999px;
 
     @media (prefers-color-scheme: dark) {
         --theme-background-color: var(--color-gray-95);

--- a/special-pages/shared/styles/variables.css
+++ b/special-pages/shared/styles/variables.css
@@ -137,6 +137,7 @@
     --border-radius-md: 8px;
     --border-radius-sm: 6px;
     --border-radius-xs: 4px;
+    --border-radius-pill: 9999px; /* fully rounded (pill/capsule) */
 
     @media (prefers-color-scheme: dark) {
         --theme-background-color: var(--color-gray-95);


### PR DESCRIPTION
**Asana Task/Github Issue:** <!-- Link to Asana Task/Github Issue -->

## Description
This PR applies the Rebranding UX on the macOS Release Notes:

1. Buttons (Retry / Reload) must have rounded corners
2. We're also applying the Color `accent-text-primary` in the bottom link (`See what else we've been working on`)

## Testing Steps

- <!-- Include simple steps on how to check this change is working. Write "N/A" if not applicable. -->

## Screenshots

Now | Before
-|-
<img width="500" alt="Now Light" src="https://github.com/user-attachments/assets/3dec783c-2f90-45c5-b412-32a760109a44" /> | <img width="500" alt="Before Light" src="https://github.com/user-attachments/assets/466001cc-bee6-4da0-82bf-90d918d47de7" />
<img width="500" alt="Now Dark" src="https://github.com/user-attachments/assets/ce6c0a4f-5693-4084-8db0-e662a3879eb8" /> | <img width="500" alt="Before Dark" src="https://github.com/user-attachments/assets/0f654980-2da1-4eef-9945-2f29a16a3f08" />


## Checklist

<!--
  These questions are a friendly reminder to shipping code, if you're uncertain ask the AoR owners.
  It's also totally appropriate to not check some of these boxes, if they don't apply to your change.
-->
*Please tick all that apply:*

- [ ] I have tested this change locally
- [ ] I have tested this change locally in all supported browsers
- [ ] This change will be visible to users
- [ ] I have added automated tests that cover this change
- [ ] I have ensured the change is gated by config
- [ ] This change was covered by a ship review
- [ ] This change was covered by a tech design
- [ ] Any dependent config has been merged



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS-only, user-visible styling scoped to the macOS release notes page; no auth, data, or logic changes.
> 
> **Overview**
> Applies **macOS Release Notes rebranding** by scoping new light/dark **accent CSS variables** on `.main` in `App.module.css`, then using them for page chrome only (not global theme tokens).
> 
> On **`[data-platform-name="macos"]`**, Retry/Reload-style buttons get **full pill radius** via new shared `--border-radius-full` and **accent-primary** fill/hover/focus/active states, with a higher-specificity `button[class]` rule so dark-mode button text overrides don’t win.
> 
> The **“See what else we've been working on”** link (`.updatesLink`) now uses **`--theme-accent-text-primary`** instead of default link color.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit caef9f75a28c79627bdd40a5be46202c8ce5e49d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->