### PR TITLE
Support formats for a generated date of birth

### DIFF
--- a/injected/integration-test/broker-protection-tests/broker-protection.spec.js
+++ b/injected/integration-test/broker-protection-tests/broker-protection.spec.js
@@ -609,6 +609,25 @@ test.describe('Broker Protection communications', () => {
             await dbp.doesInputValueEqual('#user_dob', '');
         });
 
+        test('fillForm spreads one generated date of birth across separately formatted fields', async ({ page }, workerInfo) => {
+            const dbp = BrokerProtectionPage.create(page, workerInfo.project.use);
+            await dbp.enabled();
+            await dbp.navigatesTo('form.html');
+            await dbp.receivesAction('fill-form-generated-dob-parts.json');
+            const response = await dbp.collector.waitForMessage('actionCompleted');
+            dbp.isSuccessMessage(response);
+            await dbp.isDateOfBirthSplitAcrossFields(
+                {
+                    date: '#user_dob',
+                    year: '#user_dob_year',
+                    month: '#user_dob_month',
+                    day: '#user_dob_day',
+                    us: '#user_dob_us',
+                },
+                51,
+            );
+        });
+
         test('fillForm with optional information', async ({ page }, workerInfo) => {
             const dbp = BrokerProtectionPage.create(page, workerInfo.project.use);
             await dbp.enabled();

--- a/injected/integration-test/page-objects/broker-protection.js
+++ b/injected/integration-test/page-objects/broker-protection.js
@@ -106,6 +106,26 @@ export class BrokerProtectionPage {
     }
 
     /**
+     * @param {object} selectors
+     * @param {string} selectors.date - an `<input type="date">` filled with the default format
+     * @param {string} selectors.year - filled with `YYYY`
+     * @param {string} selectors.month - filled with `MM`
+     * @param {string} selectors.day - filled with `D`
+     * @param {string} selectors.us - filled with `MM/DD/YYYY`
+     * @param {number} age - the age the date of birth should imply as of today
+     * @return {Promise<void>}
+     */
+    async isDateOfBirthSplitAcrossFields(selectors, age) {
+        await this.isDateOfBirthForAge(selectors.date, age);
+
+        const [year, month, day] = (await this.getFormFieldValue(selectors.date)).split('-');
+        await this.doesInputValueEqual(selectors.year, year);
+        await this.doesInputValueEqual(selectors.month, month);
+        await this.doesInputValueEqual(selectors.day, String(Number(day)));
+        await this.doesInputValueEqual(selectors.us, `${month}/${day}/${year}`);
+    }
+
+    /**
      * @param {string} responseElementSelector
      * @return {Promise<void>}
      */

--- a/injected/integration-test/test-pages/broker-protection/actions/fill-form-generated-dob-parts.json
+++ b/injected/integration-test/test-pages/broker-protection/actions/fill-form-generated-dob-parts.json
@@ -1,0 +1,24 @@
+{
+    "state": {
+        "action": {
+            "actionType": "fillForm",
+            "id": "fill-generated-dob-parts",
+            "selector": ".ahm",
+            "dataSource": "extractedProfile",
+            "elements": [
+                { "type": "$generated_dob$", "selector": "#user_dob" },
+                { "type": "$generated_dob$", "selector": "#user_dob_year", "format": "YYYY" },
+                { "type": "$generated_dob$", "selector": "#user_dob_month", "format": "MM" },
+                { "type": "$generated_dob$", "selector": "#user_dob_day", "format": "D" },
+                { "type": "$generated_dob$", "selector": "#user_dob_us", "format": "MM/DD/YYYY" }
+            ]
+        },
+        "data": {
+            "extractedProfile": {
+                "firstName": "John",
+                "lastName": "Sample",
+                "age": "51"
+            }
+        }
+    }
+}

--- a/injected/integration-test/test-pages/broker-protection/pages/form.html
+++ b/injected/integration-test/test-pages/broker-protection/pages/form.html
@@ -78,6 +78,36 @@
         <input type="date" name="dob" id="user_dob">
     </label>
     <label>
+        Date of Birth (year):
+        <input type="text" name="dob_year" id="user_dob_year">
+    </label>
+    <label>
+        Date of Birth (month):
+        <select name="dob_month" id="user_dob_month">
+            <option value=""></option>
+            <option value="01">January</option>
+            <option value="02">February</option>
+            <option value="03">March</option>
+            <option value="04">April</option>
+            <option value="05">May</option>
+            <option value="06">June</option>
+            <option value="07">July</option>
+            <option value="08">August</option>
+            <option value="09">September</option>
+            <option value="10">October</option>
+            <option value="11">November</option>
+            <option value="12">December</option>
+        </select>
+    </label>
+    <label>
+        Date of Birth (day):
+        <input type="text" name="dob_day" id="user_dob_day">
+    </label>
+    <label>
+        Date of Birth (US format):
+        <input type="text" name="dob_us" id="user_dob_us">
+    </label>
+    <label>
         Age:
         <select name="age" id="age">
             <option value="30">30</option>

--- a/injected/src/features/broker-protection/actions/fill-form.js
+++ b/injected/src/features/broker-protection/actions/fill-form.js
@@ -1,6 +1,6 @@
 import { getElement, generateRandomInt } from '../utils/utils.js';
 import { ErrorResponse, SuccessResponse } from '../types.js';
-import { generatePhoneNumber, generateZipCode, generateStreetAddress, generateDateOfBirth } from './generators.js';
+import { generatePhoneNumber, generateZipCode, generateStreetAddress, generateDateOfBirth, formatDateOfBirth } from './generators.js';
 import { states } from '../comparisons/constants.js';
 import { sameCityState } from '../comparisons/address.js';
 
@@ -38,7 +38,7 @@ export function fillForm(action, userData, root = document, userProfile = null) 
 /**
  * Try to fill form elements. Collecting results + warnings for reporting.
  * @param {HTMLElement} root
- * @param {{selector: string; type: string; min?: string; max?: string;}[]} elements
+ * @param {{selector: string; type: string; min?: string; max?: string; format?: string;}[]} elements
  * @param {Record<string, any>} data
  * @param {Record<string, any> | null} [userProfile]
  * @return {({result: true} | {result: false; error: string})[]}
@@ -49,6 +49,11 @@ export function fillMany(root, elements, data, userProfile = null) {
     /** @type {Record<string, any> | null} */
     const address = selectAddress(data.addresses, userProfile?.addresses);
     const extras = { ...data.extras, ...address?.extras };
+
+    // Generated once per form, so a form that splits the date of birth across separate year, month
+    // and day fields fills three parts of one date rather than parts of three different dates.
+    /** @type {string | null} */
+    let dateOfBirth = null;
 
     for (const element of elements) {
         const inputElem = getElement(root, element.selector);
@@ -64,22 +69,26 @@ export function fillMany(root, elements, data, userProfile = null) {
         } else if (element.type === '$generated_zip_code$') {
             results.push(setValueForInput(inputElem, generateZipCode()));
         } else if (element.type === '$generated_dob$') {
-            if (!Object.prototype.hasOwnProperty.call(data, 'age')) {
-                results.push({
-                    result: false,
-                    error: `element found with selector '${element.selector}', but data didn't contain an 'age' to generate a date of birth from`,
-                });
-                continue;
+            if (dateOfBirth === null) {
+                if (!Object.prototype.hasOwnProperty.call(data, 'age')) {
+                    results.push({
+                        result: false,
+                        error: `element found with selector '${element.selector}', but data didn't contain an 'age' to generate a date of birth from`,
+                    });
+                    continue;
+                }
+                const age = parseInt(data.age, 10);
+                if (!Number.isFinite(age) || age < 0) {
+                    results.push({
+                        result: false,
+                        error: `element found with selector '${element.selector}', but data contained an 'age' that wasn't a non-negative number`,
+                    });
+                    continue;
+                }
+                dateOfBirth = generateDateOfBirth(age);
             }
-            const age = parseInt(data.age, 10);
-            if (!Number.isFinite(age) || age < 0) {
-                results.push({
-                    result: false,
-                    error: `element found with selector '${element.selector}', but data contained an 'age' that wasn't a non-negative number`,
-                });
-                continue;
-            }
-            results.push(setValueForInput(inputElem, generateDateOfBirth(age)));
+
+            results.push(setValueForInput(inputElem, formatDateOfBirth(dateOfBirth, element.format)));
         } else if (element.type === '$generated_random_number$') {
             if (!element.min || !element.max) {
                 results.push({

--- a/injected/src/features/broker-protection/actions/generators.js
+++ b/injected/src/features/broker-protection/actions/generators.js
@@ -37,6 +37,45 @@ export function generateDateOfBirth(age, today = new Date()) {
     return `${dob.getFullYear()}-${month}-${day}`;
 }
 
+const DEFAULT_DATE_OF_BIRTH_FORMAT = 'YYYY-MM-DD';
+
+/**
+ * @type {Record<string, Intl.DateTimeFormatOptions>}
+ */
+const DATE_OF_BIRTH_TOKENS = {
+    YYYY: { year: 'numeric' },
+    YY: { year: '2-digit' },
+    MMMM: { month: 'long' },
+    MMM: { month: 'short' },
+    MM: { month: '2-digit' },
+    M: { month: 'numeric' },
+    DD: { day: '2-digit' },
+    D: { day: 'numeric' },
+};
+
+const DATE_OF_BIRTH_TOKEN = new RegExp(
+    Object.keys(DATE_OF_BIRTH_TOKENS)
+        // Longest token first, so `YYYY` isn't read as two `YY` and `MMMM` isn't read as `MMM` then `M`.
+        .sort((a, b) => b.length - a.length)
+        .join('|'),
+    'g',
+);
+
+/**
+ * Rewrite a `YYYY-MM-DD` date of birth into `format`, so forms that split it across separate
+ * year/month/day fields can be filled a part at a time. Anything in `format` that isn't a token is
+ * kept as a literal, which is how separators like `MM/DD/YYYY` work.
+ *
+ * @param {string} dateOfBirth - as returned by {@link generateDateOfBirth}
+ * @param {string} [format] - e.g. `YYYY`, `MMMM`, `MM/DD/YYYY`. Defaults to what a date input expects.
+ * @return {string}
+ */
+export function formatDateOfBirth(dateOfBirth, format = DEFAULT_DATE_OF_BIRTH_FORMAT) {
+    const [year, month, day] = dateOfBirth.split('-');
+    const date = new Date(Number(year), Number(month) - 1, Number(day));
+    return format.replace(DATE_OF_BIRTH_TOKEN, (token) => new Intl.DateTimeFormat('en-US', DATE_OF_BIRTH_TOKENS[token]).format(date));
+}
+
 export function generateStreetAddress() {
     const streetDigits = generateRandomInt(1, 5);
     const streetNumber = generateRandomInt(2, streetDigits * 1000);

--- a/injected/unit-test/broker-protection.js
+++ b/injected/unit-test/broker-protection.js
@@ -13,6 +13,7 @@ import {
     generateZipCode,
     generateStreetAddress,
     generateDateOfBirth,
+    formatDateOfBirth,
 } from '../src/features/broker-protection/actions/generators.js';
 import { ProfileHashTransformer } from '../src/features/broker-protection/extractors/profile-url.js';
 import { getComparisonFunction } from '../src/features/broker-protection/actions/click.js';
@@ -750,6 +751,41 @@ describe('generators', () => {
                     });
                 });
             });
+        });
+    });
+    describe('formatDateOfBirth', () => {
+        it('fills each token from the date', () => {
+            /** @type {[string, string][]} */
+            const cases = [
+                ['YYYY', '1975'],
+                ['YY', '75'],
+                ['MMMM', 'March'],
+                ['MMM', 'Mar'],
+                ['MM', '03'],
+                ['M', '3'],
+                ['DD', '07'],
+                ['D', '7'],
+            ];
+            cases.forEach(([format, expected]) => {
+                expect(formatDateOfBirth('1975-03-07', format)).toBe(expected);
+            });
+        });
+
+        it('keeps anything that is not a token as a literal', () => {
+            expect(formatDateOfBirth('1975-03-07', 'MM/DD/YYYY')).toBe('03/07/1975');
+            expect(formatDateOfBirth('1975-03-07', 'D.M.YY')).toBe('7.3.75');
+            expect(formatDateOfBirth('1975-03-07', 'MMMM D, YYYY')).toBe('March 7, 1975');
+        });
+
+        it('defaults to the format a date input expects', () => {
+            expect(formatDateOfBirth('1975-03-07')).toBe('1975-03-07');
+        });
+
+        it('reads a date of birth in the local timezone', () => {
+            // `new Date('1975-01-01')` would be UTC midnight, which is the last day of 1974 in any
+            // timezone behind UTC.
+            expect(formatDateOfBirth('1975-01-01', 'YYYY-MM-DD')).toBe('1975-01-01');
+            expect(formatDateOfBirth('1975-12-31', 'YYYY-MM-DD')).toBe('1975-12-31');
         });
     });
 });

--- a/injected/unit-test/verify-artifacts.js
+++ b/injected/unit-test/verify-artifacts.js
@@ -8,7 +8,7 @@ console.log(ROOT);
 const BUILD = join(ROOT, 'build');
 const APPLE_BUILD = join(ROOT, 'Sources/ContentScopeScripts/dist');
 
-let CSS_OUTPUT_SIZE = 880_000;
+let CSS_OUTPUT_SIZE = 890_000;
 if (process.platform === 'win32') {
     CSS_OUTPUT_SIZE = CSS_OUTPUT_SIZE * 1.1; // 10% larger for Windows due to line endings
 }


### PR DESCRIPTION
**Asana Task/Github Issue:** N/A

## Description

Expands on #2929 to allow filling different types of date of birth field. Follow up to https://github.com/duckduckgo/content-scope-scripts/pull/2929#pullrequestreview-4864276723.

A `$generated_dob$` element can now carry an optional `format`, so each field gets the part it expects:

```json
{ "type": "$generated_dob$", "selector": "#dob_year", "format": "YYYY" },
{ "type": "$generated_dob$", "selector": "#dob_month", "format": "MM" },
{ "type": "$generated_dob$", "selector": "#dob_day", "format": "D" }
```

`format` defaults to `YYYY-MM-DD`, so existing configs are unaffected. Any character that isn't a token is kept as a literal, so a single field can be filled with e.g. `MM/DD/YYYY`.

| Token | Example |
|---|---|
| `YYYY` | `1975` |
| `YY` | `75` |
| `MMMM` | `March` |
| `MMM` | `Mar` |
| `MM` | `03` |
| `M` | `3` |
| `DD` | `07` |
| `D` | `7` |

## Testing Steps

There’s no case for this yet, so rely on the included integration tests. 

## Checklist

*Please tick all that apply:*

- [x] I have tested this change locally
- [ ] I have tested this change locally in all supported browsers
- [ ] This change will be visible to users
- [x] I have added automated tests that cover this change
- [x] I have ensured the change is gated by config
- [ ] This change was covered by a ship review
- [ ] This change was covered by a tech design
- [x] Any dependent config has been merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to broker-protection form fill logic, default behavior is unchanged, and coverage is added; only risk is incorrect DOB formatting on real broker forms.
> 
> **Overview**
> **Broker Protection `fillForm`** now supports an optional **`format`** on **`$generated_dob$`** elements so one generated birth date can be written into split or differently styled fields (year/month/day, `MM/DD/YYYY`, month names, etc.). Without **`format`**, behavior stays **`YYYY-MM-DD`**.
> 
> **`fillMany`** generates the date of birth **once per form** and reuses it for every **`$generated_dob$`** field, so split fields always share the same date instead of independent random draws.
> 
> Unit and integration tests cover token formatting, literals, and multi-field fills; the injected bundle size ceiling was raised slightly to match the added code.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1aef742837eadfae4a2df10b906e91eea4e3a3ab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->