### PR TITLE
[Next Steps Card] Update Sync & Backup next steps card copy

### DIFF
--- a/special-pages/pages/new-tab/app/next-steps-list/strings.json
+++ b/special-pages/pages/new-tab/app/next-steps-list/strings.json
@@ -116,11 +116,11 @@
     "note": "Button text of the Next Steps List card for DuckDuckGo subscription"
   },
   "nextStepsList_sync_title": {
-    "title": "Sync and Back Up Your Bookmarks and Passwords",
+    "title": "Sync and Back Up Your Bookmarks, Passwords, and Chats",
     "note": "Title of the Next Steps List card for syncing data across devices"
   },
   "nextStepsList_sync_summary": {
-    "title": "Securely sync your bookmarks, passwords, and identity data on mobile and desktop.",
+    "title": "Securely sync your bookmarks, autofill data, and Duck.ai chats with end-to-end encryption between your devices.",
     "note": "Summary of the Next Steps List card for syncing data across devices"
   },
   "nextStepsList_sync_actionText": {

--- a/special-pages/pages/new-tab/public/locales/de/new-tab.json
+++ b/special-pages/pages/new-tab/public/locales/de/new-tab.json
@@ -269,7 +269,7 @@
     "description" : "Error shown when an attached image cannot be processed."
   },
   "omnibar_advancedModelsSectionHeader" : {
-    "title" : "Erweiterte Modelle – DuckDuckGo-Abo",
+    "title" : "Exklusiv für Abonnenten",
     "description" : "Section header in the model picker for premium models that require a subscription."
   },
   "omnibar_viewAllChats" : {
@@ -400,9 +400,9 @@
     "title" : "Keine passenden Tabs",
     "description" : "Empty-state message shown when no open tabs match what the user typed, in the @-mention tab picker and the Add Tabs dialog search."
   },
-  "omnibar_attachTabsNoOpenTabs" : {
-    "title" : "Keine offenen Tabs",
-    "description" : "Empty-state message shown in the attach dropdown's Recent Tabs section and the Add Tabs dialog when there are no open tabs available to attach."
+  "omnibar_attachTabsNoPageContent" : {
+    "title" : "Kein Seiteninhalt verfügbar",
+    "description" : "Empty-state message shown in the attach dropdown and the Add Tabs dialog when there are no open tabs with attachable page content."
   },
   "omnibar_removeAttachedTabLabel" : {
     "title" : "{title} entfernen",
@@ -415,22 +415,6 @@
   "omnibar_removeAiChat" : {
     "title" : "Diesen Chat löschen",
     "description" : "Accessible label and tooltip for the button that deletes a recent AI chat."
-  },
-  "omnibar_tryForFree" : {
-    "title" : "Gratis testen",
-    "description" : "CTA on a subscription-gated model or reasoning-effort option that opens the subscription upsell when tapped."
-  },
-  "omnibar_upgrade" : {
-    "title" : "Upgrade",
-    "description" : "CTA shown on a model or reasoning-effort option gated behind a higher subscription tier; opens the upgrade flow when tapped."
-  },
-  "omnibar_modelBadgePlus" : {
-    "title" : "Plus",
-    "description" : "Badge shown next to an AI model in the model selector that requires a Plus subscription tier."
-  },
-  "omnibar_modelBadgePro" : {
-    "title" : "Pro",
-    "description" : "Badge shown next to an AI model in the model selector that requires a Pro subscription tier."
   },
   "omnibar_modelBadgeInternal" : {
     "title" : "Intern",
@@ -553,11 +537,11 @@
     "note" : "Button text of the Next Steps List card for DuckDuckGo subscription"
   },
   "nextStepsList_sync_title" : {
-    "title" : "Lesezeichen und Passwörter synchronisieren und sichern",
+    "title" : "Lesezeichen, Passwörter und Chats synchronisieren und sichern",
     "note" : "Title of the Next Steps List card for syncing data across devices"
   },
   "nextStepsList_sync_summary" : {
-    "title" : "Synchronisiere deine Lesezeichen, Passwörter und Identitätsdaten sicher auf Handy und Desktop.",
+    "title" : "Synchronisiere deine Lesezeichen, Autofill-Daten und Duck.ai-Chats sicher mit Ende-zu-Ende-Verschlüsselung zwischen deinen Geräten.",
     "note" : "Summary of the Next Steps List card for syncing data across devices"
   },
   "nextStepsList_sync_actionText" : {

--- a/special-pages/pages/new-tab/public/locales/en/new-tab.json
+++ b/special-pages/pages/new-tab/public/locales/en/new-tab.json
@@ -538,11 +538,11 @@
     "note": "Button text of the Next Steps List card for DuckDuckGo subscription"
   },
   "nextStepsList_sync_title": {
-    "title": "Sync and Back Up Your Bookmarks and Passwords",
+    "title": "Sync and Back Up Your Bookmarks, Passwords, and Chats",
     "note": "Title of the Next Steps List card for syncing data across devices"
   },
   "nextStepsList_sync_summary": {
-    "title": "Securely sync your bookmarks, passwords, and identity data on mobile and desktop.",
+    "title": "Securely sync your bookmarks, autofill data, and Duck.ai chats with end-to-end encryption between your devices.",
     "note": "Summary of the Next Steps List card for syncing data across devices"
   },
   "nextStepsList_sync_actionText": {

--- a/special-pages/pages/new-tab/public/locales/es/new-tab.json
+++ b/special-pages/pages/new-tab/public/locales/es/new-tab.json
@@ -269,7 +269,7 @@
     "description" : "Error shown when an attached image cannot be processed."
   },
   "omnibar_advancedModelsSectionHeader" : {
-    "title" : "Modelos avanzados - suscripción a DuckDuckGo",
+    "title" : "Exclusivo para suscriptores",
     "description" : "Section header in the model picker for premium models that require a subscription."
   },
   "omnibar_viewAllChats" : {
@@ -400,9 +400,9 @@
     "title" : "No hay pestañas coincidentes",
     "description" : "Empty-state message shown when no open tabs match what the user typed, in the @-mention tab picker and the Add Tabs dialog search."
   },
-  "omnibar_attachTabsNoOpenTabs" : {
-    "title" : "No hay pestañas abiertas",
-    "description" : "Empty-state message shown in the attach dropdown's Recent Tabs section and the Add Tabs dialog when there are no open tabs available to attach."
+  "omnibar_attachTabsNoPageContent" : {
+    "title" : "No hay contenido de página disponible",
+    "description" : "Empty-state message shown in the attach dropdown and the Add Tabs dialog when there are no open tabs with attachable page content."
   },
   "omnibar_removeAttachedTabLabel" : {
     "title" : "Eliminar {title}",
@@ -415,22 +415,6 @@
   "omnibar_removeAiChat" : {
     "title" : "Borrar este chat",
     "description" : "Accessible label and tooltip for the button that deletes a recent AI chat."
-  },
-  "omnibar_tryForFree" : {
-    "title" : "Probar gratis",
-    "description" : "CTA on a subscription-gated model or reasoning-effort option that opens the subscription upsell when tapped."
-  },
-  "omnibar_upgrade" : {
-    "title" : "Actualizar",
-    "description" : "CTA shown on a model or reasoning-effort option gated behind a higher subscription tier; opens the upgrade flow when tapped."
-  },
-  "omnibar_modelBadgePlus" : {
-    "title" : "Plus",
-    "description" : "Badge shown next to an AI model in the model selector that requires a Plus subscription tier."
-  },
-  "omnibar_modelBadgePro" : {
-    "title" : "Pro",
-    "description" : "Badge shown next to an AI model in the model selector that requires a Pro subscription tier."
   },
   "omnibar_modelBadgeInternal" : {
     "title" : "Interno",
@@ -553,11 +537,11 @@
     "note" : "Button text of the Next Steps List card for DuckDuckGo subscription"
   },
   "nextStepsList_sync_title" : {
-    "title" : "Sincroniza y haz copia de seguridad de tus marcadores y contraseñas",
+    "title" : "Sincroniza y haz copia de seguridad de tus marcadores, contraseñas y chats",
     "note" : "Title of the Next Steps List card for syncing data across devices"
   },
   "nextStepsList_sync_summary" : {
-    "title" : "Sincroniza de forma segura tus marcadores, contraseñas y datos de identidad en dispositivos móviles y de escritorio.",
+    "title" : "Sincroniza de forma segura tus marcadores, datos de autocompletaR y chats de Duck.ai con encriptación de extremo a extremo entre tus dispositivos.",
     "note" : "Summary of the Next Steps List card for syncing data across devices"
   },
   "nextStepsList_sync_actionText" : {

--- a/special-pages/pages/new-tab/public/locales/fr/new-tab.json
+++ b/special-pages/pages/new-tab/public/locales/fr/new-tab.json
@@ -269,7 +269,7 @@
     "description" : "Error shown when an attached image cannot be processed."
   },
   "omnibar_advancedModelsSectionHeader" : {
-    "title" : "Modèles avancés - Abonnement DuckDuckGo",
+    "title" : "Réservé aux abonnés",
     "description" : "Section header in the model picker for premium models that require a subscription."
   },
   "omnibar_viewAllChats" : {
@@ -400,9 +400,9 @@
     "title" : "Aucun onglet correspondant",
     "description" : "Empty-state message shown when no open tabs match what the user typed, in the @-mention tab picker and the Add Tabs dialog search."
   },
-  "omnibar_attachTabsNoOpenTabs" : {
-    "title" : "Aucun onglet ouvert",
-    "description" : "Empty-state message shown in the attach dropdown's Recent Tabs section and the Add Tabs dialog when there are no open tabs available to attach."
+  "omnibar_attachTabsNoPageContent" : {
+    "title" : "Aucun contenu de page disponible",
+    "description" : "Empty-state message shown in the attach dropdown and the Add Tabs dialog when there are no open tabs with attachable page content."
   },
   "omnibar_removeAttachedTabLabel" : {
     "title" : "Supprimer {title}",
@@ -415,22 +415,6 @@
   "omnibar_removeAiChat" : {
     "title" : "Supprimer cette discussion",
     "description" : "Accessible label and tooltip for the button that deletes a recent AI chat."
-  },
-  "omnibar_tryForFree" : {
-    "title" : "Essai gratuit",
-    "description" : "CTA on a subscription-gated model or reasoning-effort option that opens the subscription upsell when tapped."
-  },
-  "omnibar_upgrade" : {
-    "title" : "Changer de forfait",
-    "description" : "CTA shown on a model or reasoning-effort option gated behind a higher subscription tier; opens the upgrade flow when tapped."
-  },
-  "omnibar_modelBadgePlus" : {
-    "title" : "Plus",
-    "description" : "Badge shown next to an AI model in the model selector that requires a Plus subscription tier."
-  },
-  "omnibar_modelBadgePro" : {
-    "title" : "Pro",
-    "description" : "Badge shown next to an AI model in the model selector that requires a Pro subscription tier."
   },
   "omnibar_modelBadgeInternal" : {
     "title" : "Interne",
@@ -553,11 +537,11 @@
     "note" : "Button text of the Next Steps List card for DuckDuckGo subscription"
   },
   "nextStepsList_sync_title" : {
-    "title" : "Synchronisez et sauvegardez vos favoris et mots de passe",
+    "title" : "Synchronise et sauvegarde tes favoris, tes mots de passe, et tes discussions",
     "note" : "Title of the Next Steps List card for syncing data across devices"
   },
   "nextStepsList_sync_summary" : {
-    "title" : "Synchronisez en toute sécurité vos favoris, mots de passe et données d'identité sur mobile et ordinateur de bureau.",
+    "title" : "Synchronise en toute sécurité tes signets, tes données de remplissage automatique, et tes discussions Duck.ai avec un cryptage de bout en bout entre tes appareils.",
     "note" : "Summary of the Next Steps List card for syncing data across devices"
   },
   "nextStepsList_sync_actionText" : {

--- a/special-pages/pages/new-tab/public/locales/it/new-tab.json
+++ b/special-pages/pages/new-tab/public/locales/it/new-tab.json
@@ -269,7 +269,7 @@
     "description" : "Error shown when an attached image cannot be processed."
   },
   "omnibar_advancedModelsSectionHeader" : {
-    "title" : "Modelli avanzati - Abbonamento DuckDuckGo",
+    "title" : "Esclusiva per abbonati",
     "description" : "Section header in the model picker for premium models that require a subscription."
   },
   "omnibar_viewAllChats" : {
@@ -400,9 +400,9 @@
     "title" : "Nessuna scheda corrispondente",
     "description" : "Empty-state message shown when no open tabs match what the user typed, in the @-mention tab picker and the Add Tabs dialog search."
   },
-  "omnibar_attachTabsNoOpenTabs" : {
-    "title" : "Nessuna scheda aperta",
-    "description" : "Empty-state message shown in the attach dropdown's Recent Tabs section and the Add Tabs dialog when there are no open tabs available to attach."
+  "omnibar_attachTabsNoPageContent" : {
+    "title" : "Non sono disponibili contenuti della pagina",
+    "description" : "Empty-state message shown in the attach dropdown and the Add Tabs dialog when there are no open tabs with attachable page content."
   },
   "omnibar_removeAttachedTabLabel" : {
     "title" : "Rimuovi {title}",
@@ -415,22 +415,6 @@
   "omnibar_removeAiChat" : {
     "title" : "Elimina questa chat",
     "description" : "Accessible label and tooltip for the button that deletes a recent AI chat."
-  },
-  "omnibar_tryForFree" : {
-    "title" : "Prova gratuitamente",
-    "description" : "CTA on a subscription-gated model or reasoning-effort option that opens the subscription upsell when tapped."
-  },
-  "omnibar_upgrade" : {
-    "title" : "Fai l'upgrade",
-    "description" : "CTA shown on a model or reasoning-effort option gated behind a higher subscription tier; opens the upgrade flow when tapped."
-  },
-  "omnibar_modelBadgePlus" : {
-    "title" : "Plus",
-    "description" : "Badge shown next to an AI model in the model selector that requires a Plus subscription tier."
-  },
-  "omnibar_modelBadgePro" : {
-    "title" : "Pro",
-    "description" : "Badge shown next to an AI model in the model selector that requires a Pro subscription tier."
   },
   "omnibar_modelBadgeInternal" : {
     "title" : "Interno",
@@ -553,11 +537,11 @@
     "note" : "Button text of the Next Steps List card for DuckDuckGo subscription"
   },
   "nextStepsList_sync_title" : {
-    "title" : "Sincronizza e fai il backup dei tuoi segnalibri e delle tue password",
+    "title" : "Sincronizza e fai il backup di segnalibri, password e chat",
     "note" : "Title of the Next Steps List card for syncing data across devices"
   },
   "nextStepsList_sync_summary" : {
-    "title" : "Sincronizza in modo sicuro i tuoi segnalibri, le password e i dati di identità su mobile e desktop.",
+    "title" : "Sincronizza in modo sicuro i tuoi segnalibri, i dati di compilazione automatica e le chat di Duck.ai con crittografia end-to-end tra i tuoi dispositivi.",
     "note" : "Summary of the Next Steps List card for syncing data across devices"
   },
   "nextStepsList_sync_actionText" : {

--- a/special-pages/pages/new-tab/public/locales/nl/new-tab.json
+++ b/special-pages/pages/new-tab/public/locales/nl/new-tab.json
@@ -269,7 +269,7 @@
     "description" : "Error shown when an attached image cannot be processed."
   },
   "omnibar_advancedModelsSectionHeader" : {
-    "title" : "Geavanceerde modellen - DuckDuckGo-abonnement",
+    "title" : "Alleen voor abonnees",
     "description" : "Section header in the model picker for premium models that require a subscription."
   },
   "omnibar_viewAllChats" : {
@@ -400,9 +400,9 @@
     "title" : "Geen overeenkomende tabbladen",
     "description" : "Empty-state message shown when no open tabs match what the user typed, in the @-mention tab picker and the Add Tabs dialog search."
   },
-  "omnibar_attachTabsNoOpenTabs" : {
-    "title" : "Geen open tabbladen",
-    "description" : "Empty-state message shown in the attach dropdown's Recent Tabs section and the Add Tabs dialog when there are no open tabs available to attach."
+  "omnibar_attachTabsNoPageContent" : {
+    "title" : "Geen pagina-inhoud beschikbaar",
+    "description" : "Empty-state message shown in the attach dropdown and the Add Tabs dialog when there are no open tabs with attachable page content."
   },
   "omnibar_removeAttachedTabLabel" : {
     "title" : "{title} verwijderen",
@@ -415,22 +415,6 @@
   "omnibar_removeAiChat" : {
     "title" : "Deze chat verwijderen",
     "description" : "Accessible label and tooltip for the button that deletes a recent AI chat."
-  },
-  "omnibar_tryForFree" : {
-    "title" : "Probeer het gratis",
-    "description" : "CTA on a subscription-gated model or reasoning-effort option that opens the subscription upsell when tapped."
-  },
-  "omnibar_upgrade" : {
-    "title" : "Upgrade",
-    "description" : "CTA shown on a model or reasoning-effort option gated behind a higher subscription tier; opens the upgrade flow when tapped."
-  },
-  "omnibar_modelBadgePlus" : {
-    "title" : "Plus",
-    "description" : "Badge shown next to an AI model in the model selector that requires a Plus subscription tier."
-  },
-  "omnibar_modelBadgePro" : {
-    "title" : "Pro",
-    "description" : "Badge shown next to an AI model in the model selector that requires a Pro subscription tier."
   },
   "omnibar_modelBadgeInternal" : {
     "title" : "Intern",
@@ -553,11 +537,11 @@
     "note" : "Button text of the Next Steps List card for DuckDuckGo subscription"
   },
   "nextStepsList_sync_title" : {
-    "title" : "Synchroniseer en back-up je bladwijzers en wachtwoorden",
+    "title" : "Synchroniseer en back-up je bladwijzers, wachtwoorden en chats",
     "note" : "Title of the Next Steps List card for syncing data across devices"
   },
   "nextStepsList_sync_summary" : {
-    "title" : "Synchroniseer veilig je bladwijzers, wachtwoorden en identiteitsgegevens op mobiel en desktop.",
+    "title" : "Synchroniseer veilig je bladwijzers, automatisch ingevulde gegevens en Duck.ai-chats met end-to-end-versleuteling tussen je apparaten.",
     "note" : "Summary of the Next Steps List card for syncing data across devices"
   },
   "nextStepsList_sync_actionText" : {

--- a/special-pages/pages/new-tab/public/locales/pl/new-tab.json
+++ b/special-pages/pages/new-tab/public/locales/pl/new-tab.json
@@ -269,7 +269,7 @@
     "description" : "Error shown when an attached image cannot be processed."
   },
   "omnibar_advancedModelsSectionHeader" : {
-    "title" : "Zaawansowane modele – subskrypcja DuckDuckGo",
+    "title" : "Tylko dla subskrybentów",
     "description" : "Section header in the model picker for premium models that require a subscription."
   },
   "omnibar_viewAllChats" : {
@@ -400,9 +400,9 @@
     "title" : "Brak pasujących kart",
     "description" : "Empty-state message shown when no open tabs match what the user typed, in the @-mention tab picker and the Add Tabs dialog search."
   },
-  "omnibar_attachTabsNoOpenTabs" : {
-    "title" : "Brak otwartych kart",
-    "description" : "Empty-state message shown in the attach dropdown's Recent Tabs section and the Add Tabs dialog when there are no open tabs available to attach."
+  "omnibar_attachTabsNoPageContent" : {
+    "title" : "Brak dostępnej zawartości strony",
+    "description" : "Empty-state message shown in the attach dropdown and the Add Tabs dialog when there are no open tabs with attachable page content."
   },
   "omnibar_removeAttachedTabLabel" : {
     "title" : "Usuń {title}",
@@ -415,22 +415,6 @@
   "omnibar_removeAiChat" : {
     "title" : "Usuń ten czat",
     "description" : "Accessible label and tooltip for the button that deletes a recent AI chat."
-  },
-  "omnibar_tryForFree" : {
-    "title" : "Wypróbuj bezpłatnie",
-    "description" : "CTA on a subscription-gated model or reasoning-effort option that opens the subscription upsell when tapped."
-  },
-  "omnibar_upgrade" : {
-    "title" : "Zmień subskrypcję",
-    "description" : "CTA shown on a model or reasoning-effort option gated behind a higher subscription tier; opens the upgrade flow when tapped."
-  },
-  "omnibar_modelBadgePlus" : {
-    "title" : "Plus",
-    "description" : "Badge shown next to an AI model in the model selector that requires a Plus subscription tier."
-  },
-  "omnibar_modelBadgePro" : {
-    "title" : "Pro",
-    "description" : "Badge shown next to an AI model in the model selector that requires a Pro subscription tier."
   },
   "omnibar_modelBadgeInternal" : {
     "title" : "Wewnętrzny",
@@ -553,11 +537,11 @@
     "note" : "Button text of the Next Steps List card for DuckDuckGo subscription"
   },
   "nextStepsList_sync_title" : {
-    "title" : "Synchronizuj zakładki i hasła oraz twórz ich kopie zapasowe",
+    "title" : "Synchronizuj zakładki, hasła i czaty oraz twórz ich kopie zapasowe",
     "note" : "Title of the Next Steps List card for syncing data across devices"
   },
   "nextStepsList_sync_summary" : {
-    "title" : "Bezpiecznie synchronizuj zakładki, hasła i dane tożsamości na urządzeniach mobilnych i stacjonarnych.",
+    "title" : "Bezpiecznie synchronizuj swoje zakładki, dane autouzupełniania i czaty Duck.ai między urządzeniami z użyciem szyfrowania end-to-end.",
     "note" : "Summary of the Next Steps List card for syncing data across devices"
   },
   "nextStepsList_sync_actionText" : {

--- a/special-pages/pages/new-tab/public/locales/pt/new-tab.json
+++ b/special-pages/pages/new-tab/public/locales/pt/new-tab.json
@@ -269,7 +269,7 @@
     "description" : "Error shown when an attached image cannot be processed."
   },
   "omnibar_advancedModelsSectionHeader" : {
-    "title" : "Modelos Avançados - subscrição da DuckDuckGo",
+    "title" : "Exclusivo para subscritores",
     "description" : "Section header in the model picker for premium models that require a subscription."
   },
   "omnibar_viewAllChats" : {
@@ -400,9 +400,9 @@
     "title" : "Nenhum separador correspondente",
     "description" : "Empty-state message shown when no open tabs match what the user typed, in the @-mention tab picker and the Add Tabs dialog search."
   },
-  "omnibar_attachTabsNoOpenTabs" : {
-    "title" : "Nenhum separador aberto",
-    "description" : "Empty-state message shown in the attach dropdown's Recent Tabs section and the Add Tabs dialog when there are no open tabs available to attach."
+  "omnibar_attachTabsNoPageContent" : {
+    "title" : "Não há conteúdo disponível na página",
+    "description" : "Empty-state message shown in the attach dropdown and the Add Tabs dialog when there are no open tabs with attachable page content."
   },
   "omnibar_removeAttachedTabLabel" : {
     "title" : "Remover {title}",
@@ -415,22 +415,6 @@
   "omnibar_removeAiChat" : {
     "title" : "Eliminar esta conversa",
     "description" : "Accessible label and tooltip for the button that deletes a recent AI chat."
-  },
-  "omnibar_tryForFree" : {
-    "title" : "Experimentar gratuitamente",
-    "description" : "CTA on a subscription-gated model or reasoning-effort option that opens the subscription upsell when tapped."
-  },
-  "omnibar_upgrade" : {
-    "title" : "Atualizar",
-    "description" : "CTA shown on a model or reasoning-effort option gated behind a higher subscription tier; opens the upgrade flow when tapped."
-  },
-  "omnibar_modelBadgePlus" : {
-    "title" : "Plus",
-    "description" : "Badge shown next to an AI model in the model selector that requires a Plus subscription tier."
-  },
-  "omnibar_modelBadgePro" : {
-    "title" : "Pro",
-    "description" : "Badge shown next to an AI model in the model selector that requires a Pro subscription tier."
   },
   "omnibar_modelBadgeInternal" : {
     "title" : "Interno",
@@ -553,11 +537,11 @@
     "note" : "Button text of the Next Steps List card for DuckDuckGo subscription"
   },
   "nextStepsList_sync_title" : {
-    "title" : "Sincroniza e faz cópias de segurança dos teus marcadores e palavras-passe",
+    "title" : "Sincroniza e faz cópias de segurança dos teus marcadores, palavras-passe e conversas",
     "note" : "Title of the Next Steps List card for syncing data across devices"
   },
   "nextStepsList_sync_summary" : {
-    "title" : "Sincroniza de forma segura os teus marcadores, palavras-passe e dados de identidade no telemóvel e no computador.",
+    "title" : "Sincroniza de forma segura os teus marcadores, dados de preenchimento automático e conversas do Duck.ai com encriptação ponto a ponto entre os teus dispositivos.",
     "note" : "Summary of the Next Steps List card for syncing data across devices"
   },
   "nextStepsList_sync_actionText" : {

--- a/special-pages/pages/new-tab/public/locales/ru/new-tab.json
+++ b/special-pages/pages/new-tab/public/locales/ru/new-tab.json
@@ -269,7 +269,7 @@
     "description" : "Error shown when an attached image cannot be processed."
   },
   "omnibar_advancedModelsSectionHeader" : {
-    "title" : "Расширенные модели — подписка на DuckDuckGo",
+    "title" : "Только для подписчиков",
     "description" : "Section header in the model picker for premium models that require a subscription."
   },
   "omnibar_viewAllChats" : {
@@ -400,9 +400,9 @@
     "title" : "Нет соответствующих вкладок",
     "description" : "Empty-state message shown when no open tabs match what the user typed, in the @-mention tab picker and the Add Tabs dialog search."
   },
-  "omnibar_attachTabsNoOpenTabs" : {
-    "title" : "Нет открытых вкладок",
-    "description" : "Empty-state message shown in the attach dropdown's Recent Tabs section and the Add Tabs dialog when there are no open tabs available to attach."
+  "omnibar_attachTabsNoPageContent" : {
+    "title" : "Содержимое страницы недоступно",
+    "description" : "Empty-state message shown in the attach dropdown and the Add Tabs dialog when there are no open tabs with attachable page content."
   },
   "omnibar_removeAttachedTabLabel" : {
     "title" : "Удалить {title}",
@@ -415,22 +415,6 @@
   "omnibar_removeAiChat" : {
     "title" : "Удалить этот чат",
     "description" : "Accessible label and tooltip for the button that deletes a recent AI chat."
-  },
-  "omnibar_tryForFree" : {
-    "title" : "Попробовать бесплатно",
-    "description" : "CTA on a subscription-gated model or reasoning-effort option that opens the subscription upsell when tapped."
-  },
-  "omnibar_upgrade" : {
-    "title" : "Повысить тариф",
-    "description" : "CTA shown on a model or reasoning-effort option gated behind a higher subscription tier; opens the upgrade flow when tapped."
-  },
-  "omnibar_modelBadgePlus" : {
-    "title" : "Plus",
-    "description" : "Badge shown next to an AI model in the model selector that requires a Plus subscription tier."
-  },
-  "omnibar_modelBadgePro" : {
-    "title" : "Pro",
-    "description" : "Badge shown next to an AI model in the model selector that requires a Pro subscription tier."
   },
   "omnibar_modelBadgeInternal" : {
     "title" : "Внутренний",
@@ -553,11 +537,11 @@
     "note" : "Button text of the Next Steps List card for DuckDuckGo subscription"
   },
   "nextStepsList_sync_title" : {
-    "title" : "Создать резервную копию закладок и паролей",
+    "title" : "Синхронизация и резервное копирование закладок, паролей и чатов",
     "note" : "Title of the Next Steps List card for syncing data across devices"
   },
   "nextStepsList_sync_summary" : {
-    "title" : "Синхронизируйте закладки, пароли, а также личные и учетные данные в мобильном и настольном приложениях.",
+    "title" : "Безопасно синхронизируй закладки, данные автозаполнения и чаты Duck.ai со сквозным шифрованием между своими устройствами.",
     "note" : "Summary of the Next Steps List card for syncing data across devices"
   },
   "nextStepsList_sync_actionText" : {


### PR DESCRIPTION
Mentions Duck.ai chats and end-to-end encryption in Sync next steps card

**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/72649045549333/task/1217771180718749?focus=true
https://app.asana.com/1/137249556945/project/72649045549333/task/1214486593007985?focus=true

## Description
As a part of chat sync promotions, we want to include the notion of "chats" in sync and backup, as chats are part of that service.

<!--
  Provide a terse summary of what the change is, detailed descriptions should belong in ship reviews or tech designs
-->

## Testing Steps

- The updated build can be seen at https://rawcdn.githack.com/duckduckgo/content-scope-scripts/f0f5ec6d98b94cd568e2efafc892acbd1c290b19/build/integration/pages/new-tab/index.html?next-steps-list=sync&rebrand=enabled

<img width="3024" height="1666" alt="CleanShot 2026-09-01 at 10 08 19@2x" src="https://github.com/user-attachments/assets/28cb3332-d080-4e8a-a28c-d4e6e1291209" />


## Checklist

<!--
  These questions are a friendly reminder to shipping code, if you're uncertain ask the AoR owners.
  It's also totally appropriate to not check some of these boxes, if they don't apply to your change.
-->
*Please tick all that apply:*

- [ ] I have tested this change locally
- [ ] I have tested this change locally in all supported browsers
- [ ] This change will be visible to users
- [ ] I have added automated tests that cover this change
- [ ] I have ensured the change is gated by config
- [ ] This change was covered by a ship review
- [ ] This change was covered by a tech design
- [ ] Any dependent config has been merged



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> User-visible copy and translation updates only; no application logic changes in this diff.
> 
> **Overview**
> Updates **Sync & Backup** Next Steps List messaging in `strings.json` and locale files so the card explicitly covers **Duck.ai chats**, **autofill data**, and **end-to-end encryption** between devices (not just bookmarks/passwords/identity sync).
> 
> The same locale pass also aligns several omnibar strings with current product copy: the premium model section header is shortened to a **subscriber-exclusive** label, the tab-attach empty state key moves from `omnibar_attachTabsNoOpenTabs` to **`omnibar_attachTabsNoPageContent`** (no attachable page content), and legacy subscription CTAs/badges (`Try for Free`, `Upgrade`, Plus/Pro badges) are dropped from the translated `new-tab.json` files where they no longer apply.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e45b747c3e97b88a8855dcfeb23271c54a371986. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->