### PR TITLE
Implements Video Autoplay Detection

### DIFF
--- a/injected/integration-test/test-pages/web-telemetry/config/web-telemetry.json
+++ b/injected/integration-test/test-pages/web-telemetry/config/web-telemetry.json
@@ -7,6 +7,7 @@
             "exceptions": [],
             "settings": {
                 "videoPlayback": "enabled",
+                "videoAutoplay": "enabled",
                 "urlChanged": "enabled"
             }
         }

--- a/injected/src/features/web-telemetry.js
+++ b/injected/src/features/web-telemetry.js
@@ -22,9 +22,7 @@ export class WebTelemetry extends ContentFeature {
 
     init() {
         this.videoPlaybackEnabled = this.getFeatureSettingEnabled('videoPlayback');
-        // TEMPORARY: defaulted on so autoplay telemetry fires without a config change.
-        // Revert to `this.getFeatureSettingEnabled('videoAutoplay')` before merging.
-        this.videoAutoplayEnabled = this.getFeatureSettingEnabled('videoAutoplay', 'enabled');
+        this.videoAutoplayEnabled = this.getFeatureSettingEnabled('videoAutoplay');
         if (this.videoPlaybackEnabled || this.videoAutoplayEnabled) {
             this.videoPlaybackObserve();
         }

--- a/injected/src/features/web-telemetry.js
+++ b/injected/src/features/web-telemetry.js
@@ -18,7 +18,7 @@ export class WebTelemetry extends ContentFeature {
         // Kept separate from the dedupe above, so neither message suppresses the other.
         this.reportedAutoplayElements = new WeakSet();
         this.videoPlaybackEnabled = false;
-        this.videoAutoplayEnabled = true;
+        this.videoAutoplayEnabled = false;
     }
 
     init() {
@@ -82,22 +82,20 @@ export class WebTelemetry extends ContentFeature {
         this.messaging.notify(MSG_VIDEO_PLAYBACK, message);
     }
 
-    fireTelemetryForVideoAutoplay(video) {
+    reportAutoplay(video) {
         if (this.reportedAutoplayElements.has(video)) {
             return; // report each element once
         }
         this.reportedAutoplayElements.add(video);
-        const message = {
-            userInteraction: navigator.userActivation.isActive,
-        };
-        this.messaging.notify(MSG_VIDEO_AUTOPLAY, message);
+        this.messaging.notify(MSG_VIDEO_AUTOPLAY);
     }
 
     addPlayObserver(video) {
-        // Reported on sight, so an element that never starts is still counted.
-        // Safe to re-run: fireTelemetryForVideoAutoplay dedupes per element.
-        if (this.videoAutoplayEnabled && video.hasAttribute('autoplay')) {
-            this.fireTelemetryForVideoAutoplay(video);
+        // Declarative autoplay, reported on sight so an element that never starts is
+        // still counted. `video.autoplay` covers both the HTML attribute and a JS
+        // property assignment. Safe to re-run: reportAutoplay dedupes per element.
+        if (this.videoAutoplayEnabled && video.autoplay) {
+            this.reportAutoplay(video);
         }
         if (this.seenVideoElements.has(video)) {
             return; // already observed
@@ -107,9 +105,9 @@ export class WebTelemetry extends ContentFeature {
             if (this.videoPlaybackEnabled) {
                 this.fireTelemetryForVideo(video);
             }
-            // Catches script-driven playback that carries no autoplay attribute.
+            // Script-driven autoplay: playback that started without a user gesture.
             if (this.videoAutoplayEnabled && !navigator.userActivation.isActive) {
-                this.fireTelemetryForVideoAutoplay(video);
+                this.reportAutoplay(video);
             }
         });
     }
@@ -144,8 +142,9 @@ export class WebTelemetry extends ContentFeature {
 
         this.addListenersToAllVideos(documentBody);
 
-        // Backfill: fire telemetry for already playing videos. Playback only —
-        // these started before we could observe their attributes or activation.
+        // Backfill: fire telemetry for already playing videos. Playback only — their
+        // `play` event already fired, so script-driven autoplay can't be detected here.
+        // The declarative case is covered by addListenersToAllVideos above.
         documentBody.querySelectorAll('video').forEach((video) => {
             if (this.videoPlaybackEnabled && !video.paused && !video.ended) {
                 this.fireTelemetryForVideo(video);

--- a/injected/src/features/web-telemetry.js
+++ b/injected/src/features/web-telemetry.js
@@ -5,6 +5,7 @@ import ContentFeature from '../content-feature.js';
  */
 
 const MSG_VIDEO_PLAYBACK = 'video-playback';
+const MSG_VIDEO_AUTOPLAY = 'video-autoplay';
 const MSG_URL_CHANGED = 'url-changed';
 
 export class WebTelemetry extends ContentFeature {
@@ -14,10 +15,18 @@ export class WebTelemetry extends ContentFeature {
         super(featureName, importConfig, features, args);
         this.seenVideoElements = new WeakSet();
         this.seenVideoUrls = new Set();
+        // Kept separate from the dedupe above, so neither message suppresses the other.
+        this.reportedAutoplayElements = new WeakSet();
+        this.videoPlaybackEnabled = false;
+        this.videoAutoplayEnabled = true;
     }
 
     init() {
-        if (this.getFeatureSettingEnabled('videoPlayback')) {
+        this.videoPlaybackEnabled = this.getFeatureSettingEnabled('videoPlayback');
+        // TEMPORARY: defaulted on so autoplay telemetry fires without a config change.
+        // Revert to `this.getFeatureSettingEnabled('videoAutoplay')` before merging.
+        this.videoAutoplayEnabled = this.getFeatureSettingEnabled('videoAutoplay', 'enabled');
+        if (this.videoPlaybackEnabled || this.videoAutoplayEnabled) {
             this.videoPlaybackObserve();
         }
     }
@@ -73,12 +82,36 @@ export class WebTelemetry extends ContentFeature {
         this.messaging.notify(MSG_VIDEO_PLAYBACK, message);
     }
 
+    fireTelemetryForVideoAutoplay(video) {
+        if (this.reportedAutoplayElements.has(video)) {
+            return; // report each element once
+        }
+        this.reportedAutoplayElements.add(video);
+        const message = {
+            userInteraction: navigator.userActivation.isActive,
+        };
+        this.messaging.notify(MSG_VIDEO_AUTOPLAY, message);
+    }
+
     addPlayObserver(video) {
+        // Reported on sight, so an element that never starts is still counted.
+        // Safe to re-run: fireTelemetryForVideoAutoplay dedupes per element.
+        if (this.videoAutoplayEnabled && video.hasAttribute('autoplay')) {
+            this.fireTelemetryForVideoAutoplay(video);
+        }
         if (this.seenVideoElements.has(video)) {
             return; // already observed
         }
         this.seenVideoElements.add(video);
-        video.addEventListener('play', () => this.fireTelemetryForVideo(video));
+        video.addEventListener('play', () => {
+            if (this.videoPlaybackEnabled) {
+                this.fireTelemetryForVideo(video);
+            }
+            // Catches script-driven playback that carries no autoplay attribute.
+            if (this.videoAutoplayEnabled && !navigator.userActivation.isActive) {
+                this.fireTelemetryForVideoAutoplay(video);
+            }
+        });
     }
 
     addListenersToAllVideos(node) {
@@ -111,9 +144,10 @@ export class WebTelemetry extends ContentFeature {
 
         this.addListenersToAllVideos(documentBody);
 
-        // Backfill: fire telemetry for already playing videos
+        // Backfill: fire telemetry for already playing videos. Playback only —
+        // these started before we could observe their attributes or activation.
         documentBody.querySelectorAll('video').forEach((video) => {
-            if (!video.paused && !video.ended) {
+            if (this.videoPlaybackEnabled && !video.paused && !video.ended) {
                 this.fireTelemetryForVideo(video);
             }
         });
@@ -130,6 +164,9 @@ export class WebTelemetry extends ContentFeature {
                             }
                         }
                     });
+                } else if (mutation.type === 'attributes' && mutation.target.tagName === 'VIDEO') {
+                    // `autoplay` set by JS after insertion.
+                    this.addPlayObserver(mutation.target);
                 }
             }
         };
@@ -137,6 +174,8 @@ export class WebTelemetry extends ContentFeature {
         observer.observe(documentBody, {
             childList: true,
             subtree: true,
+            attributes: true,
+            attributeFilter: ['autoplay'],
         });
     }
 }

--- a/injected/src/features/web-telemetry.js
+++ b/injected/src/features/web-telemetry.js
@@ -15,7 +15,6 @@ export class WebTelemetry extends ContentFeature {
         super(featureName, importConfig, features, args);
         this.seenVideoElements = new WeakSet();
         this.seenVideoUrls = new Set();
-        // Kept separate from the dedupe above, so neither message suppresses the other.
         this.reportedAutoplayElements = new WeakSet();
         this.videoPlaybackEnabled = false;
         this.videoAutoplayEnabled = false;
@@ -84,16 +83,14 @@ export class WebTelemetry extends ContentFeature {
 
     reportAutoplay(video) {
         if (this.reportedAutoplayElements.has(video)) {
-            return; // report each element once
+            return;
         }
         this.reportedAutoplayElements.add(video);
         this.messaging.notify(MSG_VIDEO_AUTOPLAY);
     }
 
     addPlayObserver(video) {
-        // Declarative autoplay, reported on sight so an element that never starts is
-        // still counted. `video.autoplay` covers both the HTML attribute and a JS
-        // property assignment. Safe to re-run: reportAutoplay dedupes per element.
+        // `video.autoplay` covers both the HTML attribute and a JS property assignment.
         if (this.videoAutoplayEnabled && video.autoplay) {
             this.reportAutoplay(video);
         }
@@ -105,7 +102,6 @@ export class WebTelemetry extends ContentFeature {
             if (this.videoPlaybackEnabled) {
                 this.fireTelemetryForVideo(video);
             }
-            // Script-driven autoplay: playback that started without a user gesture.
             if (this.videoAutoplayEnabled && !navigator.userActivation.isActive) {
                 this.reportAutoplay(video);
             }
@@ -142,9 +138,7 @@ export class WebTelemetry extends ContentFeature {
 
         this.addListenersToAllVideos(documentBody);
 
-        // Backfill: fire telemetry for already playing videos. Playback only — their
-        // `play` event already fired, so script-driven autoplay can't be detected here.
-        // The declarative case is covered by addListenersToAllVideos above.
+        // Backfill: fire telemetry for already playing videos
         documentBody.querySelectorAll('video').forEach((video) => {
             if (this.videoPlaybackEnabled && !video.paused && !video.ended) {
                 this.fireTelemetryForVideo(video);


### PR DESCRIPTION
**Asana Task/Github Issue:** <!-- Link to Asana Task/Github Issue -->
https://app.asana.com/1/137249556945/project/1211150618152277/task/1217376780027469?focus=true

## Description
This PR implements a new Web Telemetry message, `video-autoplay`, posted whenever:

1. Video with the `autoplay` HTML attribute is detected (OR)
2. A `play()` invocation is detected, that wasn't triggered via User Interaction

## Testing Steps

These changes have been included in the latest demo binary for the `Video Autoplay Promo Ship Review`.
Link to the binary, along with Testing Steps, can be found here:

https://app.asana.com/1/137249556945/project/72649045549333/task/1217249937058591?focus=true

Thanks a lot!!

## Checklist

<!--
  These questions are a friendly reminder to shipping code, if you're uncertain ask the AoR owners.
  It's also totally appropriate to not check some of these boxes, if they don't apply to your change.
-->
*Please tick all that apply:*

- [ ] I have tested this change locally
- [ ] I have tested this change locally in all supported browsers
- [ ] This change will be visible to users
- [ ] I have added automated tests that cover this change
- [ ] I have ensured the change is gated by config
- [ ] This change was covered by a ship review
- [ ] This change was covered by a tech design
- [ ] Any dependent config has been merged


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Expands injected-page DOM observation and emits a new telemetry message; the temporary default-on `videoAutoplay` setting increases exposure until reverted before merge.
> 
> **Overview**
> Adds a separate **video autoplay** telemetry path alongside existing video playback reporting, gated by a new `videoAutoplay` web telemetry setting (integration test config updated accordingly).
> 
> When autoplay telemetry is on, each `<video>` can emit a one-time `video-autoplay` message: for **declarative** autoplay (`video.autoplay` on observe, including after a JS `autoplay` attribute change via a new `MutationObserver` on `autoplay`), and for **script-driven** autoplay when `play` fires without `navigator.userActivation`. Autoplay uses its own per-element dedupe so it does not suppress playback events; playback backfill and `play` handlers now only send `video-playback` when `videoPlayback` is enabled.
> 
> **Note:** `videoAutoplay` is temporarily read with a default of `enabled` in `init()` (comment says to revert before merge), so autoplay may fire even without remote config until that is removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3e89f644786258e8d9709e9765373d4e6cfe3a19. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->