### PR TITLE
fix(NTP): restore native scrollbar on macOS

### DIFF
--- a/special-pages/pages/new-tab/app/components/App.module.css
+++ b/special-pages/pages/new-tab/app/components/App.module.css
@@ -103,8 +103,8 @@ body[data-rebrand="true"] {
 }
 
 .mainScroller {
-    /* macOS keeps the native overlay scrollbar (auto-hides); Windows has no
-       native overlay style, so it keeps this thin custom one. */
+    /* Windows keeps the custom scrollbar; macOS falls back to native.
+       https://app.asana.com/1/137249556945/project/1176956903599313/task/1217462538495084 */
     :root:has(body[data-platform-name="windows"]) & {
         &::-webkit-scrollbar {
             width: 4px;

--- a/special-pages/pages/new-tab/app/components/App.module.css
+++ b/special-pages/pages/new-tab/app/components/App.module.css
@@ -103,17 +103,21 @@ body[data-rebrand="true"] {
 }
 
 .mainScroller {
-    &::-webkit-scrollbar {
-        width: 4px;
-    }
+    /* macOS keeps the native overlay scrollbar (auto-hides); Windows has no
+       native overlay style, so it keeps this thin custom one. */
+    :root:has(body[data-platform-name="windows"]) & {
+        &::-webkit-scrollbar {
+            width: 4px;
+        }
 
-    &::-webkit-scrollbar-track {
-        border-radius: 6px;
-    }
+        &::-webkit-scrollbar-track {
+            border-radius: 6px;
+        }
 
-    &::-webkit-scrollbar-thumb {
-        background: rgb(108, 108, 108);
-        border-radius: 6px;
+        &::-webkit-scrollbar-thumb {
+            background: rgb(108, 108, 108);
+            border-radius: 6px;
+        }
     }
 }
 


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1176956903599313/task/1217462538495084

## Description

The custom `::-webkit-scrollbar` styling in `.mainScroller` (`App.module.css`) was applied unconditionally, overriding macOS's native auto-hiding overlay scrollbar. Scoped it to `platform="windows"` only, since Windows has no equivalent native overlay style. macOS now falls back to the native scrollbar.

## Testing Steps

<img width="1149" height="917" alt="scroll-mac" src="https://github.com/user-attachments/assets/7fc5e871-baa7-4548-9ddb-aa06fdbcd14c" />

Before on MacOS: thin Scrollbar that doesn't autohide:
<img width="580" height="821" alt="Screenshot 2026-08-19 at 10 54 11" src="https://github.com/user-attachments/assets/2c364e26-b454-4b6d-bca5-23d272968683" />

Native that follows macOS settings:
<img width="921" height="813" alt="Screenshot 2026-08-19 at 10 57 40" src="https://github.com/user-attachments/assets/64d33d02-290d-4fbb-900e-acd2545c67e7" />


1. `cd special-pages && npm run watch -- --page=new-tab`
2. Open `http://127.0.0.1:8000/?platform=macos` . Resize the window/zoom so content overflows, scroll. No persistent scrollbar, native overlay behavior.
3. Open `http://127.0.0.1:8000/?platform=windows`. Thin custom scrollbar still shows, unchanged.

## Checklist

- [x] I have tested this change locally
- [x] I have tested this change locally in all supported browsers
- [x] This change will be visible to users
- [ ] I have added automated tests that cover this change
- [ ] I have ensured the change is gated by config
- [ ] This change was covered by a ship review
- [ ] This change was covered by a tech design
- [ ] Any dependent config has been merged


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS-only, platform-scoped scrollbar styling on NTP with no auth, data, or business-logic impact.
> 
> **Overview**
> **Restores macOS native overlay scrollbars** on the new tab main scroll area by no longer applying custom `::-webkit-scrollbar` rules globally.
> 
> The thin gray custom scrollbar on `.mainScroller` in `App.module.css` is now gated with `:root:has(body[data-platform-name="windows"])` — the same platform attribute pattern used elsewhere on NTP. **Windows** keeps the 4px styled scrollbar; **macOS** (and other platforms) no longer get those overrides, so scrolling can use system auto-hiding behavior and user scrollbar settings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 31e2189a8a67e72ae24d828a4f959286a292ece4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


