### PR TITLE
Add initial xpath support

### DIFF
--- a/injected/integration-test/test-pages/web-detection/pages/xpath-rendered-text.html
+++ b/injected/integration-test/test-pages/web-detection/pages/xpath-rendered-text.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>XPath - Rendered Text And Script</title>
+</head>
+<body>
+    <div class="wall"><p>adblock detected</p></div>
+    <script>
+        // Same pattern in a script in a separate subtree: must not suppress the rendered occurrence
+        var config = { "text": "adblock detected" };
+        window.__wallConfig = config;
+    </script>
+</body>
+</html>

--- a/injected/integration-test/test-pages/web-detection/pages/xpath-script-only.html
+++ b/injected/integration-test/test-pages/web-detection/pages/xpath-script-only.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>XPath - Pattern Only In Script</title>
+</head>
+<body>
+    <h1>Welcome</h1>
+    <p>Here is some ordinary article content.</p>
+    <div>
+        <script>
+            // The pattern appears only in script source, so nothing on the page shows it to the user
+            var config = { "text": "adblock detected" };
+            window.__wallConfig = config;
+        </script>
+    </div>
+</body>
+</html>

--- a/injected/integration-test/web-detection.spec.js
+++ b/injected/integration-test/web-detection.spec.js
@@ -70,6 +70,22 @@ const CAPTCHA_DETECTORS = {
 };
 
 /**
+ * Adwall detectors using an `xpath` text condition to select only rendered text, so a pattern that
+ * appears only inside a `<script>` body does not match. Not in the test-page config JSON because
+ * those files are validated against the published privacy-configuration schema.
+ */
+const XPATH_DETECTORS = {
+    rendered_text: {
+        match: {
+            text: {
+                pattern: ['ad ?block(er)? detected'],
+                xpath: '//body//text()[not(ancestor::script) and not(ancestor::style) and not(ancestor::template) and not(ancestor::noscript)]',
+            },
+        },
+    },
+};
+
+/**
  * Helper class for web-detection tests.
  */
 class WebDetectionTestHelper {
@@ -181,6 +197,24 @@ class WebDetectionTestHelper {
     }
 
     /**
+     * Set up collector with the xpath adwall detector group installed.
+     *
+     * @param {import('@playwright/test').Page} page
+     * @param {Record<string, any>} projectUse
+     * @returns {Promise<{collector: ResultsCollector, helper: WebDetectionTestHelper}>}
+     */
+    static async setupXpathTest(page, projectUse) {
+        const config = JSON.parse(readFileSync(CONFIG, 'utf8'));
+        config.features.webDetection.settings.detectors.xpath = XPATH_DETECTORS;
+
+        const collector = ResultsCollector.create(page, projectUse);
+        await collector.load('/web-detection/index.html', config);
+        const helper = new WebDetectionTestHelper(page, collector);
+
+        return { collector, helper };
+    }
+
+    /**
      * Set up collector for captcha detection tests: enables webEvents and installs the captcha
      * detector group (auto-run + per-provider fireEvent), with fake timers.
      *
@@ -245,6 +279,37 @@ test.describe('WebDetection Feature', () => {
             const results = await helper.runDetectors();
 
             // No detectors should match on a clean page
+            expect(results.length).toBe(0);
+        });
+    });
+
+    test.describe('text pattern matching with xpath', () => {
+        test('does not match a pattern that only appears inside a script', async ({ page }, testInfo) => {
+            const { helper } = await WebDetectionTestHelper.setupXpathTest(page, testInfo.project.use);
+            await helper.navigateTo('/web-detection/pages/xpath-script-only.html');
+
+            const results = await helper.runDetectors();
+
+            expect(results.find((r) => r.detectorId === 'xpath.rendered_text')).toBeUndefined();
+            // The selector-based detector matches the same page - this is the false positive being avoided
+            expect(results.find((r) => r.detectorId === 'adwall.generic_text')?.detected).toBe(true);
+        });
+
+        test('matches rendered text alongside a script containing the same pattern', async ({ page }, testInfo) => {
+            const { helper } = await WebDetectionTestHelper.setupXpathTest(page, testInfo.project.use);
+            await helper.navigateTo('/web-detection/pages/xpath-rendered-text.html');
+
+            const results = await helper.runDetectors();
+
+            expect(results.find((r) => r.detectorId === 'xpath.rendered_text')?.detected).toBe(true);
+        });
+
+        test('does not match on a clean page', async ({ page }, testInfo) => {
+            const { helper } = await WebDetectionTestHelper.setupXpathTest(page, testInfo.project.use);
+            await helper.navigateTo('/web-detection/pages/no-detection.html');
+
+            const results = await helper.runDetectors();
+
             expect(results.length).toBe(0);
         });
     });

--- a/injected/package.json
+++ b/injected/package.json
@@ -35,7 +35,7 @@
   },
   "type": "module",
   "dependencies": {
-    "@duckduckgo/privacy-configuration": "github:duckduckgo/privacy-configuration#1785998426937",
+    "@duckduckgo/privacy-configuration": "github:duckduckgo/privacy-configuration#1786094392564",
     "@duckduckgo/tracker-surrogates": "github:duckduckgo/tracker-surrogates#0528e3226df15b1a3e319ad68ef76612a8f26623",
     "esbuild": "^0.28.1",
     "minimist": "^1.2.8",

--- a/injected/package.json
+++ b/injected/package.json
@@ -35,7 +35,7 @@
   },
   "type": "module",
   "dependencies": {
-    "@duckduckgo/privacy-configuration": "github:duckduckgo/privacy-configuration#1785861896319",
+    "@duckduckgo/privacy-configuration": "github:duckduckgo/privacy-configuration#1785998426937",
     "@duckduckgo/tracker-surrogates": "github:duckduckgo/tracker-surrogates#0528e3226df15b1a3e319ad68ef76612a8f26623",
     "esbuild": "^0.28.1",
     "minimist": "^1.2.8",

--- a/injected/src/features/web-detection/matching.js
+++ b/injected/src/features/web-detection/matching.js
@@ -145,6 +145,43 @@ function hasContent(element) {
 const ORDERED_NODE_SNAPSHOT_TYPE = 7;
 
 /**
+ * Compiled XPath expressions, keyed by document and then by expression source.
+ *
+ * `document.evaluate()` re-parses the expression string on every call, and
+ * detectors re-evaluate their conditions on every poll tick against a fixed,
+ * config-supplied set of expressions. Compiling once removes that repeated parse.
+ *
+ * Keyed by document because an `XPathExpression` belongs to the document that
+ * created it.
+ *
+ * @type {WeakMap<Document, Map<string, XPathExpression>>}
+ */
+const compiledXPaths = new WeakMap();
+
+/**
+ * Compile an XPath expression, reusing a previously compiled one where possible.
+ *
+ * An invalid expression throws `SyntaxError` here rather than at evaluation time;
+ * either way it propagates to the caller and surfaces as `detected: 'error'`.
+ *
+ * @param {string} expression
+ * @returns {XPathExpression}
+ */
+function compileXPath(expression) {
+    let cache = compiledXPaths.get(document);
+    if (!cache) {
+        cache = new Map();
+        compiledXPaths.set(document, cache);
+    }
+    let compiled = cache.get(expression);
+    if (!compiled) {
+        compiled = document.createExpression(expression, null);
+        cache.set(expression, compiled);
+    }
+    return compiled;
+}
+
+/**
  * Concatenate the text of every node selected by an XPath expression.
  *
  * Nodes are joined without a separator so the result is equivalent to
@@ -160,7 +197,7 @@ const ORDERED_NODE_SNAPSHOT_TYPE = 7;
  * @returns {string}
  */
 function xpathText(expression) {
-    const snapshot = document.evaluate(expression, document, null, ORDERED_NODE_SNAPSHOT_TYPE, null);
+    const snapshot = compileXPath(expression).evaluate(document, ORDERED_NODE_SNAPSHOT_TYPE, null);
     let text = '';
     for (let i = 0; i < snapshot.snapshotLength; i++) {
         text += snapshot.snapshotItem(i)?.textContent || '';
@@ -198,13 +235,10 @@ function evaluateSingleTextCondition(condition) {
 
     const patternComb = new RegExp(patterns.join('|'), 'i');
 
-    // Disjunction: any expression whose selected text matches is success
-    if (xpaths.some((expression) => patternComb.test(xpathText(expression)))) {
-        return true;
-    }
-
-    // Disjunction: any selector having a matching element is success
-    return selectors.some((selector) => {
+    // Disjunction: any selector having a matching element is success.
+    // Checked before xpath because CSS matching avoids the per-call expression
+    // parse and snapshot allocation that `document.evaluate` requires.
+    const selectorMatch = selectors.some((selector) => {
         const elements = document.querySelectorAll(selector);
         for (const element of elements) {
             if (patternComb.test(element.textContent || '')) {
@@ -213,6 +247,12 @@ function evaluateSingleTextCondition(condition) {
         }
         return false;
     });
+    if (selectorMatch) {
+        return true;
+    }
+
+    // Disjunction: any expression whose selected text matches is success
+    return xpaths.some((expression) => patternComb.test(xpathText(expression)));
 }
 
 /**

--- a/injected/src/features/web-detection/matching.js
+++ b/injected/src/features/web-detection/matching.js
@@ -181,28 +181,96 @@ function compileXPath(expression) {
     return compiled;
 }
 
+/** Characters accumulated between pattern tests when scanning XPath text. */
+const DEFAULT_CHUNK_SIZE = 8192;
+
+/** `chunkSize` divisor giving the default `chunkTail`. */
+const CHUNK_TAIL_RATIO = 16;
+
+/** Reused for the tail walk-back. Must stay free of `g`/`y` so `.test()` is stateless. */
+const WORD_CHARACTER = /\w/;
+
 /**
- * Concatenate the text of every node selected by an XPath expression.
+ * Resolve chunking configuration against the built-in defaults.
  *
- * Nodes are joined without a separator so the result is equivalent to
- * `textContent` over the selected set: a pattern may span node boundaries, so
- * `//div//text()` still matches "adblocker detected" in
- * `<div>adblocker <b>detected</b></div>`.
+ * @param {ConditionTypes['text']['xpathConfig']} [config]
+ * @returns {{ chunkSize: number, chunkTail: number }}
+ */
+function resolveXPathConfig(config) {
+    // Used exactly as configured - nothing is clamped or rejected. Range checking lives in
+    // privacy-configuration CI, so a bad value fails a build naming the detector rather than
+    // being silently rewritten on a user's page. Safe only because no value can break the
+    // scan loop in `xpathMatches`.
+    const chunkSize = config?.chunkSize ?? DEFAULT_CHUNK_SIZE;
+    const chunkTail = config?.chunkTail ?? Math.floor(chunkSize / CHUNK_TAIL_RATIO);
+    return { chunkSize, chunkTail };
+}
+
+/**
+ * Reduce a scanned buffer to its trailing `chunkTail` characters, extending the
+ * cut backwards to the nearest non-word character.
+ *
+ * @param {string} buffer
+ * @param {number} chunkTail
+ * @returns {string}
+ */
+function retainTail(buffer, chunkTail) {
+    let cut = buffer.length - chunkTail;
+    if (cut <= 0) return buffer;
+    // Ceiling on the walk-back, so an unbroken run of word characters (a base64 payload, a
+    // minified blob) cannot grow the buffer without limit: retained text stays within
+    // 2 * chunkTail. Reaching it leaves position 0 mid-word, giving up the guarantee below
+    // for this flush - a hard memory bound is worth more than exact `\b` semantics inside a
+    // blob that a pattern is unlikely to match anyway.
+    const limit = Math.max(0, cut - chunkTail);
+    // Land the cut just after a non-word character, so position 0 is a real word boundary
+    // rather than an artefact of where the chunk ended - otherwise a `\b`-prefixed pattern
+    // asserts at position 0 of every chunk and matches mid-word. This only lengthens the
+    // tail, so it introduces no false negative.
+    while (cut > limit && WORD_CHARACTER.test(buffer.charAt(cut - 1))) cut--;
+    return buffer.slice(cut);
+}
+
+/**
+ * Test a pattern against the text of every node selected by an XPath expression,
+ * scanning in bounded chunks rather than concatenating the whole selection.
+ *
+ * Nodes are joined without a separator so matching is equivalent to `textContent`
+ * over the selected set: a pattern may span node boundaries, so `//div//text()`
+ * still matches "adblocker detected" in `<div>adblocker <b>detected</b></div>`.
  *
  * An invalid expression throws `SyntaxError`, which propagates and surfaces as
  * `detected: 'error'` for the detector - the same behaviour as an invalid CSS
  * selector passed to `querySelectorAll`.
  *
+ * @param {RegExp} pattern Must be free of `g`/`y`, so `.test()` is stateless and
+ *   the overlap between chunks cannot corrupt `lastIndex`.
  * @param {string} expression
- * @returns {string}
+ * @param {{ chunkSize: number, chunkTail: number }} chunking
+ * @returns {boolean}
  */
-function xpathText(expression) {
+function xpathMatches(pattern, expression, { chunkSize, chunkTail }) {
     const snapshot = compileXPath(expression).evaluate(document, ORDERED_NODE_SNAPSHOT_TYPE, null);
-    let text = '';
+    let buffer = '';
+    // Characters added since the last test, rather than the length of the buffer. Each test
+    // then advances `chunkSize` fresh characters whatever `chunkTail` is, so an oversized tail
+    // costs proportionally more scanning instead of re-testing the whole buffer per node -
+    // which is what makes configured values safe to use unvalidated.
+    let pending = 0;
     for (let i = 0; i < snapshot.snapshotLength; i++) {
-        text += snapshot.snapshotItem(i)?.textContent || '';
+        const text = snapshot.snapshotItem(i)?.textContent || '';
+        buffer += text;
+        pending += text.length;
+        // chunkSize 0 disables chunking, accumulating everything for the single test below
+        if (chunkSize > 0 && pending >= chunkSize) {
+            if (pattern.test(buffer)) return true;
+            // Retained text is contiguous with what follows, so a phrase split across nodes
+            // still matches across a flush
+            buffer = retainTail(buffer, chunkTail);
+            pending = 0;
+        }
     }
-    return text;
+    return pattern.test(buffer);
 }
 
 /**
@@ -219,7 +287,12 @@ function xpathText(expression) {
  *   Unlike `selector`, an expression may select text nodes and filter on ancestry, so it can exclude
  *   text that is present in the DOM but never rendered - eg text inside `<script>`:
  *   `//body//text()[not(ancestor::script)]`. The text of all nodes selected by one expression is
- *   concatenated and matched as a whole.
+ *   matched as a whole, but is scanned in bounded chunks rather than concatenated in full, so a
+ *   large page does not allocate its entire rendered text on each evaluation.
+ *
+ * `xpathConfig` [optional]: Tunes that chunking, and applies to `xpath` only. A match longer than
+ *   `chunkTail` that straddles a chunk boundary is missed; `chunkSize: 0` turns chunking off
+ *   entirely. See `xpathMatches` and `resolveXPathConfig`.
  *
  * The overall condition matches if ANY pattern matches the text of ANY source (selected element or
  * XPath expression).
@@ -252,7 +325,11 @@ function evaluateSingleTextCondition(condition) {
     }
 
     // Disjunction: any expression whose selected text matches is success
-    return xpaths.some((expression) => patternComb.test(xpathText(expression)));
+    if (xpaths.length === 0) {
+        return false;
+    }
+    const chunking = resolveXPathConfig(condition.xpathConfig);
+    return xpaths.some((expression) => xpathMatches(patternComb, expression, chunking));
 }
 
 /**

--- a/injected/src/features/web-detection/matching.js
+++ b/injected/src/features/web-detection/matching.js
@@ -187,8 +187,43 @@ const DEFAULT_CHUNK_SIZE = 8192;
 /** `chunkSize` divisor giving the default `chunkTail`. */
 const CHUNK_TAIL_RATIO = 16;
 
-/** Reused for the tail walk-back. Must stay free of `g`/`y` so `.test()` is stateless. */
-const WORD_CHARACTER = /\w/;
+/**
+ * How far the tail cut may walk back looking for a word boundary.
+ *
+ * The walk only has to escape the token the cut landed in, so this is a bound on word
+ * length rather than a tuning knob - past it there is no boundary to reach, only a hash,
+ * base64 or minified blob. The longest token in any shipped detector pattern is 16
+ * characters; 64 leaves room for compound words in the languages we match.
+ *
+ * Deliberately independent of `chunkTail`, which is sized for a different purpose (the
+ * longest match allowed to span a boundary). Deriving one from the other would make a
+ * config raising the tail silently multiply the cost of this scan.
+ */
+const MAX_WORD_LENGTH = 64;
+
+/**
+ * Whether a character code is a word character, matching `\w` exactly.
+ *
+ * `\w` is `[A-Za-z0-9_]`, verified equivalent to these ranges across every code unit.
+ * It is deliberately ASCII-only, and so is `\b` - both share the same definition, which
+ * is what keeps this consistent with the assertion it exists to protect, whatever the
+ * language of the text.
+ *
+ * The equivalence holds for every regex flag except `i` combined with `u`/`v`, where
+ * case folding pulls U+017F and U+212A into `\w`. Using character codes sidesteps that,
+ * along with the `g`/`y` statefulness that made the previous `RegExp.test` form fragile.
+ *
+ * @param {number} code
+ * @returns {boolean}
+ */
+function isWordCode(code) {
+    return (
+        (code >= 97 && code <= 122) || // a-z
+        (code >= 65 && code <= 90) || // A-Z
+        (code >= 48 && code <= 57) || // 0-9
+        code === 95 // _
+    );
+}
 
 /**
  * Resolve chunking configuration against the built-in defaults.
@@ -217,17 +252,17 @@ function resolveXPathConfig(config) {
 function retainTail(buffer, chunkTail) {
     let cut = buffer.length - chunkTail;
     if (cut <= 0) return buffer;
-    // Ceiling on the walk-back, so an unbroken run of word characters (a base64 payload, a
-    // minified blob) cannot grow the buffer without limit: retained text stays within
-    // 2 * chunkTail. Reaching it leaves position 0 mid-word, giving up the guarantee below
-    // for this flush - a hard memory bound is worth more than exact `\b` semantics inside a
-    // blob that a pattern is unlikely to match anyway.
-    const limit = Math.max(0, cut - chunkTail);
+    // Ceiling on the walk, so an unbroken run of word characters cannot grow the buffer
+    // without limit. Reaching it leaves position 0 mid-word, giving up the guarantee below
+    // for this flush - a hard bound is worth more than exact `\b` semantics inside a blob
+    // that a phrase pattern will not match anyway. Never more than `chunkTail`, so a tail
+    // of 0 still retains nothing.
+    const limit = Math.max(0, cut - Math.min(chunkTail, MAX_WORD_LENGTH));
     // Land the cut just after a non-word character, so position 0 is a real word boundary
     // rather than an artefact of where the chunk ended - otherwise a `\b`-prefixed pattern
     // asserts at position 0 of every chunk and matches mid-word. This only lengthens the
     // tail, so it introduces no false negative.
-    while (cut > limit && WORD_CHARACTER.test(buffer.charAt(cut - 1))) cut--;
+    while (cut > limit && isWordCode(buffer.charCodeAt(cut - 1))) cut--;
     return buffer.slice(cut);
 }
 

--- a/injected/src/features/web-detection/matching.js
+++ b/injected/src/features/web-detection/matching.js
@@ -133,6 +133,42 @@ function hasContent(element) {
 }
 
 /**
+ * Value of `XPathResult.ORDERED_NODE_SNAPSHOT_TYPE`, inlined because the
+ * `XPathResult` global is not present in every environment this module runs in
+ * (eg unit tests provide `document` without the surrounding window). The value
+ * is fixed by the DOM spec.
+ *
+ * A snapshot (rather than an iterator) is required: `iterateNext()` throws
+ * `InvalidStateError` if the document mutates during iteration, and detectors
+ * run against live pages that mutate underneath them.
+ */
+const ORDERED_NODE_SNAPSHOT_TYPE = 7;
+
+/**
+ * Concatenate the text of every node selected by an XPath expression.
+ *
+ * Nodes are joined without a separator so the result is equivalent to
+ * `textContent` over the selected set: a pattern may span node boundaries, so
+ * `//div//text()` still matches "adblocker detected" in
+ * `<div>adblocker <b>detected</b></div>`.
+ *
+ * An invalid expression throws `SyntaxError`, which propagates and surfaces as
+ * `detected: 'error'` for the detector - the same behaviour as an invalid CSS
+ * selector passed to `querySelectorAll`.
+ *
+ * @param {string} expression
+ * @returns {string}
+ */
+function xpathText(expression) {
+    const snapshot = document.evaluate(expression, document, null, ORDERED_NODE_SNAPSHOT_TYPE, null);
+    let text = '';
+    for (let i = 0; i < snapshot.snapshotLength; i++) {
+        text += snapshot.snapshotItem(i)?.textContent || '';
+    }
+    return text;
+}
+
+/**
  * Evaluate text pattern match condition.
  *
  * `pattern` (disj): Array of regex patterns (or string representing a single pattern) - ANY pattern matching = success.
@@ -140,18 +176,32 @@ function hasContent(element) {
  *
  * `selector` (disj): Array of CSS selectors (or string representing a single selector) - ANY selector matching = success.
  *   Equivalent to `selector: ".a, .b"` for `selector: [".a", ".b"]`.
- *   Defaults to `body` if not provided.
+ *   Defaults to `body` when neither `selector` nor `xpath` is provided.
  *
- * The overall condition matches if ANY pattern matches text in ANY selected element.
+ * `xpath` (disj): Array of XPath expressions (or a single expression) - ANY expression matching = success.
+ *   Unlike `selector`, an expression may select text nodes and filter on ancestry, so it can exclude
+ *   text that is present in the DOM but never rendered - eg text inside `<script>`:
+ *   `//body//text()[not(ancestor::script)]`. The text of all nodes selected by one expression is
+ *   concatenated and matched as a whole.
+ *
+ * The overall condition matches if ANY pattern matches the text of ANY source (selected element or
+ * XPath expression).
  *
  * @param {ConditionTypes['text']} condition
  * @returns {boolean}
  */
 function evaluateSingleTextCondition(condition) {
     const patterns = asArray(condition.pattern);
-    const selectors = asArray(condition.selector, ['body']);
+    const xpaths = asArray(condition.xpath);
+    // `body` is only the implicit source when the condition names no source of its own
+    const selectors = asArray(condition.selector, xpaths.length > 0 ? [] : ['body']);
 
     const patternComb = new RegExp(patterns.join('|'), 'i');
+
+    // Disjunction: any expression whose selected text matches is success
+    if (xpaths.some((expression) => patternComb.test(xpathText(expression)))) {
+        return true;
+    }
 
     // Disjunction: any selector having a matching element is success
     return selectors.some((selector) => {

--- a/injected/unit-test/web-detection.js
+++ b/injected/unit-test/web-detection.js
@@ -951,7 +951,7 @@ describe('WebDetection', () => {
                     expect(matchChunked(html, '\\badblocker', { chunkSize: 100, chunkTail: 9 })).toBe(true);
                 });
 
-                it('should cap the retained tail at twice chunkTail', () => {
+                it('should cap the walk-back at chunkTail when that is the smaller ceiling', () => {
                     // The node ends in an unbroken run of word characters, so the walk-back runs
                     // until it hits its ceiling. That fixes the retained text at exactly 2 * chunkTail.
                     const html = `<span>${'z'.repeat(75)}0123456789abcdefghijklmno</span><span>detected</span>`;
@@ -960,6 +960,18 @@ describe('WebDetection', () => {
                     expect(matchChunked(html, '56789abcdefghijklmnodetected', config)).toBe(true);
                     // Needs 21, one past the ceiling
                     expect(matchChunked(html, '456789abcdefghijklmnodetected', config)).toBe(false);
+                });
+
+                it('should cap the walk-back at the word-length limit for a large chunkTail', () => {
+                    // Same unbroken run, but a tail past the 64 character word-length ceiling, so
+                    // the walk stops there instead: 100 retained plus at most 64 walked back.
+                    const run = 'abcdefghij'.repeat(20);
+                    const html = `<span>${'z'.repeat(800)}${run}</span><span>detected</span>`;
+                    const config = { chunkSize: 1000, chunkTail: 100 };
+                    // Needs exactly the 164 retained characters
+                    expect(matchChunked(html, run.slice(36) + 'detected', config)).toBe(true);
+                    // Needs 165, one past the ceiling
+                    expect(matchChunked(html, run.slice(35) + 'detected', config)).toBe(false);
                 });
 
                 it('should honour chunkTail: 0 rather than promoting it to a floor', () => {

--- a/injected/unit-test/web-detection.js
+++ b/injected/unit-test/web-detection.js
@@ -894,6 +894,109 @@ describe('WebDetection', () => {
             it('should throw on an invalid expression, surfacing as a detector error', () => {
                 expect(() => matchInDOM('<p>adblocker</p>', { text: { pattern: 'adblocker', xpath: '//[bad' } })).toThrow();
             });
+
+            describe('chunked scanning', () => {
+                /**
+                 * Selected text is scanned in chunks rather than concatenated in full. Each case
+                 * below sizes `chunkSize` to the fixture so flushes land at known offsets.
+                 *
+                 * @param {string} html
+                 * @param {string} pattern
+                 * @param {{ chunkSize?: number, chunkTail?: number }} [xpathConfig]
+                 * @returns {boolean}
+                 */
+                function matchChunked(html, pattern, xpathConfig) {
+                    return matchInDOM(html, { text: { pattern, xpath: RENDERED_TEXT, xpathConfig } });
+                }
+
+                it('should match across node boundaries when flushing on every node', () => {
+                    // chunkSize below the length of a single node, so every node triggers a test.
+                    // chunkTail is set explicitly because the derived default would floor to 0 here.
+                    expect(
+                        matchChunked('<div>adblocker <b>detected</b></div>', 'adblocker detected', { chunkSize: 4, chunkTail: 20 }),
+                    ).toBe(true);
+                });
+
+                it('should derive a chunkTail of 0 from a chunkSize below the tail ratio', () => {
+                    // floor(4 / 16) is 0, so nothing is retained and the straddling match is lost.
+                    // Config CI keeps chunkSize well above this; pinned so the arithmetic is explicit.
+                    expect(matchChunked('<div>adblocker <b>detected</b></div>', 'adblocker detected', { chunkSize: 4 })).toBe(false);
+                });
+
+                it('should match a pattern straddling a flush boundary', () => {
+                    // First node is exactly one chunk, so the flush lands mid-phrase
+                    const html = `<span>${'z'.repeat(90)}adblocker </span><span>detected</span>`;
+                    expect(matchChunked(html, 'adblocker detected', { chunkSize: 100, chunkTail: 20 })).toBe(true);
+                });
+
+                it('should miss a straddling match longer than the retained tail', () => {
+                    // Documented limitation: the tail bounds the longest match that survives a
+                    // boundary. Remedied from config by raising chunkTail or disabling chunking.
+                    const html = `<span>${'z'.repeat(90)}adblocker </span><span>detected</span>`;
+                    expect(matchChunked(html, 'adblocker detected', { chunkSize: 100, chunkTail: 2 })).toBe(false);
+                    expect(matchChunked(html, 'adblocker detected', { chunkSize: 0 })).toBe(true);
+                });
+
+                it('should not let a word-boundary pattern assert at a mid-word chunk cut', () => {
+                    // Cutting at length - chunkTail would start the buffer at "adblocker", where \b
+                    // asserts against the start of the string. The real preceding character is a
+                    // word character, so the walk-back extends the tail to include it.
+                    const html = `<span>${'z'.repeat(91)}adblocker</span>`;
+                    expect(matchChunked(html, '\\badblocker', { chunkSize: 100, chunkTail: 9 })).toBe(false);
+                    expect(matchChunked(html, '\\badblocker', { chunkSize: 0 })).toBe(false);
+                });
+
+                it('should still find a word-boundary match that the walk-back keeps intact', () => {
+                    const html = `<span>${'z'.repeat(90)} adblocker</span>`;
+                    expect(matchChunked(html, '\\badblocker', { chunkSize: 100, chunkTail: 9 })).toBe(true);
+                });
+
+                it('should cap the retained tail at twice chunkTail', () => {
+                    // The node ends in an unbroken run of word characters, so the walk-back runs
+                    // until it hits its ceiling. That fixes the retained text at exactly 2 * chunkTail.
+                    const html = `<span>${'z'.repeat(75)}0123456789abcdefghijklmno</span><span>detected</span>`;
+                    const config = { chunkSize: 100, chunkTail: 10 };
+                    // Needs exactly the 20 retained characters
+                    expect(matchChunked(html, '56789abcdefghijklmnodetected', config)).toBe(true);
+                    // Needs 21, one past the ceiling
+                    expect(matchChunked(html, '456789abcdefghijklmnodetected', config)).toBe(false);
+                });
+
+                it('should honour chunkTail: 0 rather than promoting it to a floor', () => {
+                    const html = `<span>${'z'.repeat(90)}adblocker </span><span>detected</span>`;
+                    expect(matchChunked(html, 'adblocker detected', { chunkSize: 100, chunkTail: 0 })).toBe(false);
+                });
+
+                it('should terminate and stay correct when chunkTail far exceeds chunkSize', () => {
+                    // Pins the structural progress property: flushing is driven by characters added
+                    // since the last test, so an oversized tail cannot stall the scan. Flushing on
+                    // total buffer length instead would re-test the whole buffer for every node.
+                    const html = `<span>${'z'.repeat(200)}adblocker </span><span>detected</span>`;
+                    expect(matchChunked(html, 'adblocker detected', { chunkSize: 10, chunkTail: 1000 })).toBe(true);
+                    expect(matchChunked(html, 'absent phrase', { chunkSize: 10, chunkTail: 1000 })).toBe(false);
+                });
+
+                it('should use the built-in defaults when xpathConfig is omitted', () => {
+                    // Smaller than the default chunk, so this is a single test either way
+                    expect(matchChunked('<div>adblocker <b>detected</b></div>', 'adblocker detected')).toBe(true);
+                    expect(matchChunked('<div>adblocker <b>detected</b></div>', 'adblocker detected', {})).toBe(true);
+                });
+
+                it('should produce concat-identical results across the fixture set with chunkSize: 0', () => {
+                    const fixtures = [
+                        '<p>Hello!</p>',
+                        '<div class="wall"><p>adblocker detected</p></div>',
+                        'adblocker detected',
+                        `adblocker detected<script>console.log('Hello!');</script>`,
+                        '<div><script>var msg = "adblocker detected"; showWall(msg);</script></div>',
+                        '<div>adblocker <b>detected</b></div>',
+                        '<style>/* adblocker detected */</style>',
+                    ];
+                    for (const html of fixtures) {
+                        expect(matchChunked(html, 'adblocker detected', { chunkSize: 0 })).toBe(matchRenderedText(html));
+                    }
+                });
+            });
         });
 
         describe('element matching', () => {

--- a/injected/unit-test/web-detection.js
+++ b/injected/unit-test/web-detection.js
@@ -876,6 +876,21 @@ describe('WebDetection', () => {
                 expect(matchInDOM('<div id="neither">adblocker</div>', match)).toBe(false);
             });
 
+            it('should see content added between evaluations', () => {
+                // Compiled expressions are reused across evaluations; the DOM they run against is not
+                const dom = new JSDOM('<!DOCTYPE html><html><body><p>Loading...</p></body></html>');
+                const originalDocument = globalThis.document;
+                globalThis.document = dom.window.document;
+                try {
+                    const match = { text: { pattern: 'adblocker detected', xpath: RENDERED_TEXT } };
+                    expect(evaluateMatch(match)).toBe(false);
+                    dom.window.document.body.insertAdjacentHTML('beforeend', '<div class="wall">adblocker detected</div>');
+                    expect(evaluateMatch(match)).toBe(true);
+                } finally {
+                    globalThis.document = originalDocument;
+                }
+            });
+
             it('should throw on an invalid expression, surfacing as a detector error', () => {
                 expect(() => matchInDOM('<p>adblocker</p>', { text: { pattern: 'adblocker', xpath: '//[bad' } })).toThrow();
             });

--- a/injected/unit-test/web-detection.js
+++ b/injected/unit-test/web-detection.js
@@ -796,6 +796,91 @@ describe('WebDetection', () => {
             });
         });
 
+        describe('text matching with xpath', () => {
+            // Excludes text that is in the DOM but never rendered, so a pattern appearing only
+            // inside a <script> body does not match.
+            const RENDERED_TEXT =
+                '//body//text()[not(ancestor::script) and not(ancestor::style) and not(ancestor::template) and not(ancestor::noscript)]';
+
+            /**
+             * @param {string} html
+             * @returns {boolean}
+             */
+            function matchRenderedText(html) {
+                return matchInDOM(html, { text: { pattern: 'adblocker detected', xpath: RENDERED_TEXT } });
+            }
+
+            it('should not match when the pattern is absent', () => {
+                expect(matchRenderedText('<p>Hello!</p>')).toBe(false);
+            });
+
+            it('should match text wrapped in elements', () => {
+                expect(matchRenderedText('<div class="wall"><p>adblocker detected</p></div>')).toBe(true);
+            });
+
+            it('should match bare text in body', () => {
+                expect(matchRenderedText('adblocker detected')).toBe(true);
+            });
+
+            it('should match bare text alongside a script without the pattern', () => {
+                expect(matchRenderedText(`adblocker detected<script>console.log('Hello!');</script>`)).toBe(true);
+            });
+
+            it('should not match when the pattern only appears inside a script', () => {
+                expect(matchRenderedText('<div><script>var msg = "adblocker detected"; showWall(msg);</script></div>')).toBe(false);
+            });
+
+            it('should match when the pattern appears in both a rendered subtree and a script', () => {
+                expect(
+                    matchRenderedText(
+                        '<div class="wall"><p>adblocker detected</p></div><script>var msg = "adblocker detected"; log(msg);</script>',
+                    ),
+                ).toBe(true);
+            });
+
+            it('should match bare text that is a sibling of a script containing the pattern', () => {
+                expect(matchRenderedText('adblocker detected<script>var msg = "adblocker detected"; log(msg);</script>')).toBe(true);
+            });
+
+            it('should match a pattern spanning inline element boundaries', () => {
+                // Text of all selected nodes is concatenated, so patterns are not confined to one text node
+                expect(matchRenderedText('<div>adblocker <b>detected</b></div>')).toBe(true);
+            });
+
+            it('should not match when the pattern only appears in a style element', () => {
+                expect(matchRenderedText('<style>/* adblocker detected */</style>')).toBe(false);
+            });
+
+            it('should support ancestry-based scoping', () => {
+                const match = { text: { pattern: 'adblocker', xpath: '//div[@id="wall"]//text()' } };
+                expect(matchInDOM('<div id="wall"><span>adblocker</span></div>', match)).toBe(true);
+                expect(matchInDOM('<div id="other"><span>adblocker</span></div>', match)).toBe(false);
+            });
+
+            it('should match if ANY expression matches (OR)', () => {
+                const match = { text: { pattern: 'adblocker', xpath: ['//div[@id="a"]//text()', '//div[@id="b"]//text()'] } };
+                expect(matchInDOM('<div id="a">adblocker</div><div id="b">other</div>', match)).toBe(true);
+                expect(matchInDOM('<div id="a">other</div><div id="b">adblocker</div>', match)).toBe(true);
+                expect(matchInDOM('<div id="a">other</div><div id="b">none</div>', match)).toBe(false);
+            });
+
+            it('should not fall back to body when only xpath is provided', () => {
+                // `body` is the implicit selector only when the condition names no source of its own
+                expect(matchInDOM('<p>adblocker detected</p>', { text: { pattern: 'adblocker', xpath: '//div//text()' } })).toBe(false);
+            });
+
+            it('should combine with selector as a disjunction', () => {
+                const match = { text: { pattern: 'adblocker', selector: '#viaSelector', xpath: '//div[@id="viaXpath"]//text()' } };
+                expect(matchInDOM('<div id="viaSelector">adblocker</div>', match)).toBe(true);
+                expect(matchInDOM('<div id="viaXpath">adblocker</div>', match)).toBe(true);
+                expect(matchInDOM('<div id="neither">adblocker</div>', match)).toBe(false);
+            });
+
+            it('should throw on an invalid expression, surfacing as a detector error', () => {
+                expect(() => matchInDOM('<p>adblocker</p>', { text: { pattern: 'adblocker', xpath: '//[bad' } })).toThrow();
+            });
+        });
+
         describe('element matching', () => {
             describe('visibility: any', () => {
                 it('should match when element exists', () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,7 @@
     "injected": {
       "hasInstallScript": true,
       "dependencies": {
-        "@duckduckgo/privacy-configuration": "github:duckduckgo/privacy-configuration#1785861896319",
+        "@duckduckgo/privacy-configuration": "github:duckduckgo/privacy-configuration#1785998426937",
         "@duckduckgo/tracker-surrogates": "github:duckduckgo/tracker-surrogates#0528e3226df15b1a3e319ad68ef76612a8f26623",
         "esbuild": "^0.28.1",
         "minimist": "^1.2.8",
@@ -881,7 +881,7 @@
     },
     "node_modules/@duckduckgo/privacy-configuration": {
       "version": "1.0.0",
-      "resolved": "git+ssh://git@github.com/duckduckgo/privacy-configuration.git#771e48668f3c0f723e0d684135d308e209be74cf",
+      "resolved": "git+ssh://git@github.com/duckduckgo/privacy-configuration.git#c9e0d85261ca5929e976b22823d843f02dce2491",
       "license": "Apache 2.0",
       "dependencies": {
         "eslint-plugin-json": "^4.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,7 @@
     "injected": {
       "hasInstallScript": true,
       "dependencies": {
-        "@duckduckgo/privacy-configuration": "github:duckduckgo/privacy-configuration#1785998426937",
+        "@duckduckgo/privacy-configuration": "github:duckduckgo/privacy-configuration#1786094392564",
         "@duckduckgo/tracker-surrogates": "github:duckduckgo/tracker-surrogates#0528e3226df15b1a3e319ad68ef76612a8f26623",
         "esbuild": "^0.28.1",
         "minimist": "^1.2.8",
@@ -881,7 +881,7 @@
     },
     "node_modules/@duckduckgo/privacy-configuration": {
       "version": "1.0.0",
-      "resolved": "git+ssh://git@github.com/duckduckgo/privacy-configuration.git#c9e0d85261ca5929e976b22823d843f02dce2491",
+      "resolved": "git+ssh://git@github.com/duckduckgo/privacy-configuration.git#63f10d1020dfbd5744e9bec870f09832d11df551",
       "license": "Apache 2.0",
       "dependencies": {
         "eslint-plugin-json": "^4.0.1",


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/492600419927320/task/1217111223619806?focus=true

## Description

Adds support for targeting text detection on xpath selectors.

## Testing Steps

Unit tests.

For manual test, load updated extension. In the service worker console paste:

```
await globalThis.components.remoteConfig.modify((config) => {
    const settings = config.features.webDetection.settings;

    settings.detectors.adwalls.generic_en_xpath = {
        match: {
            text: {
                xpath: "//body//text()[not(ancestor::script) and not(ancestor::style) and not(ancestor::noscript)]",
                pattern: [
                    'ad ?block(er)? detected',
                    'adjust(ing)?( your)? ad blocking settings',
                    '(turn(ing)? off|disable|disabling|deactivate)( your| my)? ad ?block(er)?',
                    'your ad ?blocker is on',
                    "you('re| are| may be) using an ad blocker",
                ],
            },
        },
    };

    const before = settings.conditionalChanges.length;
    settings.conditionalChanges = settings.conditionalChanges.filter(
        (change) => ![].concat(change.condition?.domain ?? []).includes('homedepot.com'),
    );
    console.log(`dropped ${before - settings.conditionalChanges.length} homedepot.com conditional change(s)`);

    config.version = Date.now();
    return config;
});
```

Visit a site with the phrase "adblocker detected". Make a breakage report and view request. You should see both `adwalls.generic_en` and `adwalls.generic_en_xpath` in the `webDetection` results.

Now visit homedepot.com and repeat. You should only see `adwalls.generic_en` in the results (xpath variant prevents being detected inside script).

## Checklist

<!--
  These questions are a friendly reminder to shipping code, if you're uncertain ask the AoR owners.
  It's also totally appropriate to not check some of these boxes, if they don't apply to your change.
-->
*Please tick all that apply:*

- [x] I have tested this change locally
- [ ] I have tested this change locally in all supported browsers
- [ ] This change will be visible to users
- [x] I have added automated tests that cover this change
- [x] I have ensured the change is gated by config
- [ ] This change was covered by a ship review
- [x] This change was covered by a tech design
- [x] Any dependent config has been merged



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes live-page text matching for configured detectors (false positive/negative and per-tick CPU on large DOMs), though behavior is gated by config and existing selector-based detectors are unchanged unless xpath is added.
> 
> **Overview**
> **Web-detection text conditions** can now target text via **`xpath`** (in addition to CSS **`selector`**), so detectors can match **rendered** page text while ignoring strings that only live in `<script>`, `<style>`, `<template>`, or `<noscript>`. **`selector` and `xpath` are OR’d**; implicit **`body`** scanning applies only when neither source is set.
> 
> XPath evaluation uses **compiled expressions**, **ordered node snapshots**, and **chunked scanning** with optional **`xpathConfig`** (`chunkSize` / `chunkTail`) so large pages are not fully concatenated on each poll. Tail retention walks back to word boundaries so `\b`-style patterns are less likely to false-match at chunk cuts (with documented limits when matches span boundaries longer than the tail).
> 
> The **`@duckduckgo/privacy-configuration`** dependency is bumped to a revision that includes the schema for these fields. **Unit and Playwright integration tests** cover script-only vs rendered text, clean pages, and chunking edge cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 019a04f3193300900f22095f7e590eb5b6e8f812. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->