### PR TITLE
PIR: Add support for executeScript action

### DIFF
--- a/injected/integration-test/broker-protection-tests/broker-protection.spec.js
+++ b/injected/integration-test/broker-protection-tests/broker-protection.spec.js
@@ -1056,4 +1056,81 @@ test.describe('Broker Protection communications', () => {
             dbp.isErrorMessage(response);
         });
     });
+
+    test.describe('executeScript', () => {
+        /**
+         * @param {string} id
+         * @param {string} script
+         */
+        const executeScript = (id, script) => ({ state: { action: { actionType: 'executeScript', id, script } } });
+
+        /**
+         * @param {import('@playwright/test').Page} page
+         * @param {import('@playwright/test').TestInfo} testInfo
+         */
+        async function onExecuteScriptPage(page, testInfo) {
+            const dbp = BrokerProtectionPage.create(page, testInfo.project.use);
+            await dbp.enabled();
+            await dbp.navigatesTo('execute-script.html');
+            return dbp;
+        }
+
+        test('runs the script against the profile, reports a null response, and a following click reaches the encoded destination', async ({
+            page,
+        }, testInfo) => {
+            const dbp = await onExecuteScriptPage(page, testInfo);
+            await dbp.receivesAction('execute-script.json');
+
+            const response = await dbp.getActionCompletedParams();
+            dbp.isSuccessMessage(response);
+            expect(response[0].payload.params.result.success.actionType).toBe('executeScript');
+            expect(response[0].payload.params.result.success.response).toBeNull();
+
+            await dbp.receivesInlineAction({
+                state: {
+                    action: {
+                        actionType: 'click',
+                        id: 'execute-script-click',
+                        elements: [{ type: 'button', selector: '#pir-probe-anchor' }],
+                    },
+                },
+            });
+
+            const clickResponse = await dbp.collector.waitForMessage('actionCompleted', 2);
+            expect('success' in clickResponse[1].payload.params.result).toBe(true);
+            await page.waitForURL((url) => url.hash === '#name=Daniel+Silva', { timeout: 2000 });
+        });
+
+        test('returns the action error shape when the script throws', async ({ page }, testInfo) => {
+            const dbp = await onExecuteScriptPage(page, testInfo);
+            await dbp.receivesInlineAction(executeScript('execute-script-throw', "throw new Error('boom');"));
+
+            expect(await dbp.getErrorMessage()).toContain('executeScript failed');
+        });
+
+        test('returns the action error shape when the script rejects', async ({ page }, testInfo) => {
+            const dbp = await onExecuteScriptPage(page, testInfo);
+            await dbp.receivesInlineAction(executeScript('execute-script-reject', "return Promise.reject(new Error('nope'));"));
+
+            expect(await dbp.getErrorMessage()).toContain('executeScript failed');
+        });
+
+        test('discards the value returned by the script', async ({ page }, testInfo) => {
+            const dbp = await onExecuteScriptPage(page, testInfo);
+            await dbp.receivesInlineAction(executeScript('execute-script-return', 'return { leaked: root.body.innerHTML };'));
+
+            const response = await dbp.getActionCompletedParams();
+            dbp.isSuccessMessage(response);
+            const result = response[0].payload.params.result;
+            expect(result.success.response).toBeNull();
+            expect(JSON.stringify(result)).not.toContain('Daniel Silva');
+        });
+
+        test('returns the action error shape when the script is empty', async ({ page }, testInfo) => {
+            const dbp = await onExecuteScriptPage(page, testInfo);
+            await dbp.receivesInlineAction(executeScript('execute-script-empty', ''));
+
+            expect(await dbp.getErrorMessage()).toContain('No script provided to executeScript action');
+        });
+    });
 });

--- a/injected/integration-test/broker-protection-tests/broker-protection.spec.js
+++ b/injected/integration-test/broker-protection-tests/broker-protection.spec.js
@@ -1,6 +1,9 @@
-import { test, expect } from '@playwright/test';
+import { test as base, expect } from '@playwright/test';
 import { BrokerProtectionPage } from '../page-objects/broker-protection.js';
 import { BROKER_PROTECTION_CONFIGS } from './tests-config.js';
+import { createConfiguredDbpTest } from './fixtures.js';
+
+const test = createConfiguredDbpTest(base);
 
 test.describe('Broker Protection communications', () => {
     test('sends an error when the action is not found', async ({ page }, workerInfo) => {
@@ -1058,33 +1061,37 @@ test.describe('Broker Protection communications', () => {
     });
 
     test.describe('executeScript', () => {
-        /**
-         * @param {string} id
-         * @param {string} script
-         */
-        const executeScript = (id, script) => ({ state: { action: { actionType: 'executeScript', id, script } } });
+        const actionID = 'execute-script-test';
 
         /**
-         * @param {import('@playwright/test').Page} page
-         * @param {import('@playwright/test').TestInfo} testInfo
+         * @param {unknown} script
+         * @param {Record<string, unknown>} [overrides]
+         * @param {Record<string, unknown>} [data]
          */
-        async function onExecuteScriptPage(page, testInfo) {
-            const dbp = BrokerProtectionPage.create(page, testInfo.project.use);
-            await dbp.enabled();
-            await dbp.navigatesTo('execute-script.html');
-            return dbp;
+        function scriptAction(script, overrides = {}, data = {}) {
+            return { state: { action: { actionType: 'executeScript', id: actionID, script, ...overrides }, data } };
         }
 
-        test('runs the script against the profile, reports a null response, and a following click reaches the encoded destination', async ({
-            page,
-        }, testInfo) => {
-            const dbp = await onExecuteScriptPage(page, testInfo);
-            await dbp.receivesAction('execute-script.json');
+        /** @param {import('../page-objects/broker-protection.js').BrokerProtectionPage} dbp */
+        async function completedResult(dbp) {
+            const messages = await dbp.getActionCompletedParams();
+            expect(messages).toHaveLength(1);
+            return messages[0].payload.params.result;
+        }
 
-            const response = await dbp.getActionCompletedParams();
-            dbp.isSuccessMessage(response);
-            expect(response[0].payload.params.result.success.actionType).toBe('executeScript');
-            expect(response[0].payload.params.result.success.response).toBeNull();
+        const success = { success: { actionID, actionType: 'executeScript', response: null } };
+
+        test.beforeEach(async ({ dbp }) => {
+            await dbp.navigatesTo('execute-script.html');
+        });
+
+        test('injects a profile-based link that a following click navigates with the page as referrer', async ({ dbp, page }) => {
+            const sourceUrl = page.url();
+            await dbp.receivesAction('execute-script.json');
+            expect(await completedResult(dbp)).toEqual({
+                success: { actionID: 'execute-script-1', actionType: 'executeScript', response: null },
+            });
+            await expect(page.locator('#pir-probe-anchor')).toHaveAttribute('href', 'execute-script.html?name=Daniel+Silva');
 
             await dbp.receivesInlineAction({
                 state: {
@@ -1095,42 +1102,164 @@ test.describe('Broker Protection communications', () => {
                     },
                 },
             });
-
-            const clickResponse = await dbp.collector.waitForMessage('actionCompleted', 2);
-            expect('success' in clickResponse[1].payload.params.result).toBe(true);
-            await page.waitForURL((url) => url.hash === '#name=Daniel+Silva', { timeout: 2000 });
+            await page.waitForURL((url) => url.searchParams.get('name') === 'Daniel Silva');
+            expect(await page.evaluate(() => document.referrer)).toBe(sourceUrl);
         });
 
-        test('returns the action error shape when the script throws', async ({ page }, testInfo) => {
-            const dbp = await onExecuteScriptPage(page, testInfo);
-            await dbp.receivesInlineAction(executeScript('execute-script-throw', "throw new Error('boom');"));
-
-            expect(await dbp.getErrorMessage()).toContain('executeScript failed');
+        test('passes the profile selected by dataSource', async ({ dbp, page }) => {
+            const userProfile = { firstName: 'Daniel', lastName: 'Silva', city: 'Los Angeles', state: 'CA', birthYear: 1988 };
+            const extractedProfile = { firstName: 'Other' };
+            await dbp.receivesInlineAction(
+                scriptAction(
+                    'root.body.textContent = JSON.stringify(userProfile);',
+                    { dataSource: 'extractedProfile' },
+                    { userProfile, extractedProfile },
+                ),
+            );
+            expect(await completedResult(dbp)).toEqual(success);
+            await expect(page.locator('body')).toHaveText(JSON.stringify(extractedProfile));
         });
 
-        test('returns the action error shape when the script rejects', async ({ page }, testInfo) => {
-            const dbp = await onExecuteScriptPage(page, testInfo);
-            await dbp.receivesInlineAction(executeScript('execute-script-reject', "return Promise.reject(new Error('nope'));"));
-
-            expect(await dbp.getErrorMessage()).toContain('executeScript failed');
+        test('allows DOM-only scripts without input data', async ({ dbp, page }) => {
+            const action = scriptAction('root.body.textContent = userProfile === null ? "no profile" : "unexpected profile";');
+            await dbp.receivesInlineAction({ state: { action: action.state.action } });
+            expect(await completedResult(dbp)).toEqual(success);
+            await expect(page.locator('body')).toHaveText('no profile');
         });
 
-        test('discards the value returned by the script', async ({ page }, testInfo) => {
-            const dbp = await onExecuteScriptPage(page, testInfo);
-            await dbp.receivesInlineAction(executeScript('execute-script-return', 'return { leaked: root.body.innerHTML };'));
+        test('waits for a returned promise and discards its resolved value', async ({ dbp, page }) => {
+            await dbp.receivesInlineAction(
+                scriptAction(`return new Promise((resolve) => {
+                    root.addEventListener('finish-script', () => {
+                        root.body.dataset.finished = 'true';
+                        resolve({ privateData: root.body.innerHTML });
+                    }, { once: true });
+                    root.body.dataset.started = 'true';
+                });`),
+            );
+            await expect(page.locator('body')).toHaveAttribute('data-started', 'true');
+            const brokerMessages = (await dbp.collector.outgoingMessages()).filter(
+                (message) => message.payload.featureName === 'brokerProtection',
+            );
+            expect(brokerMessages).toEqual([]);
 
-            const response = await dbp.getActionCompletedParams();
-            dbp.isSuccessMessage(response);
-            const result = response[0].payload.params.result;
-            expect(result.success.response).toBeNull();
-            expect(JSON.stringify(result)).not.toContain('Daniel Silva');
+            await page.evaluate(() => document.dispatchEvent(new Event('finish-script')));
+            expect(await completedResult(dbp)).toEqual(success);
+            await expect(page.locator('body')).toHaveAttribute('data-finished', 'true');
         });
 
-        test('returns the action error shape when the script is empty', async ({ page }, testInfo) => {
-            const dbp = await onExecuteScriptPage(page, testInfo);
-            await dbp.receivesInlineAction(executeScript('execute-script-empty', ''));
+        test('discards synchronous results without serializing or executing returned actions', async ({ dbp }) => {
+            await dbp.receivesInlineAction(
+                scriptAction(`return {
+                    privateData: root.body.innerHTML,
+                    next: [{ actionType: 'executeScript', script: 'throw new Error("unexpected action");' }],
+                    toJSON() { throw new Error('must not serialize'); }
+                };`),
+            );
+            expect(await completedResult(dbp)).toEqual(success);
+        });
 
-            expect(await dbp.getErrorMessage()).toContain('No script provided to executeScript action');
+        for (const { label, script, message } of [
+            { label: 'a synchronous throw', script: "throw new TypeError('boom');", message: 'TypeError: boom' },
+            { label: 'a rejected promise', script: "return Promise.reject(new RangeError('nope'));", message: 'RangeError: nope' },
+            { label: 'an empty script', script: '', message: 'Error: No script provided to executeScript action' },
+            { label: 'a whitespace-only script', script: ' \n\t ', message: 'Error: No script provided to executeScript action' },
+            { label: 'a missing script', script: undefined, message: 'Error: No script provided to executeScript action' },
+            { label: 'a non-string script', script: 42, message: 'Error: No script provided to executeScript action' },
+            { label: 'a thrown string', script: 'throw "failed";', message: 'Error: failed' },
+            { label: 'a thrown null', script: 'throw null;', message: 'Error: null' },
+            {
+                label: 'an error-like object',
+                script: 'throw { name: "CustomError", message: "failed" };',
+                message: 'CustomError: failed',
+            },
+            { label: 'an error with no name', script: 'throw { message: "failed" };', message: 'Error: failed' },
+            { label: 'an error with an empty message', script: 'throw new Error("");', message: 'Error: ' },
+            {
+                label: 'a DOMException',
+                script: 'throw new DOMException("denied", "SecurityError");',
+                message: 'SecurityError: denied',
+            },
+            {
+                label: 'an object that cannot be converted to a string',
+                script: 'throw Object.create(null);',
+                message: 'Error: Unknown error',
+            },
+            {
+                label: 'an error whose message getter throws',
+                script: 'throw { name: "CustomError", get message() { throw new Error("private getter failure"); } };',
+                message: 'CustomError: Unknown error',
+            },
+            {
+                label: 'an error name exceeding the 500-character limit',
+                script: 'throw { name: "n".repeat(600), message: "message" };',
+                message: 'n'.repeat(478),
+            },
+            {
+                label: 'an error with controls before printable Unicode',
+                script: 'throw new Error("\\n".repeat(1000) + "café 日本語");',
+                message: 'Error: café 日本語',
+            },
+            {
+                label: 'an oversized error with controls and an unreadable stack',
+                script: `const controls = String.fromCharCode(
+                        ...Array.from({ length: 32 }, (_, index) => index),
+                        ...Array.from({ length: 33 }, (_, index) => 127 + index),
+                        0x2028, 0x2029
+                    );
+                    const error = new Error('line1' + controls + 'line2' + 'x'.repeat(600));
+                    error.name = 'Type' + controls + 'Error';
+                    Object.defineProperty(error, 'stack', {
+                        get() { throw new Error('must not read the stack'); }
+                    });
+                    throw error;`,
+                message: 'TypeError: line1line2' + 'x'.repeat(500 - 'executeScript failed: TypeError: line1line2'.length),
+            },
+            {
+                label: 'an error from an iframe',
+                script: `const frame = root.createElement('iframe');
+                    root.body.appendChild(frame);
+                    const error = new frame.contentWindow.RangeError('out of range');
+                    frame.remove();
+                    if (error instanceof Error) throw new Error('expected an error from another realm');
+                    throw error;`,
+                message: 'RangeError: out of range',
+            },
+        ]) {
+            test(`reports the action error for ${label}`, async ({ dbp }) => {
+                await dbp.receivesInlineAction(scriptAction(script));
+                expect(await completedResult(dbp)).toEqual({ error: { actionID, message: `executeScript failed: ${message}` } });
+            });
+        }
+
+        test('reports syntax errors without running any of the script', async ({ dbp, page }) => {
+            await dbp.receivesInlineAction(scriptAction('root.body.dataset.started = "true"; const = ;'));
+            expect(await completedResult(dbp)).toEqual({
+                error: { actionID, message: expect.stringMatching(/^executeScript failed: SyntaxError: /) },
+            });
+            await expect(page.locator('body')).not.toHaveAttribute('data-started');
+        });
+
+        for (const { failureType, script } of [
+            { failureType: 'synchronous', script: 'throw new Error("failed");' },
+            { failureType: 'asynchronous', script: 'return Promise.reject(new Error("failed"));' },
+        ]) {
+            test(`does not retry ${failureType} failures when retries are configured`, async ({ dbp, page }) => {
+                await dbp.receivesInlineAction(
+                    scriptAction(
+                        `root.body.dataset.attempts = String(Number(root.body.dataset.attempts || 0) + 1);
+                        ${script}`,
+                        { retry: { environment: 'web', maxAttempts: 3, interval: { ms: 1 } } },
+                    ),
+                );
+                expect(await completedResult(dbp)).toEqual({ error: { actionID, message: 'executeScript failed: Error: failed' } });
+                await expect(page.locator('body')).toHaveAttribute('data-attempts', '1');
+            });
+        }
+
+        test('reports failures even when failSilently is true', async ({ dbp }) => {
+            await dbp.receivesInlineAction(scriptAction('throw new Error("failed");', { failSilently: true }));
+            expect(await completedResult(dbp)).toEqual({ error: { actionID, message: 'executeScript failed: Error: failed' } });
         });
     });
 });

--- a/injected/integration-test/test-pages/broker-protection/actions/execute-script.json
+++ b/injected/integration-test/test-pages/broker-protection/actions/execute-script.json
@@ -1,0 +1,18 @@
+{
+  "state": {
+    "action": {
+      "id": "execute-script-1",
+      "actionType": "executeScript",
+      "script": "const params = new URLSearchParams({ name: userProfile.firstName + ' ' + userProfile.lastName }); const anchor = root.createElement('a'); anchor.id = 'pir-probe-anchor'; anchor.href = '#' + params.toString(); anchor.textContent = 'probe'; root.body.appendChild(anchor);"
+    },
+    "data": {
+      "userProfile": {
+        "firstName": "Daniel",
+        "lastName": "Silva",
+        "city": "Los Angeles",
+        "state": "CA",
+        "birthYear": 1988
+      }
+    }
+  }
+}

--- a/injected/integration-test/test-pages/broker-protection/actions/execute-script.json
+++ b/injected/integration-test/test-pages/broker-protection/actions/execute-script.json
@@ -3,7 +3,7 @@
     "action": {
       "id": "execute-script-1",
       "actionType": "executeScript",
-      "script": "const params = new URLSearchParams({ name: userProfile.firstName + ' ' + userProfile.lastName }); const anchor = root.createElement('a'); anchor.id = 'pir-probe-anchor'; anchor.href = '#' + params.toString(); anchor.textContent = 'probe'; root.body.appendChild(anchor);"
+      "script": "const params = new URLSearchParams({ name: userProfile.firstName + ' ' + userProfile.lastName }); const anchor = root.createElement('a'); anchor.id = 'pir-probe-anchor'; anchor.href = 'execute-script.html?' + params.toString(); anchor.textContent = 'probe'; root.body.appendChild(anchor);"
     },
     "data": {
       "userProfile": {

--- a/injected/integration-test/test-pages/broker-protection/pages/execute-script.html
+++ b/injected/integration-test/test-pages/broker-protection/pages/execute-script.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width">
+    <title>Broker Protection</title>
+</head>
+<body>
+    <div class="result">
+        <div class="name">Daniel Silva</div>
+        <div class="age">37</div>
+    </div>
+</body>
+</html>

--- a/injected/src/features/broker-protection.js
+++ b/injected/src/features/broker-protection.js
@@ -100,6 +100,10 @@ export default class BrokerProtection extends ActionExecutorBase {
      * @returns
      */
     retryConfigFor(action) {
+        // Scripts can have non-idempotent side effects. Never retry, even when
+        // broker JSON supplies an explicit web retry configuration.
+        if (action.actionType === 'executeScript') return undefined;
+
         /**
          * Note: We're not currently guarding against concurrent actions here
          * since the native side contains the scheduling logic to prevent it.

--- a/injected/src/features/broker-protection/actions/actions.js
+++ b/injected/src/features/broker-protection/actions/actions.js
@@ -1,6 +1,7 @@
 export { extract } from './extract.js';
 export { fillForm } from './fill-form.js';
 export { click } from './click.js';
+export { executeScript } from './execute-script.js';
 export { expectation } from './expectation.js';
 export { navigate } from './navigate.js';
 export { getCaptchaInfo, solveCaptcha } from '../captcha-services/captcha.service.js';

--- a/injected/src/features/broker-protection/actions/execute-script.js
+++ b/injected/src/features/broker-protection/actions/execute-script.js
@@ -1,0 +1,23 @@
+import { ErrorResponse, SuccessResponse } from '../types.js';
+
+/**
+ * @param {Record<string, any>} action
+ * @param {Record<string, any>} userData
+ * @param {Document} root
+ * @return {Promise<import('../types.js').ActionResponse>}
+ */
+export async function executeScript(action, userData, root) {
+    if (typeof action.script !== 'string' || !action.script.length) {
+        return new ErrorResponse({ actionID: action.id, message: 'No script provided to executeScript action' });
+    }
+
+    try {
+        // eslint-disable-next-line no-new-func -- compiling the configured script body at runtime requires new Function
+        const fn = new Function('userProfile', 'root', action.script);
+        await fn(userData, root);
+        return new SuccessResponse({ actionID: action.id, actionType: action.actionType, response: null });
+    } catch (e) {
+        const message = e instanceof Error ? e.message : String(e);
+        return new ErrorResponse({ actionID: action.id, message: `executeScript failed: ${message}` });
+    }
+}

--- a/injected/src/features/broker-protection/actions/execute-script.js
+++ b/injected/src/features/broker-protection/actions/execute-script.js
@@ -1,23 +1,55 @@
 import { ErrorResponse, SuccessResponse } from '../types.js';
 
 /**
- * @param {Record<string, any>} action
- * @param {Record<string, any>} userData
+ * Runs a configured function body once. Native owns the action timeout and
+ * failSilently handling; every failure must be reported for native telemetry.
+ *
+ * @param {import('../types.js').PirAction} action
+ * @param {import('../types.js').ProfileData | null} userProfile
  * @param {Document} root
  * @return {Promise<import('../types.js').ActionResponse>}
  */
-export async function executeScript(action, userData, root) {
-    if (typeof action.script !== 'string' || !action.script.length) {
-        return new ErrorResponse({ actionID: action.id, message: 'No script provided to executeScript action' });
+export async function executeScript(action, userProfile, root) {
+    if (typeof action.script !== 'string' || !action.script.trim()) {
+        return new ErrorResponse({
+            actionID: action.id,
+            message: 'executeScript failed: Error: No script provided to executeScript action',
+        });
     }
 
     try {
         // eslint-disable-next-line no-new-func -- compiling the configured script body at runtime requires new Function
         const fn = new Function('userProfile', 'root', action.script);
-        await fn(userData, root);
+        // Only returned promises delay completion. Returned values never reach native.
+        await fn(userProfile, root);
         return new SuccessResponse({ actionID: action.id, actionType: action.actionType, response: null });
     } catch (e) {
-        const message = e instanceof Error ? e.message : String(e);
-        return new ErrorResponse({ actionID: action.id, message: `executeScript failed: ${message}` });
+        return new ErrorResponse({ actionID: action.id, message: formatScriptError(e) });
     }
+}
+
+/**
+ * Native forwards this message to an error pixel. Omit stacks and strip control
+ * characters (including Unicode line separators) before limiting the whole message.
+ * @param {unknown} error
+ * @returns {string}
+ */
+function formatScriptError(error) {
+    let name = 'Error';
+    let message = 'Unknown error';
+    try {
+        // Also handles errors from another realm, such as an iframe on the page.
+        if (error !== null && typeof error === 'object' && 'message' in error) {
+            const errorName = 'name' in error ? error.name : undefined;
+            if (typeof errorName === 'string' && errorName) name = errorName;
+            message = String(error.message);
+        } else {
+            message = String(error);
+        }
+    } catch {
+        // Scripts may throw objects whose getters or string conversion also throw.
+        // Keep a bounded error response even when those objects cannot be inspected.
+    }
+    // eslint-disable-next-line no-control-regex -- remove control characters from native telemetry
+    return `executeScript failed: ${name}: ${message}`.replace(/[\u0000-\u001f\u007f-\u009f\u2028\u2029]/g, '').slice(0, 500);
 }

--- a/injected/src/features/broker-protection/execute.js
+++ b/injected/src/features/broker-protection/execute.js
@@ -1,5 +1,16 @@
-// eslint-disable-next-line no-redeclare
-import { navigate, extract, click, scroll, expectation, fillForm, getCaptchaInfo, solveCaptcha, condition } from './actions/actions';
+import {
+    navigate,
+    extract,
+    click,
+    // eslint-disable-next-line no-redeclare
+    scroll,
+    expectation,
+    fillForm,
+    getCaptchaInfo,
+    solveCaptcha,
+    condition,
+    executeScript,
+} from './actions/actions';
 import { ErrorResponse } from './types';
 
 /**
@@ -35,6 +46,8 @@ export async function execute(action, inputData, root = document) {
                 return condition(action, root);
             case 'scroll':
                 return scroll(action, root);
+            case 'executeScript':
+                return await executeScript(action, data(action, inputData, 'userProfile'), root);
             default: {
                 return new ErrorResponse({
                     actionID: action.id,

--- a/injected/src/features/broker-protection/types.js
+++ b/injected/src/features/broker-protection/types.js
@@ -12,8 +12,9 @@
 /**
  * @typedef {object} PirAction
  * @property {string} id
- * @property {"extract" | "fillForm" | "click" | "expectation" | "getCaptchaInfo" | "solveCaptcha" | "navigate" | "condition" | "scroll"} actionType
+ * @property {"extract" | "fillForm" | "click" | "expectation" | "getCaptchaInfo" | "solveCaptcha" | "navigate" | "condition" | "scroll" | "executeScript"} actionType
  * @property {string} [selector]
+ * @property {string} [script]
  * @property {ActionParent} [parent]
  * @property {string} [captchaType]
  * @property {string} [injectCaptchaHandler]

--- a/scripts/check-strict-core.js
+++ b/scripts/check-strict-core.js
@@ -42,6 +42,7 @@ const CORE_FILES = new Set([
     'injected/src/detectors/detections/fraud-detection.js',
     'injected/src/features/broker-protection/actions/actions.js',
     'injected/src/features/broker-protection/actions/condition.js',
+    'injected/src/features/broker-protection/actions/execute-script.js',
     'injected/src/features/broker-protection/actions/expectation.js',
     'injected/src/features/broker-protection/actions/generators.js',
     'injected/src/features/broker-protection/actions/navigate.js',

--- a/scripts/check-strict-core.js
+++ b/scripts/check-strict-core.js
@@ -40,6 +40,7 @@ const CORE_FILES = new Set([
     'injected/src/detectors/detections/fraud-detection.js',
     'injected/src/features/broker-protection/actions/actions.js',
     'injected/src/features/broker-protection/actions/condition.js',
+    'injected/src/features/broker-protection/actions/execute-script.js',
     'injected/src/features/broker-protection/actions/expectation.js',
     'injected/src/features/broker-protection/actions/generators.js',
     'injected/src/features/broker-protection/actions/navigate.js',


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/task/1217806727201842
**Tech Design:** https://app.asana.com/1/137249556945/project/481882893211075/task/1217897464444079

## Description

Adds an `executeScript` broker action for page workarounds that the existing actions cannot express. Scripts are supplied in broker JSON and run as function bodies with `userProfile` and `root` (the page Document). Profile selection uses the existing `dataSource` behavior, defaulting to `userProfile`.

- Awaits returned Promises, discards all return values, and reports success through `actionCompleted` with a null response. Scripts can prepare DOM content for subsequent actions.
- Reports invalid or empty scripts, compilation errors, throws, and rejected Promises through the existing action error response. Messages include the `executeScript failed:` prefix, error name, and message; control characters are stripped, stacks are omitted, and the complete message is capped at 500 characters.
- Never retries scripts, even when broker JSON supplies web retry settings. Native owns the 60-second timeout and `failSilently` handling; C-S-S always reports failures so native can record them before continuing.

Integration coverage includes injecting a profile-based link and following it with a click that sends the source page as referrer, async completion, discarded results, data selection, error sanitization, and retry suppression. The action implementation is included in strict TypeScript checking.

## Testing Steps

- Run `npm run build`.
- Run `npm run test-unit`.
- Run `npm run test-int -w injected -- broker-protection-tests --reporter list`.
- Run `npm run lint`.

## Checklist

*Please tick all that apply:*

- [x] I have tested this change locally
- [ ] I have tested this change locally in all supported browsers
- [ ] This change will be visible to users
- [x] I have added automated tests that cover this change
- [x] I have ensured the change is gated by config
- [ ] This change was covered by a ship review
- [x] This change was covered by a tech design
- [ ] Any dependent config has been merged


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Runs arbitrary broker-configured code in the page context via `new Function`, which is powerful and could have side effects; mitigations include no retries, bounded error telemetry, and no return-value chaining from scripts.
> 
> **Overview**
> Adds a new **`executeScript`** broker action so PIR flows can run broker-supplied JavaScript on the page when built-in actions are not enough. Scripts are compiled with `new Function` and receive **`userProfile`** (via existing **`dataSource`**, defaulting to `userProfile`) and **`root`** (the page `Document`). Completion **awaits returned Promises**; **return values are discarded** and success is reported with a **null** `actionCompleted` payload.
> 
> Failures (missing/invalid script, syntax errors, throws, rejections) go through the normal error response with an **`executeScript failed:`** prefix; messages are **sanitized** (no stacks, control chars stripped, **500-char** cap). **`retryConfigFor` never retries** `executeScript`, even when broker JSON sets web retries.
> 
> Wiring: new `execute-script.js` action, `execute.js` dispatch, `PirAction` types, strict-core allowlist, plus integration fixtures/pages and a large **`executeScript`** Playwright suite (DOM prep + follow-on click, async behavior, error edge cases, retry suppression).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6904eb18e6d54d6663d30870a3b033edd717eb47. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->