### PR TITLE
fix(broker-protection): preserve matched CAPTCHA context

### DIFF
--- a/injected/integration-test/broker-protection-tests/broker-protection-captcha.spec.js
+++ b/injected/integration-test/broker-protection-tests/broker-protection-captcha.spec.js
@@ -8,7 +8,7 @@ import {
     createGetCloudFlareCaptchaInfoAction,
     createSolveCloudFlareCaptchaAction,
 } from '../mocks/broker-protection/captcha.js';
-import { BROKER_PROTECTION_CONFIGS } from './tests-config.js';
+import { createProfileMatchParent, createUserProfile } from '../mocks/broker-protection/profile.js';
 
 const test = createConfiguredDbpTest(base);
 
@@ -16,10 +16,10 @@ test.describe('Broker Protection Captcha', () => {
     test.describe('recaptcha2', () => {
         const recaptchaTargetPage = 're-captcha.html';
         const recaptchaResponseSelector = '#g-recaptcha-response';
+        const recaptchaWidgetSelector = '.g-recaptcha';
 
         test.describe('getCaptchaInfo', () => {
-            test('returns the expected response for the correct action data', async ({ createConfiguredDbp }) => {
-                const dbp = await createConfiguredDbp(BROKER_PROTECTION_CONFIGS.default);
+            test('returns the expected response for the correct action data', async ({ dbp }) => {
                 await dbp.navigatesTo(recaptchaTargetPage);
                 await dbp.receivesInlineAction(createGetRecaptchaInfoAction());
                 const sucessResponse = await dbp.getSuccessResponse();
@@ -27,10 +27,7 @@ test.describe('Broker Protection Captcha', () => {
                 dbp.isCaptchaMatch(sucessResponse, { captchaType: 'recaptcha2', targetPage: recaptchaTargetPage });
             });
 
-            test('returns the expected response for the correct action data without the "captchaType" field', async ({
-                createConfiguredDbp,
-            }) => {
-                const dbp = await createConfiguredDbp(BROKER_PROTECTION_CONFIGS.default);
+            test('returns the expected response for the correct action data without the "captchaType" field', async ({ dbp }) => {
                 await dbp.navigatesTo(recaptchaTargetPage);
                 await dbp.receivesInlineAction(createGetRecaptchaInfoAction({ captchaType: undefined }));
                 const sucessResponse = await dbp.getSuccessResponse();
@@ -38,10 +35,7 @@ test.describe('Broker Protection Captcha', () => {
                 dbp.isCaptchaMatch(sucessResponse, { captchaType: 'recaptcha2', targetPage: recaptchaTargetPage });
             });
 
-            test('returns the expected type when the "captchaType" field does not match the detected captcha type', async ({
-                createConfiguredDbp,
-            }) => {
-                const dbp = await createConfiguredDbp(BROKER_PROTECTION_CONFIGS.default);
+            test('returns the expected type when the "captchaType" field does not match the detected captcha type', async ({ dbp }) => {
                 await dbp.navigatesTo(recaptchaTargetPage);
                 await dbp.receivesInlineAction(createGetRecaptchaInfoAction({ captchaType: 'recaptchaEnterprise' }));
                 const sucessResponse = await dbp.getSuccessResponse();
@@ -49,8 +43,7 @@ test.describe('Broker Protection Captcha', () => {
                 dbp.isCaptchaMatch(sucessResponse, { captchaType: 'recaptcha2', targetPage: recaptchaTargetPage });
             });
 
-            test('returns an error response for an action data with an invalid "captchaType" field', async ({ createConfiguredDbp }) => {
-                const dbp = await createConfiguredDbp(BROKER_PROTECTION_CONFIGS.default);
+            test('returns an error response for an action data with an invalid "captchaType" field', async ({ dbp }) => {
                 await dbp.navigatesTo(recaptchaTargetPage);
                 await dbp.receivesInlineAction(createGetRecaptchaInfoAction({ captchaType: 'invalid' }));
 
@@ -59,8 +52,7 @@ test.describe('Broker Protection Captcha', () => {
         });
 
         test.describe('solveCaptchaInfo', () => {
-            test('solves the captcha for the correct action data', async ({ createConfiguredDbp }) => {
-                const dbp = await createConfiguredDbp(BROKER_PROTECTION_CONFIGS.default);
+            test('solves the captcha for the correct action data', async ({ dbp }) => {
                 await dbp.navigatesTo(recaptchaTargetPage);
                 await dbp.receivesInlineAction(createSolveRecaptchaAction());
                 dbp.getSuccessResponse();
@@ -68,19 +60,30 @@ test.describe('Broker Protection Captcha', () => {
                 await dbp.isCaptchaTokenFilled(recaptchaResponseSelector);
             });
 
-            test('solves the captcha for the correct action data without the "captchaType" field', async ({ createConfiguredDbp }) => {
-                const dbp = await createConfiguredDbp(BROKER_PROTECTION_CONFIGS.default);
+            test('without parent keeps first captcha behavior', async ({ dbp }) => {
                 await dbp.navigatesTo(recaptchaTargetPage);
                 await dbp.receivesInlineAction(createSolveRecaptchaAction({ captchaType: undefined }));
-                dbp.getSuccessResponse();
+                const successResponse = await dbp.getSuccessResponse();
 
                 await dbp.isCaptchaTokenFilled(recaptchaResponseSelector);
+                await dbp.runsCaptchaCallback(successResponse);
+                await dbp.isWidgetNotified(recaptchaWidgetSelector, 'data-callback-token');
+            });
+
+            test('notifies nothing when the matching widget has no callable client', async ({ dbp }) => {
+                await dbp.navigatesTo(recaptchaTargetPage);
+                await dbp.rendersRecaptchaClients({ widgetId: 9, clients: { 0: 'data-client-0-token', 9: null } });
+                await dbp.receivesInlineAction(createSolveRecaptchaAction());
+                const successResponse = await dbp.getSuccessResponse();
+
+                await dbp.runsCaptchaCallback(successResponse);
+
+                await dbp.isWidgetNotNotified(recaptchaWidgetSelector, 'data-client-0-token');
             });
 
             test('solves the captcha for an action data when the "captchaType" field does not match the detected captcha type', async ({
-                createConfiguredDbp,
+                dbp,
             }) => {
-                const dbp = await createConfiguredDbp(BROKER_PROTECTION_CONFIGS.default);
                 await dbp.navigatesTo(recaptchaTargetPage);
                 await dbp.receivesInlineAction(createSolveRecaptchaAction({ captchaType: 'recaptchaEnterprise' }));
                 dbp.getSuccessResponse();
@@ -88,8 +91,7 @@ test.describe('Broker Protection Captcha', () => {
                 await dbp.isCaptchaTokenFilled(recaptchaResponseSelector);
             });
 
-            test('returns an error response for an action data with an invalid "captchaType" field', async ({ createConfiguredDbp }) => {
-                const dbp = await createConfiguredDbp(BROKER_PROTECTION_CONFIGS.default);
+            test('returns an error response for an action data with an invalid "captchaType" field', async ({ dbp }) => {
                 await dbp.navigatesTo(recaptchaTargetPage);
                 await dbp.receivesInlineAction(createSolveRecaptchaAction({ captchaType: 'invalid' }));
 
@@ -97,8 +99,126 @@ test.describe('Broker Protection Captcha', () => {
             });
         });
 
-        test('remove query params from captcha url', async ({ createConfiguredDbp }) => {
-            const dbp = await createConfiguredDbp(BROKER_PROTECTION_CONFIGS.default);
+        test.describe('with parent profileMatch', () => {
+            const parentTargetPage = 're-captcha-parent.html';
+            const userProfile = createUserProfile();
+            const nonMatchingUserProfile = createUserProfile({
+                firstName: 'Jane',
+                middleName: undefined,
+                lastName: 'Doe',
+                age: '55',
+                addresses: [{ addressLine1: '1 Other Rd', city: 'Chicago', state: 'IL' }],
+            });
+
+            test('gets the captcha belonging to the record that matches the user profile', async ({ dbp }) => {
+                await dbp.navigatesTo(parentTargetPage);
+                await dbp.receivesInlineAction(createGetRecaptchaInfoAction({ parent: createProfileMatchParent() }, { userProfile }));
+                const successResponse = await dbp.getSuccessResponse();
+
+                dbp.isCaptchaMatch(successResponse, {
+                    captchaType: 'recaptcha2',
+                    targetPage: parentTargetPage,
+                    siteKey: 'test-site-key-2',
+                });
+            });
+
+            test('gets the first captcha on the page when no parent is specified', async ({ dbp }) => {
+                await dbp.navigatesTo(parentTargetPage);
+                await dbp.receivesInlineAction(createGetRecaptchaInfoAction({}, { userProfile }));
+                const successResponse = await dbp.getSuccessResponse();
+
+                dbp.isCaptchaMatch(successResponse, {
+                    captchaType: 'recaptcha2',
+                    targetPage: parentTargetPage,
+                    siteKey: 'test-site-key-0',
+                });
+            });
+
+            test('returns an error response when no record matches the user profile', async ({ dbp }) => {
+                await dbp.navigatesTo(parentTargetPage);
+                await dbp.receivesInlineAction(
+                    createGetRecaptchaInfoAction({ parent: createProfileMatchParent() }, { userProfile: nonMatchingUserProfile }),
+                );
+
+                await dbp.isCaptchaError();
+            });
+
+            test('solves only the captcha belonging to the supplied profile', async ({ dbp }) => {
+                await dbp.navigatesTo(parentTargetPage);
+                await dbp.receivesInlineAction(createSolveRecaptchaAction({ parent: createProfileMatchParent() }, { userProfile }));
+                const successResponse = await dbp.getSuccessResponse();
+
+                await dbp.isCaptchaTokenFilled('#g-recaptcha-response-2');
+                await dbp.doesInputValueEqual('#g-recaptcha-response', '');
+                await dbp.doesInputValueEqual('#g-recaptcha-response-1', '');
+
+                await dbp.runsCaptchaCallback(successResponse);
+                await dbp.isWidgetNotified('[data-sitekey="test-site-key-2"]', 'data-callback-token');
+                await dbp.isWidgetNotNotified('[data-sitekey="test-site-key-0"]', 'data-callback-token');
+                await dbp.isWidgetNotNotified('[data-sitekey="test-site-key-1"]', 'data-callback-token');
+            });
+
+            test('native retry keeps captcha context after a failed solve', async ({ dbp }) => {
+                await dbp.navigatesTo(parentTargetPage);
+                await dbp.receivesInlineAction(createGetRecaptchaInfoAction({ parent: createProfileMatchParent() }, { userProfile }));
+                await dbp.getSuccessResponse();
+                const failedSolveAction = createSolveRecaptchaAction({
+                    id: 'failed-solve',
+                    parent: createProfileMatchParent(),
+                    selector: '#missing-captcha',
+                });
+                await dbp.receivesInlineAction(failedSolveAction);
+                await dbp.isCaptchaError(failedSolveAction.state.action.id);
+
+                const solveAction = createSolveRecaptchaAction({ parent: createProfileMatchParent() }, { token: undefined, userProfile });
+                await dbp.receivesInlineAction(solveAction);
+                const successResponse = await dbp.getSuccessResponse(solveAction.state.action.id);
+
+                await dbp.isCaptchaTokenFilled('#g-recaptcha-response-2');
+                await dbp.doesInputValueEqual('#g-recaptcha-response', '');
+                await dbp.doesInputValueEqual('#g-recaptcha-response-1', '');
+
+                await dbp.runsCaptchaCallback(successResponse);
+                await dbp.isWidgetNotified('[data-sitekey="test-site-key-2"]', 'data-callback-token');
+                await dbp.isWidgetNotNotified('[data-sitekey="test-site-key-0"]', 'data-callback-token');
+                await dbp.isWidgetNotNotified('[data-sitekey="test-site-key-1"]', 'data-callback-token');
+            });
+
+            test('missing held profile after a page load writes nothing', async ({ dbp }) => {
+                await dbp.navigatesTo(parentTargetPage);
+                await dbp.receivesInlineAction(createGetRecaptchaInfoAction({ parent: createProfileMatchParent() }, { userProfile }));
+                await dbp.getSuccessResponse();
+                await dbp.navigatesTo(parentTargetPage);
+                await dbp.receivesInlineAction(createSolveRecaptchaAction({ parent: createProfileMatchParent() }));
+
+                await dbp.isCaptchaError();
+                await dbp.doesInputValueEqual('#g-recaptcha-response', '');
+                await dbp.doesInputValueEqual('#g-recaptcha-response-1', '');
+                await dbp.doesInputValueEqual('#g-recaptcha-response-2', '');
+                await dbp.hasNoNotifiedWidget();
+            });
+
+            test('returns an error response when solving and no record matches the user profile', async ({ dbp }) => {
+                await dbp.navigatesTo(parentTargetPage);
+                await dbp.receivesInlineAction(
+                    createSolveRecaptchaAction({ parent: createProfileMatchParent() }, { userProfile: nonMatchingUserProfile }),
+                );
+
+                await dbp.isCaptchaError();
+            });
+
+            test('returns an error when the matched record has no resolvable widget id', async ({ dbp }) => {
+                await dbp.navigatesTo(parentTargetPage);
+                await dbp.removesRecaptchaWidgetId(2);
+
+                await dbp.receivesInlineAction(createSolveRecaptchaAction({ parent: createProfileMatchParent() }, { userProfile }));
+
+                await dbp.isCaptchaError();
+                await dbp.doesInputValueEqual('#captcha-response-without-widget-id', '');
+            });
+        });
+
+        test('remove query params from captcha url', async ({ dbp }) => {
             await dbp.navigatesTo('re-captcha.html?fname=john&lname=smith');
             await dbp.receivesInlineAction(createGetRecaptchaInfoAction());
             const sucessResponse = await dbp.getSuccessResponse();
@@ -112,26 +232,21 @@ test.describe('Broker Protection Captcha', () => {
         const imageCaptchaResponseSelector = '#svgCaptchaInputId';
 
         test.describe('getCaptchaInfo', () => {
-            test('returns the expected response for the correct action data', async ({ createConfiguredDbp }) => {
-                const dbp = await createConfiguredDbp(BROKER_PROTECTION_CONFIGS.default);
+            test('returns the expected response for the correct action data', async ({ dbp }) => {
                 await dbp.navigatesTo(imageCaptchaTargetPage);
                 await dbp.receivesInlineAction(createGetImageCaptchaInfoAction({ selector: '#svg-captcha-rendering svg' }));
                 const sucessResponse = await dbp.getSuccessResponse();
                 dbp.isCaptchaMatch(sucessResponse, { captchaType: 'image', targetPage: imageCaptchaTargetPage });
             });
 
-            test('returns an error response when the selector is not an svg or image tag', async ({ createConfiguredDbp }) => {
-                const dbp = await createConfiguredDbp(BROKER_PROTECTION_CONFIGS.default);
+            test('returns an error response when the selector is not an svg or image tag', async ({ dbp }) => {
                 await dbp.navigatesTo(imageCaptchaTargetPage);
                 await dbp.receivesInlineAction(createGetImageCaptchaInfoAction({ selector: '#svg-captcha-rendering' }));
 
                 await dbp.isCaptchaError();
             });
 
-            test('preserves the original format/header for a gif captcha already inlined as a data URL', async ({
-                createConfiguredDbp,
-            }) => {
-                const dbp = await createConfiguredDbp(BROKER_PROTECTION_CONFIGS.default);
+            test('preserves the original format/header for a gif captcha already inlined as a data URL', async ({ dbp }) => {
                 await dbp.navigatesTo(imageCaptchaTargetPage);
                 await dbp.receivesInlineAction(createGetImageCaptchaInfoAction({ selector: '#gifCaptchaImage' }));
                 const successResponse = await dbp.getSuccessResponse();
@@ -141,8 +256,7 @@ test.describe('Broker Protection Captcha', () => {
                 expect(successResponse.siteKey).toMatch(/^data:image\/gif;base64,/);
             });
 
-            test('preserves the original format/header for a url-hosted gif captcha', async ({ createConfiguredDbp }) => {
-                const dbp = await createConfiguredDbp(BROKER_PROTECTION_CONFIGS.default);
+            test('preserves the original format/header for a url-hosted gif captcha', async ({ dbp }) => {
                 await dbp.navigatesTo(imageCaptchaTargetPage);
                 await dbp.receivesInlineAction(createGetImageCaptchaInfoAction({ selector: '#hostedGifCaptchaImage' }));
                 const successResponse = await dbp.getSuccessResponse();
@@ -152,8 +266,7 @@ test.describe('Broker Protection Captcha', () => {
                 expect(successResponse.siteKey).toMatch(/^data:image\/gif;base64,/);
             });
 
-            test('returns an error response when a url-hosted captcha image cannot be fetched', async ({ createConfiguredDbp }) => {
-                const dbp = await createConfiguredDbp(BROKER_PROTECTION_CONFIGS.default);
+            test('returns an error response when a url-hosted captcha image cannot be fetched', async ({ dbp }) => {
                 await dbp.navigatesTo(imageCaptchaTargetPage);
                 await dbp.receivesInlineAction(createGetImageCaptchaInfoAction({ selector: '#missingHostedCaptchaImage' }));
 
@@ -162,8 +275,7 @@ test.describe('Broker Protection Captcha', () => {
                 await dbp.isCaptchaError();
             });
 
-            test('reports the requested alias type to the backend for an aliased image captcha', async ({ createConfiguredDbp }) => {
-                const dbp = await createConfiguredDbp(BROKER_PROTECTION_CONFIGS.default);
+            test('reports the requested alias type to the backend for an aliased image captcha', async ({ dbp }) => {
                 await dbp.navigatesTo(imageCaptchaTargetPage);
                 // 'red-circle' is registered as an alias of the image provider, so it is resolved and
                 // extracted via the same DOM mechanisms...
@@ -180,8 +292,7 @@ test.describe('Broker Protection Captcha', () => {
         });
 
         test.describe('solveCaptchaInfo', () => {
-            test('solves the captcha for the correct action data', async ({ createConfiguredDbp }) => {
-                const dbp = await createConfiguredDbp(BROKER_PROTECTION_CONFIGS.default);
+            test('solves the captcha for the correct action data', async ({ dbp }) => {
                 await dbp.navigatesTo(imageCaptchaTargetPage);
                 await dbp.receivesInlineAction(createSolveImageCaptchaAction({ selector: imageCaptchaResponseSelector }));
                 dbp.getSuccessResponse();
@@ -195,8 +306,7 @@ test.describe('Broker Protection Captcha', () => {
         const cloudFlareCaptchaTargetPage = 'cloudflare-captcha.html';
 
         test.describe('getCaptchaInfo', () => {
-            test('returns the expected response for the correct action data', async ({ createConfiguredDbp }) => {
-                const dbp = await createConfiguredDbp(BROKER_PROTECTION_CONFIGS.default);
+            test('returns the expected response for the correct action data', async ({ dbp }) => {
                 await dbp.navigatesTo(cloudFlareCaptchaTargetPage);
                 await dbp.receivesInlineAction(createGetCloudFlareCaptchaInfoAction({ selector: '#captcha-widget' }));
                 const sucessResponse = await dbp.getSuccessResponse();
@@ -208,8 +318,7 @@ test.describe('Broker Protection Captcha', () => {
                 });
             });
 
-            test('returns an error if the sitekey attribute is missing', async ({ createConfiguredDbp }) => {
-                const dbp = await createConfiguredDbp(BROKER_PROTECTION_CONFIGS.default);
+            test('returns an error if the sitekey attribute is missing', async ({ dbp }) => {
                 await dbp.navigatesTo(cloudFlareCaptchaTargetPage);
                 await dbp.receivesInlineAction(createGetCloudFlareCaptchaInfoAction({ selector: '#missing-sitekey' }));
 
@@ -218,16 +327,14 @@ test.describe('Broker Protection Captcha', () => {
         });
 
         test.describe('solveCaptchaInfo', () => {
-            test('returns an error if the callback attribute is missing', async ({ createConfiguredDbp }) => {
-                const dbp = await createConfiguredDbp(BROKER_PROTECTION_CONFIGS.default);
+            test('returns an error if the callback attribute is missing', async ({ dbp }) => {
                 await dbp.navigatesTo(cloudFlareCaptchaTargetPage);
                 await dbp.receivesInlineAction(createSolveCloudFlareCaptchaAction({ selector: '#missing-callback' }));
 
                 await dbp.isCaptchaError();
             });
 
-            test('solves the captcha for the correct action data', async ({ createConfiguredDbp }) => {
-                const dbp = await createConfiguredDbp(BROKER_PROTECTION_CONFIGS.default);
+            test('solves the captcha for the correct action data', async ({ dbp }) => {
                 await dbp.navigatesTo(cloudFlareCaptchaTargetPage);
                 await dbp.receivesInlineAction(createSolveCloudFlareCaptchaAction({ selector: '#captcha-widget' }));
                 dbp.getSuccessResponse();

--- a/injected/integration-test/broker-protection-tests/fixtures.js
+++ b/injected/integration-test/broker-protection-tests/fixtures.js
@@ -1,56 +1,19 @@
 import { BrokerProtectionPage } from '../page-objects/broker-protection.js';
+import { BROKER_PROTECTION_CONFIGS } from './tests-config.js';
 /**
- * @import {PlaywrightTestArgs, PlaywrightTestOptions, PlaywrightWorkerArgs, PlaywrightWorkerOptions, TestType} from "@playwright/test"
+ * @import {PlaywrightTestArgs, PlaywrightTestOptions, PlaywrightWorkerArgs, PlaywrightWorkerOptions, TestType, test as playwrightTest} from "@playwright/test"
  */
 
 /**
- * @param {typeof import("@playwright/test").test} test
- * @return {TestType<PlaywrightTestArgs & PlaywrightTestOptions & PlaywrightWorkerArgs & PlaywrightWorkerOptions & { createConfiguredDbp: (config: Record<string, any>) => Promise<BrokerProtectionPage> }, {}>}
+ * @param {typeof playwrightTest} test
+ * @return {TestType<PlaywrightTestArgs & PlaywrightTestOptions & PlaywrightWorkerArgs & PlaywrightWorkerOptions & { dbp: BrokerProtectionPage }, {}>}
  */
 export function createConfiguredDbpTest(test) {
     return test.extend({
-        createConfiguredDbp: async ({ page }, use, workerInfo) => {
-            /**
-             * @param {Record<string, any>} config
-             */
-            const createWithConfig = async (config) => {
-                const dbp = BrokerProtectionPage.create(page, workerInfo.project.use);
-                await dbp.withFeatureConfig(config);
-                return dbp;
-            };
-
-            await use(createWithConfig);
-        },
-    });
-}
-
-/**
- * @param {typeof import("@playwright/test").test} test
- * @return {TestType<PlaywrightTestArgs & PlaywrightTestOptions & PlaywrightWorkerArgs & PlaywrightWorkerOptions & { createConfiguredDbp: (config: Record<string, any>) => Promise<BrokerProtectionPage> }, {}>}
- */
-export function createConfiguredDbpTestWithNavigation(test) {
-    return test.extend({
-        createConfiguredDbp: async ({ page }, use, workerInfo) => {
-            /**
-             * @param {object} params
-             * @param {string} params.targetPage
-             * @param {string|object} params.action
-             * @param {Record<string, any>} params.config
-             */
-            const createWithConfig = async (params) => {
-                const { config, targetPage, action } = params;
-                const dbp = BrokerProtectionPage.create(page, workerInfo.project.use);
-                await dbp.withFeatureConfig(config);
-                await dbp.navigatesTo(targetPage);
-                if (typeof action === 'string') {
-                    dbp.receivesAction(action);
-                } else {
-                    await dbp.receivesInlineAction(action);
-                }
-                return dbp;
-            };
-
-            await use(createWithConfig);
+        dbp: async ({ page }, use, workerInfo) => {
+            const dbp = BrokerProtectionPage.create(page, workerInfo.project.use);
+            await dbp.withFeatureConfig(BROKER_PROTECTION_CONFIGS.default);
+            await use(dbp);
         },
     });
 }

--- a/injected/integration-test/mocks/broker-protection/captcha.js
+++ b/injected/integration-test/mocks/broker-protection/captcha.js
@@ -1,36 +1,38 @@
 import { createPirState, getBrokerProtectionTestPageUrl } from './utils';
 /**
- * @import { PirAction } from '../../../src/features/broker-protection/types.js'
+ * @import { PirAction, PirInputData } from '../../../src/features/broker-protection/types.js'
  */
 
 const MOCK_SITE_KEY = '6LeCl8UUAAAAAGssOpatU5nzFXH2D7UZEYelSLTn';
 
-// Captcha actions
-
 /**
  * @param {object} params
  * @param {Omit<PirAction, 'id' | 'actionType'>} params.action
+ * @param {PirInputData} [params.data]
  */
-export function createGetCaptchaInfoAction({ action }) {
+export function createGetCaptchaInfoAction({ action, data }) {
     return createPirState({
         action: {
             id: '8324',
             actionType: 'getCaptchaInfo',
             ...action,
         },
+        ...(data && { data }),
     });
 }
 
 /**
  * @param {Partial<PirAction>} [actionOverrides]
+ * @param {PirInputData} [data]
  */
-export function createGetRecaptchaInfoAction(actionOverrides = {}) {
+export function createGetRecaptchaInfoAction(actionOverrides = {}, data) {
     return createGetCaptchaInfoAction({
         action: {
             captchaType: 'recaptcha2',
             selector: '.g-recaptcha',
             ...actionOverrides,
         },
+        data,
     });
 }
 
@@ -61,7 +63,7 @@ export function createGetCloudFlareCaptchaInfoAction(actionOverrides = {}) {
 /**
  * @param {object} params
  * @param {Omit<PirAction, 'id' | 'actionType'>} params.action
- * @param {Record<string, any>} [params.data]
+ * @param {PirInputData} [params.data]
  */
 export function createSolveCaptchaAction({ action, data }) {
     return createPirState({
@@ -79,14 +81,16 @@ export function createSolveCaptchaAction({ action, data }) {
 
 /**
  * @param {Partial<PirAction>} [actionOverrides]
+ * @param {PirInputData} [data]
  */
-export function createSolveRecaptchaAction(actionOverrides = {}) {
+export function createSolveRecaptchaAction(actionOverrides = {}, data) {
     return createSolveCaptchaAction({
         action: {
             captchaType: 'recaptcha2',
             selector: '.g-recaptcha',
             ...actionOverrides,
         },
+        data,
     });
 }
 

--- a/injected/integration-test/mocks/broker-protection/profile.js
+++ b/injected/integration-test/mocks/broker-protection/profile.js
@@ -1,0 +1,56 @@
+/**
+ * @import { ActionParent } from '../../../src/features/broker-protection/types.js'
+ */
+
+/**
+ * @typedef {object} Address
+ * @property {string} addressLine1
+ * @property {string} city
+ * @property {string} state
+ */
+
+/**
+ * @typedef {object} UserProfile
+ * @property {string} firstName
+ * @property {string} [middleName]
+ * @property {string} lastName
+ * @property {string} age
+ * @property {Address[]} addresses
+ */
+
+/**
+ * @param {Partial<UserProfile>} [overrides]
+ * @returns {UserProfile}
+ */
+export function createUserProfile(overrides = {}) {
+    return {
+        firstName: 'James',
+        middleName: 'William',
+        lastName: 'Daly',
+        age: '52',
+        addresses: [{ addressLine1: '123 Fake St', city: 'Gilbert', state: 'AZ' }],
+        ...overrides,
+    };
+}
+
+/**
+ * @returns {ActionParent}
+ */
+export function createProfileMatchParent() {
+    return {
+        profileMatch: {
+            selector: '#people-search-results li',
+            profile: {
+                name: {
+                    selector:
+                        ".//div[contains(concat(' ', normalize-space(@class), ' '), ' !text-black-900 ') and contains(concat(' ', normalize-space(@class), ' '), ' text-lg ')]",
+                },
+                age: { selector: ".//div[@class='text-lg']" },
+                addressCityStateList: {
+                    selector: ".//div[@class='text-xs']/following-sibling::div",
+                    findElements: true,
+                },
+            },
+        },
+    };
+}

--- a/injected/integration-test/page-objects/broker-protection.js
+++ b/injected/integration-test/page-objects/broker-protection.js
@@ -5,11 +5,20 @@ import { ResultsCollector } from './results-collector.js';
 import { createCaptchaResponse } from '../mocks/broker-protection/captcha.js';
 import { createFeatureConfig } from '../mocks/broker-protection/feature-config.js';
 
+/**
+ * @import { Page } from '@playwright/test'
+ * @import { Build } from '../type-helpers.mjs'
+ * @import { PlatformInfo } from '@duckduckgo/messaging/lib/test-utils.mjs'
+ */
+
+const RECAPTCHA_RESPONSE_ID = 'g-recaptcha-response';
+const RECAPTCHA_RESPONSE_SELECTOR = `#${RECAPTCHA_RESPONSE_ID}`;
+
 export class BrokerProtectionPage {
     /**
-     * @param {import("@playwright/test").Page} page
-     * @param {import("../type-helpers.mjs").Build} build
-     * @param {import("@duckduckgo/messaging/lib/test-utils.mjs").PlatformInfo} platform
+     * @param {Page} page
+     * @param {Build} build
+     * @param {PlatformInfo} platform
      */
     constructor(page, build, platform) {
         this.page = page;
@@ -136,6 +145,66 @@ export class BrokerProtectionPage {
     }
 
     /**
+     * @param {object} params
+     * @param {number} params.widgetId
+     * @param {Record<number, string|null>} params.clients
+     */
+    async rendersRecaptchaClients({ widgetId, clients }) {
+        await this.page.evaluate(
+            ({ responseId, widgetId, clients }) => {
+                const responseElement = document.querySelector(`#${responseId}`);
+                if (!(responseElement instanceof HTMLElement)) {
+                    throw new Error('reCAPTCHA response element is missing');
+                }
+                responseElement.id = `${responseId}-${widgetId}`;
+                globalThis.___grecaptcha_cfg.clients = Object.fromEntries(
+                    Object.entries(clients).map(([id, callbackAttribute]) => [
+                        id,
+                        globalThis.createRecaptchaClient({ callbackAttribute, callable: callbackAttribute !== null }),
+                    ]),
+                );
+            },
+            { responseId: RECAPTCHA_RESPONSE_ID, widgetId, clients },
+        );
+    }
+
+    /**
+     * @param {{callback: {eval: string}}} response
+     */
+    async runsCaptchaCallback(response) {
+        await this.page.evaluate(response.callback.eval);
+    }
+
+    /**
+     * @param {string} selector
+     * @param {string} callbackAttribute
+     */
+    async isWidgetNotified(selector, callbackAttribute) {
+        await expect(this.page.locator(selector)).toHaveAttribute(callbackAttribute, 'test_token');
+    }
+
+    /**
+     * @param {string} selector
+     * @param {string} callbackAttribute
+     */
+    async isWidgetNotNotified(selector, callbackAttribute) {
+        await expect(this.page.locator(selector)).not.toHaveAttribute(callbackAttribute, 'test_token');
+    }
+
+    async hasNoNotifiedWidget() {
+        await expect(this.page.locator('.g-recaptcha[data-callback-token="test_token"]')).toHaveCount(0);
+    }
+
+    /**
+     * @param {number} widgetId
+     */
+    async removesRecaptchaWidgetId(widgetId) {
+        await this.page.locator(`${RECAPTCHA_RESPONSE_SELECTOR}-${widgetId}`).evaluate((element) => {
+            element.id = 'captcha-response-without-widget-id';
+        });
+    }
+
+    /**
      * @return {void}
      */
     isExtractMatch(response, person) {
@@ -173,8 +242,11 @@ export class BrokerProtectionPage {
         }
     }
 
-    async isCaptchaError() {
-        expect(await this.getErrorMessage()).not.toBeFalsy();
+    /**
+     * @param {string} [actionID]
+     */
+    async isCaptchaError(actionID) {
+        expect(await this.getErrorMessage(actionID)).not.toBeFalsy();
     }
 
     /**
@@ -229,39 +301,58 @@ export class BrokerProtectionPage {
         return await this.collector.waitForMessage('actionCompleted');
     }
 
-    async getSuccessResponse() {
+    /**
+     * @param {string} [actionID]
+     */
+    async getSuccessResponse(actionID) {
+        if (!actionID) {
+            const response = await this.getActionCompletedParams();
+            this.isSuccessMessage(response);
+            return this._getResultFromResponse(response).success.response;
+        }
+
+        await expect.poll(async () => this._getResultFromResponse(await this.getActionCompletedParams(), actionID)).toBeDefined();
+
         const response = await this.getActionCompletedParams();
-        this.isSuccessMessage(response);
-        return this._getResultFromResponse(response).success.response;
+        this.isSuccessMessage(response, actionID);
+        return this._getResultFromResponse(response, actionID).success.response;
     }
 
-    async getErrorMessage() {
+    async getErrorMessage(actionID) {
         const response = await this.getActionCompletedParams();
-        this.isErrorMessage(response);
-        return this._getResultFromResponse(response).error.message;
+        this.isErrorMessage(response, actionID);
+        return this._getResultFromResponse(response, actionID).error.message;
     }
 
     /**
      * @param {object} response
+     * @param {string} [actionID]
      */
-    isErrorMessage(response) {
-        expect('error' in this._getResultFromResponse(response)).toBe(true);
+    isErrorMessage(response, actionID) {
+        expect('error' in this._getResultFromResponse(response, actionID)).toBe(true);
     }
 
-    isSuccessMessage(response) {
-        expect('success' in this._getResultFromResponse(response)).toBe(true);
+    isSuccessMessage(response, actionID) {
+        const result = this._getResultFromResponse(response, actionID);
+        expect('success' in result, JSON.stringify(result)).toBe(true);
     }
 
     /**
      * @param {object} response
+     * @param {string} [actionID]
      */
-    _getResultFromResponse(response) {
-        return response[0].payload?.params?.result;
+    _getResultFromResponse(response, actionID) {
+        const results = response.map((message) => message.payload?.params?.result);
+        if (!actionID) {
+            return results[0];
+        }
+
+        return results.find((result) => (result?.success ?? result?.error)?.actionID === actionID);
     }
 
     /**
      * Helper for creating an instance per platform
-     * @param {import("@playwright/test").Page} page
+     * @param {Page} page
      * @param {Record<string, any>} use
      */
     static create(page, use) {

--- a/injected/integration-test/page-objects/broker-protection.js
+++ b/injected/integration-test/page-objects/broker-protection.js
@@ -319,6 +319,10 @@ export class BrokerProtectionPage {
     }
 
     async getErrorMessage(actionID) {
+        if (actionID) {
+            await expect.poll(async () => this._getResultFromResponse(await this.getActionCompletedParams(), actionID)).toBeDefined();
+        }
+
         const response = await this.getActionCompletedParams();
         this.isErrorMessage(response, actionID);
         return this._getResultFromResponse(response, actionID).error.message;

--- a/injected/integration-test/test-pages/broker-protection/pages/re-captcha-parent.html
+++ b/injected/integration-test/test-pages/broker-protection/pages/re-captcha-parent.html
@@ -1,0 +1,54 @@
+<ul id="people-search-results">
+    <li>
+        <div>
+            <div class="!text-black-900 text-lg">James Daly</div>
+        </div>
+        <div class="g-recaptcha" data-sitekey="test-site-key-0">
+            <iframe src="https://www.google.com/recaptcha/api2/anchor?k=test-site-key-0"></iframe>
+            <textarea id="g-recaptcha-response" name="g-recaptcha-response"></textarea>
+        </div>
+    </li>
+    <li>
+        <div>
+            <div class="!text-black-900 text-lg">James A Daly</div>
+            <div class="text-lg">52 Years Old</div>
+            <div class="text-xs">Locations Include</div>
+            <div>Gilbert, AZ</div>
+        </div>
+        <div class="g-recaptcha" data-sitekey="test-site-key-1">
+            <iframe src="https://www.google.com/recaptcha/api2/anchor?k=test-site-key-1"></iframe>
+            <textarea id="g-recaptcha-response-1" name="g-recaptcha-response"></textarea>
+        </div>
+    </li>
+    <li>
+        <div>
+            <div class="!text-black-900 text-lg">James W Daly</div>
+            <div class="text-lg">52 Years Old</div>
+            <div class="text-xs">Locations Include</div>
+            <div>Gilbert, AZ</div>
+        </div>
+        <div class="g-recaptcha" data-sitekey="test-site-key-2">
+            <iframe src="https://www.google.com/recaptcha/api2/anchor?k=test-site-key-2"></iframe>
+            <textarea id="g-recaptcha-response-2" name="g-recaptcha-response"></textarea>
+        </div>
+    </li>
+</ul>
+<script>
+    const captchaElements = document.querySelectorAll('.g-recaptcha');
+    globalThis.___grecaptcha_cfg = {
+        clients: Object.fromEntries(
+            Array.from(captchaElements).map((captchaElement, index) => [
+                index,
+                {
+                    config: {
+                        widget: {
+                            sitekey: captchaElement.getAttribute('data-sitekey'),
+                            size: 'normal',
+                            callback: (token) => captchaElement.setAttribute('data-callback-token', token),
+                        },
+                    },
+                },
+            ]),
+        ),
+    };
+</script>

--- a/injected/integration-test/test-pages/broker-protection/pages/re-captcha.html
+++ b/injected/integration-test/test-pages/broker-protection/pages/re-captcha.html
@@ -1,1 +1,23 @@
-<div style="width: 304px; height: 78px;" class="g-recaptcha"><div><iframe title="reCAPTCHA" src="https://www.google.com/recaptcha/api2/anchor?ar=1&amp;k=6LeCl8UUAAAAAGssOpatU5nzFXH2D7UZEYelSLTn&amp;co=aHR0cHM6Ly92ZXJlY29yLmNvbTo0NDM.&amp;hl=en&amp;v=SglpK98hSCn2CroR0bKRSJl5&amp;size=normal&amp;cb=3zdhtvz8lup8" width="304" height="78" role="presentation" name="a-pex208cuk2aj" frameborder="0" scrolling="no" sandbox="allow-forms allow-popups allow-same-origin allow-scripts allow-top-navigation allow-modals allow-popups-to-escape-sandbox" data-dashlane-rid="a5c78b7ba9489a73" data-dashlane-frameid="3102" data-form-type="other"></iframe></div><textarea id="g-recaptcha-response" name="g-recaptcha-response" class="g-recaptcha-response" style="width: 250px; height: 40px; border: 1px solid rgb(193, 193, 193); margin: 10px 25px; padding: 0px; resize: none; display: none;"></textarea></div>
+<div id="captcha-record">
+    <div id="captcha-near-ancestor">
+        <div style="width: 304px; height: 78px;" class="g-recaptcha"><div><iframe title="reCAPTCHA" src="https://www.google.com/recaptcha/api2/anchor?ar=1&amp;k=6LeCl8UUAAAAAGssOpatU5nzFXH2D7UZEYelSLTn&amp;co=aHR0cHM6Ly92ZXJlY29yLmNvbTo0NDM.&amp;hl=en&amp;v=SglpK98hSCn2CroR0bKRSJl5&amp;size=normal&amp;cb=3zdhtvz8lup8" width="304" height="78" role="presentation" name="a-pex208cuk2aj" frameborder="0" scrolling="no" sandbox="allow-forms allow-popups allow-same-origin allow-scripts allow-top-navigation allow-modals allow-popups-to-escape-sandbox" data-dashlane-rid="a5c78b7ba9489a73" data-dashlane-frameid="3102" data-form-type="other"></iframe></div><textarea id="g-recaptcha-response" name="g-recaptcha-response" class="g-recaptcha-response" style="width: 250px; height: 40px; border: 1px solid rgb(193, 193, 193); margin: 10px 25px; padding: 0px; resize: none; display: none;"></textarea></div>
+    </div>
+</div>
+<script>
+    const captchaElement = document.querySelector('.g-recaptcha');
+    globalThis.createRecaptchaClient = ({ element, callbackAttribute = 'data-callback-token', callable = true }) => ({
+        ...(element && { element }),
+        config: {
+            widget: {
+                sitekey: 'test-site-key',
+                size: 'normal',
+                callback: callable ? (token) => captchaElement.setAttribute(callbackAttribute, token) : null,
+            },
+        },
+    });
+    globalThis.___grecaptcha_cfg = {
+        clients: {
+            0: globalThis.createRecaptchaClient({ element: captchaElement.firstElementChild }),
+        },
+    };
+</script>

--- a/injected/src/features/broker-protection/actions/captcha-callback.js
+++ b/injected/src/features/broker-protection/actions/captcha-callback.js
@@ -1,22 +1,25 @@
 /**
  * @param {object} args
  * @param {string} args.token
+ * @param {number} [args.widgetId]
  */
 export function captchaCallback(args) {
     const clients = findRecaptchaClients(globalThis);
 
-    // if a client was found, check there was a function
     if (clients.length === 0) {
         return console.log('cannot find clients');
     }
 
-    if (typeof clients[0].function === 'function') {
-        try {
-            clients[0].function(args.token);
-            console.log('called function with path', clients[0].callback);
-        } catch (e) {
-            console.error('could not call function');
-        }
+    const client = args.widgetId === undefined ? clients[0] : clients.find(({ id }) => Number(id) === args.widgetId);
+    if (!client || typeof client.function !== 'function') {
+        return console.log('cannot find a callable reCAPTCHA client for widget', args.widgetId);
+    }
+
+    try {
+        client.function(args.token);
+        console.log('called function with path', client.callback);
+    } catch (e) {
+        console.error('could not call function');
     }
 
     /**

--- a/injected/src/features/broker-protection/actions/captcha-deprecated.js
+++ b/injected/src/features/broker-protection/actions/captcha-deprecated.js
@@ -3,11 +3,15 @@ import { getElement } from '../utils/utils.js';
 import { ErrorResponse, SuccessResponse } from '../types.js';
 
 /**
+ * @import { ActionResponse, PirAction } from '../types.js'
+ */
+
+/**
  * Gets the captcha information to send to the backend
  *
- * @param {import('../types.js').PirAction} action
- * @param {Document | HTMLElement} root
- * @return {import('../types.js').ActionResponse}
+ * @param {PirAction} action
+ * @param {Document} root
+ * @return {ActionResponse}
  */
 export function getCaptchaInfo(action, root = document) {
     const pageUrl = window.location.href;
@@ -90,7 +94,7 @@ export function getCaptchaInfo(action, root = document) {
  * @param action
  * @param {string} token
  * @param {Document} root
- * @return {import('../types.js').ActionResponse}
+ * @return {ActionResponse}
  */
 export function solveCaptcha(action, token, root = document) {
     const selectors = ['h-captcha-response', 'g-recaptcha-response'];

--- a/injected/src/features/broker-protection/actions/click.js
+++ b/injected/src/features/broker-protection/actions/click.js
@@ -1,13 +1,17 @@
 import { getElements } from '../utils/utils.js';
-import { ErrorResponse, SuccessResponse } from '../types.js';
-import { extractProfiles } from './extract.js';
+import { ErrorResponse, PirError, SuccessResponse } from '../types.js';
+import { selectRootElement } from '../utils/select-root-element.js';
 import { processTemplateStringWithUserData } from './build-url-transforms.js';
+
+/**
+ * @import { ActionResponse } from '../types.js'
+ */
 
 /**
  * @param {Record<string, any>} action
  * @param {Record<string, any>} userData
  * @param {Document | HTMLElement} root
- * @return {import('../types.js').ActionResponse}
+ * @return {ActionResponse}
  */
 export function click(action, userData, root = document) {
     /** @type {Array<any> | null} */
@@ -40,12 +44,10 @@ export function click(action, userData, root = document) {
 
     // there can be multiple elements provided by the action
     for (const element of elements) {
-        let rootElement;
+        const rootElement = selectRootElement(element, userData, root);
 
-        try {
-            rootElement = selectRootElement(element, userData, root);
-        } catch (error) {
-            return new ErrorResponse({ actionID: action.id, message: `Could not find root element: ${error.message}` });
+        if (PirError.isError(rootElement)) {
+            return new ErrorResponse({ actionID: action.id, message: `Could not find root element: ${rootElement.error.message}` });
         }
 
         const elements = getElements(rootElement, element.selector);
@@ -81,31 +83,6 @@ export function click(action, userData, root = document) {
     }
 
     return new SuccessResponse({ actionID: action.id, actionType: action.actionType, response: null });
-}
-
-/**
- * @param {{parent?: {profileMatch?: Record<string, any>}}} clickElement
- * @param {Record<string, any>} userData
- * @param {Document | HTMLElement} root
- * @return {Node}
- */
-function selectRootElement(clickElement, userData, root = document) {
-    // if there's no 'parent' field, just use the document
-    if (!clickElement.parent) return root;
-
-    // if the 'parent' field contains 'profileMatch', try to match it
-    if (clickElement.parent.profileMatch) {
-        const extraction = extractProfiles(clickElement.parent.profileMatch, userData, root);
-        if ('results' in extraction) {
-            const sorted = extraction.results.filter((x) => x.result === true).sort((a, b) => b.score - a.score);
-            const first = sorted[0];
-            if (first && first.element) {
-                return first.element;
-            }
-        }
-    }
-
-    throw new Error('`parent` was present on the element, but the configuration is not supported');
 }
 
 /**

--- a/injected/src/features/broker-protection/captcha-services/captcha.service.js
+++ b/injected/src/features/broker-protection/captcha-services/captcha.service.js
@@ -3,13 +3,22 @@ import { removeUrlQueryParams } from '../utils/url.js';
 import { ErrorResponse, PirError, SuccessResponse } from '../types';
 import { getCaptchaProvider, getCaptchaSolveProvider } from './get-captcha-provider';
 import { captchaFactory } from './providers/registry.js';
+import { selectRootElement } from '../utils/select-root-element.js';
 import { getCaptchaInfo as getCaptchaInfoDeprecated, solveCaptcha as solveCaptchaDeprecated } from '../actions/captcha-deprecated';
+
+/**
+ * @import { ActionResponse, PirAction, ProfileData } from '../types.js'
+ * @typedef {{profile: ProfileData|null, token: string|null}} PendingCaptchaContext
+ */
+
+/** @type {PendingCaptchaContext|null} */
+let pendingCaptchaContext = null;
 
 /**
  *
  * @param {Document | HTMLElement} root
- * @param {import('../types.js').PirAction['selector']} [selector]
- * @returns {HTMLElement | import('../types.js').PirError}
+ * @param {PirAction['selector']} [selector]
+ * @returns {HTMLElement | PirError}
  */
 const getCaptchaContainer = (root, selector) => {
     if (!selector) {
@@ -25,10 +34,20 @@ const getCaptchaContainer = (root, selector) => {
 };
 
 /**
+ * @param {PirAction} action
+ * @param {ProfileData|null} userData
+ * @param {Document | HTMLElement} root
+ * @returns {Document | HTMLElement | PirError}
+ */
+const getCaptchaRoot = (action, userData, root) => {
+    return selectRootElement(action, userData ?? {}, root);
+};
+
+/**
  * Returns the supporting code to inject for the given captcha type
  *
- * @param {import('../types.js').PirAction} action
- * @return {import('../types.js').ActionResponse}
+ * @param {PirAction} action
+ * @return {ActionResponse}
  */
 export function getSupportingCodeToInject(action) {
     const { id: actionID, actionType, injectCaptchaHandler: captchaType } = action;
@@ -49,20 +68,27 @@ export function getSupportingCodeToInject(action) {
 /**
  * Gets the captcha information to send to the backend
  *
- * @param {import('../types.js').PirAction} action
- * @param {Document | HTMLElement} root
- * @return {Promise<import('../types.js').ActionResponse>}
+ * @param {PirAction} action
+ * @param {ProfileData|null} userData
+ * @param {Document} root
+ * @return {Promise<ActionResponse>}
  */
-export async function getCaptchaInfo(action, root = document) {
+export async function getCaptchaInfo(action, userData, root = document) {
     const { id: actionID, actionType, captchaType, selector } = action;
+    pendingCaptchaContext = null;
+
     if (!captchaType) {
         // ensures backward compatibility with old actions
         return getCaptchaInfoDeprecated(action, root);
     }
 
     const createError = ErrorResponse.generateErrorResponseFunction({ actionID, context: `[getCaptchaInfo] captchaType: ${captchaType}` });
+    const captchaRoot = getCaptchaRoot(action, userData, root);
+    if (PirError.isError(captchaRoot)) {
+        return createError(captchaRoot.error.message);
+    }
 
-    const captchaContainer = getCaptchaContainer(root, selector);
+    const captchaContainer = getCaptchaContainer(captchaRoot, selector);
     if (PirError.isError(captchaContainer)) {
         return createError(captchaContainer.error.message);
     }
@@ -94,18 +120,23 @@ export async function getCaptchaInfo(action, root = document) {
         type: reportedType,
     };
 
+    if (action.parent) {
+        pendingCaptchaContext = { profile: userData, token: null };
+    }
+
     return SuccessResponse.create({ actionID, actionType, response });
 }
 
 /**
  * Takes the solved captcha token and injects it into the page to solve the captcha
  *
- * @param {import('../types.js').PirAction} action
+ * @param {PirAction} action
  * @param {string} token
+ * @param {ProfileData|null} userData
  * @param {Document} root
- * @return {import('../types.js').ActionResponse}
+ * @return {ActionResponse}
  */
-export function solveCaptcha(action, token, root = document) {
+export function solveCaptcha(action, token, userData, root = document) {
     const { id: actionID, actionType, captchaType, selector } = action;
     if (!captchaType) {
         // ensures backward compatibility with old actions
@@ -113,8 +144,25 @@ export function solveCaptcha(action, token, root = document) {
     }
 
     const createError = ErrorResponse.generateErrorResponseFunction({ actionID, context: `[solveCaptcha] captchaType: ${captchaType}` });
+    const matchingProfile = userData ?? pendingCaptchaContext?.profile ?? null;
 
-    const captchaContainer = getCaptchaContainer(root, selector);
+    if (action.parent && !matchingProfile) {
+        return createError('no profile available to scope the captcha solve');
+    }
+
+    const captchaToken = token ?? pendingCaptchaContext?.token ?? null;
+    if (!captchaToken) {
+        return createError('no token available to solve the captcha');
+    }
+
+    pendingCaptchaContext = action.parent ? { profile: matchingProfile, token: captchaToken } : null;
+
+    const captchaRoot = getCaptchaRoot(action, matchingProfile, root);
+    if (PirError.isError(captchaRoot)) {
+        return createError(captchaRoot.error.message);
+    }
+
+    const captchaContainer = getCaptchaContainer(captchaRoot, selector);
     if (PirError.isError(captchaContainer)) {
         return createError(captchaContainer.error.message);
     }
@@ -128,7 +176,12 @@ export function solveCaptcha(action, token, root = document) {
         return createError('cannot solve captcha');
     }
 
-    const tokenResponse = captchaSolveProvider.injectToken(captchaContainer, token);
+    const callback = captchaSolveProvider.getSolveCallback(captchaContainer, captchaToken);
+    if (PirError.isError(callback)) {
+        return createError(callback.error.message);
+    }
+
+    const tokenResponse = captchaSolveProvider.injectToken(captchaContainer, captchaToken);
     if (PirError.isError(tokenResponse)) {
         return createError(tokenResponse.error.message);
     }
@@ -137,9 +190,11 @@ export function solveCaptcha(action, token, root = document) {
         return createError('could not inject token');
     }
 
+    pendingCaptchaContext = null;
+
     return SuccessResponse.create({
         actionID,
         actionType,
-        response: { callback: { eval: captchaSolveProvider.getSolveCallback(captchaContainer, token) } },
+        response: { callback: { eval: callback } },
     });
 }

--- a/injected/src/features/broker-protection/captcha-services/providers/recaptcha.js
+++ b/injected/src/features/broker-protection/captcha-services/providers/recaptcha.js
@@ -5,6 +5,7 @@ import { injectTokenIntoElement } from '../utils/token';
 // TODO move on the same folder level once we deprecate the existing captcha scripts
 import { captchaCallback } from '../../actions/captcha-callback';
 import { safeCallWithError } from '../../utils/safe-call';
+import { PirError } from '../../types.js';
 
 // define the config below to reuse it in the class
 /**
@@ -60,14 +61,20 @@ export class ReCaptchaProvider {
     }
 
     /**
-     * @param {HTMLElement} _captchaContainerElement - The element containing the captcha
+     * @param {HTMLElement} captchaContainerElement - The element containing the captcha
      * @param {string} token
      */
-    getSolveCallback(_captchaContainerElement, token) {
+    getSolveCallback(captchaContainerElement, token) {
+        const responseElement = getElementByTagName(captchaContainerElement, this.#config.responseElementName);
+        const callbackArgs = createCaptchaCallbackArgs(responseElement, this.#config.responseElementName, token);
+        if (PirError.isError(callbackArgs)) {
+            return callbackArgs;
+        }
+
         return stringifyFunction({
             functionBody: captchaCallback,
             functionName: 'captchaCallback',
-            args: { token },
+            args: callbackArgs,
         });
     }
 
@@ -93,4 +100,31 @@ export class ReCaptchaProvider {
     _getCaptchaElement(captchaContainerElement) {
         return getElementWithSrcStart(captchaContainerElement, this.#config.providerUrl);
     }
+}
+
+/**
+ * @param {HTMLElement | null} responseElement
+ * @param {string} responseElementName
+ * @param {string} token
+ */
+function createCaptchaCallbackArgs(responseElement, responseElementName, token) {
+    if (!responseElement) {
+        return PirError.create('could not find the reCAPTCHA response element for the matched record');
+    }
+
+    if (responseElement.id === responseElementName) {
+        return { token, widgetId: 0 };
+    }
+
+    const prefix = `${responseElementName}-`;
+    if (!responseElement.id.startsWith(prefix)) {
+        return PirError.create('could not resolve a unique reCAPTCHA widget for the matched record');
+    }
+
+    const widgetId = responseElement.id.slice(prefix.length);
+    if (!/^\d+$/.test(widgetId)) {
+        return PirError.create('could not resolve a unique reCAPTCHA widget for the matched record');
+    }
+
+    return { token, widgetId: Number(widgetId) };
 }

--- a/injected/src/features/broker-protection/execute.js
+++ b/injected/src/features/broker-protection/execute.js
@@ -3,10 +3,14 @@ import { navigate, extract, click, scroll, expectation, fillForm, getCaptchaInfo
 import { ErrorResponse } from './types';
 
 /**
- * @param {import('./types.js').PirAction} action
+ * @import { ActionResponse, PirAction, PirInputData, ProfileData } from './types.js'
+ */
+
+/**
+ * @param {PirAction} action
  * @param {Record<string, any>} inputData
  * @param {Document} [root] - optional root element
- * @return {Promise<import('./types.js').ActionResponse>}
+ * @return {Promise<ActionResponse>}
  */
 export async function execute(action, inputData, root = document) {
     try {
@@ -24,9 +28,9 @@ export async function execute(action, inputData, root = document) {
                 return fillForm(action, data(action, inputData, 'extractedProfile'), root, userProfile);
             }
             case 'getCaptchaInfo':
-                return await getCaptchaInfo(action, root);
+                return await getCaptchaInfo(action, profileForMatching(inputData), root);
             case 'solveCaptcha':
-                return solveCaptcha(action, data(action, inputData, 'token'), root);
+                return solveCaptcha(action, data(action, inputData, 'token'), profileForMatching(inputData), root);
             case 'condition':
                 return condition(action, root);
             case 'scroll':
@@ -45,6 +49,14 @@ export async function execute(action, inputData, root = document) {
             message: `unhandled exception: ${e.message}`,
         });
     }
+}
+
+/**
+ * @param {PirInputData} inputData
+ * @returns {ProfileData|null}
+ */
+function profileForMatching(inputData) {
+    return inputData?.userProfile ?? inputData?.extractedProfile ?? null;
 }
 
 /**

--- a/injected/src/features/broker-protection/types.js
+++ b/injected/src/features/broker-protection/types.js
@@ -2,6 +2,11 @@
  * @typedef {SuccessResponse | ErrorResponse} ActionResponse
  * @typedef {{ result: true } | { result: false; error: string }} BooleanResult
  * @typedef {{type: "element" | "text" | "url"; selector: string; parent?: string; expect?: string; failSilently?: boolean}} Expectation
+ * @typedef {Record<string, unknown>} ProfileData
+ * @import { Action as ExtractAction, ProfileSpec } from './actions/extract.js'
+ * @typedef {{selector: string, profile: ProfileSpec}} ProfileMatch
+ * @typedef {{profileMatch: ProfileMatch}} ActionParent
+ * @typedef {{userProfile?: ProfileData, extractedProfile?: ProfileData, token?: string}} PirInputData
  */
 
 /**
@@ -9,6 +14,7 @@
  * @property {string} id
  * @property {"extract" | "fillForm" | "click" | "expectation" | "getCaptchaInfo" | "solveCaptcha" | "navigate" | "condition" | "scroll"} actionType
  * @property {string} [selector]
+ * @property {ActionParent} [parent]
  * @property {string} [captchaType]
  * @property {string} [injectCaptchaHandler]
  * @property {string} [dataSource]
@@ -135,7 +141,7 @@ export class ErrorResponse {
  * @property {PirAction['id']} actionID
  * @property {PirAction['actionType']} actionType
  * @property {any} response
- * @property {import("./actions/extract").Action[]} [next]
+ * @property {ExtractAction[]} [next]
  * @property {Record<string, any>} [meta] - optional meta data
  */
 

--- a/injected/src/features/broker-protection/utils/select-root-element.js
+++ b/injected/src/features/broker-protection/utils/select-root-element.js
@@ -1,0 +1,29 @@
+import { extractProfiles } from '../actions/extract.js';
+import { PirError } from '../types.js';
+
+/**
+ * @import { ActionParent, ProfileData } from '../types.js'
+ */
+
+/**
+ * @param {{parent?: ActionParent}} elementConfig
+ * @param {ProfileData} userData
+ * @param {Document | HTMLElement} root
+ * @return {Document | HTMLElement | PirError}
+ */
+export function selectRootElement(elementConfig, userData, root = document) {
+    if (!elementConfig.parent) return root;
+
+    if (elementConfig.parent.profileMatch) {
+        const extraction = extractProfiles(elementConfig.parent.profileMatch, userData, root);
+        if ('results' in extraction) {
+            const sorted = extraction.results.filter((x) => x.result === true).sort((a, b) => b.score - a.score);
+            const first = sorted[0];
+            if (first && first.element) {
+                return first.element;
+            }
+        }
+    }
+
+    return PirError.create('`parent` was present on the element, but the configuration is not supported');
+}

--- a/scripts/check-strict-core.js
+++ b/scripts/check-strict-core.js
@@ -1,11 +1,12 @@
 #!/usr/bin/env node
+import { execSync } from 'node:child_process';
+
 /**
  * Checks that injected core source files pass TypeScript strict mode.
  *
  * Runs tsc with tsconfig.strict-core.json and filters output to only core files.
  * Feature files are checked transitively but their errors are not reported here.
  */
-import { execSync } from 'node:child_process';
 
 const CORE_FILES = new Set([
     'injected/entry-points/android-adsjs.js',
@@ -68,6 +69,7 @@ const CORE_FILES = new Set([
     'injected/src/features/broker-protection/types.js',
     'injected/src/features/broker-protection/utils/expectations.js',
     'injected/src/features/broker-protection/utils/safe-call.js',
+    'injected/src/features/broker-protection/utils/select-root-element.js',
     'injected/src/features/broker-protection/utils/url.js',
     'injected/src/features/click-to-load/components/ctl-placeholder-blocked.js',
     'injected/src/features/click-to-load/components/index.js',


### PR DESCRIPTION
### Summary

Asana: https://app.asana.com/1/137249556945/task/1217336732941004

This PR:

* keeps the matched profile between `getCaptchaInfo` and `solveCaptcha`, because Apple and Android send only the solved token with the second action.
* uses that profile to inject the token and call the reCAPTCHA callback for the matched PropertyRecord row. Actions without `parent` keep the existing CAPTCHA flow.

## Why this is needed

PropertyRecord renders one reCAPTCHA per result row. We already use `parent.profileMatch` to select the correct row and apply the existing CAPTCHA selector within that row, which gives us the correct DOM widget.

`getCaptchaInfo` and `solveCaptcha` are separate calls. Apple and Android send the profile with `getCaptchaInfo`, then send only the solved token with `solveCaptcha`. Content-scope-scripts therefore keeps the matched profile until the token comes back and selects the same row again.

After we write the token, we must call reCAPTCHA's JavaScript callback. Google stores those callbacks in the global `___grecaptcha_cfg.clients` registry, outside the result row, so row-scoped selectors cannot identify the right one. For example, matching row 2 may give us `g-recaptcha-response-1`. The widget ID maps that element to client 1, instead of the old behavior that always called client 0.

The change reuses the existing profile matching for row selection, keeps only the state needed across the native CAPTCHA round trip, and uses the widget ID only to call the callback for the CAPTCHA we already selected.

## Test plan

* [ ] Build the Apple app with this content-scope-scripts branch, load the PropertyRecord JSON in the PIR debugger, run Opt out for an approved test profile with multiple records, and confirm the success page names the matched record.
* [ ] Load the unchanged Spokeo JSON in the PIR debugger, run Scan for a test profile, and confirm the existing CAPTCHA flow still reaches the results page.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 00f73648850bad2ebd1634b860d9563181536070. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
