### PR TITLE
Filter out brand duplication

### DIFF
--- a/injected/src/features/ua-ch-brands.js
+++ b/injected/src/features/ua-ch-brands.js
@@ -45,7 +45,7 @@ export default class UaChBrands extends ContentFeature {
             const targetBrand = this.getBrandOverride();
             const mutatedBrands = this.applyBrandMutationsToList(this.originalBrands, targetBrand);
 
-            if (mutatedBrands.length) {
+            if (mutatedBrands.length && !this.brandListsMatch(this.originalBrands, mutatedBrands)) {
                 this.log.info(
                     'shimUserAgentDataBrands - about to apply override with:',
                     mutatedBrands.map((b) => `"${b.brand}" v${b.version}`).join(', '),
@@ -59,15 +59,26 @@ export default class UaChBrands extends ContentFeature {
     }
 
     /**
-     * Append target brand to the brands list, using the Chromium version
+     * Ensure the brands list carries the target brand exactly once, using the Chromium version
      * @param {Array<{brand: string, version: string}>} list - Original brands list
-     * @param {string} targetBrand - Brand name to append
+     * @param {string} targetBrand - Brand name to apply
      * @returns {Array<{brand: string, version: string}>} - Modified brands array
      */
     applyBrandMutationsToList(list, targetBrand) {
         if (!Array.isArray(list) || !list.length) {
             this.log.info('applyBrandMutationsToList - no brands to mutate');
             return [];
+        }
+
+        if (list.some((b) => b.brand === targetBrand)) {
+            return [...list];
+        }
+
+        // Chromium supplies the brand itself when --ddg-user-agent-brand is passed, so a host taking a
+        // different brand needs that entry renamed rather than a second one appended.
+        if (list.some((b) => b.brand === 'DuckDuckGo')) {
+            this.log.info(`Renamed "DuckDuckGo" to "${targetBrand}"`);
+            return list.map((b) => (b.brand === 'DuckDuckGo' ? { brand: targetBrand, version: b.version } : b));
         }
 
         const mutated = [...list];
@@ -80,6 +91,15 @@ export default class UaChBrands extends ContentFeature {
         const brandNames = mutated.map((b) => `"${b.brand}" v${b.version}`).join(', ');
         this.log.info(`Final brands: [${brandNames}]`);
         return mutated;
+    }
+
+    /**
+     * @param {Array<{brand: string, version: string}>} a
+     * @param {Array<{brand: string, version: string}>} b
+     * @returns {boolean}
+     */
+    brandListsMatch(a, b) {
+        return a.length === b.length && a.every((entry, index) => entry.brand === b[index].brand && entry.version === b[index].version);
     }
 
     /**

--- a/injected/src/features/ua-ch-brands.js
+++ b/injected/src/features/ua-ch-brands.js
@@ -60,15 +60,16 @@ export default class UaChBrands extends ContentFeature {
     }
 
     /**
-     * True when the page is meant to look exactly like the default browser, so our brand has to be
-     * taken back out of whatever Chromium produced: the site is excepted from this feature, or the
-     * user has turned protections off for it. Self-gating means the framework no longer applies the
-     * exceptions for us, so they are read here - see selfGatingFeatures.
+     * True when the site is excepted from this feature and so is meant to look exactly like the
+     * default browser, which means taking our brand back out of whatever Chromium produced. Turning
+     * protections off is deliberately not part of this: it says nothing about which brand a site
+     * should see. Self-gating means the framework no longer applies the exceptions for us, so they
+     * are read here - see selfGatingFeatures.
      * @returns {boolean}
      */
     shouldPresentStockBrands() {
         const exceptions = this.bundledConfig?.features?.uaChBrands?.exceptions || [];
-        return isUnprotectedDomain(getTabHostname(), exceptions) || !!this.args?.site?.allowlisted;
+        return isUnprotectedDomain(getTabHostname(), exceptions);
     }
 
     /**

--- a/injected/src/features/ua-ch-brands.js
+++ b/injected/src/features/ua-ch-brands.js
@@ -1,5 +1,7 @@
 import ContentFeature from '../content-feature.js';
-import { DDGReflect, getTabHostname, isUnprotectedDomain } from '../utils.js';
+import { DDGReflect, getTabHostname, isGloballyDisabled, isUnprotectedDomain } from '../utils.js';
+
+const DUCK_DUCK_GO_BRAND = 'DuckDuckGo';
 
 export default class UaChBrands extends ContentFeature {
     constructor(featureName, importConfig, features, args) {
@@ -17,8 +19,8 @@ export default class UaChBrands extends ContentFeature {
      * @returns {string} - Brand name to use for replacement/append
      */
     getBrandOverride() {
-        const brandName = this.getFeatureSetting('brandName') || 'DuckDuckGo';
-        if (brandName !== 'DuckDuckGo') {
+        const brandName = this.getFeatureSetting('brandName') || DUCK_DUCK_GO_BRAND;
+        if (brandName !== DUCK_DUCK_GO_BRAND) {
             this.log.info(`Using brand override: "${brandName}"`);
         }
         return brandName;
@@ -60,14 +62,18 @@ export default class UaChBrands extends ContentFeature {
     }
 
     /**
-     * True when the site is excepted from this feature and so is meant to look exactly like the
-     * default browser, which means taking our brand back out of whatever Chromium produced. Turning
-     * protections off is deliberately not part of this: it says nothing about which brand a site
-     * should see. Self-gating means the framework no longer applies the exceptions for us, so they
-     * are read here - see selfGatingFeatures.
+     * True when the site is meant to look exactly like the default browser, which means taking our
+     * brand back out of whatever Chromium produced. That covers both a config exception and
+     * protections being off, the two cases where this feature used to not run at all. Self-gating
+     * means the framework no longer applies the exceptions for us, so they are read here - see
+     * selfGatingFeatures.
      * @returns {boolean}
      */
     shouldPresentStockBrands() {
+        if (isGloballyDisabled(this.args)) {
+            return true;
+        }
+
         const exceptions = this.bundledConfig?.features?.uaChBrands?.exceptions || [];
         return isUnprotectedDomain(getTabHostname(), exceptions);
     }
@@ -82,9 +88,9 @@ export default class UaChBrands extends ContentFeature {
             return [];
         }
 
-        const remaining = list.filter((b) => b.brand !== 'DuckDuckGo');
+        const remaining = list.filter((b) => b.brand !== DUCK_DUCK_GO_BRAND);
         if (remaining.length !== list.length) {
-            this.log.info('Removed "DuckDuckGo" so the site sees the stock brands');
+            this.log.info(`Removed "${DUCK_DUCK_GO_BRAND}" so the site sees the stock brands`);
         }
         return remaining;
     }
@@ -101,22 +107,15 @@ export default class UaChBrands extends ContentFeature {
             return [];
         }
 
-        if (list.some((b) => b.brand === targetBrand)) {
-            return [...list];
-        }
+        // Our brand must not survive next to a different one, however it got there.
+        const mutated = targetBrand === DUCK_DUCK_GO_BRAND ? [...list] : this.removeOurBrandFromList(list);
 
-        // Chromium supplies the brand itself when --ddg-user-agent-brand is passed, so a host taking a
-        // different brand needs that entry renamed rather than a second one appended.
-        if (list.some((b) => b.brand === 'DuckDuckGo')) {
-            this.log.info(`Renamed "DuckDuckGo" to "${targetBrand}"`);
-            return list.map((b) => (b.brand === 'DuckDuckGo' ? { brand: targetBrand, version: b.version } : b));
-        }
-
-        const mutated = [...list];
-        const chromium = mutated.find((b) => b.brand === 'Chromium');
-        if (chromium) {
-            mutated.push({ brand: targetBrand, version: chromium.version });
-            this.log.info(`Appended "${targetBrand}" v${chromium.version} (to match Chromium version)`);
+        if (!mutated.some((b) => b.brand === targetBrand)) {
+            const chromium = mutated.find((b) => b.brand === 'Chromium');
+            if (chromium) {
+                mutated.push({ brand: targetBrand, version: chromium.version });
+                this.log.info(`Appended "${targetBrand}" v${chromium.version} (to match Chromium version)`);
+            }
         }
 
         const brandNames = mutated.map((b) => `"${b.brand}" v${b.version}`).join(', ');

--- a/injected/src/features/ua-ch-brands.js
+++ b/injected/src/features/ua-ch-brands.js
@@ -70,7 +70,7 @@ export default class UaChBrands extends ContentFeature {
      * @returns {boolean}
      */
     shouldPresentStockBrands() {
-        if (isGloballyDisabled(this.args)) {
+        if (this.args && isGloballyDisabled(this.args)) {
             return true;
         }
 

--- a/injected/src/features/ua-ch-brands.js
+++ b/injected/src/features/ua-ch-brands.js
@@ -1,5 +1,5 @@
 import ContentFeature from '../content-feature.js';
-import { DDGReflect } from '../utils.js';
+import { DDGReflect, getTabHostname, isUnprotectedDomain } from '../utils.js';
 
 export default class UaChBrands extends ContentFeature {
     constructor(featureName, importConfig, features, args) {
@@ -42,8 +42,9 @@ export default class UaChBrands extends ContentFeature {
                 this.originalBrands.map((b) => `"${b.brand}" v${b.version}`).join(', '),
             );
 
-            const targetBrand = this.getBrandOverride();
-            const mutatedBrands = this.applyBrandMutationsToList(this.originalBrands, targetBrand);
+            const mutatedBrands = this.shouldPresentStockBrands()
+                ? this.removeOurBrandFromList(this.originalBrands)
+                : this.applyBrandMutationsToList(this.originalBrands, this.getBrandOverride());
 
             if (mutatedBrands.length && !this.brandListsMatch(this.originalBrands, mutatedBrands)) {
                 this.log.info(
@@ -56,6 +57,35 @@ export default class UaChBrands extends ContentFeature {
         } catch (error) {
             this.log.error('Error in shimUserAgentDataBrands:', error);
         }
+    }
+
+    /**
+     * True when the page is meant to look exactly like the default browser, so our brand has to be
+     * taken back out of whatever Chromium produced: the site is excepted from this feature, or the
+     * user has turned protections off for it. Self-gating means the framework no longer applies the
+     * exceptions for us, so they are read here - see selfGatingFeatures.
+     * @returns {boolean}
+     */
+    shouldPresentStockBrands() {
+        const exceptions = this.bundledConfig?.features?.uaChBrands?.exceptions || [];
+        return isUnprotectedDomain(getTabHostname(), exceptions) || !!this.args?.site?.allowlisted;
+    }
+
+    /**
+     * Drops our brand, leaving the list Chromium would have produced on its own.
+     * @param {Array<{brand: string, version: string}>} list - Original brands list
+     * @returns {Array<{brand: string, version: string}>} - List without our brand
+     */
+    removeOurBrandFromList(list) {
+        if (!Array.isArray(list) || !list.length) {
+            return [];
+        }
+
+        const remaining = list.filter((b) => b.brand !== 'DuckDuckGo');
+        if (remaining.length !== list.length) {
+            this.log.info('Removed "DuckDuckGo" so the site sees the stock brands');
+        }
+        return remaining;
     }
 
     /**
@@ -130,8 +160,9 @@ export default class UaChBrands extends ContentFeature {
                         result = newBrands;
                     }
                     if (key === 'fullVersionList' && args[0]?.includes('fullVersionList') && value) {
-                        const targetBrand = featureInstance.getBrandOverride();
-                        result = featureInstance.applyBrandMutationsToList(value, targetBrand);
+                        result = featureInstance.shouldPresentStockBrands()
+                            ? featureInstance.removeOurBrandFromList(value)
+                            : featureInstance.applyBrandMutationsToList(value, featureInstance.getBrandOverride());
                     }
 
                     modifiedResult[key] = result;

--- a/injected/src/features/ua-ch-brands.js
+++ b/injected/src/features/ua-ch-brands.js
@@ -1,4 +1,4 @@
-import ContentFeature from '../content-feature';
+import ContentFeature from '../content-feature.js';
 import { DDGReflect } from '../utils';
 
 export default class UaChBrands extends ContentFeature {

--- a/injected/src/features/ua-ch-brands.js
+++ b/injected/src/features/ua-ch-brands.js
@@ -1,5 +1,5 @@
 import ContentFeature from '../content-feature.js';
-import { DDGReflect } from '../utils';
+import { DDGReflect } from '../utils.js';
 
 export default class UaChBrands extends ContentFeature {
     constructor(featureName, importConfig, features, args) {

--- a/injected/src/utils.js
+++ b/injected/src/utils.js
@@ -937,7 +937,6 @@ export const platformSpecificFeatures = [
     'hover',
     'trackerProtection', // only enabled on apple platforms
     'textSelection',
-    'uaChBrands', // Chromium can add the brand before any of this runs
 ];
 /**
  * Features that bypass exception-based disabling in computeEnabledFeatures.

--- a/injected/src/utils.js
+++ b/injected/src/utils.js
@@ -937,6 +937,7 @@ export const platformSpecificFeatures = [
     'hover',
     'trackerProtection', // only enabled on apple platforms
     'textSelection',
+    'uaChBrands',
 ];
 /**
  * Features that bypass exception-based disabling in computeEnabledFeatures.

--- a/injected/src/utils.js
+++ b/injected/src/utils.js
@@ -937,6 +937,7 @@ export const platformSpecificFeatures = [
     'hover',
     'trackerProtection', // only enabled on apple platforms
     'textSelection',
+    'uaChBrands', // Chromium can add the brand before any of this runs
 ];
 /**
  * Features that bypass exception-based disabling in computeEnabledFeatures.
@@ -944,7 +945,7 @@ export const platformSpecificFeatures = [
  * for reporting on excepted domains while adjusting behavior).
  * @type {FeatureName[]}
  */
-export const selfGatingFeatures = ['trackerProtection'];
+export const selfGatingFeatures = ['trackerProtection', 'uaChBrands'];
 
 /**
  * @param {string} featureName

--- a/injected/unit-test/ua-ch-brands.spec.js
+++ b/injected/unit-test/ua-ch-brands.spec.js
@@ -11,6 +11,40 @@ const chromiumBrands = [
     { brand: 'Not=A?Brand', version: '99' },
 ];
 
+function createFeatureForSite(site, exceptions = []) {
+    const feature = createFeature();
+    Object.defineProperty(feature, 'args', { value: { site } });
+    Object.defineProperty(feature, 'bundledConfig', { value: { features: { uaChBrands: { exceptions } } } });
+    return feature;
+}
+
+describe('UaChBrands stock-brand sites', () => {
+    it('treats a site the user allowlisted as needing the stock brands', () => {
+        expect(createFeatureForSite({ allowlisted: true }).shouldPresentStockBrands()).toBeTrue();
+    });
+
+    it('treats an ordinary site as brandable', () => {
+        expect(createFeatureForSite({}).shouldPresentStockBrands()).toBeFalse();
+    });
+
+    it('removes the brand Chromium added, leaving the stock list', () => {
+        const branded = [...chromiumBrands, { brand: 'DuckDuckGo', version: '151' }];
+
+        const result = createFeature().removeOurBrandFromList(branded);
+
+        expect(result).toEqual(chromiumBrands);
+        expect(branded.length).toBe(3);
+    });
+
+    it('leaves an already stock list alone', () => {
+        expect(createFeature().removeOurBrandFromList(chromiumBrands)).toEqual(chromiumBrands);
+    });
+
+    it('returns an empty list when there are no brands', () => {
+        expect(createFeature().removeOurBrandFromList([])).toEqual([]);
+    });
+});
+
 describe('UaChBrands applyBrandMutationsToList', () => {
     it('appends the target brand using the Chromium version', () => {
         const result = createFeature().applyBrandMutationsToList(chromiumBrands, 'DuckDuckGo');

--- a/injected/unit-test/ua-ch-brands.spec.js
+++ b/injected/unit-test/ua-ch-brands.spec.js
@@ -1,0 +1,59 @@
+import UaChBrands from '../src/features/ua-ch-brands.js';
+
+function createFeature() {
+    const feature = Object.create(UaChBrands.prototype);
+    feature.log = { info: () => {}, error: () => {} };
+    return feature;
+}
+
+const chromiumBrands = [
+    { brand: 'Chromium', version: '151' },
+    { brand: 'Not=A?Brand', version: '99' },
+];
+
+describe('UaChBrands applyBrandMutationsToList', () => {
+    it('appends the target brand using the Chromium version', () => {
+        const result = createFeature().applyBrandMutationsToList(chromiumBrands, 'DuckDuckGo');
+
+        expect(result).toEqual([...chromiumBrands, { brand: 'DuckDuckGo', version: '151' }]);
+    });
+
+    it('leaves the list untouched when the target brand is already present', () => {
+        const branded = [...chromiumBrands, { brand: 'DuckDuckGo', version: '151' }];
+
+        const result = createFeature().applyBrandMutationsToList(branded, 'DuckDuckGo');
+
+        expect(result).toEqual(branded);
+    });
+
+    it('renames the existing brand instead of appending a second one', () => {
+        const branded = [...chromiumBrands, { brand: 'DuckDuckGo', version: '151' }];
+
+        const result = createFeature().applyBrandMutationsToList(branded, 'Chrome');
+
+        expect(result).toEqual([...chromiumBrands, { brand: 'Chrome', version: '151' }]);
+        expect(branded[2].brand).toBe('DuckDuckGo');
+    });
+
+    it('returns an empty list when there are no brands', () => {
+        expect(createFeature().applyBrandMutationsToList([], 'DuckDuckGo')).toEqual([]);
+    });
+});
+
+describe('UaChBrands brandListsMatch', () => {
+    it('is true for identical lists', () => {
+        expect(createFeature().brandListsMatch(chromiumBrands, [...chromiumBrands])).toBeTrue();
+    });
+
+    it('is false when a brand differs', () => {
+        const other = [{ brand: 'Chromium', version: '151' }, { brand: 'DuckDuckGo', version: '151' }];
+
+        expect(createFeature().brandListsMatch(chromiumBrands, other)).toBeFalse();
+    });
+
+    it('is false when the lengths differ', () => {
+        const longer = [...chromiumBrands, { brand: 'DuckDuckGo', version: '151' }];
+
+        expect(createFeature().brandListsMatch(chromiumBrands, longer)).toBeFalse();
+    });
+});

--- a/injected/unit-test/ua-ch-brands.spec.js
+++ b/injected/unit-test/ua-ch-brands.spec.js
@@ -46,7 +46,10 @@ describe('UaChBrands brandListsMatch', () => {
     });
 
     it('is false when a brand differs', () => {
-        const other = [{ brand: 'Chromium', version: '151' }, { brand: 'DuckDuckGo', version: '151' }];
+        const other = [
+            { brand: 'Chromium', version: '151' },
+            { brand: 'DuckDuckGo', version: '151' },
+        ];
 
         expect(createFeature().brandListsMatch(chromiumBrands, other)).toBeFalse();
     });

--- a/injected/unit-test/ua-ch-brands.spec.js
+++ b/injected/unit-test/ua-ch-brands.spec.js
@@ -2,7 +2,7 @@ import UaChBrands from '../src/features/ua-ch-brands.js';
 
 function createFeature() {
     const feature = Object.create(UaChBrands.prototype);
-    feature.log = { info: () => {}, error: () => {} };
+    Object.defineProperty(feature, 'log', { value: { info: () => {}, error: () => {} } });
     return feature;
 }
 

--- a/injected/unit-test/ua-ch-brands.spec.js
+++ b/injected/unit-test/ua-ch-brands.spec.js
@@ -19,8 +19,24 @@ function createFeatureForSite(site, exceptions = []) {
 }
 
 describe('UaChBrands stock-brand sites', () => {
-    it('leaves a site the user allowlisted brandable - protections say nothing about the brand', () => {
-        expect(createFeatureForSite({ allowlisted: true }).shouldPresentStockBrands()).toBeFalse();
+    it('presents stock brands on a site the user allowlisted', () => {
+        expect(createFeatureForSite({ allowlisted: true }).shouldPresentStockBrands()).toBeTrue();
+    });
+
+    it('presents stock brands on a site protections consider broken', () => {
+        expect(createFeatureForSite({ isBroken: true }).shouldPresentStockBrands()).toBeTrue();
+    });
+
+    it('presents stock brands on a site excepted from this feature', () => {
+        const top = globalThis.top;
+        globalThis.top = /** @type {any} */ ({ location: { href: 'https://example.com/' } });
+
+        try {
+            expect(createFeatureForSite({}, [{ domain: 'example.com' }]).shouldPresentStockBrands()).toBeTrue();
+            expect(createFeatureForSite({}, [{ domain: 'other.example' }]).shouldPresentStockBrands()).toBeFalse();
+        } finally {
+            globalThis.top = top;
+        }
     });
 
     it('treats an ordinary site as brandable', () => {
@@ -60,13 +76,21 @@ describe('UaChBrands applyBrandMutationsToList', () => {
         expect(result).toEqual(branded);
     });
 
-    it('renames the existing brand instead of appending a second one', () => {
+    it('replaces our brand instead of appending a second one', () => {
         const branded = [...chromiumBrands, { brand: 'DuckDuckGo', version: '151' }];
 
         const result = createFeature().applyBrandMutationsToList(branded, 'Chrome');
 
         expect(result).toEqual([...chromiumBrands, { brand: 'Chrome', version: '151' }]);
         expect(branded[2].brand).toBe('DuckDuckGo');
+    });
+
+    it('drops our brand when a different one is already present', () => {
+        const both = [...chromiumBrands, { brand: 'DuckDuckGo', version: '151' }, { brand: 'Chrome', version: '151' }];
+
+        const result = createFeature().applyBrandMutationsToList(both, 'Chrome');
+
+        expect(result).toEqual([...chromiumBrands, { brand: 'Chrome', version: '151' }]);
     });
 
     it('returns an empty list when there are no brands', () => {

--- a/injected/unit-test/ua-ch-brands.spec.js
+++ b/injected/unit-test/ua-ch-brands.spec.js
@@ -19,8 +19,8 @@ function createFeatureForSite(site, exceptions = []) {
 }
 
 describe('UaChBrands stock-brand sites', () => {
-    it('treats a site the user allowlisted as needing the stock brands', () => {
-        expect(createFeatureForSite({ allowlisted: true }).shouldPresentStockBrands()).toBeTrue();
+    it('leaves a site the user allowlisted brandable - protections say nothing about the brand', () => {
+        expect(createFeatureForSite({ allowlisted: true }).shouldPresentStockBrands()).toBeFalse();
     });
 
     it('treats an ordinary site as brandable', () => {


### PR DESCRIPTION
**Asana Task/Github Issue:**
https://app.asana.com/1/137249556945/project/1211781871643034/task/1217648376194223?focus=true

## Description
In order to allow browser extensions to be able to identify DuckDuckGo we need to include the DuckDuckGo brand in UA hints on web pages of browser extension. Those web pages are not running C.S.S, so that we are adding the UA hint in the Webview. In order to prevent U.A hints become duplicated on normal page, I am tweaking the logic to only add the hint if it is not already there.

Related PRs:
Windows-Browser: https://github.com/duckduckgo/windows-browser/pull/8816
C.S.S: https://github.com/duckduckgo/content-scope-scripts/pull/2986
Webview: https://github.com/duckduckgo/ddg-cef-build-automation/pull/1878

## Testing Steps

N/A

## Checklist

<!--
  These questions are a friendly reminder to shipping code, if you're uncertain ask the AoR owners.
  It's also totally appropriate to not check some of these boxes, if they don't apply to your change.
-->
*Please tick all that apply:*

- [X] I have tested this change locally
- [ ] I have tested this change locally in all supported browsers
- [ ] This change will be visible to users
- [X] I have added automated tests that cover this change
- [ ] I have ensured the change is gated by config
- [ ] This change was covered by a ship review
- [ ] This change was covered by a tech design
- [X] Any dependent config has been merged



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes client-hint branding visible to sites and extensions; behavior is gated per domain and protections state, but incorrect gating could break extension detection or site compatibility.
> 
> **Overview**
> **`uaChBrands`** now stays loaded on allowlisted, “broken,” and config-excepted sites (registered as a **self-gating** platform feature) instead of being turned off by the framework. On those sites it **strips the DuckDuckGo brand** from `navigator.userAgentData.brands` and `getHighEntropyValues`’s `fullVersionList` so pages see stock Chromium brands; on normal sites it still applies the configured brand override.
> 
> Brand mutation logic is tightened so the target brand is added **only if missing** (using Chromium’s version), **DuckDuckGo is removed** when a different `brandName` is configured, and the shim is **skipped** when the mutated list matches what Chromium already exposed—avoiding duplicate DuckDuckGo entries when the webview already injects the hint.
> 
> Unit tests cover stock-brand gating, list mutation, and list-equality checks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 38f45e64101980988ec98d8c857d8c2137ef4a8b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->