### PR TITLE
fix(broker-protection): read the captcha profile from the client

### DIFF
--- a/injected/integration-test/broker-protection-tests/broker-protection-captcha.spec.js
+++ b/injected/integration-test/broker-protection-tests/broker-protection-captcha.spec.js
@@ -158,36 +158,7 @@ test.describe('Broker Protection Captcha', () => {
                 await dbp.isWidgetNotNotified('[data-sitekey="test-site-key-1"]', 'data-callback-token');
             });
 
-            test('native retry keeps captcha context after a failed solve', async ({ dbp }) => {
-                await dbp.navigatesTo(parentTargetPage);
-                await dbp.receivesInlineAction(createGetRecaptchaInfoAction({ parent: createProfileMatchParent() }, { userProfile }));
-                await dbp.getSuccessResponse();
-                const failedSolveAction = createSolveRecaptchaAction({
-                    id: 'failed-solve',
-                    parent: createProfileMatchParent(),
-                    selector: '#missing-captcha',
-                });
-                await dbp.receivesInlineAction(failedSolveAction);
-                await dbp.isCaptchaError(failedSolveAction.state.action.id);
-
-                const solveAction = createSolveRecaptchaAction({ parent: createProfileMatchParent() }, { token: undefined, userProfile });
-                await dbp.receivesInlineAction(solveAction);
-                const successResponse = await dbp.getSuccessResponse(solveAction.state.action.id);
-
-                await dbp.isCaptchaTokenFilled('#g-recaptcha-response-2');
-                await dbp.doesInputValueEqual('#g-recaptcha-response', '');
-                await dbp.doesInputValueEqual('#g-recaptcha-response-1', '');
-
-                await dbp.runsCaptchaCallback(successResponse);
-                await dbp.isWidgetNotified('[data-sitekey="test-site-key-2"]', 'data-callback-token');
-                await dbp.isWidgetNotNotified('[data-sitekey="test-site-key-0"]', 'data-callback-token');
-                await dbp.isWidgetNotNotified('[data-sitekey="test-site-key-1"]', 'data-callback-token');
-            });
-
-            test('missing held profile after a page load writes nothing', async ({ dbp }) => {
-                await dbp.navigatesTo(parentTargetPage);
-                await dbp.receivesInlineAction(createGetRecaptchaInfoAction({ parent: createProfileMatchParent() }, { userProfile }));
-                await dbp.getSuccessResponse();
+            test('returns an error response when solving and the client sent no profile', async ({ dbp }) => {
                 await dbp.navigatesTo(parentTargetPage);
                 await dbp.receivesInlineAction(createSolveRecaptchaAction({ parent: createProfileMatchParent() }));
 
@@ -195,7 +166,6 @@ test.describe('Broker Protection Captcha', () => {
                 await dbp.doesInputValueEqual('#g-recaptcha-response', '');
                 await dbp.doesInputValueEqual('#g-recaptcha-response-1', '');
                 await dbp.doesInputValueEqual('#g-recaptcha-response-2', '');
-                await dbp.hasNoNotifiedWidget();
             });
 
             test('returns an error response when solving and no record matches the user profile', async ({ dbp }) => {

--- a/injected/integration-test/page-objects/broker-protection.js
+++ b/injected/integration-test/page-objects/broker-protection.js
@@ -191,10 +191,6 @@ export class BrokerProtectionPage {
         await expect(this.page.locator(selector)).not.toHaveAttribute(callbackAttribute, 'test_token');
     }
 
-    async hasNoNotifiedWidget() {
-        await expect(this.page.locator('.g-recaptcha[data-callback-token="test_token"]')).toHaveCount(0);
-    }
-
     /**
      * @param {number} widgetId
      */
@@ -242,11 +238,8 @@ export class BrokerProtectionPage {
         }
     }
 
-    /**
-     * @param {string} [actionID]
-     */
-    async isCaptchaError(actionID) {
-        expect(await this.getErrorMessage(actionID)).not.toBeFalsy();
+    async isCaptchaError() {
+        expect(await this.getErrorMessage()).not.toBeFalsy();
     }
 
     /**
@@ -301,57 +294,35 @@ export class BrokerProtectionPage {
         return await this.collector.waitForMessage('actionCompleted');
     }
 
-    /**
-     * @param {string} [actionID]
-     */
-    async getSuccessResponse(actionID) {
-        if (!actionID) {
-            const response = await this.getActionCompletedParams();
-            this.isSuccessMessage(response);
-            return this._getResultFromResponse(response).success.response;
-        }
-
-        await expect.poll(async () => this._getResultFromResponse(await this.getActionCompletedParams(), actionID)).toBeDefined();
-
+    async getSuccessResponse() {
         const response = await this.getActionCompletedParams();
-        this.isSuccessMessage(response, actionID);
-        return this._getResultFromResponse(response, actionID).success.response;
+        this.isSuccessMessage(response);
+        return this._getResultFromResponse(response).success.response;
     }
 
-    async getErrorMessage(actionID) {
-        if (actionID) {
-            await expect.poll(async () => this._getResultFromResponse(await this.getActionCompletedParams(), actionID)).toBeDefined();
-        }
-
+    async getErrorMessage() {
         const response = await this.getActionCompletedParams();
-        this.isErrorMessage(response, actionID);
-        return this._getResultFromResponse(response, actionID).error.message;
+        this.isErrorMessage(response);
+        return this._getResultFromResponse(response).error.message;
     }
 
     /**
      * @param {object} response
-     * @param {string} [actionID]
      */
-    isErrorMessage(response, actionID) {
-        expect('error' in this._getResultFromResponse(response, actionID)).toBe(true);
+    isErrorMessage(response) {
+        expect('error' in this._getResultFromResponse(response)).toBe(true);
     }
 
-    isSuccessMessage(response, actionID) {
-        const result = this._getResultFromResponse(response, actionID);
+    isSuccessMessage(response) {
+        const result = this._getResultFromResponse(response);
         expect('success' in result, JSON.stringify(result)).toBe(true);
     }
 
     /**
      * @param {object} response
-     * @param {string} [actionID]
      */
-    _getResultFromResponse(response, actionID) {
-        const results = response.map((message) => message.payload?.params?.result);
-        if (!actionID) {
-            return results[0];
-        }
-
-        return results.find((result) => (result?.success ?? result?.error)?.actionID === actionID);
+    _getResultFromResponse(response) {
+        return response[0].payload?.params?.result;
     }
 
     /**

--- a/injected/src/features/broker-protection/captcha-services/captcha.service.js
+++ b/injected/src/features/broker-protection/captcha-services/captcha.service.js
@@ -8,11 +8,7 @@ import { getCaptchaInfo as getCaptchaInfoDeprecated, solveCaptcha as solveCaptch
 
 /**
  * @import { ActionResponse, PirAction, ProfileData } from '../types.js'
- * @typedef {{profile: ProfileData|null, token: string|null}} PendingCaptchaContext
  */
-
-/** @type {PendingCaptchaContext|null} */
-let pendingCaptchaContext = null;
 
 /**
  *
@@ -75,8 +71,6 @@ export function getSupportingCodeToInject(action) {
  */
 export async function getCaptchaInfo(action, userData, root = document) {
     const { id: actionID, actionType, captchaType, selector } = action;
-    pendingCaptchaContext = null;
-
     if (!captchaType) {
         // ensures backward compatibility with old actions
         return getCaptchaInfoDeprecated(action, root);
@@ -120,10 +114,6 @@ export async function getCaptchaInfo(action, userData, root = document) {
         type: reportedType,
     };
 
-    if (action.parent) {
-        pendingCaptchaContext = { profile: userData, token: null };
-    }
-
     return SuccessResponse.create({ actionID, actionType, response });
 }
 
@@ -144,20 +134,11 @@ export function solveCaptcha(action, token, userData, root = document) {
     }
 
     const createError = ErrorResponse.generateErrorResponseFunction({ actionID, context: `[solveCaptcha] captchaType: ${captchaType}` });
-    const matchingProfile = userData ?? pendingCaptchaContext?.profile ?? null;
-
-    if (action.parent && !matchingProfile) {
+    if (action.parent && !userData) {
         return createError('no profile available to scope the captcha solve');
     }
 
-    const captchaToken = token ?? pendingCaptchaContext?.token ?? null;
-    if (!captchaToken) {
-        return createError('no token available to solve the captcha');
-    }
-
-    pendingCaptchaContext = action.parent ? { profile: matchingProfile, token: captchaToken } : null;
-
-    const captchaRoot = getCaptchaRoot(action, matchingProfile, root);
+    const captchaRoot = getCaptchaRoot(action, userData, root);
     if (PirError.isError(captchaRoot)) {
         return createError(captchaRoot.error.message);
     }
@@ -176,12 +157,12 @@ export function solveCaptcha(action, token, userData, root = document) {
         return createError('cannot solve captcha');
     }
 
-    const callback = captchaSolveProvider.getSolveCallback(captchaContainer, captchaToken);
+    const callback = captchaSolveProvider.getSolveCallback(captchaContainer, token);
     if (PirError.isError(callback)) {
         return createError(callback.error.message);
     }
 
-    const tokenResponse = captchaSolveProvider.injectToken(captchaContainer, captchaToken);
+    const tokenResponse = captchaSolveProvider.injectToken(captchaContainer, token);
     if (PirError.isError(tokenResponse)) {
         return createError(tokenResponse.error.message);
     }
@@ -189,8 +170,6 @@ export function solveCaptcha(action, token, userData, root = document) {
     if (!tokenResponse.response.injected) {
         return createError('could not inject token');
     }
-
-    pendingCaptchaContext = null;
 
     return SuccessResponse.create({
         actionID,


### PR DESCRIPTION
### Summary

Asana: https://app.asana.com/1/137249556945/task/1217611870578214

This PR:

* removes the profile we keep in memory between `getCaptchaInfo` and `solveCaptcha`, because Apple and Android now send it with the token and the held copy was only standing in for that.
* keeps the scoped solve and the error when a scoped action arrives without a profile, because solving the first widget on the page removes a stranger's record and leaves our user's in place.

Merge this only after the Apple and Android changes that send the profile reach a release. Until then both clients send the token alone and every scoped solve would fail.
