### PR TITLE
NTP: UI updates to match the native

### DIFF
--- a/special-pages/pages/new-tab/app/omnibar/components/chat-tools/tab-attachment/AttachMenu.js
+++ b/special-pages/pages/new-tab/app/omnibar/components/chat-tools/tab-attachment/AttachMenu.js
@@ -237,6 +237,7 @@ function OpenDropdownBody({
 
     const recentTabs = openTabs.slice(0, MAX_INLINE_RECENT_TABS);
     const showGutter = recentTabs.some((tab) => isAttached(tab.tabId));
+    const noTabsAvailable = !isLoadingTabs && openTabs.length === 0;
 
     /** @returns {import('preact').ComponentChildren[]} */
     const renderRecentTabRows = () => {
@@ -244,7 +245,7 @@ function OpenDropdownBody({
             return [<TabStatusRow key="loading" text={t('omnibar_attachTabsLoading')} />];
         }
         if (recentTabs.length === 0) {
-            return [<TabStatusRow key="empty" text={t('omnibar_attachTabsNoOpenTabs')} />];
+            return [<TabStatusRow key="empty" text={t('omnibar_attachTabsNoPageContent')} />];
         }
         return recentTabs.map((tab) => (
             <TabRow
@@ -283,10 +284,13 @@ function OpenDropdownBody({
                 showCheckGutter={showGutter}
                 icon={<TabContentAttachIcon class={styles.menuItemIcon} />}
                 name={t('omnibar_attachPageContentLabel')}
+                disabled={noTabsAvailable}
                 onSelect={onOpenTabsModal}
             />
             <DropdownSeparator />
-            <TabsSectionHeader label={t('omnibar_attachTabsRecentTabs')} showGutter={showGutter} />
+            {/* Header only when tab rows exist: while loading nothing is cached yet, so hiding it
+                keeps loading → empty a pure text swap with no layout shift. */}
+            {recentTabs.length > 0 && <TabsSectionHeader label={t('omnibar_attachTabsRecentTabs')} showGutter={showGutter} />}
             {renderRecentTabRows()}
         </Dropdown>
     );

--- a/special-pages/pages/new-tab/app/omnibar/components/chat-tools/tab-attachment/AttachMenu.js
+++ b/special-pages/pages/new-tab/app/omnibar/components/chat-tools/tab-attachment/AttachMenu.js
@@ -288,8 +288,6 @@ function OpenDropdownBody({
                 onSelect={onOpenTabsModal}
             />
             <DropdownSeparator />
-            {/* Header only when tab rows exist: while loading nothing is cached yet, so hiding it
-                keeps loading → empty a pure text swap with no layout shift. */}
             {recentTabs.length > 0 && <TabsSectionHeader label={t('omnibar_attachTabsRecentTabs')} showGutter={showGutter} />}
             {renderRecentTabRows()}
         </Dropdown>

--- a/special-pages/pages/new-tab/app/omnibar/components/chat-tools/tab-attachment/AttachTabsModal.js
+++ b/special-pages/pages/new-tab/app/omnibar/components/chat-tools/tab-attachment/AttachTabsModal.js
@@ -83,7 +83,7 @@ export function AttachTabsModal({ onClose, onToggleTab, isAttached, maxTabs = Nu
             return <StatusRow text={t('omnibar_attachTabsLoading')} />;
         }
         if (visibleTabs.length === 0) {
-            return <StatusRow text={searchQuery ? t('omnibar_attachTabsNoMatches') : t('omnibar_attachTabsNoOpenTabs')} />;
+            return <StatusRow text={searchQuery ? t('omnibar_attachTabsNoMatches') : t('omnibar_attachTabsNoPageContent')} />;
         }
         return visibleTabs.map((tab) => {
             const isStaged = stagedTabIds.has(tab.tabId);

--- a/special-pages/pages/new-tab/app/omnibar/components/chat-tools/tab-attachment/OpenTabsProvider.js
+++ b/special-pages/pages/new-tab/app/omnibar/components/chat-tools/tab-attachment/OpenTabsProvider.js
@@ -24,18 +24,18 @@ export function OpenTabsProvider({ tabId, enabled, children }) {
     const { getOpenTabs } = useContext(OmnibarContext);
     const [rawTabs, setRawTabs] = useStateWithLocalPersistence(tabId);
     const [isFetching, setIsFetching] = useState(false);
+    const [hasFetched, setHasFetched] = useState(false);
 
     // Native sends tab-strip order (oldest first); reverse to show most recent first.
     const openTabs = useMemo(() => [...rawTabs].reverse(), [rawTabs]);
-
-    // Only show a loading state when nothing is cached yet.
-    const isLoadingTabs = isFetching && rawTabs.length === 0;
+    const isLoadingTabs = isFetching && !hasFetched && rawTabs.length === 0;
 
     const refetchTabs = useCallback(async () => {
         setIsFetching(true);
         try {
             const response = await getOpenTabs();
             setRawTabs(response.tabs ?? []);
+            setHasFetched(true);
         } catch (err) {
             console.error('omnibar_getOpenTabs failed', err);
         } finally {

--- a/special-pages/pages/new-tab/app/omnibar/components/chat-tools/tab-attachment/TabRows.module.css
+++ b/special-pages/pages/new-tab/app/omnibar/components/chat-tools/tab-attachment/TabRows.module.css
@@ -92,7 +92,7 @@
     box-sizing: border-box;
     cursor: default;
     display: flex;
-    height: calc(var(--sp-7) * 3);
+    height: var(--sp-7);
     justify-content: center;
     outline: none;
     padding: 0 var(--sp-4);

--- a/special-pages/pages/new-tab/app/omnibar/integration-tests/omnibar-attachments.spec.js
+++ b/special-pages/pages/new-tab/app/omnibar/integration-tests/omnibar-attachments.spec.js
@@ -89,6 +89,25 @@ test.describe('omnibar tab attachment', () => {
         await expect(omnibar.attachmentChips()).toHaveCount(0);
     });
 
+    test('with no open tabs, Add Tabs is disabled and the empty state replaces Recent Tabs', async ({ page }, workerInfo) => {
+        const { ntp, omnibar } = setup(page, workerInfo);
+        await ntp.reducedMotion();
+        await ntp.openPage({
+            additional: {
+                'omnibar.mode': 'ai',
+                'omnibar.enableAttachTabs': 'true',
+                'omnibar.selectedModelId': 'openai_gpt-oss-120b',
+                'omnibar.noOpenTabs': 'true',
+            },
+        });
+        await omnibar.ready();
+
+        await omnibar.attachMenuButton().click();
+        await expect(omnibar.attachMenu().getByText('No page content available')).toBeVisible();
+        await expect(omnibar.attachPageContentMenuItem()).toHaveAttribute('aria-disabled', 'true');
+        await expect(omnibar.attachMenu().getByText('Recent Tabs')).toHaveCount(0);
+    });
+
     test('the Add Tabs dialog filters by search and shows a no-matches state', async ({ page }, workerInfo) => {
         const { ntp, omnibar } = setup(page, workerInfo);
         await ntp.reducedMotion();

--- a/special-pages/pages/new-tab/app/omnibar/mocks/omnibar.mock-transport.js
+++ b/special-pages/pages/new-tab/app/omnibar/mocks/omnibar.mock-transport.js
@@ -480,6 +480,9 @@ export function omnibarMockTransport() {
                 }
                 case 'omnibar_getOpenTabs': {
                     await new Promise((resolve) => setTimeout(resolve, 50));
+                    if (parseBooleanQueryParam('omnibar.noOpenTabs') === true) {
+                        return { tabs: [] };
+                    }
                     return getMockOpenTabs();
                 }
                 case 'omnibar_getTabContent': {

--- a/special-pages/pages/new-tab/app/omnibar/strings.json
+++ b/special-pages/pages/new-tab/app/omnibar/strings.json
@@ -239,9 +239,9 @@
     "title": "No matching tabs",
     "description": "Empty-state message shown when no open tabs match what the user typed, in the @-mention tab picker and the Add Tabs dialog search."
   },
-  "omnibar_attachTabsNoOpenTabs": {
-    "title": "No open tabs",
-    "description": "Empty-state message shown in the attach dropdown's Recent Tabs section and the Add Tabs dialog when there are no open tabs available to attach."
+  "omnibar_attachTabsNoPageContent": {
+    "title": "No page content available",
+    "description": "Empty-state message shown in the attach dropdown and the Add Tabs dialog when there are no open tabs with attachable page content."
   },
   "omnibar_removeAttachedTabLabel": {
     "title": "Remove {title}",

--- a/special-pages/pages/new-tab/public/locales/en/new-tab.json
+++ b/special-pages/pages/new-tab/public/locales/en/new-tab.json
@@ -401,9 +401,9 @@
     "title": "No matching tabs",
     "description": "Empty-state message shown when no open tabs match what the user typed, in the @-mention tab picker and the Add Tabs dialog search."
   },
-  "omnibar_attachTabsNoOpenTabs": {
-    "title": "No open tabs",
-    "description": "Empty-state message shown in the attach dropdown's Recent Tabs section and the Add Tabs dialog when there are no open tabs available to attach."
+  "omnibar_attachTabsNoPageContent": {
+    "title": "No page content available",
+    "description": "Empty-state message shown in the attach dropdown and the Add Tabs dialog when there are no open tabs with attachable page content."
   },
   "omnibar_removeAttachedTabLabel": {
     "title": "Remove {title}",


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1211592734365220/task/1216933378834044?focus=true

## Description

This is a follow-up PR to https://github.com/duckduckgo/content-scope-scripts/pull/2963 to match the native UI.

- "Add tabs" is disabled when there are 0 tabs.
- Updated the copy to "No page content available.

## Testing Steps

1. Open https://rawcdn.githack.com/duckduckgo/content-scope-scripts/c08f8a90ae33177f5db91341a8d6c8d5b69d638f/build/integration/pages/new-tab/index.html?omnibar.mode=ai&omnibar.enableAttachTabs=true&omnibar.enableAiChatTools=true&omnibar.selectedModelId=claude-haiku-4-5&omnibar.noOpenTabs=true
2. Click the clip icon.
3. Verify that "Add Tabs" button is disabled.
4. Verify that the copy reads "No page content available"


## Checklist

<!--
  These questions are a friendly reminder to shipping code, if you're uncertain ask the AoR owners.
  It's also totally appropriate to not check some of these boxes, if they don't apply to your change.
-->
*Please tick all that apply:*

- [ ] I have tested this change locally
- [ ] I have tested this change locally in all supported browsers
- [ ] This change will be visible to users
- [ ] I have added automated tests that cover this change
- [ ] I have ensured the change is gated by config
- [ ] This change was covered by a ship review
- [ ] This change was covered by a tech design
- [ ] Any dependent config has been merged



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI/copy and loading-state tweaks in the attach-tabs menu only; no auth, data, or API contract changes.
> 
> **Overview**
> Aligns the NTP attach-tabs menu with native: when there are no open tabs, **Add Tabs** is disabled, the Recent Tabs header is hidden, and the empty copy is **No page content available**.
> 
> `OpenTabsProvider` now tracks `hasFetched` so a refetch of an empty list does not flash the loading row. The empty status row is shorter. Adds an integration test and `omnibar.noOpenTabs` mock.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f49676807c0cb7d9d5fd429a7ea5865db73d2660. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->