### PR TITLE
Strip invisible format characters from page context collection

### DIFF
--- a/injected/src/features/page-context.js
+++ b/injected/src/features/page-context.js
@@ -27,9 +27,70 @@ export function checkNodeIsVisible(node) {
     }
 }
 
+const RE_DEFAULT_IGNORABLE = /^\p{Default_Ignorable_Code_Point}$/u;
+const RE_LATIN = /^\p{Script=Latin}$/u;
+const RE_ARABIC = /^\p{Script=Arabic}$/u;
+const RE_EMOJI = /^\p{Extended_Pictographic}$/u;
+const RE_EMOJI_PROP = /^\p{Emoji}$/u;
+
 /**
- * Strip Unicode default-ignorable code points (ZWSP, ZWNJ, ZWJ, WJ, BOM, soft hyphen,
- * Tags U+E0000–E007F, …) and C0/C1 controls other than tab/newline/carriage-return.
+ * @param {number} cp
+ * @returns {boolean}
+ */
+function isZeroWidthJoinerOrNonJoiner(cp) {
+    return cp === 0x200c || cp === 0x200d;
+}
+
+/**
+ * @param {number} cp
+ * @returns {boolean}
+ */
+function isVariationSelector(cp) {
+    return cp >= 0xfe00 && cp <= 0xfe0f;
+}
+
+/**
+ * @param {number} cp
+ * @returns {boolean}
+ */
+function isEmojiModifier(cp) {
+    return cp >= 0x1f3fb && cp <= 0x1f3ff;
+}
+
+/**
+ * @param {string | null} ch
+ * @returns {boolean}
+ */
+function isEmojiRelatedClusterChar(ch) {
+    if (!ch) {
+        return false;
+    }
+    const cp = /** @type {number} */ (ch.codePointAt(0));
+    return isZeroWidthJoinerOrNonJoiner(cp) || isVariationSelector(cp) || isEmojiModifier(cp) || RE_EMOJI.test(ch) || RE_EMOJI_PROP.test(ch);
+}
+
+/**
+ * Nearest scalar that is not a joiner / variation selector (skips emoji cluster glue).
+ * @param {string[]} chars
+ * @param {number} index
+ * @param {number} direction
+ * @returns {string | null}
+ */
+function findScriptNeighbor(chars, index, direction) {
+    for (let j = index + direction; j >= 0 && j < chars.length; j += direction) {
+        const ch = chars[j];
+        const cp = /** @type {number} */ (ch.codePointAt(0));
+        if (isZeroWidthJoinerOrNonJoiner(cp) || isVariationSelector(cp)) {
+            continue;
+        }
+        return ch;
+    }
+    return null;
+}
+
+/**
+ * Keep ZWNJ/ZWJ for Arabic/Persian shaping and ZWJ/VS for emoji; strip when used
+ * next to Latin (anti-smuggling). All other default-ignorables (Tags, ZWSP, …) go.
  * Aligns with Apple `removingInvisibleFormatCharacters()`.
  * @param {string} str
  * @returns {string}
@@ -38,9 +99,54 @@ export function stripInvisibleFormatCharacters(str) {
     if (typeof str !== 'string' || str.length === 0) {
         return typeof str === 'string' ? str : '';
     }
-    return str
-        .replace(/\p{Default_Ignorable_Code_Point}/gu, '')
-        .replace(/[\u0000-\u0008\u000B\u000C\u000E-\u001F\u007F-\u009F]/g, '');
+
+    const chars = Array.from(str);
+    let out = '';
+
+    for (let i = 0; i < chars.length; i++) {
+        const ch = chars[i];
+        const cp = /** @type {number} */ (ch.codePointAt(0));
+
+        // Keep tab / LF / CR; drop other C0/C1 controls
+        if (cp <= 0x1f || (cp >= 0x7f && cp <= 0x9f)) {
+            if (cp === 0x09 || cp === 0x0a || cp === 0x0d) {
+                out += ch;
+            }
+            continue;
+        }
+
+        if (!RE_DEFAULT_IGNORABLE.test(ch)) {
+            out += ch;
+            continue;
+        }
+
+        const isJoiner = isZeroWidthJoinerOrNonJoiner(cp);
+        const isVS = isVariationSelector(cp);
+        if (!isJoiner && !isVS) {
+            continue;
+        }
+
+        const prev = findScriptNeighbor(chars, i, -1);
+        const next = findScriptNeighbor(chars, i, 1);
+
+        // Latin-adjacent joiners are smuggling / confusable — always strip
+        if ((prev && RE_LATIN.test(prev)) || (next && RE_LATIN.test(next))) {
+            continue;
+        }
+
+        // Persian / Arabic orthography (نیم‌فاصله etc.)
+        if (isJoiner && ((prev && RE_ARABIC.test(prev)) || (next && RE_ARABIC.test(next)))) {
+            out += ch;
+            continue;
+        }
+
+        // Emoji ZWJ sequences + emoji presentation VS16
+        if ((isJoiner || isVS) && (isEmojiRelatedClusterChar(prev) || isEmojiRelatedClusterChar(next))) {
+            out += ch;
+        }
+    }
+
+    return out;
 }
 
 function collapseWhitespace(str) {

--- a/injected/src/features/page-context.js
+++ b/injected/src/features/page-context.js
@@ -27,8 +27,24 @@ export function checkNodeIsVisible(node) {
     }
 }
 
+/**
+ * Strip Unicode default-ignorable code points (ZWSP, ZWNJ, ZWJ, WJ, BOM, soft hyphen,
+ * Tags U+E0000–E007F, …) and C0/C1 controls other than tab/newline/carriage-return.
+ * Aligns with Apple `removingInvisibleFormatCharacters()`.
+ * @param {string} str
+ * @returns {string}
+ */
+export function stripInvisibleFormatCharacters(str) {
+    if (typeof str !== 'string' || str.length === 0) {
+        return typeof str === 'string' ? str : '';
+    }
+    return str
+        .replace(/\p{Default_Ignorable_Code_Point}/gu, '')
+        .replace(/[\u0000-\u0008\u000B\u000C\u000E-\u001F\u007F-\u009F]/g, '');
+}
+
 function collapseWhitespace(str) {
-    return typeof str === 'string' ? str.replace(/\s+/g, ' ') : '';
+    return typeof str === 'string' ? stripInvisibleFormatCharacters(str).replace(/\s+/g, ' ') : '';
 }
 
 /**
@@ -196,7 +212,7 @@ export function domToMarkdown(node, settings, depth = 0) {
  */
 function getAttributeOrBlank(node, attr) {
     const attrValue = node.getAttribute(attr) ?? '';
-    return attrValue.trim();
+    return stripInvisibleFormatCharacters(attrValue).trim();
 }
 
 function collapseAndTrim(str) {
@@ -621,7 +637,7 @@ export default class PageContext extends ContentFeature {
     }
 
     getPageTitle() {
-        const title = document.title || '';
+        const title = stripInvisibleFormatCharacters(document.title || '');
         const maxTitleLength = this.getFeatureSetting('maxTitleLength') || 100;
 
         if (title.length > maxTitleLength) {
@@ -633,7 +649,8 @@ export default class PageContext extends ContentFeature {
 
     getMetaDescription() {
         const metaDesc = document.querySelector('meta[name="description"]');
-        return metaDesc ? metaDesc.getAttribute('content') || '' : '';
+        const content = metaDesc ? metaDesc.getAttribute('content') || '' : '';
+        return stripInvisibleFormatCharacters(content);
     }
 
     getMainContent() {
@@ -713,7 +730,7 @@ export default class PageContext extends ContentFeature {
 
         headingElements.forEach((heading) => {
             const level = parseInt(heading.tagName.charAt(1));
-            const text = heading.textContent?.trim();
+            const text = stripInvisibleFormatCharacters(heading.textContent || '').trim();
             if (text) {
                 headings.push({ level, text });
             }
@@ -728,7 +745,7 @@ export default class PageContext extends ContentFeature {
         const linkElements = document.querySelectorAll(linkSelector);
 
         linkElements.forEach((link) => {
-            const text = link.textContent?.trim();
+            const text = stripInvisibleFormatCharacters(link.textContent || '').trim();
             const href = link.getAttribute('href');
             if (text && href && text.length > 0) {
                 links.push({ text, href });
@@ -765,7 +782,7 @@ export default class PageContext extends ContentFeature {
         const imgElements = document.querySelectorAll(imgSelector);
 
         imgElements.forEach((img) => {
-            const alt = img.getAttribute('alt') || '';
+            const alt = stripInvisibleFormatCharacters(img.getAttribute('alt') || '');
             const src = img.getAttribute('src') || '';
             if (src) {
                 images.push({ alt, src });

--- a/injected/unit-test/fixtures/page-context/expected/invisible-format-characters.md
+++ b/injected/unit-test/fixtures/page-context/expected/invisible-format-characters.md
@@ -1,0 +1,2 @@
+What color is the sky? 
+helloworld

--- a/injected/unit-test/page-context-dom.spec.js
+++ b/injected/unit-test/page-context-dom.spec.js
@@ -2,7 +2,7 @@ import { JSDOM } from 'jsdom';
 import { writeFileSync, existsSync, mkdirSync, readFileSync } from 'fs';
 import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
-import { domToMarkdown } from '../src/features/page-context.js';
+import { domToMarkdown, stripInvisibleFormatCharacters } from '../src/features/page-context.js';
 
 const currentFilename = fileURLToPath(import.meta.url);
 const currentDirname = dirname(currentFilename);
@@ -15,6 +15,37 @@ const currentDirname = dirname(currentFilename);
  * @property {boolean} includeIframes - Whether to include iframe content
  * @property {boolean} trimBlankLinks - Whether to trim blank links
  */
+
+describe('page-context.js - stripInvisibleFormatCharacters', () => {
+    it('strips zero-width and other default-ignorable characters', () => {
+        expect(stripInvisibleFormatCharacters('\u200B')).toBe('');
+        expect(stripInvisibleFormatCharacters('\u200C')).toBe('');
+        expect(stripInvisibleFormatCharacters('\u200D')).toBe('');
+        expect(stripInvisibleFormatCharacters('\u2060')).toBe('');
+        expect(stripInvisibleFormatCharacters('\uFEFF')).toBe('');
+        expect(stripInvisibleFormatCharacters('\u00AD')).toBe('');
+        expect(stripInvisibleFormatCharacters('a\u200Cb\u200Bc')).toBe('abc');
+    });
+
+    it('keeps tab and newlines but strips other controls', () => {
+        expect(stripInvisibleFormatCharacters('hello\nworld')).toBe('hello\nworld');
+        expect(stripInvisibleFormatCharacters('hello\tworld')).toBe('hello\tworld');
+        expect(stripInvisibleFormatCharacters('a\u0000b')).toBe('ab');
+        expect(stripInvisibleFormatCharacters('a\u0007b')).toBe('ab');
+    });
+
+    it('strips Unicode Tag characters used for ASCII smuggling', () => {
+        // U+E0001 + TAG letters spelling "Thanks" + U+E007F
+        const smuggled =
+            'What color is the sky? \u{E0001}\u{E0054}\u{E0068}\u{E0061}\u{E006E}\u{E006B}\u{E0073}\u{E007F}';
+        expect(stripInvisibleFormatCharacters(smuggled)).toBe('What color is the sky? ');
+    });
+
+    it('returns empty string for non-strings', () => {
+        expect(stripInvisibleFormatCharacters(/** @type {any} */ (null))).toBe('');
+        expect(stripInvisibleFormatCharacters(/** @type {any} */ (undefined))).toBe('');
+    });
+});
 
 describe('page-context.js - domToMarkdown', () => {
     const fixturesDir = join(currentDirname, 'fixtures', 'page-context');
@@ -116,6 +147,11 @@ describe('page-context.js - domToMarkdown', () => {
         {
             name: 'mixed-formatting',
             html: '<p>This has <strong><em>bold and italic</em></strong> together.</p>',
+            settings: defaultSettings,
+        },
+        {
+            name: 'invisible-format-characters',
+            html: '<p>What color is the sky? \u{E0001}\u{E0054}\u{E0068}\u{E0061}\u{E006E}\u{E006B}\u{E0073}\u{E007F}</p><p>hello\u200Bworld\u200C</p>',
             settings: defaultSettings,
         },
         {

--- a/injected/unit-test/page-context-dom.spec.js
+++ b/injected/unit-test/page-context-dom.spec.js
@@ -41,6 +41,25 @@ describe('page-context.js - stripInvisibleFormatCharacters', () => {
         expect(stripInvisibleFormatCharacters(smuggled)).toBe('What color is the sky? ');
     });
 
+    it('preserves emoji ZWJ sequences and variation selectors', () => {
+        expect(stripInvisibleFormatCharacters('👨‍👩‍👧')).toBe('👨‍👩‍👧');
+        expect(stripInvisibleFormatCharacters('❤️')).toBe('❤️');
+        expect(stripInvisibleFormatCharacters('👋🏻')).toBe('👋🏻');
+    });
+
+    it('preserves Persian/Arabic ZWNJ shaping', () => {
+        expect(stripInvisibleFormatCharacters('می‌رود')).toBe('می‌رود');
+        expect(stripInvisibleFormatCharacters('خانه‌ام')).toBe('خانه‌ام');
+    });
+
+    it('strips joiners used to smuggle next to Latin', () => {
+        expect(stripInvisibleFormatCharacters('a\u200Db')).toBe('ab');
+        expect(stripInvisibleFormatCharacters('a\u200Cb')).toBe('ab');
+        expect(stripInvisibleFormatCharacters('hello\u200Bworld')).toBe('helloworld');
+        // Boundary between Latin and Arabic: strip the bridging joiner, keep internal Persian ZWNJ
+        expect(stripInvisibleFormatCharacters('test\u200Cمی‌رود')).toBe('testمی‌رود');
+    });
+
     it('returns empty string for non-strings', () => {
         expect(stripInvisibleFormatCharacters(/** @type {any} */ (null))).toBe('');
         expect(stripInvisibleFormatCharacters(/** @type {any} */ (undefined))).toBe('');


### PR DESCRIPTION
## Summary
- Sanitize page-context collected text (markdown body, title, meta, headings, links, image alt) by stripping invisible / tofu-prone Unicode format characters.
- Preserve emoji ZWJ sequences and Arabic/Persian ZWNJ/ZWJ shaping; strip joiners when adjacent to Latin to block smuggling.
- Aligns with macOS `removingInvisibleFormatCharacters()` behavior (apple-browsers `jkt/macos-strip-invisible-format-chars`).

## Test plan
- [ ] Unit: `stripInvisibleFormatCharacters` — Tags/ZWSP stripped; 👨‍👩‍👧 / ❤️ / `می‌رود` preserved; Latin-adjacent joiners removed
- [ ] Fixture `invisible-format-characters` markdown expectation still passes
- [ ] Spot-check page context from a page containing Persian text and emoji still looks correct in Duck.ai

### Related
- apple-browsers: https://github.com/duckduckgo/apple-browsers/pull/6417

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how all page-context strings are normalized before use, which could alter legitimate edge-case text but is intentional for security and parity with Apple browsers.
> 
> **Overview**
> Page context collection now **sanitizes text** through a new `stripInvisibleFormatCharacters` helper before markdown, titles, meta descriptions, headings, links, and image alt text are sent downstream (e.g. Duck.ai).
> 
> The sanitizer removes default-ignorable and control characters and **Unicode Tag smuggling**, while **keeping** Arabic/Persian ZWNJ/ZWJ shaping and emoji ZWJ/variation-selector sequences. **Latin-adjacent joiners are stripped** to block confusable smuggling. Behavior is aligned with macOS `removingInvisibleFormatCharacters()`.
> 
> Whitespace collapse and attribute reads run through this path, so invisible characters in DOM text and attributes do not appear in collected content.
> 
> Unit tests cover smuggling, emoji, Persian text, and Latin boundaries; a `domToMarkdown` fixture expects stripped output for tag-injected and zero-width HTML.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e55103da21d74564b1ba6f3b3a13ccc4435b0dc1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->