### PR TITLE
Use Anthropic tool_use for semver classification instead of JSON parsing

### DIFF
--- a/.github/scripts/semver-analysis.mjs
+++ b/.github/scripts/semver-analysis.mjs
@@ -27,6 +27,32 @@ const ANTHROPIC_API_URL = 'https://api.anthropic.com/v1/messages';
 const MAX_BUILD_DIFF_CHARS = 80_000;
 const MAX_SOURCE_DIFF_CHARS = 80_000;
 
+export const SEVERITY_VALUES = ['major', 'minor', 'patch'];
+const SEVERITY_VALUE_SET = new Set(SEVERITY_VALUES);
+export const SUBMIT_SEVERITY_TOOL_NAME = 'submit_severity';
+export const SUBMIT_SEVERITY_TOOL = {
+    name: SUBMIT_SEVERITY_TOOL_NAME,
+    description:
+        'Submit the semver classification for this PR. ' +
+        'Call this tool exactly once with your final classification. Do not include any other text or reasoning in your response.',
+    input_schema: {
+        type: 'object',
+        properties: {
+            severity: {
+                type: 'string',
+                enum: SEVERITY_VALUES,
+                description: 'The semver impact of this PR.',
+            },
+            reasoning: {
+                type: 'string',
+                description: '2-3 concise sentences explaining the classification.',
+            },
+        },
+        required: ['severity', 'reasoning'],
+        additionalProperties: false,
+    },
+};
+
 const SYSTEM_PROMPT = `You are a semver classification expert for the duckduckgo/content-scope-scripts repository.
 
 This is an npm workspace monorepo that ships privacy features and special pages to DuckDuckGo's native apps (macOS, Windows, iOS, Android). Downstream consumers integrate via npm, Swift Package Manager, and git submodules.
@@ -86,7 +112,7 @@ You also receive a **source diff** (unified git diff between base and PR) and th
 - No new entries in \`platformSupport\` or \`platformSpecificFeatures\`
 - OR source changes are limited to docs, tests, CI/tooling, or dependency updates with no semver-sensitive API changes (even when build output is unchanged)
 
-Always respond with valid JSON: { "severity": "major"|"minor"|"patch", "reasoning": "..." }
+Submit your classification by calling the ${SUBMIT_SEVERITY_TOOL_NAME} tool exactly once with both required arguments.
 The reasoning should be 2-3 concise sentences explaining the classification.`;
 
 function truncateDiff(diff, maxChars) {
@@ -127,7 +153,7 @@ ${formatBuildDiffSection(buildDiff)}
 ## Source Diff
 ${formatSourceDiffSection(sourceDiff)}
 
-Respond with JSON only: { "severity": "major"|"minor"|"patch", "reasoning": "..." }`;
+Submit your classification by calling the ${SUBMIT_SEVERITY_TOOL_NAME} tool.`;
 }
 
 export { buildUserPrompt, formatBuildDiffSection, formatSourceDiffSection };
@@ -142,8 +168,10 @@ async function callAnthropic(systemPrompt, userPrompt, apiKey) {
         },
         body: JSON.stringify({
             model: resolveAnthropicModel(),
-            max_tokens: 512,
+            max_tokens: 1024,
             system: systemPrompt,
+            tools: [SUBMIT_SEVERITY_TOOL],
+            tool_choice: { type: 'tool', name: SUBMIT_SEVERITY_TOOL_NAME, disable_parallel_tool_use: true },
             messages: [{ role: 'user', content: userPrompt }],
         }),
     });
@@ -153,25 +181,60 @@ async function callAnthropic(systemPrompt, userPrompt, apiKey) {
         throw new Error(`Anthropic API error ${response.status}: ${text}`);
     }
 
-    const data = await response.json();
-    const content = data.content?.[0]?.text;
-    if (!content) {
-        throw new Error('Empty response from Anthropic API');
-    }
-    return content;
+    return response.json();
 }
 
-function parseResponse(text) {
-    const jsonMatch = text.match(/\{[\s\S]*\}/);
-    if (!jsonMatch) {
-        throw new Error(`Could not extract JSON from LLM response: ${text}`);
+/**
+ * Extracts the severity classification from an Anthropic response that used
+ * the `submit_severity` tool.
+ *
+ * The model is bound to a single forced tool call via `tool_choice`, so the
+ * classification arrives as structured `tool_use` input rather than as JSON
+ * embedded in free-form text. That removes the whole class of failure the
+ * previous text parser had — a model-emitted trailing comma, a code fence, or
+ * a stray prose sentence around the object used to fail `JSON.parse` and take
+ * the job down even though the classification itself was correct.
+ *
+ * `severity` is validated strictly because the workflow acts on it. `reasoning`
+ * is only logged, so a missing one falls back to an empty string rather than
+ * failing the job over a cosmetic field.
+ *
+ * @param {unknown} response
+ */
+export function extractSeverityFromAnthropicResponse(response) {
+    if (!response || typeof response !== 'object') {
+        throw new Error(`Anthropic response had no content array: ${JSON.stringify(response)}`);
     }
-    const parsed = JSON.parse(jsonMatch[0]);
-    const severity = parsed.severity?.toLowerCase();
-    if (!['major', 'minor', 'patch'].includes(severity)) {
-        throw new Error(`Invalid severity "${parsed.severity}" in LLM response`);
+    const { content, stop_reason: stopReason } = /** @type {{content?: unknown, stop_reason?: string}} */ (response);
+    if (!Array.isArray(content)) {
+        throw new Error(`Anthropic response had no content array: ${JSON.stringify(response)}`);
     }
-    return { severity, reasoning: parsed.reasoning || '' };
+
+    const toolUses = content.filter((block) => block && block.type === 'tool_use');
+    if (toolUses.length === 0) {
+        if (stopReason === 'max_tokens') {
+            throw new Error(`Anthropic response hit max_tokens before completing the ${SUBMIT_SEVERITY_TOOL_NAME} call`);
+        }
+        throw new Error(`Anthropic response did not call ${SUBMIT_SEVERITY_TOOL_NAME}: ${JSON.stringify(content)}`);
+    }
+    if (toolUses.length > 1) {
+        throw new Error(`Anthropic response called ${toolUses.length} tools; expected exactly one ${SUBMIT_SEVERITY_TOOL_NAME} call`);
+    }
+
+    const [toolUse] = toolUses;
+    if (toolUse.name !== SUBMIT_SEVERITY_TOOL_NAME) {
+        throw new Error(`Anthropic response called unexpected tool '${toolUse.name}'; expected '${SUBMIT_SEVERITY_TOOL_NAME}'`);
+    }
+    const input = toolUse.input;
+    if (input === null || typeof input !== 'object' || Array.isArray(input)) {
+        throw new Error(`${SUBMIT_SEVERITY_TOOL_NAME} input was not an object: ${JSON.stringify(input)}`);
+    }
+
+    const severity = typeof input.severity === 'string' ? input.severity.toLowerCase() : input.severity;
+    if (typeof severity !== 'string' || !SEVERITY_VALUE_SET.has(severity)) {
+        throw new Error(`${SUBMIT_SEVERITY_TOOL_NAME} input has invalid severity: ${JSON.stringify(input)}`);
+    }
+    return { severity, reasoning: typeof input.reasoning === 'string' ? input.reasoning : '' };
 }
 
 async function main() {
@@ -188,8 +251,8 @@ async function main() {
     const files = process.env.PR_FILES || '';
 
     const userPrompt = buildUserPrompt({ buildDiff, sourceDiff, title, body, files });
-    const rawResponse = await callAnthropic(SYSTEM_PROMPT, userPrompt, apiKey);
-    const result = parseResponse(rawResponse);
+    const response = await callAnthropic(SYSTEM_PROMPT, userPrompt, apiKey);
+    const result = extractSeverityFromAnthropicResponse(response);
 
     console.log(JSON.stringify(result));
 }

--- a/.github/scripts/semver-analysis.test.mjs
+++ b/.github/scripts/semver-analysis.test.mjs
@@ -1,7 +1,30 @@
 import assert from 'node:assert/strict';
 import { test } from 'node:test';
 
-import { buildUserPrompt, formatBuildDiffSection, formatSourceDiffSection } from './semver-analysis.mjs';
+import {
+    buildUserPrompt,
+    extractSeverityFromAnthropicResponse,
+    formatBuildDiffSection,
+    formatSourceDiffSection,
+    SUBMIT_SEVERITY_TOOL,
+    SUBMIT_SEVERITY_TOOL_NAME,
+} from './semver-analysis.mjs';
+
+/**
+ * Builds a minimal Anthropic response carrying a single `submit_severity`
+ * tool call. `input` is deliberately loose so tests can pass malformed values.
+ *
+ * @param {unknown} input
+ * @param {Record<string, unknown>} [extra]
+ * @returns {{stop_reason: string, content: any[]}}
+ */
+function toolUseResponse(input, extra = {}) {
+    return {
+        stop_reason: 'tool_use',
+        content: [{ type: 'tool_use', id: 'toolu_123', name: SUBMIT_SEVERITY_TOOL_NAME, input }],
+        ...extra,
+    };
+}
 
 test('formatBuildDiffSection explains when build output is unchanged', () => {
     assert.match(formatBuildDiffSection(''), /no build output artifacts changed/);
@@ -28,4 +51,83 @@ test('buildUserPrompt includes build and source diff sections', () => {
     assert.match(prompt, /Source Diff/);
     assert.match(prompt, /diff --git a\/\.github\/scripts\/foo\.mjs/);
     assert.match(prompt, /Changed Source Files/);
+});
+
+test('buildUserPrompt asks for the classification via the tool', () => {
+    const prompt = buildUserPrompt({ buildDiff: '', sourceDiff: '', title: 't', body: '', files: '' });
+
+    assert.match(prompt, new RegExp(SUBMIT_SEVERITY_TOOL_NAME));
+});
+
+test('submit_severity tool constrains the classification to the three severities', () => {
+    assert.deepEqual(SUBMIT_SEVERITY_TOOL.input_schema.properties.severity.enum, ['major', 'minor', 'patch']);
+    assert.deepEqual(SUBMIT_SEVERITY_TOOL.input_schema.required, ['severity', 'reasoning']);
+    assert.equal(SUBMIT_SEVERITY_TOOL.input_schema.additionalProperties, false);
+});
+
+test('extractSeverityFromAnthropicResponse reads the forced tool call', () => {
+    const result = extractSeverityFromAnthropicResponse(toolUseResponse({ severity: 'minor', reasoning: 'Adds a new feature file.' }));
+
+    assert.deepEqual(result, { severity: 'minor', reasoning: 'Adds a new feature file.' });
+});
+
+test('extractSeverityFromAnthropicResponse ignores text blocks alongside the tool call', () => {
+    const response = toolUseResponse({ severity: 'major', reasoning: 'Removes a build artifact.' });
+    response.content.unshift({ type: 'text', text: '{"severity": "patch", "reasoning": "not the answer", }' });
+
+    // The trailing comma in that text block is exactly what used to crash the
+    // regex + JSON.parse reader; the structured tool input is authoritative now.
+    assert.deepEqual(extractSeverityFromAnthropicResponse(response), {
+        severity: 'major',
+        reasoning: 'Removes a build artifact.',
+    });
+});
+
+test('extractSeverityFromAnthropicResponse normalises severity case', () => {
+    const result = extractSeverityFromAnthropicResponse(toolUseResponse({ severity: 'PATCH', reasoning: 'Docs only.' }));
+
+    assert.equal(result.severity, 'patch');
+});
+
+test('extractSeverityFromAnthropicResponse tolerates missing reasoning', () => {
+    const result = extractSeverityFromAnthropicResponse(toolUseResponse({ severity: 'patch' }));
+
+    assert.deepEqual(result, { severity: 'patch', reasoning: '' });
+});
+
+test('extractSeverityFromAnthropicResponse rejects an invalid severity', () => {
+    assert.throws(
+        () => extractSeverityFromAnthropicResponse(toolUseResponse({ severity: 'breaking', reasoning: 'x' })),
+        /invalid severity/,
+    );
+});
+
+test('extractSeverityFromAnthropicResponse rejects malformed responses', () => {
+    assert.throws(() => extractSeverityFromAnthropicResponse(null), /no content array/);
+    assert.throws(() => extractSeverityFromAnthropicResponse({}), /no content array/);
+    assert.throws(
+        () => extractSeverityFromAnthropicResponse({ content: [{ type: 'text', text: 'minor' }] }),
+        /did not call submit_severity/,
+    );
+    assert.throws(
+        () => extractSeverityFromAnthropicResponse({ stop_reason: 'max_tokens', content: [{ type: 'text', text: '' }] }),
+        /hit max_tokens/,
+    );
+    assert.throws(
+        () => extractSeverityFromAnthropicResponse({ content: [{ type: 'tool_use', name: 'something_else', input: {} }] }),
+        /unexpected tool 'something_else'/,
+    );
+    assert.throws(() => extractSeverityFromAnthropicResponse(toolUseResponse('minor')), /input was not an object/);
+});
+
+test('extractSeverityFromAnthropicResponse rejects more than one tool call', () => {
+    const response = toolUseResponse({ severity: 'minor', reasoning: 'x' });
+    response.content.push({
+        type: 'tool_use',
+        id: 'toolu_456',
+        name: SUBMIT_SEVERITY_TOOL_NAME,
+        input: { severity: 'major', reasoning: 'y' },
+    });
+
+    assert.throws(() => extractSeverityFromAnthropicResponse(response), /called 2 tools/);
 });


### PR DESCRIPTION
## Description

Refactors the semver classification workflow to use Anthropic's structured tool calling (`submit_severity` tool) instead of parsing JSON from free-form text responses. This eliminates a class of parsing failures where model-emitted trailing commas, code fences, or prose around the JSON object would cause `JSON.parse` to fail even when the classification itself was correct.

**Key changes:**
- Defines `SUBMIT_SEVERITY_TOOL` with strict input schema (`severity` enum, required `reasoning`)
- Configures `callAnthropic()` to force a single tool call via `tool_choice`
- Replaces `parseResponse()` with `extractSeverityFromAnthropicResponse()` that reads structured tool input
- Updates system and user prompts to direct the model to use the tool instead of returning JSON
- Increases `max_tokens` from 512 to 1024 to accommodate tool use response format

The tool input is validated strictly (severity must be one of `major`/`minor`/`patch`), while `reasoning` gracefully falls back to an empty string if missing.

## Testing Steps

- Added comprehensive unit tests covering:
  - Tool definition and schema constraints
  - Extraction of severity from valid tool responses
  - Case normalization and missing reasoning handling
  - Rejection of invalid severities and malformed responses
  - Edge cases (text blocks alongside tool calls, multiple tool calls, max_tokens limit)
- All new tests pass; existing tests remain unaffected

## Checklist

- [x] I have tested this change locally
- [x] I have added automated tests that cover this change

https://claude.ai/code/session_01VXKd9pZayHD87wzdUGvge5

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only scripting change with no product API or build artifact impact; regression risk is limited to the semver automation path.
> 
> **Overview**
> The semver LLM judge in **`semver-analysis.mjs`** no longer asks the model for JSON in free text and parses it with regex + **`JSON.parse`**. It now defines a **`submit_severity`** tool ( **`severity`** enum + **`reasoning`** ), forces a single call via **`tool_choice`**, and reads the result from **`extractSeverityFromAnthropicResponse`**.
> 
> **`severity`** stays strictly validated; **`reasoning`** can default to empty. Prompts point the model at the tool instead of “JSON only”. **`max_tokens`** rises from 512 to 1024 for tool responses.
> 
> **`semver-analysis.test.mjs`** adds coverage for the tool schema, extraction, malformed responses, and the case where invalid JSON in a text block no longer breaks the job.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 607899cf4979a66229ba283070215d1aa504414f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->