### PR TITLE
feat(web-compat): Async Clipboard API shim backed by execCommand (Windows only)

### DIFF
--- a/injected/integration-test/async-clipboard.spec.js
+++ b/injected/integration-test/async-clipboard.spec.js
@@ -1,0 +1,160 @@
+import { gotoAndWait, testContextForExtension } from './helpers/harness.js';
+import { test as base, expect } from '@playwright/test';
+
+const test = testContextForExtension(base);
+
+const HTML = '/webcompat/pages/async-clipboard.html';
+
+/**
+ * The state that the test page records for us.
+ *
+ * @typedef {Window & typeof globalThis & {
+ *     clipboardResults: Record<string, { status: string, value?: unknown, name?: string, message?: string }>,
+ *     nativeClipboard: Clipboard
+ * }} ClipboardTestWindow
+ */
+
+/**
+ * @param {import("@playwright/test").Page} page
+ * @param {string} [platformName]
+ */
+async function load(page, platformName = 'windows') {
+    await gotoAndWait(page, HTML, {
+        platform: { name: platformName },
+        site: { enabledFeatures: ['webCompat'] },
+        featureSettings: {
+            webCompat: {
+                asyncClipboard: 'enabled',
+            },
+        },
+    });
+}
+
+/**
+ * The integration build marks every shimmed class, which is how we tell our
+ * implementation apart from the browser's own.
+ */
+function isShimmed() {
+    const mark = globalThis.ddgShimMark;
+    if (!mark) return false;
+    return globalThis.Clipboard[mark] === true && globalThis.ClipboardItem[mark] === true;
+}
+
+/**
+ * @param {import("@playwright/test").Page} page
+ * @param {string} name - key under `window.clipboardResults`
+ */
+async function clipboardResult(page, name) {
+    await page.waitForFunction((key) => key in /** @type {ClipboardTestWindow} */ (window).clipboardResults, name);
+    return await page.evaluate((key) => /** @type {ClipboardTestWindow} */ (window).clipboardResults[key], name);
+}
+
+test.describe('Async Clipboard API shim', () => {
+    // The tests below share one system clipboard, so they must not run at the same time.
+    test.describe.configure({ mode: 'serial' });
+
+    test('is not installed on other platforms', async ({ page }) => {
+        await load(page, 'extension');
+        expect(await page.evaluate(isShimmed)).toBe(false);
+    });
+
+    test('is installed on windows when the API is missing', async ({ page }) => {
+        await load(page);
+        expect(await page.evaluate(isShimmed)).toBe(true);
+
+        const api = await page.evaluate(() => {
+            return {
+                isClipboard: navigator.clipboard instanceof Clipboard,
+                methods: ['read', 'readText', 'write', 'writeText'].map((name) => typeof navigator.clipboard[name]),
+                clipboardToString: Clipboard.toString(),
+                writeTextToString: navigator.clipboard.writeText.toString(),
+                clipboardItemToString: ClipboardItem.toString(),
+                supportsPlainText: ClipboardItem.supports('text/plain'),
+                supportsHtml: ClipboardItem.supports('text/html'),
+                supportsPng: ClipboardItem.supports('image/png'),
+            };
+        });
+
+        expect(api.isClipboard).toBe(true);
+        expect(api.methods).toEqual(['function', 'function', 'function', 'function']);
+        expect(api.clipboardToString).toEqual('function Clipboard() { [native code] }');
+        expect(api.writeTextToString).toEqual('function writeText() { [native code] }');
+        expect(api.clipboardItemToString).toEqual('function ClipboardItem() { [native code] }');
+        expect(api.supportsPlainText).toBe(true);
+        expect(api.supportsHtml).toBe(true);
+        expect(api.supportsPng).toBe(false);
+    });
+
+    test('keeps the descriptor shape of the original navigator.clipboard', async ({ page }) => {
+        await load(page);
+        const descriptors = await page.evaluate(() => {
+            const entry = globalThis.origPropDescriptors.find(([, propertyName]) => propertyName === 'clipboard');
+            const [host, propertyName, original] = entry;
+            const current = Object.getOwnPropertyDescriptor(host, propertyName);
+            const shape = (descriptor) =>
+                Object.keys(descriptor)
+                    .sort()
+                    .map((key) => `${key}:${typeof descriptor[key] === 'function' ? 'function' : descriptor[key]}`);
+            return { original: shape(original), current: shape(current) };
+        });
+        expect(descriptors.current).toEqual(descriptors.original);
+    });
+
+    test('Clipboard cannot be constructed', async ({ page }) => {
+        await load(page);
+        const error = await page.evaluate(() => {
+            try {
+                // eslint-disable-next-line no-new
+                new Clipboard();
+                return null;
+            } catch (e) {
+                return { name: e.name, message: e.message };
+            }
+        });
+        expect(error).toEqual({ name: 'TypeError', message: 'Illegal constructor' });
+    });
+
+    test('writeText puts plain text on the system clipboard', async ({ page, context }) => {
+        await context.grantPermissions(['clipboard-read', 'clipboard-write']);
+        await load(page);
+
+        // A real click, so the deprecated copy command sees a user gesture.
+        await page.click('#write-text');
+        expect(await clipboardResult(page, 'writeText')).toEqual({ status: 'fulfilled', value: null });
+
+        // Read it back with the browser's own implementation, captured before we shimmed it.
+        const text = await page.evaluate(() => /** @type {ClipboardTestWindow} */ (window).nativeClipboard.readText());
+        expect(text).toEqual('copied by the shim');
+    });
+
+    test('write puts every supported format of a ClipboardItem on the system clipboard', async ({ page, context }) => {
+        await context.grantPermissions(['clipboard-read', 'clipboard-write']);
+        await load(page);
+
+        await page.click('#write-item');
+        expect(await clipboardResult(page, 'write')).toEqual({ status: 'fulfilled', value: null });
+
+        const contents = await page.evaluate(async () => {
+            const [item] = await /** @type {ClipboardTestWindow} */ (window).nativeClipboard.read();
+            /** @type {Record<string, string>} */
+            const out = {};
+            for (const type of item.types) {
+                out[type] = await (await item.getType(type)).text();
+            }
+            return out;
+        });
+        expect(contents['text/plain']).toEqual('plain from the shim');
+        expect(contents['text/html']).toContain('<b>rich from the shim</b>');
+    });
+
+    test('readText rejects when the browser refuses the paste command', async ({ page }) => {
+        await load(page);
+
+        // Chromium only enables the deprecated paste command for embedders that opt in,
+        // so in this test browser the shim reports the same failure as a denied permission.
+        await page.click('#read-text');
+        const result = await clipboardResult(page, 'readText');
+        expect(result.status).toEqual('rejected');
+        expect(result.name).toEqual('NotAllowedError');
+    });
+});

--- a/injected/integration-test/test-pages/webcompat/pages/async-clipboard.html
+++ b/injected/integration-test/test-pages/webcompat/pages/async-clipboard.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width">
+  <title>Async Clipboard shim</title>
+  <link rel="stylesheet" href="../../shared/style.css">
+</head>
+<body>
+    <p><a href="../index.html">[Webcompat shims]</a></p>
+
+    <p>
+        This page exercises the Async Clipboard API shim. Every call is made from a real click handler,
+        because the deprecated clipboard commands the shim relies on only run during a user gesture.
+        Outcomes are recorded on <code>window.clipboardResults</code> for the Playwright spec to read.
+    </p>
+
+    <button id="write-text">writeText</button>
+    <button id="write-item">write</button>
+    <button id="read-text">readText</button>
+
+    <script>
+        // The real implementation, captured before content-scope-scripts replaces it, so the
+        // spec can check what the shim actually put on the system clipboard.
+        window.nativeClipboard = navigator.clipboard;
+        window.clipboardResults = {};
+
+        function record (name, promise) {
+            promise.then(
+                (value) => {
+                    window.clipboardResults[name] = { status: 'fulfilled', value: value ?? null };
+                },
+                (error) => {
+                    window.clipboardResults[name] = { status: 'rejected', name: error.name, message: error.message };
+                }
+            );
+        }
+
+        document.getElementById('write-text').addEventListener('click', () => {
+            record('writeText', navigator.clipboard.writeText('copied by the shim'));
+        });
+
+        document.getElementById('write-item').addEventListener('click', () => {
+            const item = new ClipboardItem({
+                'text/plain': 'plain from the shim',
+                'text/html': '<b>rich from the shim</b>'
+            });
+            record('write', navigator.clipboard.write([item]));
+        });
+
+        document.getElementById('read-text').addEventListener('click', () => {
+            record('readText', navigator.clipboard.readText());
+        });
+    </script>
+</body>
+</html>

--- a/injected/playwright.config.js
+++ b/injected/playwright.config.js
@@ -81,6 +81,7 @@ export default defineConfig({
             name: 'chrome-mv3',
             testMatch: [
                 'integration-test/remote-pages.spec.js',
+                'integration-test/async-clipboard.spec.js',
                 'integration-test/cookie.spec.js',
                 'integration-test/device-enumeration.spec.js',
                 'integration-test/fingerprint.spec.js',

--- a/injected/src/features/web-compat.js
+++ b/injected/src/features/web-compat.js
@@ -7,6 +7,7 @@ import ContentFeature from '../content-feature.js';
 import { URL } from '../captured-globals.js';
 import { DDGProxy, DDGReflect } from '../utils';
 import { wrapToString, wrapFunction } from '../wrapper-utils.js';
+import { ClipboardImpl, ClipboardItemImpl } from './web-compat/async-clipboard.js';
 /**
  * Fixes incorrect sizing value for outerHeight and outerWidth.
  * Note: Avoid hardcoding window geometry values - use calculations or config where possible.
@@ -157,6 +158,10 @@ export class WebCompat extends ContentFeature {
 
         if (this.getFeatureSettingEnabled('presentation')) {
             this.presentationFix();
+        }
+
+        if (this.getFeatureSettingEnabled('asyncClipboard')) {
+            this.asyncClipboardFix();
         }
 
         if (this.getFeatureSettingEnabled('webShare')) {
@@ -960,6 +965,40 @@ export class WebCompat extends ContentFeature {
 
             // @ts-expect-error Presentation API is still experimental, TS types are missing
             this.shimProperty(Navigator.prototype, 'presentation', new MyPresentation(), true);
+        } catch {
+            // Ignore exceptions that could be caused by conflicting with other extensions
+        }
+    }
+
+    /**
+     * Adds the Async Clipboard API where it is missing, backed by `document.execCommand()`.
+     *
+     * Restricted to the Windows browser: it is the only platform whose WebView is known to
+     * omit `navigator.clipboard` while still honouring the deprecated clipboard commands.
+     */
+    asyncClipboardFix() {
+        if (this.platform?.name !== 'windows') {
+            return;
+        }
+        try {
+            // Never replace a working implementation. The integration build always shims,
+            // so the behaviour can be tested in a browser that has the real API.
+            if (window.navigator.clipboard && this.injectName !== 'integration') {
+                return;
+            }
+
+            this.shimInterface('ClipboardItem', ClipboardItemImpl, {
+                disallowConstructor: false,
+                allowConstructorCall: false,
+                wrapToString: true,
+            });
+
+            this.shimInterface('Clipboard', ClipboardImpl, {
+                disallowConstructor: true,
+                allowConstructorCall: false,
+                wrapToString: true,
+            });
+            this.shimProperty(Navigator.prototype, 'clipboard', new ClipboardImpl(), true);
         } catch {
             // Ignore exceptions that could be caused by conflicting with other extensions
         }

--- a/injected/src/features/web-compat/async-clipboard.js
+++ b/injected/src/features/web-compat/async-clipboard.js
@@ -1,0 +1,330 @@
+/**
+ * @file Async Clipboard API implemented on top of the deprecated `document.execCommand()`.
+ *
+ * Some WebViews expose no `navigator.clipboard` at all (it is also absent from insecure
+ * contexts), which breaks copy/paste on sites that only implement the modern API. The
+ * classes here provide the same surface, moving data through synthetic `copy`/`paste`
+ * commands instead of the native clipboard bindings.
+ *
+ * @see injected/docs/coding-guidelines.md for general patterns
+ */
+
+const TEXT_PLAIN = 'text/plain';
+const TEXT_HTML = 'text/html';
+
+/**
+ * The only formats `execCommand()` can carry, since everything travels through a
+ * `DataTransfer` as a string.
+ */
+const SUPPORTED_TYPES = [TEXT_PLAIN, TEXT_HTML];
+
+/**
+ * Creates an offscreen editable element to act as the target of the synthetic commands.
+ * `execCommand()` only operates on a focused, editable element that is part of the document.
+ * @returns {HTMLTextAreaElement | null} `null` when there is no document to attach it to
+ */
+function createScratchElement() {
+    const container = document.body || document.documentElement;
+    if (!container) return null;
+    const scratch = document.createElement('textarea');
+    scratch.setAttribute('aria-hidden', 'true');
+    scratch.setAttribute('tabindex', '-1');
+    // A non-zero size keeps the element focusable, while staying invisible and outside of
+    // the layout flow so the page doesn't shift or scroll when we focus it.
+    scratch.style.cssText =
+        'all:initial;position:fixed;top:0;left:0;width:1px;height:1px;padding:0;border:0;margin:0;opacity:0;pointer-events:none;';
+    container.appendChild(scratch);
+    return scratch;
+}
+
+/**
+ * Records the current focus and selection so they can be put back after the scratch
+ * element has hijacked them.
+ * @returns {() => void} restores what was captured
+ */
+function captureSelection() {
+    const activeElement = document.activeElement instanceof HTMLElement ? document.activeElement : null;
+    const selection = document.getSelection();
+    /** @type {Range[]} */
+    const ranges = [];
+    if (selection) {
+        for (let i = 0; i < selection.rangeCount; i++) {
+            ranges.push(selection.getRangeAt(i).cloneRange());
+        }
+    }
+
+    return () => {
+        if (selection) {
+            selection.removeAllRanges();
+            for (const range of ranges) {
+                selection.addRange(range);
+            }
+        }
+        activeElement?.focus();
+    };
+}
+
+/**
+ * @param {Event} event
+ * @returns {DataTransfer | null}
+ */
+function getClipboardData(event) {
+    return /** @type {ClipboardEvent} */ (event).clipboardData;
+}
+
+/**
+ * Writes the given payload to the system clipboard via `execCommand('copy')`.
+ * @param {Map<string, string>} data - payload keyed by MIME type
+ * @returns {boolean} whether the command was carried out
+ */
+export function copyWithExecCommand(data) {
+    const scratch = createScratchElement();
+    if (!scratch) return false;
+
+    /** @param {Event} event */
+    const onCopy = (event) => {
+        const clipboardData = getClipboardData(event);
+        // Without a DataTransfer we can't add the extra formats, so let the default
+        // copy of the scratch element's plain text go ahead.
+        if (!clipboardData) return;
+        // The event is one we triggered ourselves, so replace its payload and keep it
+        // away from the page's own copy handlers.
+        event.preventDefault();
+        event.stopImmediatePropagation();
+        for (const [type, value] of data) {
+            clipboardData.setData(type, value);
+        }
+    };
+
+    const restoreSelection = captureSelection();
+    scratch.value = data.get(TEXT_PLAIN) ?? '';
+    document.addEventListener('copy', onCopy, true);
+
+    let copied = false;
+    try {
+        scratch.focus();
+        scratch.select();
+        copied = document.execCommand('copy');
+    } catch {
+        copied = false;
+    } finally {
+        document.removeEventListener('copy', onCopy, true);
+        scratch.remove();
+        restoreSelection();
+    }
+    return copied;
+}
+
+/**
+ * Reads the system clipboard via `execCommand('paste')`.
+ * @returns {Map<string, string> | null} contents keyed by MIME type, or `null` when the
+ * command was refused (no user activation, or the embedder disallows clipboard reads)
+ */
+export function pasteWithExecCommand() {
+    const scratch = createScratchElement();
+    if (!scratch) return null;
+
+    // Held in an object so the value survives the callback for the reader below.
+    /** @type {{ data: Map<string, string> | null }} */
+    const captured = { data: null };
+
+    /** @param {Event} event */
+    const onPaste = (event) => {
+        const clipboardData = getClipboardData(event);
+        if (!clipboardData) return;
+        // The event is one we triggered ourselves, so keep it away from the page's own
+        // paste handlers. The default action still runs, filling the scratch element.
+        event.stopImmediatePropagation();
+        /** @type {Map<string, string>} */
+        const data = new Map();
+        for (const type of SUPPORTED_TYPES) {
+            const value = clipboardData.getData(type);
+            if (value) data.set(type, value);
+        }
+        captured.data = data;
+    };
+
+    const restoreSelection = captureSelection();
+    document.addEventListener('paste', onPaste, true);
+
+    let pasted = false;
+    try {
+        scratch.focus();
+        pasted = document.execCommand('paste');
+    } catch {
+        pasted = false;
+    } finally {
+        document.removeEventListener('paste', onPaste, true);
+    }
+
+    // Engines that don't expose a DataTransfer on the synthetic event still insert the
+    // text into the focused element, so read it back from there.
+    const insertedText = scratch.value;
+    scratch.remove();
+    restoreSelection();
+
+    if (!pasted) return null;
+    return captured.data ?? new Map([[TEXT_PLAIN, insertedText]]);
+}
+
+/**
+ * Reads a blob as text without depending on `Blob.text()`, which is missing in older WebViews.
+ * @param {Blob} blob
+ * @returns {Promise<string>}
+ */
+function blobToText(blob) {
+    if (typeof blob.text === 'function') {
+        return blob.text();
+    }
+    return new Promise((resolve, reject) => {
+        const reader = new FileReader();
+        reader.onload = () => resolve(typeof reader.result === 'string' ? reader.result : '');
+        reader.onerror = () => reject(new DOMException('The blob could not be read.', 'NotReadableError'));
+        reader.readAsText(blob);
+    });
+}
+
+/**
+ * Stand-in for the `ClipboardItem` interface.
+ */
+export class ClipboardItemImpl {
+    /** @type {Map<string, Promise<Blob>>} */
+    #items = new Map();
+
+    /** @type {PresentationStyle} */
+    #presentationStyle;
+
+    /**
+     * @param {Record<string, string | Blob | PromiseLike<string | Blob>>} items
+     * @param {ClipboardItemOptions} [options]
+     */
+    constructor(items, options) {
+        const entries = Object.entries(items || {});
+        if (entries.length === 0) {
+            throw new TypeError("Failed to construct 'ClipboardItem': Empty dictionary argument");
+        }
+        for (const [type, value] of entries) {
+            const blob = Promise.resolve(value).then((resolved) =>
+                typeof resolved === 'string' ? new Blob([resolved], { type }) : resolved,
+            );
+            // A caller may never ask for this type, so make sure a rejection here can't
+            // surface as an unhandled promise rejection. `getType()` still rejects.
+            blob.catch(() => {});
+            this.#items.set(type, blob);
+        }
+        this.#presentationStyle = options?.presentationStyle ?? 'unspecified';
+    }
+
+    /** @returns {PresentationStyle} */
+    get presentationStyle() {
+        return this.#presentationStyle;
+    }
+
+    /** @returns {ReadonlyArray<string>} */
+    get types() {
+        return Array.from(this.#items.keys());
+    }
+
+    /**
+     * @param {string} type
+     * @returns {Promise<Blob>}
+     */
+    getType(type) {
+        const blob = this.#items.get(type);
+        if (!blob) {
+            return Promise.reject(
+                new DOMException(`Failed to execute 'getType' on 'ClipboardItem': The type '${type}' was not found`, 'NotFoundError'),
+            );
+        }
+        return blob;
+    }
+
+    /**
+     * @param {string} type
+     * @returns {boolean}
+     */
+    static supports(type) {
+        return SUPPORTED_TYPES.includes(type);
+    }
+}
+
+/**
+ * Stand-in for the `Clipboard` interface, backed by `document.execCommand()`.
+ *
+ * Note: no private class fields here — instances are exposed through a Proxy by
+ * `shimProperty()`, and private field access on a Proxy throws.
+ */
+export class ClipboardImpl extends EventTarget {
+    /**
+     * @param {string} data
+     * @returns {Promise<void>}
+     */
+    writeText(data) {
+        const written = copyWithExecCommand(new Map([[TEXT_PLAIN, String(data)]]));
+        if (!written) {
+            return Promise.reject(new DOMException('Document is not focused.', 'NotAllowedError'));
+        }
+        return Promise.resolve();
+    }
+
+    /**
+     * @returns {Promise<string>}
+     */
+    readText() {
+        const data = pasteWithExecCommand();
+        if (!data) {
+            return Promise.reject(new DOMException('Read permission denied.', 'NotAllowedError'));
+        }
+        return Promise.resolve(data.get(TEXT_PLAIN) ?? '');
+    }
+
+    /**
+     * @param {ClipboardItem[]} data
+     * @returns {Promise<void>}
+     */
+    async write(data) {
+        const items = Array.from(data || []);
+        if (items.length !== 1) {
+            throw new DOMException('Support for multiple ClipboardItems is not implemented.', 'NotAllowedError');
+        }
+        const [item] = items;
+        if (!item) {
+            throw new DOMException('Support for multiple ClipboardItems is not implemented.', 'NotAllowedError');
+        }
+
+        /** @type {Map<string, string>} */
+        const payload = new Map();
+        for (const type of item.types) {
+            if (!SUPPORTED_TYPES.includes(type)) continue;
+            payload.set(type, await blobToText(await item.getType(type)));
+        }
+        if (payload.size === 0) {
+            throw new DOMException(`Type ${item.types[0] ?? TEXT_PLAIN} not supported on write.`, 'NotAllowedError');
+        }
+
+        if (!copyWithExecCommand(payload)) {
+            throw new DOMException('Document is not focused.', 'NotAllowedError');
+        }
+    }
+
+    /**
+     * @returns {Promise<ClipboardItem[]>}
+     */
+    read() {
+        const data = pasteWithExecCommand();
+        if (!data) {
+            return Promise.reject(new DOMException('Read permission denied.', 'NotAllowedError'));
+        }
+
+        /** @type {Record<string, Blob>} */
+        const items = {};
+        for (const [type, value] of data) {
+            items[type] = new Blob([value], { type });
+        }
+        // The clipboard always reports a plain text flavour, even when it is empty.
+        if (!(TEXT_PLAIN in items)) {
+            items[TEXT_PLAIN] = new Blob([''], { type: TEXT_PLAIN });
+        }
+        return Promise.resolve([new ClipboardItemImpl(items)]);
+    }
+}

--- a/injected/unit-test/async-clipboard.spec.js
+++ b/injected/unit-test/async-clipboard.spec.js
@@ -1,0 +1,324 @@
+import { JSDOM } from 'jsdom';
+import { ClipboardImpl, ClipboardItemImpl, copyWithExecCommand, pasteWithExecCommand } from '../src/features/web-compat/async-clipboard.js';
+
+/**
+ * The shim drives the clipboard through `document.execCommand()`, which JSDOM doesn't
+ * implement. These helpers stand in for an engine that supports the commands, so the
+ * event plumbing, the scratch element and the fallbacks can all be exercised.
+ */
+
+/**
+ * @typedef {object} ClipboardHarness
+ * @property {JSDOM} dom
+ * @property {Map<string, string>} written - what the page handed to the clipboard
+ * @property {Map<string, string>} system - what the (fake) system clipboard holds
+ * @property {string[]} commands - commands passed to `document.execCommand()`
+ * @property {() => void} teardown
+ */
+
+/**
+ * @param {object} [options]
+ * @param {boolean} [options.commandSucceeds] - what `document.execCommand()` returns
+ * @param {boolean} [options.withClipboardData] - whether events carry a `clipboardData`
+ * @param {boolean} [options.commandThrows] - whether `document.execCommand()` throws
+ * @returns {ClipboardHarness}
+ */
+function setupClipboard(options = {}) {
+    const { commandSucceeds = true, withClipboardData = true, commandThrows = false } = options;
+    const dom = new JSDOM('<!DOCTYPE html><html><body><input id="page-input" value="page value"></body></html>');
+
+    const originals = {
+        window: global.window,
+        document: global.document,
+        HTMLElement: global.HTMLElement,
+    };
+    global.window = dom.window;
+    global.document = dom.window.document;
+    global.HTMLElement = dom.window.HTMLElement;
+
+    /** @type {Map<string, string>} */
+    const written = new Map();
+    /** @type {Map<string, string>} */
+    const system = new Map();
+    /** @type {string[]} */
+    const commands = [];
+
+    const clipboardData = {
+        /**
+         * @param {string} type
+         * @param {string} value
+         */
+        setData(type, value) {
+            written.set(type, value);
+        },
+        /**
+         * @param {string} type
+         * @returns {string}
+         */
+        getData(type) {
+            return system.get(type) ?? '';
+        },
+    };
+
+    document.execCommand = (command) => {
+        commands.push(command);
+        if (commandThrows) throw new Error('command not supported');
+        if (!commandSucceeds) return false;
+
+        const target = document.activeElement ?? document.body;
+        const event = new dom.window.Event(command, { bubbles: true, cancelable: true });
+        if (withClipboardData) {
+            Object.defineProperty(event, 'clipboardData', { value: clipboardData });
+        }
+        target.dispatchEvent(event);
+
+        // Emulate the engine's default action, which the shim relies on when the event
+        // carries no `clipboardData`.
+        if (!event.defaultPrevented && target instanceof dom.window.HTMLTextAreaElement) {
+            const scratch = /** @type {HTMLTextAreaElement} */ (target);
+            if (command === 'copy') {
+                written.set('text/plain', scratch.value);
+            } else if (command === 'paste') {
+                scratch.value = system.get('text/plain') ?? '';
+            }
+        }
+        return true;
+    };
+
+    return {
+        dom,
+        written,
+        system,
+        commands,
+        teardown() {
+            global.window = originals.window;
+            global.document = originals.document;
+            global.HTMLElement = originals.HTMLElement;
+        },
+    };
+}
+
+describe('async-clipboard.js', () => {
+    describe('copyWithExecCommand', () => {
+        it('writes every requested format to the clipboard', () => {
+            const harness = setupClipboard();
+            try {
+                const copied = copyWithExecCommand(
+                    new Map([
+                        ['text/plain', 'plain value'],
+                        ['text/html', '<b>rich value</b>'],
+                    ]),
+                );
+                expect(copied).toBeTrue();
+                expect(harness.commands).toEqual(['copy']);
+                expect(harness.written.get('text/plain')).toBe('plain value');
+                expect(harness.written.get('text/html')).toBe('<b>rich value</b>');
+            } finally {
+                harness.teardown();
+            }
+        });
+
+        it('falls back to the default copy when the event carries no clipboardData', () => {
+            const harness = setupClipboard({ withClipboardData: false });
+            try {
+                expect(copyWithExecCommand(new Map([['text/plain', 'plain value']]))).toBeTrue();
+                expect(harness.written.get('text/plain')).toBe('plain value');
+            } finally {
+                harness.teardown();
+            }
+        });
+
+        it('keeps the synthetic event away from the page', () => {
+            const harness = setupClipboard();
+            try {
+                const pageHandler = jasmine.createSpy('pageHandler');
+                document.addEventListener('copy', pageHandler);
+                copyWithExecCommand(new Map([['text/plain', 'plain value']]));
+                expect(pageHandler).not.toHaveBeenCalled();
+            } finally {
+                harness.teardown();
+            }
+        });
+
+        it('removes the scratch element and restores focus', () => {
+            const harness = setupClipboard();
+            try {
+                const input = /** @type {HTMLInputElement} */ (document.getElementById('page-input'));
+                input.focus();
+                copyWithExecCommand(new Map([['text/plain', 'plain value']]));
+                expect(document.querySelectorAll('textarea').length).toBe(0);
+                expect(document.activeElement).toBe(input);
+            } finally {
+                harness.teardown();
+            }
+        });
+
+        it('reports failure when the command is refused', () => {
+            const harness = setupClipboard({ commandSucceeds: false });
+            try {
+                expect(copyWithExecCommand(new Map([['text/plain', 'plain value']]))).toBeFalse();
+            } finally {
+                harness.teardown();
+            }
+        });
+
+        it('reports failure when the command throws', () => {
+            const harness = setupClipboard({ commandThrows: true });
+            try {
+                expect(copyWithExecCommand(new Map([['text/plain', 'plain value']]))).toBeFalse();
+                expect(document.querySelectorAll('textarea').length).toBe(0);
+            } finally {
+                harness.teardown();
+            }
+        });
+    });
+
+    describe('pasteWithExecCommand', () => {
+        it('reads every supported format from the clipboard', () => {
+            const harness = setupClipboard();
+            harness.system.set('text/plain', 'plain value');
+            harness.system.set('text/html', '<b>rich value</b>');
+            try {
+                const data = pasteWithExecCommand();
+                expect(harness.commands).toEqual(['paste']);
+                expect(data?.get('text/plain')).toBe('plain value');
+                expect(data?.get('text/html')).toBe('<b>rich value</b>');
+                expect(document.querySelectorAll('textarea').length).toBe(0);
+            } finally {
+                harness.teardown();
+            }
+        });
+
+        it('reads the inserted text when the event carries no clipboardData', () => {
+            const harness = setupClipboard({ withClipboardData: false });
+            harness.system.set('text/plain', 'plain value');
+            try {
+                expect(pasteWithExecCommand()?.get('text/plain')).toBe('plain value');
+            } finally {
+                harness.teardown();
+            }
+        });
+
+        it('returns null when the command is refused', () => {
+            const harness = setupClipboard({ commandSucceeds: false });
+            try {
+                expect(pasteWithExecCommand()).toBeNull();
+            } finally {
+                harness.teardown();
+            }
+        });
+    });
+
+    describe('ClipboardImpl', () => {
+        it('writeText copies plain text', async () => {
+            const harness = setupClipboard();
+            try {
+                await new ClipboardImpl().writeText('hello');
+                expect(harness.written.get('text/plain')).toBe('hello');
+            } finally {
+                harness.teardown();
+            }
+        });
+
+        it('writeText rejects with NotAllowedError when the command is refused', async () => {
+            const harness = setupClipboard({ commandSucceeds: false });
+            try {
+                await expectAsync(new ClipboardImpl().writeText('hello')).toBeRejectedWithError(DOMException, /not focused/);
+            } finally {
+                harness.teardown();
+            }
+        });
+
+        it('readText returns the clipboard text', async () => {
+            const harness = setupClipboard();
+            harness.system.set('text/plain', 'hello');
+            try {
+                expect(await new ClipboardImpl().readText()).toBe('hello');
+            } finally {
+                harness.teardown();
+            }
+        });
+
+        it('readText rejects with NotAllowedError when the command is refused', async () => {
+            const harness = setupClipboard({ commandSucceeds: false });
+            try {
+                await expectAsync(new ClipboardImpl().readText()).toBeRejectedWithError(DOMException, /permission denied/i);
+            } finally {
+                harness.teardown();
+            }
+        });
+
+        it('write copies the supported formats of a ClipboardItem', async () => {
+            const harness = setupClipboard();
+            try {
+                const item = new ClipboardItemImpl({
+                    'text/plain': 'plain value',
+                    'text/html': new Blob(['<b>rich value</b>'], { type: 'text/html' }),
+                });
+                await new ClipboardImpl().write([item]);
+                expect(harness.written.get('text/plain')).toBe('plain value');
+                expect(harness.written.get('text/html')).toBe('<b>rich value</b>');
+            } finally {
+                harness.teardown();
+            }
+        });
+
+        it('write rejects formats that cannot travel through execCommand', async () => {
+            const harness = setupClipboard();
+            try {
+                const item = new ClipboardItemImpl({ 'image/png': new Blob([''], { type: 'image/png' }) });
+                await expectAsync(new ClipboardImpl().write([item])).toBeRejectedWithError(DOMException, /not supported/);
+            } finally {
+                harness.teardown();
+            }
+        });
+
+        it('read returns a ClipboardItem holding the clipboard formats', async () => {
+            const harness = setupClipboard();
+            harness.system.set('text/plain', 'plain value');
+            harness.system.set('text/html', '<b>rich value</b>');
+            try {
+                const [item] = await new ClipboardImpl().read();
+                expect(item.types).toEqual(['text/plain', 'text/html']);
+                expect(await (await item.getType('text/html')).text()).toBe('<b>rich value</b>');
+            } finally {
+                harness.teardown();
+            }
+        });
+
+        it('read always reports a plain text format', async () => {
+            const harness = setupClipboard();
+            try {
+                const [item] = await new ClipboardImpl().read();
+                expect(item.types).toEqual(['text/plain']);
+                expect(await (await item.getType('text/plain')).text()).toBe('');
+            } finally {
+                harness.teardown();
+            }
+        });
+    });
+
+    describe('ClipboardItemImpl', () => {
+        it('exposes the types it was created with', async () => {
+            const item = new ClipboardItemImpl({ 'text/plain': 'plain value' });
+            expect(item.types).toEqual(['text/plain']);
+            expect(item.presentationStyle).toBe('unspecified');
+            expect(await (await item.getType('text/plain')).text()).toBe('plain value');
+        });
+
+        it('rejects with NotFoundError for an unknown type', async () => {
+            const item = new ClipboardItemImpl({ 'text/plain': 'plain value' });
+            await expectAsync(item.getType('text/html')).toBeRejectedWithError(DOMException, /was not found/);
+        });
+
+        it('throws when constructed without any format', () => {
+            expect(() => new ClipboardItemImpl({})).toThrowError(TypeError, /Empty dictionary argument/);
+        });
+
+        it('reports the formats the shim supports', () => {
+            expect(ClipboardItemImpl.supports('text/plain')).toBeTrue();
+            expect(ClipboardItemImpl.supports('text/html')).toBeTrue();
+            expect(ClipboardItemImpl.supports('image/png')).toBeFalse();
+        });
+    });
+});

--- a/scripts/check-strict-core.js
+++ b/scripts/check-strict-core.js
@@ -99,6 +99,7 @@ const CORE_FILES = new Set([
     'injected/src/features/referrer.js',
     'injected/src/features/tracker-protection.js',
     'injected/src/features/tracker-protection/tracker-resolver.js',
+    'injected/src/features/web-compat/async-clipboard.js',
     'injected/src/features/web-detection.js',
     'injected/src/features/web-detection/matching.js',
     'injected/src/features/web-events.js',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**Asana Task/Github Issue:** N/A

## Description

Adds an Async Clipboard API shim to the `webCompat` feature for WebViews that don't expose `navigator.clipboard` (it is also absent from insecure contexts), which breaks copy/paste on sites that only implement the modern API.

`Clipboard` (`writeText`, `readText`, `write`, `read`) and `ClipboardItem` are implemented on top of the deprecated `document.execCommand('copy')` / `document.execCommand('paste')`. Data moves through a synthetic `copy`/`paste` event on an offscreen scratch element: `text/plain` and `text/html` are set on / read from the event's `DataTransfer`, with a fallback to the element's own value for engines that don't expose `clipboardData` on the synthetic event. Focus and selection are captured and restored, and the synthetic events are kept away from the page's own clipboard handlers. Formats that can't travel through a `DataTransfer` (images, for instance) are rejected with `NotAllowedError`, as is a command the engine refuses.

Enablement:

- Gated by the new `asyncClipboard` web-compat setting, disabled unless remote config turns it on.
- Additionally restricted in code to `platform.name === 'windows'`, so it cannot be enabled elsewhere from config alone.
- Never replaces a working `navigator.clipboard`; only the integration build always shims, so the behaviour is testable in a browser that has the real API.

Note that `document.execCommand('paste')` is only available to embedders that opt in to DOM paste, so `readText()`/`read()` reject with `NotAllowedError` in browsers that refuse it (including plain Chromium page contexts).

## Testing Steps

- `npm run test-unit` — `injected/unit-test/async-clipboard.spec.js` covers the copy/paste command plumbing, the fallbacks, the scratch element cleanup and the `Clipboard`/`ClipboardItem` behaviour with JSDOM.
- `npx playwright test --project=chrome-mv3 integration-test/async-clipboard.spec.js --reporter list` — verifies the shim is installed only on Windows, matches the shape of the native API, and really puts plain text and HTML on the system clipboard (read back with the browser's own implementation, captured before shimming).

## Checklist

*Please tick all that apply:*

- [x] I have tested this change locally
- [ ] I have tested this change locally in all supported browsers
- [x] This change will be visible to users
- [x] I have added automated tests that cover this change
- [x] I have ensured the change is gated by config
- [ ] This change was covered by a ship review
- [ ] This change was covered by a tech design
- [ ] Any dependent config has been merged

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6bab716f-5314-4e8a-aa58-f22ac99844ca?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6bab716f-5314-4e8a-aa58-f22ac99844ca&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

