### PR TITLE
Support filling a generated date of birth

### DIFF
--- a/injected/integration-test/broker-protection-tests/broker-protection.spec.js
+++ b/injected/integration-test/broker-protection-tests/broker-protection.spec.js
@@ -496,6 +496,27 @@ test.describe('Broker Protection communications', () => {
             await dbp.doesInputValueEqual('#profile_url', 'https://www.veripages.com/profile/John-Smith-12345');
         });
 
+        test('fillForm generates a date of birth matching the extracted age', async ({ page }, workerInfo) => {
+            const dbp = BrokerProtectionPage.create(page, workerInfo.project.use);
+            await dbp.enabled();
+            await dbp.navigatesTo('form.html');
+            await dbp.receivesAction('fill-form-generated-dob.json');
+            const response = await dbp.collector.waitForMessage('actionCompleted');
+            dbp.isSuccessMessage(response);
+            await dbp.isDateOfBirthForAge('#user_dob', 51);
+            await dbp.doesInputValueEqual('#user_first_name', 'John');
+        });
+
+        test('fillForm errors when a generated date of birth has no age to work from', async ({ page }, workerInfo) => {
+            const dbp = BrokerProtectionPage.create(page, workerInfo.project.use);
+            await dbp.enabled();
+            await dbp.navigatesTo('form.html');
+            await dbp.receivesAction('fill-form-generated-dob-no-age.json');
+            const response = await dbp.collector.waitForMessage('actionCompleted');
+            dbp.isErrorMessage(response);
+            await dbp.doesInputValueEqual('#user_dob', '');
+        });
+
         test('fillForm with optional information', async ({ page }, workerInfo) => {
             const dbp = BrokerProtectionPage.create(page, workerInfo.project.use);
             await dbp.enabled();

--- a/injected/integration-test/page-objects/broker-protection.js
+++ b/injected/integration-test/page-objects/broker-protection.js
@@ -91,6 +91,21 @@ export class BrokerProtectionPage {
     }
 
     /**
+     * @param {string} selector - the selector for an `<input type="date">`
+     * @param {number} age - the age the filled date of birth should imply as of today
+     * @return {Promise<void>}
+     */
+    async isDateOfBirthForAge(selector, age) {
+        const value = await this.getFormFieldValue(selector);
+        expect(value).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+
+        const [year, month, day] = value.split('-').map(Number);
+        const today = new Date();
+        const birthdayThisYear = new Date(today.getFullYear(), month - 1, day);
+        expect(today.getFullYear() - year - (today < birthdayThisYear ? 1 : 0)).toBe(age);
+    }
+
+    /**
      * @param {string} responseElementSelector
      * @return {Promise<void>}
      */

--- a/injected/integration-test/test-pages/broker-protection/actions/fill-form-generated-dob-no-age.json
+++ b/injected/integration-test/test-pages/broker-protection/actions/fill-form-generated-dob-no-age.json
@@ -1,0 +1,17 @@
+{
+    "state": {
+        "action": {
+            "actionType": "fillForm",
+            "id": "fill-generated-dob-no-age",
+            "selector": ".ahm",
+            "dataSource": "extractedProfile",
+            "elements": [{ "type": "$generated_dob$", "selector": "#user_dob" }]
+        },
+        "data": {
+            "extractedProfile": {
+                "firstName": "John",
+                "lastName": "Sample"
+            }
+        }
+    }
+}

--- a/injected/integration-test/test-pages/broker-protection/actions/fill-form-generated-dob.json
+++ b/injected/integration-test/test-pages/broker-protection/actions/fill-form-generated-dob.json
@@ -1,0 +1,21 @@
+{
+    "state": {
+        "action": {
+            "actionType": "fillForm",
+            "id": "fill-generated-dob",
+            "selector": ".ahm",
+            "dataSource": "extractedProfile",
+            "elements": [
+                { "type": "firstName", "selector": "#user_first_name" },
+                { "type": "$generated_dob$", "selector": "#user_dob" }
+            ]
+        },
+        "data": {
+            "extractedProfile": {
+                "firstName": "John",
+                "lastName": "Sample",
+                "age": "51"
+            }
+        }
+    }
+}

--- a/injected/integration-test/test-pages/broker-protection/pages/form.html
+++ b/injected/integration-test/test-pages/broker-protection/pages/form.html
@@ -74,6 +74,10 @@
         <textarea name="profile_url" id="profile_url"></textarea>
     </label>
     <label>
+        Date of Birth:
+        <input type="date" name="dob" id="user_dob">
+    </label>
+    <label>
         Age:
         <select name="age" id="age">
             <option value="30">30</option>

--- a/injected/src/features/broker-protection/actions/fill-form.js
+++ b/injected/src/features/broker-protection/actions/fill-form.js
@@ -57,11 +57,18 @@ export function fillMany(root, elements, data) {
         } else if (element.type === '$generated_zip_code$') {
             results.push(setValueForInput(inputElem, generateZipCode()));
         } else if (element.type === '$generated_dob$') {
+            if (!Object.prototype.hasOwnProperty.call(data, 'age')) {
+                results.push({
+                    result: false,
+                    error: `element found with selector '${element.selector}', but data didn't contain an 'age' to generate a date of birth from`,
+                });
+                continue;
+            }
             const age = parseInt(data.age, 10);
             if (!Number.isFinite(age) || age < 0) {
                 results.push({
                     result: false,
-                    error: `element found with selector '${element.selector}', but data didn't contain an 'age' to generate a date of birth from`,
+                    error: `element found with selector '${element.selector}', but data contained an 'age' that wasn't a positive number`,
                 });
                 continue;
             }

--- a/injected/src/features/broker-protection/actions/fill-form.js
+++ b/injected/src/features/broker-protection/actions/fill-form.js
@@ -1,6 +1,6 @@
 import { getElement, generateRandomInt } from '../utils/utils.js';
 import { ErrorResponse, SuccessResponse } from '../types.js';
-import { generatePhoneNumber, generateZipCode, generateStreetAddress } from './generators.js';
+import { generatePhoneNumber, generateZipCode, generateStreetAddress, generateDateOfBirth } from './generators.js';
 import { states } from '../comparisons/constants.js';
 
 /**
@@ -56,6 +56,16 @@ export function fillMany(root, elements, data) {
             results.push(setValueForInput(inputElem, generatePhoneNumber()));
         } else if (element.type === '$generated_zip_code$') {
             results.push(setValueForInput(inputElem, generateZipCode()));
+        } else if (element.type === '$generated_dob$') {
+            const age = parseInt(data.age, 10);
+            if (!Number.isFinite(age) || age < 0) {
+                results.push({
+                    result: false,
+                    error: `element found with selector '${element.selector}', but data didn't contain an 'age' to generate a date of birth from`,
+                });
+                continue;
+            }
+            results.push(setValueForInput(inputElem, generateDateOfBirth(age)));
         } else if (element.type === '$generated_random_number$') {
             if (!element.min || !element.max) {
                 results.push({

--- a/injected/src/features/broker-protection/actions/fill-form.js
+++ b/injected/src/features/broker-protection/actions/fill-form.js
@@ -68,7 +68,7 @@ export function fillMany(root, elements, data) {
             if (!Number.isFinite(age) || age < 0) {
                 results.push({
                     result: false,
-                    error: `element found with selector '${element.selector}', but data contained an 'age' that wasn't a positive number`,
+                    error: `element found with selector '${element.selector}', but data contained an 'age' that wasn't a non-negative number`,
                 });
                 continue;
             }

--- a/injected/src/features/broker-protection/actions/generators.js
+++ b/injected/src/features/broker-protection/actions/generators.js
@@ -19,6 +19,24 @@ export function generateZipCode() {
     return zipCode;
 }
 
+/**
+ * A random date of birth for someone who is `age` years old, in the `YYYY-MM-DD` format.
+ *
+ * @param {number} age
+ * @param {Date} [today]
+ * @return {string}
+ */
+export function generateDateOfBirth(age, today = new Date()) {
+    const dob = new Date(today.getFullYear() - age, today.getMonth(), today.getDate());
+    // If `today` is a leap day (Feb 29) then `dob` at this point is March 1. Go back to last day of prev month (Feb 28).
+    if (dob.getMonth() !== today.getMonth()) dob.setDate(0);
+    dob.setDate(dob.getDate() - generateRandomInt(0, 364));
+
+    const month = (dob.getMonth() + 1).toString().padStart(2, '0');
+    const day = dob.getDate().toString().padStart(2, '0');
+    return `${dob.getFullYear()}-${month}-${day}`;
+}
+
 export function generateStreetAddress() {
     const streetDigits = generateRandomInt(1, 5);
     const streetNumber = generateRandomInt(2, streetDigits * 1000);

--- a/injected/unit-test/broker-protection.js
+++ b/injected/unit-test/broker-protection.js
@@ -8,7 +8,12 @@ import { replaceTemplatedUrl } from '../src/features/broker-protection/actions/b
 import { processTemplateStringWithUserData } from '../src/features/broker-protection/actions/build-url-transforms.js';
 import { names } from '../src/features/broker-protection/comparisons/constants.js';
 import { generateRandomInt, hashObject, sortAddressesByStateAndCity } from '../src/features/broker-protection/utils/utils.js';
-import { generatePhoneNumber, generateZipCode, generateStreetAddress } from '../src/features/broker-protection/actions/generators.js';
+import {
+    generatePhoneNumber,
+    generateZipCode,
+    generateStreetAddress,
+    generateDateOfBirth,
+} from '../src/features/broker-protection/actions/generators.js';
 import { ProfileHashTransformer } from '../src/features/broker-protection/extractors/profile-url.js';
 import { getComparisonFunction } from '../src/features/broker-protection/actions/click.js';
 import { isElementType } from '../src/features/broker-protection/captcha-services/utils/element.js';
@@ -652,6 +657,34 @@ describe('generators', () => {
                 const streetAddress = generateStreetAddress();
                 expect(typeof streetAddress).toEqual('string');
                 expect(streetAddress).toMatch(/^\d+ [A-Za-z]+(?: [A-Za-z]+)?$/);
+            });
+        });
+    });
+    describe('generateDateOfBirth', () => {
+        /**
+         * @param {string} dob - `YYYY-MM-DD`
+         * @param {Date} on
+         * @return {number}
+         */
+        function ageOn(dob, on) {
+            const [year, month, day] = dob.split('-').map(Number);
+            const birthdayThatYear = new Date(on.getFullYear(), month - 1, day);
+            return on.getFullYear() - year - (on < birthdayThatYear ? 1 : 0);
+        }
+
+        // A leap day, the day before one, and an ordinary day
+        const days = [new Date(2028, 1, 29), new Date(2028, 1, 28), new Date(2026, 6, 28)];
+
+        it('generates a date of birth for someone of exactly that age', () => {
+            days.forEach((today) => {
+                [0, 18, 41, 99].forEach((age) => {
+                    // Enough draws to cover the whole year the date can be picked from
+                    Array.from({ length: 365 }).forEach(() => {
+                        const dob = generateDateOfBirth(age, today);
+                        expect(dob).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+                        expect(ageOn(dob, today)).toBe(age);
+                    });
+                });
             });
         });
     });


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/task/1216773212741748

**Tech Design:** https://app.asana.com/1/137249556945/project/1209121419454298/task/1216773212741757

## Description

Adds support for filling out a fake date of birth using `$generated_dob$`.

Some opt-out forms ask for a date of birth we don't hold — we only have the age extracted from the profile. This fills a random date that makes the profile exactly that age as of today, so the form can be submitted without the config having to invent a date.

Split out of #2907, which no longer contains this change. The two are independent.

## Testing Steps

Integration tests (`npm run test-int`) and unit tests (`npm run test-unit`) cover both the generated date of birth and the error when there's no age to generate one from.

To test manually, clone the `apple-browsers` repo and follow the steps in https://github.com/duckduckgo/apple-browsers/pull/5995.

## Checklist

*Please tick all that apply:*

- [x] I have tested this change locally
- [ ] I have tested this change locally in all supported browsers
- [ ] This change will be visible to users
- [x] I have added automated tests that cover this change
- [x] I have ensured the change is gated by config
- [ ] This change was covered by a ship review
- [x] This change was covered by a tech design
- [x] Any dependent config has been merged

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Extends an existing fill-form generator pattern with validation and tests; no auth or persistence changes, and behavior is config-driven for broker opt-out flows.
> 
> **Overview**
> Adds **`$generated_dob$`** to broker-protection **`fillForm`**, alongside existing generated field types. When a form asks for a date of birth but the profile only has **age**, configs can use this type to fill a random **`YYYY-MM-DD`** value that yields that exact age as of today.
> 
> **`generateDateOfBirth`** picks a day within the birth year (with leap-day handling) and **`fillMany`** validates that **`age`** is present and a non-negative number; otherwise the action fails with a clear error like other generated fields.
> 
> Coverage includes unit tests over many random draws, integration success/error scenarios, a **`user_dob`** date input on the test form, and a page-object helper to assert age from the filled value.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3ae2a1d0483eacd6570f66c589ce9dbe3d81de16. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->