### PR TITLE
web-telemetry: scope autoplay detection to per-element observers

### DIFF
--- a/injected/src/features/web-telemetry.js
+++ b/injected/src/features/web-telemetry.js
@@ -104,6 +104,17 @@ export class WebTelemetry extends ContentFeature {
                 this.reportAutoplay(video);
             }
         });
+        // Watch this element's own `autoplay` attribute rather than the whole document subtree,
+        // so autoplay detection never observes attributes across the page.
+        if (this.videoAutoplayEnabled && !this.reportedAutoplayElements.has(video)) {
+            const attributeObserver = new MutationObserver(() => {
+                if (video.autoplay) {
+                    this.reportAutoplay(video);
+                    attributeObserver.disconnect();
+                }
+            });
+            attributeObserver.observe(video, { attributes: true, attributeFilter: ['autoplay'] });
+        }
     }
 
     addListenersToAllVideos(node) {
@@ -155,9 +166,6 @@ export class WebTelemetry extends ContentFeature {
                             }
                         }
                     });
-                } else if (mutation.type === 'attributes' && mutation.target.tagName === 'VIDEO') {
-                    // `autoplay` set by JS after insertion.
-                    this.addPlayObserver(mutation.target);
                 }
             }
         };
@@ -165,8 +173,6 @@ export class WebTelemetry extends ContentFeature {
         observer.observe(documentBody, {
             childList: true,
             subtree: true,
-            attributes: true,
-            attributeFilter: ['autoplay'],
         });
     }
 }

--- a/injected/src/features/web-telemetry.js
+++ b/injected/src/features/web-telemetry.js
@@ -16,6 +16,7 @@ export class WebTelemetry extends ContentFeature {
         this.seenVideoElements = new WeakSet();
         this.seenVideoUrls = new Set();
         this.reportedAutoplayElements = new WeakSet();
+        this.autoplayObservers = new WeakMap();
         this.videoPlaybackEnabled = false;
         this.videoAutoplayEnabled = false;
     }
@@ -84,6 +85,8 @@ export class WebTelemetry extends ContentFeature {
             return;
         }
         this.reportedAutoplayElements.add(video);
+        this.autoplayObservers.get(video)?.disconnect();
+        this.autoplayObservers.delete(video);
         this.messaging.notify(MSG_VIDEO_AUTOPLAY);
     }
 
@@ -110,10 +113,10 @@ export class WebTelemetry extends ContentFeature {
             const attributeObserver = new MutationObserver(() => {
                 if (video.autoplay) {
                     this.reportAutoplay(video);
-                    attributeObserver.disconnect();
                 }
             });
             attributeObserver.observe(video, { attributes: true, attributeFilter: ['autoplay'] });
+            this.autoplayObservers.set(video, attributeObserver);
         }
     }
 


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/414709148257752/task/1217491870935694?focus=true

## Description

#2950 made web-telemetry watch the `autoplay` attribute across the whole page.

This watches each `<video>`'s own `autoplay` attribute instead, so detection still works without observing the whole page.

## Testing Steps

-

## Checklist

- [x] I have tested this change locally
- [x] I have ensured the change is gated by config

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Telemetry-only change behind feature config; narrows DOM observation scope without touching auth or data handling.
> 
> **Overview**
> **Autoplay telemetry** no longer uses a document-level `MutationObserver` on the whole body subtree for the `autoplay` attribute (introduced in #2950). Each `<video>` now gets its own observer in `addPlayObserver`, stored in `autoplayObservers` and torn down in `reportAutoplay`.
> 
> The root observer in `setup()` only watches **childList** for new videos; attribute-based autoplay (e.g. JS setting `autoplay` after insert) is handled per element. Behavior stays behind the existing `videoAutoplay` config gate.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d342c40ace7127ce0582faf9f3ef67f46b9b8e97. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->