### PR TITLE
Element hiding: Improve performance by taking advantage of browser selector indexing

### DIFF
--- a/injected/integration-test/test-pages/element-hiding/config/element-hiding.json
+++ b/injected/integration-test/test-pages/element-hiding/config/element-hiding.json
@@ -13,6 +13,22 @@
                 "domains": [],
                 "rules": [
                     {
+                        "selector": "div:::malformed-selector",
+                        "type": "hide-empty"
+                    },
+                    {
+                        "selector": ":ddg-nonexistent-pseudo-class",
+                        "type": "hide-empty"
+                    },
+                    {
+                        "selector": ".invalid-canary-test",
+                        "type": "hide-empty"
+                    },
+                    {
+                        "selector": ".invalid-list-test, div:::malformed-in-list",
+                        "type": "hide-empty"
+                    },
+                    {
                         "selector": ".hide-test",
                         "type": "hide"
                     },

--- a/injected/integration-test/test-pages/element-hiding/pages/element-hiding.html
+++ b/injected/integration-test/test-pages/element-hiding/pages/element-hiding.html
@@ -80,6 +80,14 @@
         </div>
     </div>
 
+    <!-- Invalid selector containment test elements -->
+    <div id="invalid-selector">
+        <div class="container invalid-canary-test" id="invalid-canary">
+        </div>
+        <div class="container invalid-list-test" id="invalid-list-member">
+        </div>
+    </div>
+
     <!-- Closest-empty rule test elements -->
     <div id="closest-empty">
         <div class="container closest-empty-test" id="closest-empty-single-div">
@@ -363,6 +371,23 @@
                     name: "Parent of element that loads 3p frame after delay is NOT hidden",
                     result: isElementHidden('closest-empty-delayed-frame'),
                     expected: false
+                }
+            ];
+        });
+
+        test('Invalid selector containment tests', async () => {
+            await new Promise(resolve => setTimeout(resolve, 100));
+
+            return [
+                {
+                    name: "Rule following a malformed selector is still applied",
+                    result: isElementHidden('invalid-canary'),
+                    expected: true
+                },
+                {
+                    name: "Valid selector in a list containing a malformed selector is still applied",
+                    result: isElementHidden('invalid-list-member'),
+                    expected: true
                 }
             ];
         });

--- a/injected/src/features/element-hiding.js
+++ b/injected/src/features/element-hiding.js
@@ -374,10 +374,10 @@ function forgivingSelector(selector) {
 
 /**
  * Resolve a rule's selector for use with querySelectorAll
- * 
+ *
  * :is() makes a selector list forgiving, but has a perf cost since
  * it's a pseudo-class that isn't indexed. Only wrap when the selector
- * might be a list, in which case one malformed selector can lead to 
+ * might be a list, in which case one malformed selector can lead to
  * the rest of the list not applying
  */
 function querySelectorFor(selector) {

--- a/injected/src/features/element-hiding.js
+++ b/injected/src/features/element-hiding.js
@@ -62,6 +62,7 @@ const parser = new DOMParser();
 let hiddenElements = new WeakMap();
 let modifiedElements = new WeakMap();
 let appliedRules = new Set();
+const resolvedSelectors = new Map();
 let shouldInjectStyleTag = false;
 let styleTagInjected = false;
 let mediaAndFormSelectors = 'video,canvas,embed,object,audio,map,form,input,textarea,select,option,button';
@@ -331,10 +332,15 @@ function hideAdNodes(rules) {
     const document = globalThis.document;
 
     rules.filter(hasSelector).forEach((rule) => {
-        const selector = forgivingSelector(rule.selector);
-        const matchingElementArray = [...document.querySelectorAll(selector)];
+        let matchingElementArray;
+        try {
+            matchingElementArray = [...document.querySelectorAll(querySelectorFor(rule.selector))];
+        } catch {
+            // Invalid or unsupported selector. Skip this rule only - an
+            // uncaught throw here would abort the whole pass.
+            return;
+        }
         matchingElementArray.forEach((element) => {
-            // @ts-expect-error https://app.asana.com/0/1201614831475344/1203979574128023/f
             collapseDomNode(element, rule);
         });
     });
@@ -347,10 +353,13 @@ function unhideLoadedAds() {
     const document = globalThis.document;
 
     appliedRules.forEach((rule) => {
-        const selector = forgivingSelector(rule.selector);
-        const matchingElementArray = [...document.querySelectorAll(selector)];
+        let matchingElementArray;
+        try {
+            matchingElementArray = [...document.querySelectorAll(querySelectorFor(rule.selector))];
+        } catch {
+            return;
+        }
         matchingElementArray.forEach((element) => {
-            // @ts-expect-error https://app.asana.com/0/1201614831475344/1203979574128023/f
             expandNonEmptyDomNode(element, rule);
         });
     });
@@ -361,6 +370,23 @@ function unhideLoadedAds() {
  */
 function forgivingSelector(selector) {
     return `:is(${selector})`;
+}
+
+/**
+ * Resolve a rule's selector for use with querySelectorAll
+ * 
+ * :is() makes a selector list forgiving, but has a perf cost since
+ * it's a pseudo-class that isn't indexed. Only wrap when the selector
+ * might be a list, in which case one malformed selector can lead to 
+ * the rest of the list not applying
+ */
+function querySelectorFor(selector) {
+    let resolved = resolvedSelectors.get(selector);
+    if (resolved === undefined) {
+        resolved = selector.includes(',') ? forgivingSelector(selector) : selector;
+        resolvedSelectors.set(selector, resolved);
+    }
+    return resolved;
 }
 
 export default class ElementHiding extends ContentFeature {

--- a/injected/src/features/element-hiding.js
+++ b/injected/src/features/element-hiding.js
@@ -62,7 +62,6 @@ const parser = new DOMParser();
 let hiddenElements = new WeakMap();
 let modifiedElements = new WeakMap();
 let appliedRules = new Set();
-const resolvedSelectors = new Map();
 let shouldInjectStyleTag = false;
 let styleTagInjected = false;
 let mediaAndFormSelectors = 'video,canvas,embed,object,audio,map,form,input,textarea,select,option,button';
@@ -381,12 +380,7 @@ function forgivingSelector(selector) {
  * the rest of the list not applying
  */
 function querySelectorFor(selector) {
-    let resolved = resolvedSelectors.get(selector);
-    if (resolved === undefined) {
-        resolved = selector.includes(',') ? forgivingSelector(selector) : selector;
-        resolvedSelectors.set(selector, resolved);
-    }
-    return resolved;
+    return selector.includes(',') ? forgivingSelector(selector) : selector;
 }
 
 export default class ElementHiding extends ContentFeature {


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/task/1217648927550635?focus=true

## Description
Despite most of our element hiding rules being simple indexable selectors, we're actually not getting any benefit from browser engine indexing because we're wrapping them in an `:is()` pseudo-class to make them [forgiving selectors](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Selectors/:is#forgiving_selector_parsing). We did this in 2022 to address browser engine compatibility differences—Firefox didn't support the :has() pseudo-class at the time, and we needed it in element hiding to address Sign in with Google pop-ups. By making the selectors forgiving, it made it so the code wouldn't throw an error when we attempted to query the page for unsupported selector types.

This PR adds logic to the element hiding algo so we only wrap selector lists in `:is()`, and we catch errors thrown if malformed selector rules are added to remote config.

## Testing Steps
- Pull branch
- Run integration tests

## Checklist

<!--
  These questions are a friendly reminder to shipping code, if you're uncertain ask the AoR owners.
  It's also totally appropriate to not check some of these boxes, if they don't apply to your change.
-->
*Please tick all that apply:*

- [x] I have tested this change locally
- [ ] I have tested this change locally in all supported browsers
- [ ] This change will be visible to users
- [x] I have added automated tests that cover this change
- [ ] I have ensured the change is gated by config
- [ ] This change was covered by a ship review
- [ ] This change was covered by a tech design
- [ ] Any dependent config has been merged


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how ad-hiding selectors are queried on every page pass. A bug could miss hides or skip remaining rules, but behavior is covered by new containment tests.
> 
> **Overview**
> Stops wrapping every element-hiding `querySelectorAll` selector in `:is()`, so simple indexable selectors can use the browser’s selector index. `:is()` is now applied only when the selector contains a comma (a list).
> 
> Invalid or unsupported selectors are caught per rule so one bad remote-config rule no longer aborts the whole hide/unhide pass. Integration tests cover malformed selectors, unknown pseudo-classes, and mixed valid/invalid lists.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e0e14dca0de3789bebd08480f81a209b030d4ef3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->