### PR TITLE
NTP: Limit attached tabs to three in NTP omnibar

### DIFF
--- a/special-pages/pages/new-tab/app/omnibar/components/Omnibar.js
+++ b/special-pages/pages/new-tab/app/omnibar/components/Omnibar.js
@@ -239,7 +239,7 @@ function AiChatContent({
     const canAttachFiles = !imageGenerationActive && (selectedModel?.supportedFileTypes?.length ?? 0) > 0;
 
     const canAttachTabs = enableAttachTabs && !imageGenerationActive;
-    const tabAttachments = useTabAttachments(tabId);
+    const tabAttachments = useTabAttachments(tabId, attachmentLimits?.tabs?.maxAttached);
     const textareaRef = useRef(/** @type {HTMLTextAreaElement|null} */ (null));
     const mention = useMentionPicker({
         enabled: canAttachTabs,
@@ -334,11 +334,14 @@ function AiChatContent({
 
     const fileWarning = canAttachFiles && fileState.fileLimitExceeded;
     const fileError = canAttachFiles ? fileState.fileError : null;
+    const tabWarning = canAttachTabs && tabAttachments.tabLimitExceeded;
 
     const imageMessageShowing = !!(canAttachImages && (imageState.imageLimitExceeded || imageState.imageError));
     const showFileError = !!fileError && !imageMessageShowing;
     const showFileWarning = fileWarning && !imageMessageShowing && !showFileError;
-    const disabled = !query || imageWarning || fileWarning;
+    // Only one attachment message shows at a time; the tab warning falls last in precedence.
+    const showTabWarning = tabWarning && !imageMessageShowing && !showFileError && !showFileWarning;
+    const disabled = !query || imageWarning || fileWarning || tabWarning;
 
     const isVoiceChatMode =
         enableVoiceChatAccess &&
@@ -485,6 +488,11 @@ function AiChatContent({
                     {showFileWarning && (
                         <p class={styles.attachmentWarning} role="alert">
                             {t('omnibar_fileAttachmentLimitWarning', { limit: String(fileState.maxFiles) })}
+                        </p>
+                    )}
+                    {showTabWarning && (
+                        <p class={styles.attachmentWarning} role="alert">
+                            {t('omnibar_tabAttachmentLimitWarning', { limit: String(tabAttachments.maxTabs) })}
                         </p>
                     )}
                     <ImageAttachmentContent

--- a/special-pages/pages/new-tab/app/omnibar/components/Omnibar.js
+++ b/special-pages/pages/new-tab/app/omnibar/components/Omnibar.js
@@ -372,7 +372,7 @@ function AiChatContent({
         <div
             ref={containerRef}
             class={styles.aiChatContent}
-            data-attachment-warning={imageWarning || fileWarning || undefined}
+            data-attachment-warning={imageWarning || fileWarning || tabWarning || undefined}
             onFocusCapture={(event) => {
                 if (
                     event.target instanceof HTMLTextAreaElement &&

--- a/special-pages/pages/new-tab/app/omnibar/components/chat-tools/tab-attachment/useTabAttachments.js
+++ b/special-pages/pages/new-tab/app/omnibar/components/chat-tools/tab-attachment/useTabAttachments.js
@@ -69,13 +69,16 @@ export function useTabAttachments(tabId, maxTabs = MAX_TABS) {
 
     /**
      * Extracts page content for each attached tab in parallel; drops failures.
+     * Iterates `attachedTabs` (open tabs only), NOT `attachedEntries`, so submission uses the exact
+     * same set the limit and the chips are computed from. Otherwise a closed-but-still-persisted
+     * entry could ship a context that isn't counted against the cap.
      * @returns {Promise<PageContext[] | null>}
      */
     const getTabsForSubmission = useCallback(async () => {
-        if (attachedEntries.length === 0) return null;
+        if (attachedTabs.length === 0) return null;
 
         const results = await Promise.all(
-            attachedEntries.map(async ({ tabId: id }) => {
+            attachedTabs.map(async ({ tabId: id }) => {
                 try {
                     const pageContext = await getTabContent(id);
                     return pageContext === null ? null : /** @type {PageContext} */ ({ ...pageContext, tabId: id });
@@ -88,7 +91,7 @@ export function useTabAttachments(tabId, maxTabs = MAX_TABS) {
 
         const ready = /** @type {PageContext[]} */ (results.filter((ctx) => ctx !== null));
         return ready.length > 0 ? ready : null;
-    }, [attachedEntries, getTabContent]);
+    }, [attachedTabs, getTabContent]);
 
     const state = useMemo(
         () => ({

--- a/special-pages/pages/new-tab/app/omnibar/components/chat-tools/tab-attachment/useTabAttachments.js
+++ b/special-pages/pages/new-tab/app/omnibar/components/chat-tools/tab-attachment/useTabAttachments.js
@@ -5,6 +5,8 @@ import { OpenTabsContext } from './OpenTabsProvider';
 
 const { useStateWithLocalPersistence } = TabAttachments;
 
+export const MAX_TABS = 3;
+
 /**
  * @typedef {import('../../../../../types/new-tab.js').TabMetadata} TabMetadata
  * @typedef {import('../../../../../types/new-tab.js').PageContext} PageContext
@@ -14,8 +16,11 @@ const { useStateWithLocalPersistence } = TabAttachments;
  * @typedef {TabMetadata & { addedAtRelative: number }} AttachedTab
  */
 
-/** @param {string|null|undefined} tabId — NTP tab the attachments are persisted under. */
-export function useTabAttachments(tabId) {
+/**
+ * @param {string|null|undefined} tabId — NTP tab the attachments are persisted under.
+ * @param {number} [maxTabs] - Max attached tabs, from native `attachmentLimits.tabs.maxAttached`. Defaults to {@link MAX_TABS}.
+ */
+export function useTabAttachments(tabId, maxTabs = MAX_TABS) {
     const { getTabContent } = useContext(OmnibarContext);
     const { openTabs } = useContext(OpenTabsContext);
     const [attachedEntries, setAttachedEntries] = useStateWithLocalPersistence(tabId);
@@ -54,6 +59,10 @@ export function useTabAttachments(tabId) {
         [setAttachedEntries],
     );
 
+    // No hard cap on attaching tabs; exceeding maxTabs warns and blocks submit until removed —
+    // mirroring the file-attachment soft cap (`useFileAttachments`).
+    const tabLimitExceeded = attachedTabs.length > maxTabs;
+
     const clearAttachedTabs = useCallback(() => {
         setAttachedEntries([]);
     }, [setAttachedEntries]);
@@ -89,8 +98,10 @@ export function useTabAttachments(tabId) {
             toggleTab,
             clearAttachedTabs,
             getTabsForSubmission,
+            tabLimitExceeded,
+            maxTabs,
         }),
-        [attachedTabs, isAttached, removeTab, toggleTab, clearAttachedTabs, getTabsForSubmission],
+        [attachedTabs, isAttached, removeTab, toggleTab, clearAttachedTabs, getTabsForSubmission, tabLimitExceeded, maxTabs],
     );
 
     return state;

--- a/special-pages/pages/new-tab/app/omnibar/components/chat-tools/tab-attachment/useTabAttachments.js
+++ b/special-pages/pages/new-tab/app/omnibar/components/chat-tools/tab-attachment/useTabAttachments.js
@@ -5,8 +5,6 @@ import { OpenTabsContext } from './OpenTabsProvider';
 
 const { useStateWithLocalPersistence } = TabAttachments;
 
-export const MAX_TABS = 3;
-
 /**
  * @typedef {import('../../../../../types/new-tab.js').TabMetadata} TabMetadata
  * @typedef {import('../../../../../types/new-tab.js').PageContext} PageContext
@@ -18,9 +16,9 @@ export const MAX_TABS = 3;
 
 /**
  * @param {string|null|undefined} tabId — NTP tab the attachments are persisted under.
- * @param {number} [maxTabs] - Max attached tabs, from native `attachmentLimits.tabs.maxAttached`. Defaults to {@link MAX_TABS}.
+ * @param {number} [maxTabs] - Max attached tabs, from native `attachmentLimits.tabs.maxAttached`. Absent means no limit (kill switch off).
  */
-export function useTabAttachments(tabId, maxTabs = MAX_TABS) {
+export function useTabAttachments(tabId, maxTabs = Number.POSITIVE_INFINITY) {
     const { getTabContent } = useContext(OmnibarContext);
     const { openTabs } = useContext(OpenTabsContext);
     const [attachedEntries, setAttachedEntries] = useStateWithLocalPersistence(tabId);

--- a/special-pages/pages/new-tab/app/omnibar/integration-tests/omnibar-attachments.spec.js
+++ b/special-pages/pages/new-tab/app/omnibar/integration-tests/omnibar-attachments.spec.js
@@ -101,9 +101,7 @@ test.describe('omnibar tab attachment', () => {
         expect(params.pageContext?.map((c) => c.tabId).sort()).toEqual(['tab-1', 'tab-2']);
     });
 
-    test('tabs over the configured cap warn (naming the limit), block submit, and recover on removal', async ({
-        page,
-    }, workerInfo) => {
+    test('tabs over the configured cap warn (naming the limit), block submit, and recover on removal', async ({ page }, workerInfo) => {
         const { ntp, omnibar } = setup(page, workerInfo);
         await ntp.reducedMotion();
         await ntp.openPage({

--- a/special-pages/pages/new-tab/app/omnibar/integration-tests/omnibar-attachments.spec.js
+++ b/special-pages/pages/new-tab/app/omnibar/integration-tests/omnibar-attachments.spec.js
@@ -101,6 +101,43 @@ test.describe('omnibar tab attachment', () => {
         expect(params.pageContext?.map((c) => c.tabId).sort()).toEqual(['tab-1', 'tab-2']);
     });
 
+    test('tabs over the configured cap warn (naming the limit), block submit, and recover on removal', async ({
+        page,
+    }, workerInfo) => {
+        const { ntp, omnibar } = setup(page, workerInfo);
+        await ntp.reducedMotion();
+        await ntp.openPage({
+            additional: {
+                'omnibar.mode': 'ai',
+                'omnibar.enableAttachTabs': 'true',
+                'omnibar.selectedModelId': 'openai_gpt-oss-120b',
+                // Backend-configured cap of one tab (default is three). A cap of one keeps the
+                // picker interactions to two attaches — reopening the picker per attach is slow,
+                // so more attaches make the test flaky under parallel load.
+                'omnibar.tabMaxAttached': '1',
+            },
+        });
+        await omnibar.ready();
+
+        // One tab is within the configured cap — no warning.
+        await omnibar.attachTab('Starbucks Coffee Company');
+        await expect(omnibar.tabChip()).toHaveCount(1);
+        await expect(omnibar.tabLimitWarning()).toHaveCount(0);
+
+        // A second tab exceeds the cap → kept, but warns (naming the configured limit) and blocks submit.
+        await omnibar.attachTab('MacBook Neo - Apple');
+        await expect(omnibar.tabChip()).toHaveCount(2);
+        await expect(omnibar.context().getByText('You can only attach 1 tabs at a time.')).toBeVisible();
+        await omnibar.types({ mode: 'ai', value: 'summarize these' });
+        await expect(omnibar.chatSubmitButton()).toBeDisabled();
+
+        // Removing the excess tab clears the warning and re-enables submit.
+        await omnibar.removeTabButton('MacBook Neo - Apple').click();
+        await expect(omnibar.tabChip()).toHaveCount(1);
+        await expect(omnibar.tabLimitWarning()).toHaveCount(0);
+        await expect(omnibar.chatSubmitButton()).toBeEnabled();
+    });
+
     test('removing a chip drops its context from the next submit', async ({ page }, workerInfo) => {
         const { ntp, omnibar } = setup(page, workerInfo);
         await ntp.reducedMotion();

--- a/special-pages/pages/new-tab/app/omnibar/integration-tests/omnibar.page.js
+++ b/special-pages/pages/new-tab/app/omnibar/integration-tests/omnibar.page.js
@@ -447,6 +447,10 @@ export class OmnibarPage {
         return this.attachmentChips().locator('button[aria-label="Remove image"]');
     }
 
+    tabLimitWarning() {
+        return this.context().getByText(/You can only attach \d+ tabs at a time/);
+    }
+
     fileLimitWarning() {
         return this.context().getByText(/You can only attach \d+ files at a time/);
     }

--- a/special-pages/pages/new-tab/app/omnibar/mocks/omnibar.mock-transport.js
+++ b/special-pages/pages/new-tab/app/omnibar/mocks/omnibar.mock-transport.js
@@ -168,6 +168,9 @@ export function omnibarMockTransport() {
         enableAskAiSuggestion: true,
         enableAttachTabs: false,
         attachmentLimits: {
+            tabs: {
+                maxAttached: 3,
+            },
             files: {
                 maxPerConversation: 3,
                 maxFileSizeMB: 3,
@@ -272,11 +275,16 @@ export function omnibarMockTransport() {
                     config.customizationActive = parseBooleanQueryParam('omnibar.customizationActive') ?? config.customizationActive;
                     if (config.attachmentLimits) {
                         const imageMaxPerTurn = parseInt(url.searchParams.get('omnibar.imageMaxPerTurn') ?? '', 10);
-                        if (imageMaxPerTurn > 0) config.attachmentLimits.images.maxPerTurn = imageMaxPerTurn;
+                        if (imageMaxPerTurn > 0 && config.attachmentLimits.images)
+                            config.attachmentLimits.images.maxPerTurn = imageMaxPerTurn;
                         const fileMaxPerConversation = parseInt(url.searchParams.get('omnibar.fileMaxPerConversation') ?? '', 10);
-                        if (fileMaxPerConversation > 0) config.attachmentLimits.files.maxPerConversation = fileMaxPerConversation;
+                        if (fileMaxPerConversation > 0 && config.attachmentLimits.files)
+                            config.attachmentLimits.files.maxPerConversation = fileMaxPerConversation;
                         const fileMaxFileSizeMB = parseInt(url.searchParams.get('omnibar.fileMaxFileSizeMB') ?? '', 10);
-                        if (fileMaxFileSizeMB > 0) config.attachmentLimits.files.maxFileSizeMB = fileMaxFileSizeMB;
+                        if (fileMaxFileSizeMB > 0 && config.attachmentLimits.files)
+                            config.attachmentLimits.files.maxFileSizeMB = fileMaxFileSizeMB;
+                        const tabMaxAttached = parseInt(url.searchParams.get('omnibar.tabMaxAttached') ?? '', 10);
+                        if (tabMaxAttached > 0) config.attachmentLimits.tabs.maxAttached = tabMaxAttached;
                     }
                     config.enableAiChatDeletion = parseBooleanQueryParam('omnibar.enableAiChatDeletion') ?? config.enableAiChatDeletion;
                     config.enableSearchSuggestionDeletion =

--- a/special-pages/pages/new-tab/app/omnibar/mocks/omnibar.mock-transport.js
+++ b/special-pages/pages/new-tab/app/omnibar/mocks/omnibar.mock-transport.js
@@ -284,7 +284,8 @@ export function omnibarMockTransport() {
                         if (fileMaxFileSizeMB > 0 && config.attachmentLimits.files)
                             config.attachmentLimits.files.maxFileSizeMB = fileMaxFileSizeMB;
                         const tabMaxAttached = parseInt(url.searchParams.get('omnibar.tabMaxAttached') ?? '', 10);
-                        if (tabMaxAttached > 0) config.attachmentLimits.tabs.maxAttached = tabMaxAttached;
+                        if (tabMaxAttached > 0 && config.attachmentLimits.tabs)
+                            config.attachmentLimits.tabs.maxAttached = tabMaxAttached;
                     }
                     config.enableAiChatDeletion = parseBooleanQueryParam('omnibar.enableAiChatDeletion') ?? config.enableAiChatDeletion;
                     config.enableSearchSuggestionDeletion =

--- a/special-pages/pages/new-tab/app/omnibar/mocks/omnibar.mock-transport.js
+++ b/special-pages/pages/new-tab/app/omnibar/mocks/omnibar.mock-transport.js
@@ -284,8 +284,7 @@ export function omnibarMockTransport() {
                         if (fileMaxFileSizeMB > 0 && config.attachmentLimits.files)
                             config.attachmentLimits.files.maxFileSizeMB = fileMaxFileSizeMB;
                         const tabMaxAttached = parseInt(url.searchParams.get('omnibar.tabMaxAttached') ?? '', 10);
-                        if (tabMaxAttached > 0 && config.attachmentLimits.tabs)
-                            config.attachmentLimits.tabs.maxAttached = tabMaxAttached;
+                        if (tabMaxAttached > 0 && config.attachmentLimits.tabs) config.attachmentLimits.tabs.maxAttached = tabMaxAttached;
                     }
                     config.enableAiChatDeletion = parseBooleanQueryParam('omnibar.enableAiChatDeletion') ?? config.enableAiChatDeletion;
                     config.enableSearchSuggestionDeletion =

--- a/special-pages/pages/new-tab/app/omnibar/strings.json
+++ b/special-pages/pages/new-tab/app/omnibar/strings.json
@@ -91,6 +91,10 @@
     "title": "You can only attach {limit} files at a time.",
     "description": "Warning shown when user attaches more files than the allowed maximum."
   },
+  "omnibar_tabAttachmentLimitWarning": {
+    "title": "You can only attach {limit} tabs at a time.",
+    "description": "Warning shown when user attaches more open tabs than the allowed maximum."
+  },
   "omnibar_imageTooLargeError": {
     "title": "Image is too large. Please use an image smaller than 10000×10000 pixels.",
     "description": "Error shown when a user tries to attach an image that exceeds the maximum pixel dimensions."

--- a/special-pages/pages/new-tab/integration-tests/new-tab.screenshots.spec.js
+++ b/special-pages/pages/new-tab/integration-tests/new-tab.screenshots.spec.js
@@ -468,7 +468,9 @@ test.describe('NTP screenshots', { tag: ['@screenshots'] }, () => {
             const ntp = NewtabPage.create(page, workerInfo);
             const omnibar = new OmnibarPage(ntp);
             await ntp.reducedMotion();
-            await ntp.openPage({ additional: attachmentsConfig });
+            // Raise the tab cap above the chip count so this stays a pure overflow test — 4 chips
+            // exceed the default cap of 3 and would otherwise render the over-limit warning chrome.
+            await ntp.openPage({ additional: { ...attachmentsConfig, 'omnibar.tabMaxAttached': '10' } });
             await omnibar.ready();
             // Enough wide tab chips to exceed the field width; they stay on one row and the
             // trailing chip is clipped at the scroll edge rather than wrapping to a new row.

--- a/special-pages/pages/new-tab/messages/types/omnibar-config.json
+++ b/special-pages/pages/new-tab/messages/types/omnibar-config.json
@@ -8,9 +8,20 @@
   "$defs": {
     "AttachmentLimits": {
       "type": "object",
-      "description": "Limits the omnibar applies to image and file attachments. When omitted, the omnibar uses its built-in defaults.",
-      "required": ["files", "images"],
+      "description": "Limits the omnibar applies to attachments. `files` and `images` are backend-sourced and may be omitted (the omnibar falls back to its built-in defaults for whichever is absent). `tabs` is a hardcoded native cap and is always present.",
+      "required": ["tabs"],
       "properties": {
+        "tabs": {
+          "description": "Limits for attached open tabs.",
+          "type": "object",
+          "required": ["maxAttached"],
+          "properties": {
+            "maxAttached": {
+              "description": "Maximum number of open tabs that can be attached at once.",
+              "type": "integer"
+            }
+          }
+        },
         "files": {
           "description": "Limits for file attachments (e.g. PDFs).",
           "type": "object",

--- a/special-pages/pages/new-tab/messages/types/omnibar-config.json
+++ b/special-pages/pages/new-tab/messages/types/omnibar-config.json
@@ -8,11 +8,10 @@
   "$defs": {
     "AttachmentLimits": {
       "type": "object",
-      "description": "Limits the omnibar applies to attachments. `files` and `images` are backend-sourced and may be omitted (the omnibar falls back to its built-in defaults for whichever is absent). `tabs` is a hardcoded native cap and is always present.",
-      "required": ["tabs"],
+      "description": "Limits the omnibar applies to attachments. All fields are optional. `files`/`images` are backend-sourced; the omnibar falls back to its built-in defaults for whichever is absent. `tabs` is a hardcoded native cap; when omitted (kill switch off) no tab limit is applied.",
       "properties": {
         "tabs": {
-          "description": "Limits for attached open tabs.",
+          "description": "Limits for attached open tabs. Omitted when the tab-limit kill switch is off, meaning no tab limit.",
           "type": "object",
           "required": ["maxAttached"],
           "properties": {

--- a/special-pages/pages/new-tab/public/locales/de/new-tab.json
+++ b/special-pages/pages/new-tab/public/locales/de/new-tab.json
@@ -252,6 +252,10 @@
     "title" : "Du kannst immer nur {limit} Dateien gleichzeitig anhängen.",
     "description" : "Warning shown when user attaches more files than the allowed maximum."
   },
+  "omnibar_tabAttachmentLimitWarning" : {
+    "title" : "Du kannst jeweils nur {limit} Tabs gleichzeitig anhängen.",
+    "description" : "Warning shown when user attaches more open tabs than the allowed maximum."
+  },
   "omnibar_imageTooLargeError" : {
     "title" : "Das Bild ist zu groß. Bitte verwende ein Bild, das kleiner als 10000×10000 Pixel ist.",
     "description" : "Error shown when a user tries to attach an image that exceeds the maximum pixel dimensions."

--- a/special-pages/pages/new-tab/public/locales/en/new-tab.json
+++ b/special-pages/pages/new-tab/public/locales/en/new-tab.json
@@ -253,6 +253,10 @@
     "title": "You can only attach {limit} files at a time.",
     "description": "Warning shown when user attaches more files than the allowed maximum."
   },
+  "omnibar_tabAttachmentLimitWarning": {
+    "title": "You can only attach {limit} tabs at a time.",
+    "description": "Warning shown when user attaches more open tabs than the allowed maximum."
+  },
   "omnibar_imageTooLargeError": {
     "title": "Image is too large. Please use an image smaller than 10000×10000 pixels.",
     "description": "Error shown when a user tries to attach an image that exceeds the maximum pixel dimensions."

--- a/special-pages/pages/new-tab/public/locales/es/new-tab.json
+++ b/special-pages/pages/new-tab/public/locales/es/new-tab.json
@@ -252,6 +252,10 @@
     "title" : "Solo puedes adjuntar {limit} archivos a la vez.",
     "description" : "Warning shown when user attaches more files than the allowed maximum."
   },
+  "omnibar_tabAttachmentLimitWarning" : {
+    "title" : "Solo puedes adjuntar {limit} pestañas a la vez.",
+    "description" : "Warning shown when user attaches more open tabs than the allowed maximum."
+  },
   "omnibar_imageTooLargeError" : {
     "title" : "La imagen es demasiado grande. Utiliza una imagen de menos de 10 000×10 000 píxeles.",
     "description" : "Error shown when a user tries to attach an image that exceeds the maximum pixel dimensions."

--- a/special-pages/pages/new-tab/public/locales/fr/new-tab.json
+++ b/special-pages/pages/new-tab/public/locales/fr/new-tab.json
@@ -252,6 +252,10 @@
     "title" : "Vous ne pouvez joindre que {limit} fichiers à la fois.",
     "description" : "Warning shown when user attaches more files than the allowed maximum."
   },
+  "omnibar_tabAttachmentLimitWarning" : {
+    "title" : "Vous ne pouvez joindre que {limit} onglets à la fois.",
+    "description" : "Warning shown when user attaches more open tabs than the allowed maximum."
+  },
   "omnibar_imageTooLargeError" : {
     "title" : "L'image est trop grande. Veuillez en utiliser une inférieure à 10 000 × 10 000 pixels.",
     "description" : "Error shown when a user tries to attach an image that exceeds the maximum pixel dimensions."

--- a/special-pages/pages/new-tab/public/locales/it/new-tab.json
+++ b/special-pages/pages/new-tab/public/locales/it/new-tab.json
@@ -252,6 +252,10 @@
     "title" : "Puoi allegare solo {limit} file alla volta.",
     "description" : "Warning shown when user attaches more files than the allowed maximum."
   },
+  "omnibar_tabAttachmentLimitWarning" : {
+    "title" : "Puoi allegare solo {limit} schede alla volta.",
+    "description" : "Warning shown when user attaches more open tabs than the allowed maximum."
+  },
   "omnibar_imageTooLargeError" : {
     "title" : "L'immagine è troppo grande. Utilizza un'immagine di dimensioni inferiori a 10.000×10.000 pixel.",
     "description" : "Error shown when a user tries to attach an image that exceeds the maximum pixel dimensions."

--- a/special-pages/pages/new-tab/public/locales/nl/new-tab.json
+++ b/special-pages/pages/new-tab/public/locales/nl/new-tab.json
@@ -252,6 +252,10 @@
     "title" : "Je kunt slechts {limit} bestanden tegelijk bijvoegen.",
     "description" : "Warning shown when user attaches more files than the allowed maximum."
   },
+  "omnibar_tabAttachmentLimitWarning" : {
+    "title" : "Je kunt slechts {limit} tabbladen tegelijk bijvoegen.",
+    "description" : "Warning shown when user attaches more open tabs than the allowed maximum."
+  },
   "omnibar_imageTooLargeError" : {
     "title" : "De afbeelding is te groot. Gebruik een afbeelding kleiner dan 10.000×10.000 pixels.",
     "description" : "Error shown when a user tries to attach an image that exceeds the maximum pixel dimensions."

--- a/special-pages/pages/new-tab/public/locales/pl/new-tab.json
+++ b/special-pages/pages/new-tab/public/locales/pl/new-tab.json
@@ -252,6 +252,10 @@
     "title" : "Możesz dołączyć tylko {limit} plików naraz.",
     "description" : "Warning shown when user attaches more files than the allowed maximum."
   },
+  "omnibar_tabAttachmentLimitWarning" : {
+    "title" : "Jednocześnie możesz załączyć tylko następującą liczbę kart: {limit}.",
+    "description" : "Warning shown when user attaches more open tabs than the allowed maximum."
+  },
   "omnibar_imageTooLargeError" : {
     "title" : "Obraz jest zbyt duży. Użyj obrazu mniejszego niż 10000×10000 pikseli.",
     "description" : "Error shown when a user tries to attach an image that exceeds the maximum pixel dimensions."

--- a/special-pages/pages/new-tab/public/locales/pt/new-tab.json
+++ b/special-pages/pages/new-tab/public/locales/pt/new-tab.json
@@ -252,6 +252,10 @@
     "title" : "Só podes anexar {limit} ficheiros de cada vez.",
     "description" : "Warning shown when user attaches more files than the allowed maximum."
   },
+  "omnibar_tabAttachmentLimitWarning" : {
+    "title" : "Só podes anexar {limit} separadores de cada vez.",
+    "description" : "Warning shown when user attaches more open tabs than the allowed maximum."
+  },
   "omnibar_imageTooLargeError" : {
     "title" : "A imagem é demasiado grande. Usa uma imagem menor que 10 000 × 10 000 píxeis.",
     "description" : "Error shown when a user tries to attach an image that exceeds the maximum pixel dimensions."

--- a/special-pages/pages/new-tab/public/locales/ru/new-tab.json
+++ b/special-pages/pages/new-tab/public/locales/ru/new-tab.json
@@ -252,6 +252,10 @@
     "title" : "Число файлов, прикрепляемых за один раз, ограничено: максимум {limit}.",
     "description" : "Warning shown when user attaches more files than the allowed maximum."
   },
+  "omnibar_tabAttachmentLimitWarning" : {
+    "title" : "Число вкладок, прикрепляемых за один раз, ограничено: максимум {limit}.",
+    "description" : "Warning shown when user attaches more open tabs than the allowed maximum."
+  },
   "omnibar_imageTooLargeError" : {
     "title" : "Слишком большой файл. Выберите изображение размером до 10 000 × 10 000 пикселей.",
     "description" : "Error shown when a user tries to attach an image that exceeds the maximum pixel dimensions."

--- a/special-pages/pages/new-tab/readme.md
+++ b/special-pages/pages/new-tab/readme.md
@@ -296,6 +296,12 @@
  - **Example**: `?omnibar.selectedModelId=claude-haiku-4-5`
  - **Options**: Any model ID from the `aiModelSections` config
 
+### Max Attached Tabs
+ - **Purpose**: Overrides the cap on how many open tabs can be attached as context (defaults to 3). Attaching more shows the over-limit warning and blocks submit until one is removed.
+ - **Parameter**: `omnibar.tabMaxAttached`
+ - **Example**: `?omnibar.tabMaxAttached=1`
+ - **Options**: Any positive integer
+
 ### Subscription (simulate subscribed user)
  - **Purpose**: Flips `isEnabled: true` on every AI model in the mock, unlocking the "Advanced Models - DuckDuckGo subscription" section. Lets tests pick subscription-tier models (e.g. Opus 4.6, GPT-5.2) as `selectedModelId`.
  - **Parameter**: `omnibar.subscription`

--- a/special-pages/pages/new-tab/types/new-tab.ts
+++ b/special-pages/pages/new-tab/types/new-tab.ts
@@ -757,13 +757,22 @@ export interface AIModelItem {
   supportedReasoningEffort?: ReasoningEffort[];
 }
 /**
- * Limits the omnibar applies to image and file attachments. When omitted, the omnibar uses its built-in defaults.
+ * Limits the omnibar applies to attachments. `files` and `images` are backend-sourced and may be omitted (the omnibar falls back to its built-in defaults for whichever is absent). `tabs` is a hardcoded native cap and is always present.
  */
 export interface AttachmentLimits {
   /**
+   * Limits for attached open tabs.
+   */
+  tabs: {
+    /**
+     * Maximum number of open tabs that can be attached at once.
+     */
+    maxAttached: number;
+  };
+  /**
    * Limits for file attachments (e.g. PDFs).
    */
-  files: {
+  files?: {
     /**
      * Maximum number of file attachments allowed.
      */
@@ -784,7 +793,7 @@ export interface AttachmentLimits {
   /**
    * Limits for image attachments.
    */
-  images: {
+  images?: {
     /**
      * Maximum number of images allowed in a single submission.
      */

--- a/special-pages/pages/new-tab/types/new-tab.ts
+++ b/special-pages/pages/new-tab/types/new-tab.ts
@@ -757,13 +757,13 @@ export interface AIModelItem {
   supportedReasoningEffort?: ReasoningEffort[];
 }
 /**
- * Limits the omnibar applies to attachments. `files` and `images` are backend-sourced and may be omitted (the omnibar falls back to its built-in defaults for whichever is absent). `tabs` is a hardcoded native cap and is always present.
+ * Limits the omnibar applies to attachments. All fields are optional. `files`/`images` are backend-sourced; the omnibar falls back to its built-in defaults for whichever is absent. `tabs` is a hardcoded native cap; when omitted (kill switch off) no tab limit is applied.
  */
 export interface AttachmentLimits {
   /**
-   * Limits for attached open tabs.
+   * Limits for attached open tabs. Omitted when the tab-limit kill switch is off, meaning no tab limit.
    */
-  tabs: {
+  tabs?: {
     /**
      * Maximum number of open tabs that can be attached at once.
      */


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1204006570077678/task/1216831900874432?focus=true

## Description
New tab page now has a limit on how many tabs can be attached; the number will be three, and it will be sent by native. We have a fallback just in case.

## Testing Steps
- Use Xcode to open the branch at https://github.com/duckduckgo/apple-browsers/pull/5994
- Point it to this code
- When running the macOS browser, got to Debug -> Set Internal User
- Go to Debug -> Feature Flags -> and turn on `aiChatNtpAttachMoreTabas`
- Open four tabs in some sites
- Go to new tab page, select the four tabs to be attached
- Check that an error appears and the submit is disabled

<img width="1107" height="618" alt="Screenshot 2026-07-23 at 7 12 12 PM" src="https://github.com/user-attachments/assets/209fa182-1a61-4fcf-a91b-66d08855e0ff" />

*Please tick all that apply:*

- [ ] I have tested this change locally
- [ ] I have tested this change locally in all supported browsers
- [ ] This change will be visible to users
- [ ] I have added automated tests that cover this change
- [ ] I have ensured the change is gated by config
- [ ] This change was covered by a ship review
- [ ] This change was covered by a tech design
- [ ] Any dependent config has been merged


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped omnibar UX and submission gating behind optional config; submission logic fix reduces risk of sending tab context that bypasses the cap.
> 
> **Overview**
> The NTP AI omnibar now enforces a **configurable maximum on attached open tabs** (default **3** from native `attachmentLimits.tabs.maxAttached`). When the kill switch omits that config, there is **no tab limit**.
> 
> Behavior matches the existing **file attachment soft cap**: users can still attach more tabs than the limit, but the UI shows a **warning**, sets **`data-attachment-warning`**, and **disables chat submit** until they remove excess chips.
> 
> `useTabAttachments` takes `maxTabs`, exposes `tabLimitExceeded` and `maxTabs`, and **`getTabsForSubmission`** now walks **open `attachedTabs`** only so closed-but-persisted entries do not count toward the cap or ship hidden context.
> 
> Config/schema/types add optional `tabs.maxAttached`; mocks and `omnibar.tabMaxAttached` support tests. New string **`omnibar_tabAttachmentLimitWarning`** plus locales. Integration test covers warn/block/recover; screenshot test raises the tab cap so overflow UI is not conflated with the limit warning.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 97ae066ceecb31e7695f2d5bfbcc44e1010cce66. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->