### PR TITLE
[macOS] add configurable link to error page

### DIFF
--- a/special-pages/pages/errorpage/app/errorpage.md
+++ b/special-pages/pages/errorpage/app/errorpage.md
@@ -15,6 +15,7 @@ Native performs string replacement on the HTML before loading:
 | `$HEADER$` | Error title text |
 | `$ERROR_DESCRIPTION$` | Error description text |
 | `$THEME_VARIANT$` | Theme variant name (falls back to default if not replaced) |
+| `/* $ERROR_PAGE_LINK_CONFIGURATION$ */` | Optional inert marker that native can replace with action-link configuration |
 
 ## Runtime Theme Updates
 
@@ -32,3 +33,18 @@ window.onChangeTheme({ themeVariant: 'coolGray' });
 ```
 
 Available theme variants: `default`, `coolGray`, `slateBlue`, `green`, `violet`, `rose`, `orange`, `desert`
+
+## Optional Action Link
+
+The action link is hidden by default. Provide non-empty text and a click function to show it:
+
+```javascript
+window.configureErrorPageLink({
+  text: 'Send Feedback',
+  onClick: function() {
+    // Handle the action in native.
+  }
+});
+```
+
+Missing or invalid configuration hides the link and clears its text and click function. Calling `window.configureErrorPageLink` again replaces the previous configuration.

--- a/special-pages/pages/errorpage/integration-tests/errorpage.js
+++ b/special-pages/pages/errorpage/integration-tests/errorpage.js
@@ -1,0 +1,102 @@
+import { join } from 'node:path';
+import { perPlatform } from 'injected/integration-test/type-helpers.mjs';
+
+export class ErrorPage {
+    /**
+     * @param {import('@playwright/test').Page} page
+     * @param {import('injected/integration-test/type-helpers.mjs').Build} build
+     */
+    constructor(page, build) {
+        this.page = page;
+        this.build = build;
+    }
+
+    async openPage() {
+        await this.page.route('/**', (route, request) => {
+            const url = new URL(request.url());
+            const filePath = url.pathname === '/' ? 'index.html' : url.pathname;
+            return route.fulfill({
+                status: 200,
+                path: join(this.basePath, filePath),
+            });
+        });
+        await this.page.goto('/');
+    }
+
+    get basePath() {
+        return this.build.switch({
+            apple: () => '../Sources/ContentScopeScripts/dist/pages/errorpage',
+        });
+    }
+
+    get link() {
+        return this.page.locator('#error-page-link');
+    }
+
+    /**
+     * @param {string} text
+     * @param {string} callbackName
+     */
+    async configureLink(text, callbackName) {
+        await this.page.evaluate(
+            ({ text, callbackName }) => {
+                const configureErrorPageLink = /** @type {any} */ (window).configureErrorPageLink;
+                configureErrorPageLink({
+                    text,
+                    onClick: function () {
+                        const calls = document.body.dataset.errorPageLinkCalls;
+                        document.body.dataset.errorPageLinkCalls = calls ? `${calls},${callbackName}` : callbackName;
+                    },
+                });
+            },
+            { text, callbackName },
+        );
+    }
+
+    /**
+     * @param {'blank-text' | 'non-function-callback'} invalidValue
+     */
+    async clearLinkWithInvalidConfiguration(invalidValue) {
+        await this.page.evaluate((invalidValue) => {
+            const configureErrorPageLink = /** @type {any} */ (window).configureErrorPageLink;
+            const configuration =
+                invalidValue === 'blank-text'
+                    ? {
+                          text: '   ',
+                          onClick: function () {
+                              document.body.dataset.errorPageLinkCalls = 'invalid';
+                          },
+                      }
+                    : { text: 'Still visible', onClick: null };
+            configureErrorPageLink(configuration);
+        }, invalidValue);
+    }
+
+    async clickLinkProgrammatically() {
+        await this.link.evaluate((element) => /** @type {HTMLButtonElement} */ (element).click());
+    }
+
+    async callbackNames() {
+        const calls = await this.page.locator('body').getAttribute('data-error-page-link-calls');
+        return calls ? calls.split(',') : [];
+    }
+
+    /**
+     * @param {string} themeVariant
+     */
+    async changeTheme(themeVariant) {
+        await this.page.evaluate((themeVariant) => {
+            const onChangeTheme = /** @type {any} */ (window).onChangeTheme;
+            onChangeTheme({ themeVariant });
+        }, themeVariant);
+    }
+
+    /**
+     * @param {import('@playwright/test').Page} page
+     * @param {import('@playwright/test').TestInfo} testInfo
+     */
+    static create(page, testInfo) {
+        const { build } = perPlatform(testInfo.project.use);
+        return new ErrorPage(page, build);
+    }
+}

--- a/special-pages/pages/errorpage/integration-tests/errorpage.spec.js
+++ b/special-pages/pages/errorpage/integration-tests/errorpage.spec.js
@@ -31,6 +31,7 @@ test.describe('errorpage', () => {
             document.body.appendChild(reference);
 
             const link = document.getElementById('error-page-link');
+            if (!link) return false;
             return getComputedStyle(link).color === getComputedStyle(reference).color;
         });
 

--- a/special-pages/pages/errorpage/integration-tests/errorpage.spec.js
+++ b/special-pages/pages/errorpage/integration-tests/errorpage.spec.js
@@ -20,6 +20,23 @@ test.describe('errorpage', () => {
         expect(await errorPage.callbackNames()).toEqual(['configured']);
     });
 
+    test('configured action link uses the design system accent text color', async ({ page }, testInfo) => {
+        const errorPage = ErrorPage.create(page, testInfo);
+        await errorPage.openPage();
+        await errorPage.configureLink('Send Feedback', 'configured');
+
+        const usesAccentTextColor = await page.evaluate(() => {
+            const reference = document.createElement('span');
+            reference.style.color = 'var(--ds-color-theme-default-light-accent-text-primary)';
+            document.body.appendChild(reference);
+
+            const link = document.getElementById('error-page-link');
+            return getComputedStyle(link).color === getComputedStyle(reference).color;
+        });
+
+        expect(usesAccentTextColor).toBe(true);
+    });
+
     test('reconfiguring the action link replaces its function', async ({ page }, testInfo) => {
         const errorPage = ErrorPage.create(page, testInfo);
         await errorPage.openPage();

--- a/special-pages/pages/errorpage/integration-tests/errorpage.spec.js
+++ b/special-pages/pages/errorpage/integration-tests/errorpage.spec.js
@@ -1,0 +1,57 @@
+import { expect, test } from '@playwright/test';
+import { ErrorPage } from './errorpage';
+
+test.describe('errorpage', () => {
+    test('action link is hidden by default', async ({ page }, testInfo) => {
+        const errorPage = ErrorPage.create(page, testInfo);
+        await errorPage.openPage();
+
+        await expect(errorPage.link).toBeHidden();
+    });
+
+    test('configured action link shows text and calls its function once', async ({ page }, testInfo) => {
+        const errorPage = ErrorPage.create(page, testInfo);
+        await errorPage.openPage();
+        await errorPage.configureLink('Send Feedback', 'configured');
+
+        await expect(errorPage.link).toBeVisible();
+        await expect(errorPage.link).toHaveText('Send Feedback');
+        await errorPage.link.click();
+        expect(await errorPage.callbackNames()).toEqual(['configured']);
+    });
+
+    test('reconfiguring the action link replaces its function', async ({ page }, testInfo) => {
+        const errorPage = ErrorPage.create(page, testInfo);
+        await errorPage.openPage();
+        await errorPage.configureLink('First', 'first');
+        await errorPage.configureLink('Second', 'second');
+
+        await errorPage.link.click();
+        expect(await errorPage.callbackNames()).toEqual(['second']);
+    });
+
+    for (const invalidConfiguration of [
+        { name: 'blank text', value: /** @type {const} */ ('blank-text') },
+        { name: 'a non-function callback', value: /** @type {const} */ ('non-function-callback') },
+    ]) {
+        test(`configuration with ${invalidConfiguration.name} clears and hides the action link`, async ({ page }, testInfo) => {
+            const errorPage = ErrorPage.create(page, testInfo);
+            await errorPage.openPage();
+            await errorPage.configureLink('Send Feedback', 'configured');
+            await errorPage.clearLinkWithInvalidConfiguration(invalidConfiguration.value);
+
+            await expect(errorPage.link).toBeHidden();
+            await expect(errorPage.link).toHaveText('');
+            await errorPage.clickLinkProgrammatically();
+            expect(await errorPage.callbackNames()).toEqual([]);
+        });
+    }
+
+    test('runtime theme callback still updates the theme', async ({ page }, testInfo) => {
+        const errorPage = ErrorPage.create(page, testInfo);
+        await errorPage.openPage();
+        await errorPage.changeTheme('violet');
+
+        await expect(page.locator('body')).toHaveAttribute('data-theme-variant', 'violet');
+    });
+});

--- a/special-pages/pages/errorpage/public/index.html
+++ b/special-pages/pages/errorpage/public/index.html
@@ -16,6 +16,7 @@
             <div class="description-container">
                 <p class="error-description">$ERROR_DESCRIPTION$</p>
             </div>
+            <button id="error-page-link" class="error-page-link" type="button" hidden></button>
         </div>
         <div class="watermark-container">
             <img src="img/logo-horizontal.svg" alt="DuckDuckGo" class="watermark">
@@ -31,6 +32,28 @@
                 document.body.dataset.themeVariant = payload.themeVariant;
             }
         };
+
+        /**
+         * @param {{ text: string, onClick: () => void } | null} configuration
+         */
+        window.configureErrorPageLink = function(configuration) {
+            var link = document.getElementById('error-page-link');
+            var hasText = configuration && typeof configuration.text === 'string' && configuration.text.trim().length > 0;
+            var hasAction = configuration && typeof configuration.onClick === 'function';
+
+            if (!hasText || !hasAction) {
+                link.textContent = '';
+                link.onclick = null;
+                link.hidden = true;
+                return;
+            }
+
+            link.textContent = configuration.text;
+            link.onclick = configuration.onClick;
+            link.hidden = false;
+        };
+
+        /* $ERROR_PAGE_LINK_CONFIGURATION$ */
     </script>
 </body>
 </html>

--- a/special-pages/pages/errorpage/readme.md
+++ b/special-pages/pages/errorpage/readme.md
@@ -38,6 +38,23 @@ Native can call `window.onChangeTheme(payload)` to update the theme at runtime.
 window.onChangeTheme({ themeVariant: 'coolGray' });
 ```
 
+### Optional Action Link
+
+The action link is hidden by default. Native can show it by providing both non-empty text and a click function:
+
+```javascript
+window.configureErrorPageLink({
+  text: 'Send Feedback',
+  onClick: function() {
+    // Handle the action in native.
+  }
+});
+```
+
+Passing a missing or invalid value hides the link and clears its text and click function. Reconfiguring the link replaces the previous click function.
+
+Native can replace the inert `/* $ERROR_PAGE_LINK_CONFIGURATION$ */` marker with a call to `window.configureErrorPageLink`. Leaving the marker unchanged keeps the link hidden.
+
 ---
 
 ## Contributing

--- a/special-pages/pages/errorpage/src/index.css
+++ b/special-pages/pages/errorpage/src/index.css
@@ -2,68 +2,84 @@
 
 body {
     --background-color: var(--ds-color-theme-default-light-surface-canvas);
+    --accent-color: var(--ds-color-theme-default-light-accent-text-primary);
     --text-color: var(--ds-color-theme-default-light-text-primary);
 }
 body[data-theme-variant="coolGray"] {
     --background-color: var(--ds-color-theme-cool-gray-light-surface-canvas);
+    --accent-color: var(--ds-color-theme-cool-gray-light-accent-text-primary);
     --text-color: var(--ds-color-theme-cool-gray-light-text-primary);
 }
 body[data-theme-variant="slateBlue"] {
     --background-color: var(--ds-color-theme-slate-blue-light-surface-canvas);
+    --accent-color: var(--ds-color-theme-slate-blue-light-accent-text-primary);
     --text-color: var(--ds-color-theme-slate-blue-light-text-primary);
 }
 body[data-theme-variant="green"] {
     --background-color: var(--ds-color-theme-green-light-surface-canvas);
+    --accent-color: var(--ds-color-theme-green-light-accent-text-primary);
     --text-color: var(--ds-color-theme-green-light-text-primary);
 }
 body[data-theme-variant="violet"] {
     --background-color: var(--ds-color-theme-violet-light-surface-canvas);
+    --accent-color: var(--ds-color-theme-violet-light-accent-text-primary);
     --text-color: var(--ds-color-theme-violet-light-text-primary);
 }
 body[data-theme-variant="rose"] {
     --background-color: var(--ds-color-theme-rose-light-surface-canvas);
+    --accent-color: var(--ds-color-theme-rose-light-accent-text-primary);
     --text-color: var(--ds-color-theme-rose-light-text-primary);
 }
 body[data-theme-variant="orange"] {
     --background-color: var(--ds-color-theme-orange-light-surface-canvas);
+    --accent-color: var(--ds-color-theme-orange-light-accent-text-primary);
     --text-color: var(--ds-color-theme-orange-light-text-primary);
 }
 body[data-theme-variant="desert"] {
     --background-color: var(--ds-color-theme-desert-light-surface-canvas);
+    --accent-color: var(--ds-color-theme-desert-light-accent-text-primary);
     --text-color: var(--ds-color-theme-desert-light-text-primary);
 }
 
 @media (prefers-color-scheme: dark) {
     body {
         --background-color: var(--ds-color-theme-default-dark-surface-canvas);
+        --accent-color: var(--ds-color-theme-default-dark-accent-text-primary);
         --text-color: var(--ds-color-theme-default-dark-text-primary);
     }
     body[data-theme-variant="coolGray"] {
         --background-color: var(--ds-color-theme-cool-gray-dark-surface-canvas);
+        --accent-color: var(--ds-color-theme-cool-gray-dark-accent-text-primary);
         --text-color: var(--ds-color-theme-cool-gray-dark-text-primary);
     }
     body[data-theme-variant="slateBlue"] {
         --background-color: var(--ds-color-theme-slate-blue-dark-surface-canvas);
+        --accent-color: var(--ds-color-theme-slate-blue-dark-accent-text-primary);
         --text-color: var(--ds-color-theme-slate-blue-dark-text-primary);
     }
     body[data-theme-variant="green"] {
         --background-color: var(--ds-color-theme-green-dark-surface-canvas);
+        --accent-color: var(--ds-color-theme-green-dark-accent-text-primary);
         --text-color: var(--ds-color-theme-green-dark-text-primary);
     }
     body[data-theme-variant="violet"] {
         --background-color: var(--ds-color-theme-violet-dark-surface-canvas);
+        --accent-color: var(--ds-color-theme-violet-dark-accent-text-primary);
         --text-color: var(--ds-color-theme-violet-dark-text-primary);
     }
     body[data-theme-variant="rose"] {
         --background-color: var(--ds-color-theme-rose-dark-surface-canvas);
+        --accent-color: var(--ds-color-theme-rose-dark-accent-text-primary);
         --text-color: var(--ds-color-theme-rose-dark-text-primary);
     }
     body[data-theme-variant="orange"] {
         --background-color: var(--ds-color-theme-orange-dark-surface-canvas);
+        --accent-color: var(--ds-color-theme-orange-dark-accent-text-primary);
         --text-color: var(--ds-color-theme-orange-dark-text-primary);
     }
     body[data-theme-variant="desert"] {
         --background-color: var(--ds-color-theme-desert-dark-surface-canvas);
+        --accent-color: var(--ds-color-theme-desert-dark-accent-text-primary);
         --text-color: var(--ds-color-theme-desert-dark-text-primary);
     }
 }
@@ -108,7 +124,7 @@ body {
     appearance: none;
     background-color: transparent;
     border: 0;
-    color: var(--text-color);
+    color: var(--accent-color);
     cursor: pointer;
     font-family: inherit;
     font-size: 13px;

--- a/special-pages/pages/errorpage/src/index.css
+++ b/special-pages/pages/errorpage/src/index.css
@@ -104,6 +104,20 @@ body {
     padding: 8px;
 }
 
+.error-page-link {
+    appearance: none;
+    background-color: transparent;
+    border: 0;
+    color: var(--text-color);
+    cursor: pointer;
+    font-family: inherit;
+    font-size: 13px;
+    line-height: 16px;
+    margin: 0;
+    padding: 0;
+    text-decoration: underline;
+}
+
 .header-container .description-container {
     position: relative;
     width: 100%;

--- a/special-pages/playwright.config.js
+++ b/special-pages/playwright.config.js
@@ -77,6 +77,7 @@ export default defineConfig({
             testMatch: [
                 'duckplayer.spec.js',
                 'duckplayer-screenshots.spec.js',
+                'errorpage.spec.js',
                 'onboarding.v4.spec.js',
                 'release-notes.spec.js',
                 'special-error.spec.js',


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/392891325557410/task/1216394981596297?focus=true

## Description

Adds an optional, hidden-by-default action link to the shared error page. Native consumers can configure its text and click handler. Includes documentation and focused Playwright coverage.


## Testing Steps

- Run `npm run build --workspace special-pages`.
- Run `npm run test-int --workspace special-pages -- --project macos pages/errorpage/integration-tests/errorpage.spec.js --reporter list`.
- Verify the tests cover the hidden default state, configuration, callback replacement, invalid configuration, and runtime theme changes.
- Using the companion macOS branch, trigger a WebKit crash loop and verify “Send Feedback” opens the broken-site feedback sheet.

## Checklist

<!--
  These questions are a friendly reminder to shipping code, if you're uncertain ask the AoR owners.
  It's also totally appropriate to not check some of these boxes, if they don't apply to your change.
-->
*Please tick all that apply:*

- [x] I have tested this change locally
- [x] I have tested this change locally in all supported browsers
- [ ] This change will be visible to users
- [x] I have added automated tests that cover this change
- [ ] I have ensured the change is gated by config
- [x] This change was covered by a ship review
- [ ] This change was covered by a tech design
- [ ] Any dependent config has been merged


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to the error page special-page, docs, and integration tests; no auth or shared runtime infrastructure beyond a small window API for native.
> 
> **Overview**
> Adds an **optional action link** to the shared error page: a hidden-by-default `#error-page-link` button that native can show via **`window.configureErrorPageLink({ text, onClick })`**, or by replacing the inert **`/* $ERROR_PAGE_LINK_CONFIGURATION$ */`** marker in the built HTML. Invalid or partial config (blank text, non-function callback) **hides the link** and clears text and handlers; reconfiguration **replaces** the previous click handler.
> 
> Styling wires **per-theme accent text colors** into `.error-page-link` so the control matches the design system. Docs (`errorpage.md`, `readme.md`) document the API and interpolation marker.
> 
> **Playwright** coverage on the macOS project includes a new `ErrorPage` helper and `errorpage.spec.js` for default hidden state, configuration, accent color, reconfiguration, invalid config, and existing **`onChangeTheme`** behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2d1ade377671ca1430b2625a1e19d7d7379388c5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->