### PR TITLE
Capture globals

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -84,6 +84,39 @@ export default tseslint.config(
         },
     },
     {
+        // web-detection runs detector selectors, XPath expressions and text patterns from remote
+        // config against hostile pages. Every DOM and intrinsic slot it touches must come from
+        // injected/src/captured-globals.js, or a page that replaces the slot reads the config.
+        files: ['injected/src/features/web-detection/**/*.js'],
+        rules: {
+            'no-restricted-globals': [
+                'error',
+                ...['document', 'DOMParser', 'Element', 'getComputedStyle', 'Math', 'Node', 'RegExp', 'XPathResult', 'parseFloat'].map(
+                    (name) => ({
+                        name,
+                        message: `Import ${name} from captured-globals.js: the page can replace this global.`,
+                    }),
+                ),
+            ],
+            'no-restricted-syntax': [
+                'error',
+                {
+                    selector: "MethodDefinition[key.type='PrivateIdentifier']",
+                    message: 'Private methods are currently unsupported in older WebKit and ESR Firefox',
+                },
+                {
+                    selector:
+                        'CallExpression[callee.type="MemberExpression"][callee.property.name=/^(test|exec|querySelector|querySelectorAll|createExpression|evaluate|snapshotItem|parseFromString|getBoundingClientRect|getPropertyValue|hasOwnProperty|remove|item|join|some|every|filter|map|forEach|includes|push|slice|trim|charCodeAt|call|apply|bind)$/]',
+                    message: 'Call the captured-globals.js equivalent: the page can replace this prototype method.',
+                },
+                {
+                    selector: 'ForOfStatement, ArrayExpression > SpreadElement, CallExpression > SpreadElement, ArrayPattern',
+                    message: 'Iteration routes through a page-replaceable Symbol.iterator; use an index loop.',
+                },
+            ],
+        },
+    },
+    {
         files: ['special-pages/**/*.{js,jsx,ts,tsx}'],
         plugins: { 'react-hooks': reactHooks },
         rules: {

--- a/injected/docs/coding-guidelines.md
+++ b/injected/docs/coding-guidelines.md
@@ -329,6 +329,23 @@ const mySet = new capturedGlobals.Set();
 capturedGlobals.dispatchEvent(new capturedGlobals.CustomEvent('name', { detail }));
 ```
 
+DOM APIs are captured too. Values whose receiver varies per call — element queries, XPath
+evaluation, node lists, style declarations, property accessors — are exposed as functions taking the
+receiver as their first argument:
+
+```js
+import { documentQuerySelectorAll, elementQuerySelector, nodeTextContent, regExpTest } from '../captured-globals.js';
+
+const elements = documentQuerySelectorAll('.selector');
+const text = nodeTextContent(elementQuerySelector(element, 'p'));
+```
+
+Reach for these where the argument or receiver would itself disclose something: a remote-config
+selector, an XPath expression or a text pattern is readable by any page that replaces
+`querySelectorAll` or `RegExp.prototype.test`. `Array.prototype` and `String.prototype` methods carry
+the same exposure — `patterns.join('|')` hands the pattern list to a replaced `join` — so index loops
+replace them on that data. `injected/src/features/web-detection/` is held to this by ESLint.
+
 ### Frame and Context Guards
 
 Validate execution context at feature initialization:

--- a/injected/integration-test/web-detection.spec.js
+++ b/injected/integration-test/web-detection.spec.js
@@ -772,4 +772,43 @@ test.describe('WebDetection Feature', () => {
             expect(await helper.getWebEventNotifications()).toEqual([]);
         });
     });
+
+    test.describe('selector visibility to the page', () => {
+        test('detector selectors are not observable via replaced query methods', async ({ page }, testInfo) => {
+            const { helper } = await WebDetectionTestHelper.setupCaptchaTest(page, testInfo.project.use);
+            await helper.navigateTo('/web-detection/pages/captcha-recaptcha.html');
+
+            // Replace the query methods after injection. The captured
+            // references taken at document_start must not route through these.
+            await page.evaluate(() => {
+                /** @type {string[]} */
+                const observed = [];
+                Reflect.set(globalThis, '__observedSelectors', observed);
+                for (const proto of [Document.prototype, Element.prototype]) {
+                    for (const name of ['querySelector', 'querySelectorAll']) {
+                        const original = Reflect.get(proto, name);
+                        Reflect.set(proto, name, function (/** @type {string} */ selectors) {
+                            observed.push(selectors);
+
+                            return original.apply(this, arguments);
+                        });
+                    }
+                }
+                // Proves the replacement is effective, so an empty result below means the feature
+                // avoided these slots rather than that the test failed to install anything.
+                document.querySelectorAll('.replacement-is-live');
+            });
+
+            await page.clock.fastForward(100);
+
+            const observed = /** @type {string[]} */ (
+                await page.evaluate(() => Reflect.get(globalThis, '__observedSelectors'))
+            );
+            expect(observed).toContain('.replacement-is-live');
+            expect(observed.filter((selector) => selector.includes('recaptcha'))).toEqual([]);
+
+            // The detector still ran and matched, so the queries happened - just not through the page's slots.
+            expect((await helper.getWebEventNotifications()).map((e) => e.type)).toEqual(['captcha_recaptcha']);
+        });
+    });
 });

--- a/injected/integration-test/web-detection.spec.js
+++ b/injected/integration-test/web-detection.spec.js
@@ -801,9 +801,7 @@ test.describe('WebDetection Feature', () => {
 
             await page.clock.fastForward(100);
 
-            const observed = /** @type {string[]} */ (
-                await page.evaluate(() => Reflect.get(globalThis, '__observedSelectors'))
-            );
+            const observed = /** @type {string[]} */ (await page.evaluate(() => Reflect.get(globalThis, '__observedSelectors')));
             expect(observed).toContain('.replacement-is-live');
             expect(observed.filter((selector) => selector.includes('recaptcha'))).toEqual([]);
 

--- a/injected/integration-test/web-detection.spec.js
+++ b/injected/integration-test/web-detection.spec.js
@@ -773,35 +773,58 @@ test.describe('WebDetection Feature', () => {
         });
     });
 
-    test.describe('selector visibility to the page', () => {
-        test('detector selectors are not observable via replaced query methods', async ({ page }, testInfo) => {
+    test.describe('detector visibility to the page', () => {
+        test('detector configuration is not observable via replaced DOM APIs', async ({ page }, testInfo) => {
             const { helper } = await WebDetectionTestHelper.setupCaptchaTest(page, testInfo.project.use);
             await helper.navigateTo('/web-detection/pages/captcha-recaptcha.html');
 
-            // Replaced after injection, so the references captured at document_start do not
-            // route through these.
+            // Replaced after injection, so the references captured at document_start do not route
+            // through these. The control selector proves the replacements are live.
             await page.evaluate(() => {
                 /** @type {string[]} */
                 const observed = [];
-                Reflect.set(globalThis, '__observedSelectors', observed);
-                for (const proto of [Document.prototype, Element.prototype]) {
-                    for (const name of ['querySelector', 'querySelectorAll']) {
-                        const original = Reflect.get(proto, name);
-                        Reflect.set(proto, name, function (/** @type {string} */ selectors) {
-                            observed.push(selectors);
+                Reflect.set(globalThis, '__observed', observed);
 
-                            return original.apply(this, arguments);
-                        });
-                    }
+                /**
+                 * @param {object} target
+                 * @param {string} name
+                 * @param {(this: any, result: any, ...args: any[]) => string} describe
+                 */
+                function replace(target, name, describe) {
+                    const original = Reflect.get(target, name);
+                    Reflect.set(target, name, function (/** @type {any[]} */ ...args) {
+                        const result = original.apply(this, args);
+                        observed.push(describe.call(this, result, ...args));
+                        return result;
+                    });
                 }
+
+                for (const proto of [Document.prototype, Element.prototype]) {
+                    replace(proto, 'querySelector', (_result, selectors) => selectors);
+                    replace(proto, 'querySelectorAll', (_result, selectors) => selectors);
+                }
+                replace(Document.prototype, 'createExpression', (_result, expression) => expression);
+                replace(DOMParser.prototype, 'parseFromString', (_result, markup) => markup);
+                replace(NodeList.prototype, 'item', (node) => String(node?.outerHTML));
+                replace(RegExp.prototype, 'test', function () {
+                    return this.source;
+                });
+                replace(Element.prototype, 'getBoundingClientRect', function () {
+                    return this.outerHTML;
+                });
+                replace(globalThis, 'getComputedStyle', (_result, element) => element.outerHTML);
+
                 document.querySelectorAll('.replacement-is-live');
             });
 
             await page.clock.fastForward(100);
 
-            const observed = /** @type {string[]} */ (await page.evaluate(() => Reflect.get(globalThis, '__observedSelectors')));
-            expect(observed).toContain('.replacement-is-live');
-            expect(observed.filter((selector) => selector.includes('recaptcha'))).toEqual([]);
+            // Anything naming the detector's provider would disclose its configuration; the control
+            // entry is all that a page can see.
+            const observed = /** @type {string[]} */ (await page.evaluate(() => Reflect.get(globalThis, '__observed')));
+            expect(observed.filter((entry) => entry.includes('recaptcha') || entry === '.replacement-is-live')).toEqual([
+                '.replacement-is-live',
+            ]);
             expect((await helper.getWebEventNotifications()).map((e) => e.type)).toEqual(['captcha_recaptcha']);
         });
     });

--- a/injected/integration-test/web-detection.spec.js
+++ b/injected/integration-test/web-detection.spec.js
@@ -778,8 +778,8 @@ test.describe('WebDetection Feature', () => {
             const { helper } = await WebDetectionTestHelper.setupCaptchaTest(page, testInfo.project.use);
             await helper.navigateTo('/web-detection/pages/captcha-recaptcha.html');
 
-            // Replace the query methods after injection. The captured
-            // references taken at document_start must not route through these.
+            // Replaced after injection, so the references captured at document_start do not
+            // route through these.
             await page.evaluate(() => {
                 /** @type {string[]} */
                 const observed = [];
@@ -794,8 +794,6 @@ test.describe('WebDetection Feature', () => {
                         });
                     }
                 }
-                // Proves the replacement is effective, so an empty result below means the feature
-                // avoided these slots rather than that the test failed to install anything.
                 document.querySelectorAll('.replacement-is-live');
             });
 
@@ -804,8 +802,6 @@ test.describe('WebDetection Feature', () => {
             const observed = /** @type {string[]} */ (await page.evaluate(() => Reflect.get(globalThis, '__observedSelectors')));
             expect(observed).toContain('.replacement-is-live');
             expect(observed.filter((selector) => selector.includes('recaptcha'))).toEqual([]);
-
-            // The detector still ran and matched, so the queries happened - just not through the page's slots.
             expect((await helper.getWebEventNotifications()).map((e) => e.type)).toEqual(['captcha_recaptcha']);
         });
     });

--- a/injected/src/captured-globals.js
+++ b/injected/src/captured-globals.js
@@ -44,6 +44,68 @@ export const ReflectDeleteProperty = Reflect.deleteProperty.bind(Reflect);
 export const ReflectApply = Reflect.apply.bind(Reflect);
 export const getRandomValues = globalThis.crypto?.getRandomValues?.bind(globalThis.crypto);
 
+// DOM query methods, captured at module evaluation - ie document_start, before any page
+// script runs. A page can replace these slots and observe every selector we pass. Queries
+// against a document produced by `DOMParser` are equally exposed, since it shares these
+// prototypes.
+//
+// The `??` arms cover non-browser environments - the unit tests supply `document` only after
+// this module is evaluated - where the live method is safe because there is no page.
+/** @type {(selectors: string) => Element | null} */
+export const documentQuerySelector =
+    globalThis.document?.querySelector.bind(globalThis.document) ?? ((selectors) => document.querySelector(selectors));
+/** @type {(selectors: string) => NodeListOf<Element>} */
+export const documentQuerySelectorAll =
+    globalThis.document?.querySelectorAll.bind(globalThis.document) ?? ((selectors) => document.querySelectorAll(selectors));
+/** @type {(expression: string, resolver: XPathNSResolver | null) => XPathExpression} */
+export const createXPathExpression =
+    globalThis.document?.createExpression.bind(globalThis.document) ??
+    ((expression, resolver) => document.createExpression(expression, resolver));
+
+// These take their receiver per call, so unlike the above they cannot be bound: element
+// queries run against a detached `DOMParser` tree, and each XPath expression is its own
+// receiver. Undefined outside a browser, as above.
+const capturedElementQuerySelector = globalThis.Element?.prototype.querySelector;
+const capturedElementQuerySelectorAll = globalThis.Element?.prototype.querySelectorAll;
+const capturedEvaluateExpression = globalThis.XPathExpression?.prototype.evaluate;
+
+/**
+ * `element.querySelector(selectors)` via the captured method.
+ *
+ * @param {Element} element
+ * @param {string} selectors
+ * @returns {Element | null}
+ */
+export function elementQuerySelector(element, selectors) {
+    if (capturedElementQuerySelector) return ReflectApply(capturedElementQuerySelector, element, [selectors]);
+    return element.querySelector(selectors);
+}
+
+/**
+ * `element.querySelectorAll(selectors)` via the captured method.
+ *
+ * @param {Element} element
+ * @param {string} selectors
+ * @returns {NodeListOf<Element>}
+ */
+export function elementQuerySelectorAll(element, selectors) {
+    if (capturedElementQuerySelectorAll) return ReflectApply(capturedElementQuerySelectorAll, element, [selectors]);
+    return element.querySelectorAll(selectors);
+}
+
+/**
+ * `expression.evaluate(contextNode, type, null)` via the captured method.
+ *
+ * @param {XPathExpression} expression
+ * @param {Node} contextNode
+ * @param {number} type
+ * @returns {XPathResult}
+ */
+export function evaluateXPathExpression(expression, contextNode, type) {
+    if (capturedEvaluateExpression) return ReflectApply(capturedEvaluateExpression, expression, [contextNode, type, null]);
+    return expression.evaluate(contextNode, type, null);
+}
+
 // Secure context only - crypto.subtle is unavailable on HTTP
 export const generateKey = globalThis.crypto?.subtle?.generateKey?.bind(globalThis.crypto?.subtle);
 export const exportKey = globalThis.crypto?.subtle?.exportKey?.bind(globalThis.crypto?.subtle);

--- a/injected/src/captured-globals.js
+++ b/injected/src/captured-globals.js
@@ -49,25 +49,27 @@ export const getRandomValues = globalThis.crypto?.getRandomValues?.bind(globalTh
 // against a document produced by `DOMParser` are equally exposed, since it shares these
 // prototypes.
 //
-// The `??` arms cover non-browser environments - the unit tests supply `document` only after
-// this module is evaluated - where the live method is safe because there is no page.
-/** @type {(selectors: string) => Element | null} */
-export const documentQuerySelector =
-    globalThis.document?.querySelector.bind(globalThis.document) ?? ((selectors) => document.querySelector(selectors));
-/** @type {(selectors: string) => NodeListOf<Element>} */
-export const documentQuerySelectorAll =
-    globalThis.document?.querySelectorAll.bind(globalThis.document) ?? ((selectors) => document.querySelectorAll(selectors));
-/** @type {(expression: string, resolver: XPathNSResolver | null) => XPathExpression} */
-export const createXPathExpression =
-    globalThis.document?.createExpression.bind(globalThis.document) ??
-    ((expression, resolver) => document.createExpression(expression, resolver));
+// Anything calling these must have a DOM. The optional chaining only keeps module evaluation safe
+// where there is none - `src/utils.js` is imported by Node-side Playwright tooling - and the casts
+// record that as an invariant rather than a supported mode: calling without a DOM throws
+// immediately instead of silently reverting to the live, observable slot. The unit tests install a
+// single JSDOM window in a Jasmine helper so they exercise the same captured path as production;
+// see `unit-test/helpers/install-dom-globals.js`.
+export const documentQuerySelector = /** @type {(selectors: string) => Element | null} */ (
+    globalThis.document?.querySelector.bind(globalThis.document)
+);
+export const documentQuerySelectorAll = /** @type {(selectors: string) => NodeListOf<Element>} */ (
+    globalThis.document?.querySelectorAll.bind(globalThis.document)
+);
+export const createXPathExpression = /** @type {(expression: string, resolver: XPathNSResolver | null) => XPathExpression} */ (
+    globalThis.document?.createExpression.bind(globalThis.document)
+);
 
-// These take their receiver per call, so unlike the above they cannot be bound: element
-// queries run against a detached `DOMParser` tree, and each XPath expression is its own
-// receiver. Undefined outside a browser, as above.
-const capturedElementQuerySelector = globalThis.Element?.prototype.querySelector;
-const capturedElementQuerySelectorAll = globalThis.Element?.prototype.querySelectorAll;
-const capturedEvaluateExpression = globalThis.XPathExpression?.prototype.evaluate;
+// These take their receiver per call, so unlike the above they cannot be bound: element queries
+// run against a detached `DOMParser` tree, and each XPath expression is its own receiver.
+const capturedElementQuerySelector = /** @type {Element['querySelector']} */ (globalThis.Element?.prototype.querySelector);
+const capturedElementQuerySelectorAll = /** @type {Element['querySelectorAll']} */ (globalThis.Element?.prototype.querySelectorAll);
+const capturedEvaluateExpression = /** @type {XPathExpression['evaluate']} */ (globalThis.XPathExpression?.prototype.evaluate);
 
 /**
  * `element.querySelector(selectors)` via the captured method.
@@ -77,8 +79,7 @@ const capturedEvaluateExpression = globalThis.XPathExpression?.prototype.evaluat
  * @returns {Element | null}
  */
 export function elementQuerySelector(element, selectors) {
-    if (capturedElementQuerySelector) return ReflectApply(capturedElementQuerySelector, element, [selectors]);
-    return element.querySelector(selectors);
+    return ReflectApply(capturedElementQuerySelector, element, [selectors]);
 }
 
 /**
@@ -89,8 +90,7 @@ export function elementQuerySelector(element, selectors) {
  * @returns {NodeListOf<Element>}
  */
 export function elementQuerySelectorAll(element, selectors) {
-    if (capturedElementQuerySelectorAll) return ReflectApply(capturedElementQuerySelectorAll, element, [selectors]);
-    return element.querySelectorAll(selectors);
+    return ReflectApply(capturedElementQuerySelectorAll, element, [selectors]);
 }
 
 /**
@@ -102,8 +102,7 @@ export function elementQuerySelectorAll(element, selectors) {
  * @returns {XPathResult}
  */
 export function evaluateXPathExpression(expression, contextNode, type) {
-    if (capturedEvaluateExpression) return ReflectApply(capturedEvaluateExpression, expression, [contextNode, type, null]);
-    return expression.evaluate(contextNode, type, null);
+    return ReflectApply(capturedEvaluateExpression, expression, [contextNode, type, null]);
 }
 
 // Secure context only - crypto.subtle is unavailable on HTTP

--- a/injected/src/captured-globals.js
+++ b/injected/src/captured-globals.js
@@ -44,28 +44,158 @@ export const ReflectDeleteProperty = Reflect.deleteProperty.bind(Reflect);
 export const ReflectApply = Reflect.apply.bind(Reflect);
 export const getRandomValues = globalThis.crypto?.getRandomValues?.bind(globalThis.crypto);
 
-// DOM query methods, captured at module evaluation - ie document_start, before any page script
-// runs. A page can replace these slots and observe every selector passed to them, including on a
-// document produced by `DOMParser`, which shares these prototypes.
+export const RegExp = globalThis.RegExp;
+export const arrayIsArray = Array.isArray;
+export const parseFloat = globalThis.parseFloat;
+export const mathFloor = Math.floor;
+export const mathMax = Math.max;
+export const mathMin = Math.min;
+const capturedRegExpTest = RegExp.prototype.test;
+const capturedMapGet = Map.prototype.get;
+const capturedMapSet = Map.prototype.set;
+const capturedStringSlice = globalThis.String.prototype.slice;
+const capturedStringTrim = globalThis.String.prototype.trim;
+
+/**
+ * `object.hasOwnProperty(key)` via the captured method.
+ *
+ * @param {object} object
+ * @param {PropertyKey} key
+ * @returns {boolean}
+ */
+export function hasOwn(object, key) {
+    return ReflectApply(hasOwnProperty, object, [key]);
+}
+
+/**
+ * `pattern.test(string)` via the captured method, so a replaced `RegExp.prototype.test` cannot
+ * read the pattern off its receiver.
+ *
+ * @param {RegExp} pattern
+ * @param {string} string
+ * @returns {boolean}
+ */
+export function regExpTest(pattern, string) {
+    return ReflectApply(capturedRegExpTest, pattern, [string]);
+}
+
+/**
+ * `map.get(key)` via the captured method.
+ *
+ * @template K, V
+ * @param {Map<K, V>} map
+ * @param {K} key
+ * @returns {V | undefined}
+ */
+export function mapGet(map, key) {
+    return ReflectApply(capturedMapGet, map, [key]);
+}
+
+/**
+ * `map.set(key, value)` via the captured method.
+ *
+ * @template K, V
+ * @param {Map<K, V>} map
+ * @param {K} key
+ * @param {V} value
+ * @returns {void}
+ */
+export function mapSet(map, key, value) {
+    ReflectApply(capturedMapSet, map, [key, value]);
+}
+
+/**
+ * `string.slice(start)` via the captured method.
+ *
+ * @param {string} string
+ * @param {number} start
+ * @returns {string}
+ */
+export function stringSlice(string, start) {
+    return ReflectApply(capturedStringSlice, string, [start]);
+}
+
+/**
+ * `string.trim()` via the captured method.
+ *
+ * @param {string} string
+ * @returns {string}
+ */
+export function stringTrim(string) {
+    return ReflectApply(capturedStringTrim, string, []);
+}
+
+/**
+ * `string.charCodeAt(index)` via the captured method.
+ *
+ * @param {string} string
+ * @param {number} index
+ * @returns {number}
+ */
+export function stringCharCodeAt(string, index) {
+    return ReflectApply(charCodeAt, string, [index]);
+}
+
+// DOM access, captured at module evaluation - ie document_start, before any page script runs. Every
+// slot below is writable by the page: replacing one lets it read the selectors, expressions and
+// patterns passed through, and the nodes they resolve to. A `DOMParser` document shares these
+// prototypes, so a detached copy is no safer than the live page.
 //
 // Callers must have a DOM. The optional chaining keeps module evaluation safe where there is none
 // (`src/utils.js` is imported by Node-side Playwright tooling); the casts hold callers to the
 // invariant, so calling without a DOM throws.
-export const documentQuerySelector = /** @type {(selectors: string) => Element | null} */ (
-    globalThis.document?.querySelector.bind(globalThis.document)
+
+/**
+ * The document's own accessor for a property, before the page can replace it.
+ *
+ * @param {object | undefined} proto
+ * @param {string} name
+ * @returns {(this: any) => any}
+ */
+function capturedGetter(proto, name) {
+    return /** @type {(this: any) => any} */ (proto && getOwnPropertyDescriptor(proto, name)?.get);
+}
+
+export const capturedDocument = /** @type {Document} */ (globalThis.document);
+export const DOMParser = globalThis.DOMParser;
+export const getComputedStyle = /** @type {(element: Element, pseudoElement?: string | null) => CSSStyleDeclaration} */ (
+    globalThis.getComputedStyle?.bind(globalThis)
 );
-export const documentQuerySelectorAll = /** @type {(selectors: string) => NodeListOf<Element>} */ (
-    globalThis.document?.querySelectorAll.bind(globalThis.document)
+export const documentQuerySelector = /** @type {Document['querySelector']} */ (
+    globalThis.document?.querySelector?.bind(globalThis.document)
 );
-export const createXPathExpression = /** @type {(expression: string, resolver: XPathNSResolver | null) => XPathExpression} */ (
-    globalThis.document?.createExpression.bind(globalThis.document)
+export const documentQuerySelectorAll = /** @type {Document['querySelectorAll']} */ (
+    globalThis.document?.querySelectorAll?.bind(globalThis.document)
+);
+export const createXPathExpression = /** @type {Document['createExpression']} */ (
+    globalThis.document?.createExpression?.bind(globalThis.document)
 );
 
 // These take their receiver per call, so they cannot be bound: element queries run against a
-// detached `DOMParser` tree, and each XPath expression is its own receiver.
+// detached `DOMParser` tree, and each XPath expression, node list and style declaration is its own
+// receiver.
 const capturedElementQuerySelector = /** @type {Element['querySelector']} */ (globalThis.Element?.prototype.querySelector);
 const capturedElementQuerySelectorAll = /** @type {Element['querySelectorAll']} */ (globalThis.Element?.prototype.querySelectorAll);
+const capturedElementRemove = /** @type {Element['remove']} */ (globalThis.Element?.prototype.remove);
+const capturedGetBoundingClientRect = /** @type {Element['getBoundingClientRect']} */ (globalThis.Element?.prototype.getBoundingClientRect);
 const capturedEvaluateExpression = /** @type {XPathExpression['evaluate']} */ (globalThis.XPathExpression?.prototype.evaluate);
+const capturedSnapshotItem = /** @type {XPathResult['snapshotItem']} */ (globalThis.XPathResult?.prototype.snapshotItem);
+const capturedParseFromString = /** @type {DOMParser['parseFromString']} */ (globalThis.DOMParser?.prototype.parseFromString);
+const capturedNodeListItem = /** @type {NodeList['item']} */ (globalThis.NodeList?.prototype.item);
+const capturedGetPropertyValue = /** @type {CSSStyleDeclaration['getPropertyValue']} */ (
+    globalThis.CSSStyleDeclaration?.prototype.getPropertyValue
+);
+const capturedTextContent = capturedGetter(globalThis.Node?.prototype, 'textContent');
+const capturedOuterHTML = capturedGetter(globalThis.Element?.prototype, 'outerHTML');
+const capturedInnerText = capturedGetter(globalThis.HTMLElement?.prototype, 'innerText');
+const capturedHidden = capturedGetter(globalThis.HTMLElement?.prototype, 'hidden');
+const capturedIframeSrc = capturedGetter(globalThis.HTMLIFrameElement?.prototype, 'src');
+const capturedDocumentElement = capturedGetter(globalThis.Document?.prototype, 'documentElement');
+const capturedSnapshotLength = capturedGetter(globalThis.XPathResult?.prototype, 'snapshotLength');
+const capturedNodeListLength = capturedGetter(globalThis.NodeList?.prototype, 'length');
+// `getBoundingClientRect` returns a `DOMRect`, whose own accessors shadow `DOMRectReadOnly`'s.
+const capturedRectWidth = capturedGetter(globalThis.DOMRect?.prototype, 'width');
+const capturedRectHeight = capturedGetter(globalThis.DOMRect?.prototype, 'height');
 
 /**
  * `element.querySelector(selectors)` via the captured method.
@@ -90,6 +220,58 @@ export function elementQuerySelectorAll(element, selectors) {
 }
 
 /**
+ * `element.remove()` via the captured method.
+ *
+ * @param {Element} element
+ * @returns {void}
+ */
+export function elementRemove(element) {
+    ReflectApply(capturedElementRemove, element, []);
+}
+
+/**
+ * `element.getBoundingClientRect()` via the captured method.
+ *
+ * @param {Element} element
+ * @returns {DOMRect}
+ */
+export function getBoundingClientRect(element) {
+    return ReflectApply(capturedGetBoundingClientRect, element, []);
+}
+
+/**
+ * `rect.width` via the captured accessor.
+ *
+ * @param {DOMRect} rect
+ * @returns {number}
+ */
+export function rectWidth(rect) {
+    return ReflectApply(capturedRectWidth, rect, []);
+}
+
+/**
+ * `rect.height` via the captured accessor.
+ *
+ * @param {DOMRect} rect
+ * @returns {number}
+ */
+export function rectHeight(rect) {
+    return ReflectApply(capturedRectHeight, rect, []);
+}
+
+/**
+ * `style.getPropertyValue(property)` via the captured method. Property accessors such as
+ * `style.opacity` route through the same slot, so this is the only read that stays captured.
+ *
+ * @param {CSSStyleDeclaration} style
+ * @param {string} property
+ * @returns {string}
+ */
+export function cssPropertyValue(style, property) {
+    return ReflectApply(capturedGetPropertyValue, style, [property]);
+}
+
+/**
  * `expression.evaluate(contextNode, type, null)` via the captured method.
  *
  * @param {XPathExpression} expression
@@ -99,6 +281,124 @@ export function elementQuerySelectorAll(element, selectors) {
  */
 export function evaluateXPathExpression(expression, contextNode, type) {
     return ReflectApply(capturedEvaluateExpression, expression, [contextNode, type, null]);
+}
+
+/**
+ * `result.snapshotLength` via the captured accessor.
+ *
+ * @param {XPathResult} result
+ * @returns {number}
+ */
+export function snapshotLength(result) {
+    return ReflectApply(capturedSnapshotLength, result, []);
+}
+
+/**
+ * `result.snapshotItem(index)` via the captured method.
+ *
+ * @param {XPathResult} result
+ * @param {number} index
+ * @returns {Node | null}
+ */
+export function snapshotItem(result, index) {
+    return ReflectApply(capturedSnapshotItem, result, [index]);
+}
+
+/**
+ * `parser.parseFromString(markup, type)` via the captured method.
+ *
+ * @param {DOMParser} parser
+ * @param {string} markup
+ * @param {DOMParserSupportedType} type
+ * @returns {Document}
+ */
+export function parseFromString(parser, markup, type) {
+    return ReflectApply(capturedParseFromString, parser, [markup, type]);
+}
+
+/**
+ * `list.length` via the captured accessor.
+ *
+ * @param {NodeList} list
+ * @returns {number}
+ */
+export function nodeListLength(list) {
+    return ReflectApply(capturedNodeListLength, list, []);
+}
+
+/**
+ * `list.item(index)` via the captured method. Index access and iteration both route through
+ * page-replaceable slots, so this is the only read of a node list that stays captured.
+ *
+ * @template {Node} T
+ * @param {NodeListOf<T>} list
+ * @param {number} index
+ * @returns {T}
+ */
+export function nodeListItem(list, index) {
+    // Callers hold `index` below `nodeListLength`, so the null case is unreachable.
+    return /** @type {T} */ (ReflectApply(capturedNodeListItem, list, [index]));
+}
+
+/**
+ * `node.textContent` via the captured accessor.
+ *
+ * @param {Node} node
+ * @returns {string | null}
+ */
+export function nodeTextContent(node) {
+    return ReflectApply(capturedTextContent, node, []);
+}
+
+/**
+ * `element.outerHTML` via the captured accessor.
+ *
+ * @param {Element} element
+ * @returns {string}
+ */
+export function elementOuterHTML(element) {
+    return ReflectApply(capturedOuterHTML, element, []);
+}
+
+/**
+ * `element.innerText` via the captured accessor, or undefined where the DOM implementation has no
+ * `innerText` (JSDOM).
+ *
+ * @param {Element} element
+ * @returns {string | undefined}
+ */
+export function elementInnerText(element) {
+    return capturedInnerText ? ReflectApply(capturedInnerText, element, []) : undefined;
+}
+
+/**
+ * `element.hidden` via the captured accessor.
+ *
+ * @param {Element} element
+ * @returns {boolean}
+ */
+export function elementHidden(element) {
+    return ReflectApply(capturedHidden, element, []);
+}
+
+/**
+ * `frame.src` via the captured accessor.
+ *
+ * @param {Element} frame
+ * @returns {string}
+ */
+export function iframeSrc(frame) {
+    return ReflectApply(capturedIframeSrc, frame, []);
+}
+
+/**
+ * `document.documentElement` via the captured accessor.
+ *
+ * @param {Document} document
+ * @returns {Element}
+ */
+export function documentElement(document) {
+    return ReflectApply(capturedDocumentElement, document, []);
 }
 
 // Secure context only - crypto.subtle is unavailable on HTTP

--- a/injected/src/captured-globals.js
+++ b/injected/src/captured-globals.js
@@ -44,17 +44,13 @@ export const ReflectDeleteProperty = Reflect.deleteProperty.bind(Reflect);
 export const ReflectApply = Reflect.apply.bind(Reflect);
 export const getRandomValues = globalThis.crypto?.getRandomValues?.bind(globalThis.crypto);
 
-// DOM query methods, captured at module evaluation - ie document_start, before any page
-// script runs. A page can replace these slots and observe every selector we pass. Queries
-// against a document produced by `DOMParser` are equally exposed, since it shares these
-// prototypes.
+// DOM query methods, captured at module evaluation - ie document_start, before any page script
+// runs. A page can replace these slots and observe every selector passed to them, including on a
+// document produced by `DOMParser`, which shares these prototypes.
 //
-// Anything calling these must have a DOM. The optional chaining only keeps module evaluation safe
-// where there is none - `src/utils.js` is imported by Node-side Playwright tooling - and the casts
-// record that as an invariant rather than a supported mode: calling without a DOM throws
-// immediately instead of silently reverting to the live, observable slot. The unit tests install a
-// single JSDOM window in a Jasmine helper so they exercise the same captured path as production;
-// see `unit-test/helpers/install-dom-globals.js`.
+// Callers must have a DOM. The optional chaining keeps module evaluation safe where there is none
+// (`src/utils.js` is imported by Node-side Playwright tooling); the casts hold callers to the
+// invariant, so calling without a DOM throws.
 export const documentQuerySelector = /** @type {(selectors: string) => Element | null} */ (
     globalThis.document?.querySelector.bind(globalThis.document)
 );
@@ -65,8 +61,8 @@ export const createXPathExpression = /** @type {(expression: string, resolver: X
     globalThis.document?.createExpression.bind(globalThis.document)
 );
 
-// These take their receiver per call, so unlike the above they cannot be bound: element queries
-// run against a detached `DOMParser` tree, and each XPath expression is its own receiver.
+// These take their receiver per call, so they cannot be bound: element queries run against a
+// detached `DOMParser` tree, and each XPath expression is its own receiver.
 const capturedElementQuerySelector = /** @type {Element['querySelector']} */ (globalThis.Element?.prototype.querySelector);
 const capturedElementQuerySelectorAll = /** @type {Element['querySelectorAll']} */ (globalThis.Element?.prototype.querySelectorAll);
 const capturedEvaluateExpression = /** @type {XPathExpression['evaluate']} */ (globalThis.XPathExpression?.prototype.evaluate);

--- a/injected/src/features/web-detection/BUGBOT.md
+++ b/injected/src/features/web-detection/BUGBOT.md
@@ -1,4 +1,27 @@
-# Web-detection: keep captcha/anti-bot matching layout-free
+# Web-detection: keep matching captured, and captcha/anti-bot matching layout-free
+
+## Captured globals
+
+Detector selectors, XPath expressions and text patterns come from remote config and are evaluated
+against hostile pages. Every DOM API and intrinsic this directory touches must come from
+`injected/src/captured-globals.js`, taken at document_start: a page that replaces
+`Document.prototype.querySelectorAll`, `RegExp.prototype.test`, `Array.prototype.some` or any
+comparable slot otherwise reads the detector configuration out of the arguments and receivers it is
+handed. `eslint.config.js` restricts the globals, prototype methods and iteration forms this
+directory may use; treat a change that relaxes those restrictions, or adds a `// eslint-disable` for
+them, as a disclosure of the detector list.
+
+### Flag when a change in this directory
+
+- Reads a DOM global (`document`, `getComputedStyle`, `DOMParser`, …) or calls a prototype method
+  (`.test`, `.querySelectorAll`, `.some`, `.join`, …) directly rather than through a captured
+  reference.
+- Iterates config-derived data with `for...of`, spread or array destructuring, all of which route
+  through `Array.prototype[Symbol.iterator]`.
+- Adds a captured reference that is looked up lazily rather than at module evaluation: the capture
+  is only sound because it happens before any page script runs.
+
+## Layout
 
 web-detection runs its detector selectors on live pages, including
 Cloudflare/Turnstile/hCaptcha/reCAPTCHA challenge pages. Forcing synchronous
@@ -8,7 +31,7 @@ exists to detect presence WITHOUT forcing layout — it inspects a detached
 `DOMParser` copy of the element. This risk is invisible to the hermetic test
 suite, so it must be caught in review.
 
-## Flag when a change in this directory
+### Flag when a change in this directory
 
 - Introduces `getBoundingClientRect`, `getClientRects`, `getComputedStyle`,
   `offset*` / `scroll*` / `client*` dimension reads, or `elementFromPoint` into
@@ -19,7 +42,7 @@ suite, so it must be caught in review.
 - Routes captcha/challenge detectors through a path that forces layout on matched
   elements (e.g. the `visible` path, which calls `isVisible`).
 
-## Require
+### Require
 
 For captcha/anti-bot detection, keep element/visibility checks layout-free
 (prefer `visibility: 'content'`). Any change that must read live layout in a
@@ -28,7 +51,9 @@ before wide enablement. Rate such changes at least Medium risk (never Low).
 
 ## Don't flag
 
-- Layout reads in test code (`integration-test` / `unit-test`).
+- Direct DOM and prototype use in test code (`integration-test` / `unit-test`), which replaces these
+  slots deliberately to prove the captures hold.
+- Layout reads in test code.
 - The existing `visible` / `hidden` modes themselves — they legitimately force
   layout and are intended for non-challenge detectors. Only flag if a
   captcha/anti-bot detector is newly routed through them.

--- a/injected/src/features/web-detection/matching.js
+++ b/injected/src/features/web-detection/matching.js
@@ -136,10 +136,8 @@ function hasContent(element) {
         return true;
     }
     // A real (eg cross-origin Turnstile) iframe counts; about:blank does not.
-    return [...elementQuerySelectorAll(parsed, 'iframe')].some((frame) => {
-        const frameElement = /** @type {HTMLIFrameElement} */ (frame);
-        return !frameElement.hidden && frameElement.src !== '' && frameElement.src !== 'about:blank';
-    });
+    const frames = /** @type {NodeListOf<HTMLIFrameElement>} */ (elementQuerySelectorAll(parsed, 'iframe'));
+    return [...frames].some((frame) => !frame.hidden && frame.src !== '' && frame.src !== 'about:blank');
 }
 
 /**

--- a/injected/src/features/web-detection/matching.js
+++ b/injected/src/features/web-detection/matching.js
@@ -1,4 +1,3 @@
- 
 import {
     createXPathExpression,
     documentQuerySelector,
@@ -185,7 +184,7 @@ function compileXPath(expression) {
     }
     let compiled = cache.get(expression);
     if (!compiled) {
-        compiled = createXPathExpression(document, expression);
+        compiled = createXPathExpression(expression, null);
         cache.set(expression, compiled);
     }
     return compiled;
@@ -357,7 +356,7 @@ function evaluateSingleTextCondition(condition) {
     // Checked before xpath because CSS matching avoids the per-call expression
     // parse and snapshot allocation that `document.evaluate` requires.
     const selectorMatch = selectors.some((selector) => {
-        const elements = documentQuerySelectorAll(document, selector);
+        const elements = documentQuerySelectorAll(selector);
         for (const element of elements) {
             if (patternComb.test(element.textContent || '')) {
                 return true;
@@ -395,9 +394,9 @@ function evaluateSingleElementCondition(config) {
     return asArray(config.selector).some((selector) => {
         if (visibility === 'any') {
             // if we don't care about visibility, we can just do a quick existence check
-            return documentQuerySelector(document, selector) !== null;
+            return documentQuerySelector(selector) !== null;
         }
-        for (const element of documentQuerySelectorAll(document, selector)) {
+        for (const element of documentQuerySelectorAll(selector)) {
             if (visibility === 'visible' && isVisible(element)) {
                 return true;
             }

--- a/injected/src/features/web-detection/matching.js
+++ b/injected/src/features/web-detection/matching.js
@@ -1,5 +1,14 @@
-// eslint-disable-next-line no-redeclare
-import { hasOwnProperty, objectKeys } from '../../captured-globals.js';
+ 
+import {
+    createXPathExpression,
+    documentQuerySelector,
+    documentQuerySelectorAll,
+    elementQuerySelector,
+    elementQuerySelectorAll,
+    evaluateXPathExpression,
+    hasOwnProperty,
+    objectKeys,
+} from '../../captured-globals.js';
 
 /**
  * @typedef {import('@duckduckgo/privacy-configuration/schema/features/web-detection.ts').ConditionTypes} ConditionTypes
@@ -116,19 +125,20 @@ function hasContent(element) {
         contentDomParser = new DOMParser();
     }
     const parsed = contentDomParser.parseFromString(element.outerHTML, 'text/html').documentElement;
-    parsed.querySelectorAll(CONTENT_METADATA_SELECTORS).forEach((el) => el.remove());
+    elementQuerySelectorAll(parsed, CONTENT_METADATA_SELECTORS).forEach((el) => el.remove());
 
     // Text content (read on the detached copy, so no live-page layout).
     if ((parsed.innerText || parsed.textContent || '').trim() !== '') {
         return true;
     }
     // Embedded media / form controls count as content.
-    if (parsed.querySelector(CONTENT_MEDIA_SELECTORS) !== null) {
+    if (elementQuerySelector(parsed, CONTENT_MEDIA_SELECTORS) !== null) {
         return true;
     }
     // A real (eg cross-origin Turnstile) iframe counts; about:blank does not.
-    return [...parsed.querySelectorAll('iframe')].some((frame) => {
-        return !frame.hidden && frame.src !== '' && frame.src !== 'about:blank';
+    return [...elementQuerySelectorAll(parsed, 'iframe')].some((frame) => {
+        const frameElement = /** @type {HTMLIFrameElement} */ (frame);
+        return !frameElement.hidden && frameElement.src !== '' && frameElement.src !== 'about:blank';
     });
 }
 
@@ -175,7 +185,7 @@ function compileXPath(expression) {
     }
     let compiled = cache.get(expression);
     if (!compiled) {
-        compiled = document.createExpression(expression, null);
+        compiled = createXPathExpression(document, expression);
         cache.set(expression, compiled);
     }
     return compiled;
@@ -285,7 +295,7 @@ function retainTail(buffer, chunkTail) {
  * @returns {boolean}
  */
 function xpathMatches(pattern, expression, { chunkSize, chunkTail }) {
-    const snapshot = compileXPath(expression).evaluate(document, ORDERED_NODE_SNAPSHOT_TYPE, null);
+    const snapshot = evaluateXPathExpression(compileXPath(expression), document, ORDERED_NODE_SNAPSHOT_TYPE);
     let buffer = '';
     // Characters added since the last test, rather than the length of the buffer. Each test
     // then advances `chunkSize` fresh characters whatever `chunkTail` is, so an oversized tail
@@ -347,7 +357,7 @@ function evaluateSingleTextCondition(condition) {
     // Checked before xpath because CSS matching avoids the per-call expression
     // parse and snapshot allocation that `document.evaluate` requires.
     const selectorMatch = selectors.some((selector) => {
-        const elements = document.querySelectorAll(selector);
+        const elements = documentQuerySelectorAll(document, selector);
         for (const element of elements) {
             if (patternComb.test(element.textContent || '')) {
                 return true;
@@ -385,9 +395,9 @@ function evaluateSingleElementCondition(config) {
     return asArray(config.selector).some((selector) => {
         if (visibility === 'any') {
             // if we don't care about visibility, we can just do a quick existence check
-            return document.querySelector(selector) !== null;
+            return documentQuerySelector(document, selector) !== null;
         }
-        for (const element of document.querySelectorAll(selector)) {
+        for (const element of documentQuerySelectorAll(document, selector)) {
             if (visibility === 'visible' && isVisible(element)) {
                 return true;
             }

--- a/injected/src/features/web-detection/matching.js
+++ b/injected/src/features/web-detection/matching.js
@@ -5,6 +5,7 @@ import {
     elementQuerySelector,
     elementQuerySelectorAll,
     evaluateXPathExpression,
+    // eslint-disable-next-line no-redeclare
     hasOwnProperty,
     objectKeys,
 } from '../../captured-globals.js';

--- a/injected/src/features/web-detection/matching.js
+++ b/injected/src/features/web-detection/matching.js
@@ -1,14 +1,47 @@
+/* eslint-disable no-redeclare */
 import {
+    arrayIsArray,
+    capturedDocument,
     createXPathExpression,
+    cssPropertyValue,
+    documentElement,
     documentQuerySelector,
     documentQuerySelectorAll,
+    DOMParser,
+    elementHidden,
+    elementInnerText,
+    elementOuterHTML,
     elementQuerySelector,
     elementQuerySelectorAll,
+    elementRemove,
     evaluateXPathExpression,
-    // eslint-disable-next-line no-redeclare
-    hasOwnProperty,
+    getBoundingClientRect,
+    getComputedStyle,
+    hasOwn,
+    iframeSrc,
+    Map,
+    mathFloor,
+    mathMax,
+    mathMin,
+    mapGet,
+    mapSet,
+    nodeListItem,
+    nodeListLength,
+    nodeTextContent,
     objectKeys,
+    parseFloat,
+    parseFromString,
+    RegExp,
+    rectHeight,
+    rectWidth,
+    regExpTest,
+    snapshotItem,
+    snapshotLength,
+    stringCharCodeAt,
+    stringSlice,
+    stringTrim,
 } from '../../captured-globals.js';
+/* eslint-enable no-redeclare */
 
 /**
  * @typedef {import('@duckduckgo/privacy-configuration/schema/features/web-detection.ts').ConditionTypes} ConditionTypes
@@ -27,7 +60,52 @@ import {
  */
 function asArray(value, defaultValue = []) {
     if (value === undefined) return defaultValue;
-    return Array.isArray(value) ? value : [value];
+    return arrayIsArray(value) ? value : [value];
+}
+
+/**
+ * `list[index]`, for an index the caller has already bounded.
+ *
+ * Index loops throughout this module keep config-derived values off page-replaceable
+ * `Array.prototype` methods, which receive the array they are called on. This carries the one cast
+ * that `noUncheckedIndexedAccess` would otherwise require at each of them.
+ *
+ * @template T
+ * @param {T[]} list
+ * @param {number} index
+ * @returns {T}
+ */
+function at(list, index) {
+    return /** @type {T} */ (list[index]);
+}
+
+/**
+ * Whether `list` contains `value`.
+ *
+ * @param {string[]} list
+ * @param {string} value
+ * @returns {boolean}
+ */
+function contains(list, value) {
+    for (let i = 0; i < list.length; i++) {
+        if (at(list, i) === value) return true;
+    }
+    return false;
+}
+
+/**
+ * Concatenate `list` with `separator` between entries.
+ *
+ * @param {string[]} list
+ * @param {string} separator
+ * @returns {string}
+ */
+function join(list, separator) {
+    let result = '';
+    for (let i = 0; i < list.length; i++) {
+        result += i === 0 ? at(list, i) : separator + at(list, i);
+    }
+    return result;
 }
 
 /**
@@ -44,14 +122,14 @@ function asArray(value, defaultValue = []) {
  */
 function isVisible(element) {
     const style = getComputedStyle(element);
-    const rect = element.getBoundingClientRect();
+    const rect = getBoundingClientRect(element);
 
     return (
-        rect.width > 0.5 &&
-        rect.height > 0.5 &&
-        style.display !== 'none' &&
-        style.visibility !== 'hidden' &&
-        parseFloat(style.opacity) > 0.05
+        rectWidth(rect) > 0.5 &&
+        rectHeight(rect) > 0.5 &&
+        cssPropertyValue(style, 'display') !== 'none' &&
+        cssPropertyValue(style, 'visibility') !== 'hidden' &&
+        parseFloat(cssPropertyValue(style, 'opacity')) > 0.05
     );
 }
 
@@ -113,7 +191,7 @@ function hasContent(element) {
     // poll tick (reachable only via an overly broad selector). textContent is a
     // cheap, layout-free proxy for the serialized size; such a subtree clearly
     // holds content.
-    if ((element.textContent || '').length > CONTENT_TEXT_PARSE_LIMIT) {
+    if ((nodeTextContent(element) || '').length > CONTENT_TEXT_PARSE_LIMIT) {
         return true;
     }
 
@@ -124,11 +202,14 @@ function hasContent(element) {
     if (!contentDomParser) {
         contentDomParser = new DOMParser();
     }
-    const parsed = contentDomParser.parseFromString(element.outerHTML, 'text/html').documentElement;
-    elementQuerySelectorAll(parsed, CONTENT_METADATA_SELECTORS).forEach((el) => el.remove());
+    const parsed = documentElement(parseFromString(contentDomParser, elementOuterHTML(element), 'text/html'));
+    const metadata = elementQuerySelectorAll(parsed, CONTENT_METADATA_SELECTORS);
+    for (let i = 0; i < nodeListLength(metadata); i++) {
+        elementRemove(nodeListItem(metadata, i));
+    }
 
     // Text content (read on the detached copy, so no live-page layout).
-    if ((parsed.innerText || parsed.textContent || '').trim() !== '') {
+    if (stringTrim(elementInnerText(parsed) || nodeTextContent(parsed) || '') !== '') {
         return true;
     }
     // Embedded media / form controls count as content.
@@ -136,8 +217,15 @@ function hasContent(element) {
         return true;
     }
     // A real (eg cross-origin Turnstile) iframe counts; about:blank does not.
-    const frames = /** @type {NodeListOf<HTMLIFrameElement>} */ (elementQuerySelectorAll(parsed, 'iframe'));
-    return [...frames].some((frame) => !frame.hidden && frame.src !== '' && frame.src !== 'about:blank');
+    const frames = elementQuerySelectorAll(parsed, 'iframe');
+    for (let i = 0; i < nodeListLength(frames); i++) {
+        const frame = nodeListItem(frames, i);
+        const src = iframeSrc(frame);
+        if (!elementHidden(frame) && src !== '' && src !== 'about:blank') {
+            return true;
+        }
+    }
+    return false;
 }
 
 /**
@@ -153,18 +241,18 @@ function hasContent(element) {
 const ORDERED_NODE_SNAPSHOT_TYPE = 7;
 
 /**
- * Compiled XPath expressions, keyed by document and then by expression source.
+ * Compiled XPath expressions, keyed by expression source.
  *
  * `document.evaluate()` re-parses the expression string on every call, and
  * detectors re-evaluate their conditions on every poll tick against a fixed,
  * config-supplied set of expressions. Compiling once removes that repeated parse.
  *
- * Keyed by document because an `XPathExpression` belongs to the document that
- * created it.
+ * An `XPathExpression` belongs to the document that created it, which is the
+ * captured document for every entry here.
  *
- * @type {WeakMap<Document, Map<string, XPathExpression>>}
+ * @type {Map<string, XPathExpression>}
  */
-const compiledXPaths = new WeakMap();
+const compiledXPaths = new Map();
 
 /**
  * Compile an XPath expression, reusing a previously compiled one where possible.
@@ -176,15 +264,10 @@ const compiledXPaths = new WeakMap();
  * @returns {XPathExpression}
  */
 function compileXPath(expression) {
-    let cache = compiledXPaths.get(document);
-    if (!cache) {
-        cache = new Map();
-        compiledXPaths.set(document, cache);
-    }
-    let compiled = cache.get(expression);
+    let compiled = mapGet(compiledXPaths, expression);
     if (!compiled) {
         compiled = createXPathExpression(expression, null);
-        cache.set(expression, compiled);
+        mapSet(compiledXPaths, expression, compiled);
     }
     return compiled;
 }
@@ -245,7 +328,7 @@ function resolveXPathConfig(config) {
     // being silently rewritten on a user's page. Safe only because no value can break the
     // scan loop in `xpathMatches`.
     const chunkSize = config?.chunkSize ?? DEFAULT_CHUNK_SIZE;
-    const chunkTail = config?.chunkTail ?? Math.floor(chunkSize / CHUNK_TAIL_RATIO);
+    const chunkTail = config?.chunkTail ?? mathFloor(chunkSize / CHUNK_TAIL_RATIO);
     return { chunkSize, chunkTail };
 }
 
@@ -265,13 +348,13 @@ function retainTail(buffer, chunkTail) {
     // for this flush - a hard bound is worth more than exact `\b` semantics inside a blob
     // that a phrase pattern will not match anyway. Never more than `chunkTail`, so a tail
     // of 0 still retains nothing.
-    const limit = Math.max(0, cut - Math.min(chunkTail, MAX_WORD_LENGTH));
+    const limit = mathMax(0, cut - mathMin(chunkTail, MAX_WORD_LENGTH));
     // Land the cut just after a non-word character, so position 0 is a real word boundary
     // rather than an artefact of where the chunk ended - otherwise a `\b`-prefixed pattern
     // asserts at position 0 of every chunk and matches mid-word. This only lengthens the
     // tail, so it introduces no false negative.
-    while (cut > limit && isWordCode(buffer.charCodeAt(cut - 1))) cut--;
-    return buffer.slice(cut);
+    while (cut > limit && isWordCode(stringCharCodeAt(buffer, cut - 1))) cut--;
+    return stringSlice(buffer, cut);
 }
 
 /**
@@ -293,27 +376,29 @@ function retainTail(buffer, chunkTail) {
  * @returns {boolean}
  */
 function xpathMatches(pattern, expression, { chunkSize, chunkTail }) {
-    const snapshot = evaluateXPathExpression(compileXPath(expression), document, ORDERED_NODE_SNAPSHOT_TYPE);
+    const snapshot = evaluateXPathExpression(compileXPath(expression), capturedDocument, ORDERED_NODE_SNAPSHOT_TYPE);
     let buffer = '';
     // Characters added since the last test, rather than the length of the buffer. Each test
     // then advances `chunkSize` fresh characters whatever `chunkTail` is, so an oversized tail
     // costs proportionally more scanning instead of re-testing the whole buffer per node -
     // which is what makes configured values safe to use unvalidated.
     let pending = 0;
-    for (let i = 0; i < snapshot.snapshotLength; i++) {
-        const text = snapshot.snapshotItem(i)?.textContent || '';
+    const length = snapshotLength(snapshot);
+    for (let i = 0; i < length; i++) {
+        const node = snapshotItem(snapshot, i);
+        const text = (node && nodeTextContent(node)) || '';
         buffer += text;
         pending += text.length;
         // chunkSize 0 disables chunking, accumulating everything for the single test below
         if (chunkSize > 0 && pending >= chunkSize) {
-            if (pattern.test(buffer)) return true;
+            if (regExpTest(pattern, buffer)) return true;
             // Retained text is contiguous with what follows, so a phrase split across nodes
             // still matches across a flush
             buffer = retainTail(buffer, chunkTail);
             pending = 0;
         }
     }
-    return pattern.test(buffer);
+    return regExpTest(pattern, buffer);
 }
 
 /**
@@ -349,22 +434,18 @@ function evaluateSingleTextCondition(condition) {
     // `body` is only the implicit source when the condition names no source of its own
     const selectors = asArray(condition.selector, xpaths.length > 0 ? [] : ['body']);
 
-    const patternComb = new RegExp(patterns.join('|'), 'i');
+    const patternComb = new RegExp(join(patterns, '|'), 'i');
 
     // Disjunction: any selector having a matching element is success.
     // Checked before xpath because CSS matching avoids the per-call expression
     // parse and snapshot allocation that `document.evaluate` requires.
-    const selectorMatch = selectors.some((selector) => {
-        const elements = documentQuerySelectorAll(selector);
-        for (const element of elements) {
-            if (patternComb.test(element.textContent || '')) {
+    for (let i = 0; i < selectors.length; i++) {
+        const elements = documentQuerySelectorAll(at(selectors, i));
+        for (let j = 0; j < nodeListLength(elements); j++) {
+            if (regExpTest(patternComb, nodeTextContent(nodeListItem(elements, j)) || '')) {
                 return true;
             }
         }
-        return false;
-    });
-    if (selectorMatch) {
-        return true;
     }
 
     // Disjunction: any expression whose selected text matches is success
@@ -372,7 +453,12 @@ function evaluateSingleTextCondition(condition) {
         return false;
     }
     const chunking = resolveXPathConfig(condition.xpathConfig);
-    return xpaths.some((expression) => xpathMatches(patternComb, expression, chunking));
+    for (let i = 0; i < xpaths.length; i++) {
+        if (xpathMatches(patternComb, at(xpaths, i), chunking)) {
+            return true;
+        }
+    }
+    return false;
 }
 
 /**
@@ -389,13 +475,20 @@ function evaluateSingleTextCondition(condition) {
  */
 function evaluateSingleElementCondition(config) {
     const visibility = config.visibility ?? 'any';
+    const selectors = asArray(config.selector);
     // Disjunction: any selector having a matching element is success
-    return asArray(config.selector).some((selector) => {
+    for (let i = 0; i < selectors.length; i++) {
+        const selector = at(selectors, i);
         if (visibility === 'any') {
             // if we don't care about visibility, we can just do a quick existence check
-            return documentQuerySelector(selector) !== null;
+            if (documentQuerySelector(selector) !== null) {
+                return true;
+            }
+            continue;
         }
-        for (const element of documentQuerySelectorAll(selector)) {
+        const elements = documentQuerySelectorAll(selector);
+        for (let j = 0; j < nodeListLength(elements); j++) {
+            const element = nodeListItem(elements, j);
             if (visibility === 'visible' && isVisible(element)) {
                 return true;
             }
@@ -407,8 +500,8 @@ function evaluateSingleElementCondition(config) {
                 return true;
             }
         }
-        return false;
-    });
+    }
+    return false;
 }
 
 /**
@@ -428,8 +521,8 @@ function evaluateSingleElementCondition(config) {
  */
 function evaluateNode(node, evalFinal) {
     if (node === undefined) return true;
-    if (Array.isArray(node)) {
-        return node.some((n) => evaluateNode(n, evalFinal));
+    if (arrayIsArray(node)) {
+        return evaluateAny(node, evalFinal);
     }
     if (node === null || typeof node !== 'object') {
         return evalFinal(/** @type {Final} */ (node));
@@ -437,19 +530,58 @@ function evaluateNode(node, evalFinal) {
 
     const operatorKeys = ['any', 'all', 'none'];
 
-    const opKeys = operatorKeys.filter((k) => hasOwnProperty.call(node, k));
+    /** @type {string[]} */
+    const opKeys = [];
+    for (let i = 0; i < operatorKeys.length; i++) {
+        if (hasOwn(node, at(operatorKeys, i))) opKeys[opKeys.length] = at(operatorKeys, i);
+    }
     if (opKeys.length === 0) {
         return evalFinal(/** @type {Final} */ (node));
     }
-    const otherKeys = objectKeys(node).filter((k) => !operatorKeys.includes(k));
+    const keys = objectKeys(node);
+    /** @type {string[]} */
+    const otherKeys = [];
+    for (let i = 0; i < keys.length; i++) {
+        if (!contains(operatorKeys, at(keys, i))) otherKeys[otherKeys.length] = at(keys, i);
+    }
     if (otherKeys.length > 0) {
-        throw new Error(`Condition node mixes operator keys [${opKeys.join(', ')}] with leaf fields [${otherKeys.join(', ')}]`);
+        throw new Error(`Condition node mixes operator keys [${join(opKeys, ', ')}] with leaf fields [${join(otherKeys, ', ')}]`);
     }
 
     const block = /** @type {Partial<Record<'all' | 'any' | 'none', ConditionBranch<Final>>>} */ (node);
-    if (hasOwnProperty.call(block, 'all') && !asArray(block.all).every((n) => evaluateNode(n, evalFinal))) return false;
-    if (hasOwnProperty.call(block, 'any') && !asArray(block.any).some((n) => evaluateNode(n, evalFinal))) return false;
-    if (hasOwnProperty.call(block, 'none') && asArray(block.none).some((n) => evaluateNode(n, evalFinal))) return false;
+    if (hasOwn(block, 'all') && !evaluateAll(asArray(block.all), evalFinal)) return false;
+    if (hasOwn(block, 'any') && !evaluateAny(asArray(block.any), evalFinal)) return false;
+    if (hasOwn(block, 'none') && evaluateAny(asArray(block.none), evalFinal)) return false;
+    return true;
+}
+
+/**
+ * Whether any node in `nodes` evaluates true.
+ *
+ * @template Final
+ * @param {ConditionBranch<Final>[]} nodes
+ * @param {(final: Final) => boolean} evalFinal
+ * @returns {boolean}
+ */
+function evaluateAny(nodes, evalFinal) {
+    for (let i = 0; i < nodes.length; i++) {
+        if (evaluateNode(at(nodes, i), evalFinal)) return true;
+    }
+    return false;
+}
+
+/**
+ * Whether every node in `nodes` evaluates true.
+ *
+ * @template Final
+ * @param {ConditionBranch<Final>[]} nodes
+ * @param {(final: Final) => boolean} evalFinal
+ * @returns {boolean}
+ */
+function evaluateAll(nodes, evalFinal) {
+    for (let i = 0; i < nodes.length; i++) {
+        if (!evaluateNode(at(nodes, i), evalFinal)) return false;
+    }
     return true;
 }
 

--- a/injected/src/features/web-detection/parse.js
+++ b/injected/src/features/web-detection/parse.js
@@ -1,3 +1,7 @@
+/* eslint-disable no-redeclare */
+import { objectEntries, RegExp, regExpTest } from '../../captured-globals.js';
+/* eslint-enable no-redeclare */
+
 /**
  * @typedef {import('../../utils.js').FeatureState} FeatureState
  */
@@ -82,15 +86,17 @@ const DEFAULT_RUN_CONDITIONS = /** @type {import('../../config-feature.js').Cond
     },
 ]);
 
+/** Names must start with a letter and contain only alphanumeric characters and underscores. */
+const VALID_NAME = new RegExp('^[a-zA-Z][a-zA-Z0-9_]*$');
+
 /**
  * Validate that a name matches the required format.
- * Names must start with a letter and contain only alphanumeric characters and underscores.
  *
  * @param {string} name
  * @returns {boolean}
  */
 function isValidName(name) {
-    return /^[a-zA-Z][a-zA-Z0-9_]*$/.test(name);
+    return regExpTest(VALID_NAME, name);
 }
 
 /**
@@ -155,7 +161,12 @@ export function parseDetectors(detectorsConfig) {
         return detectors;
     }
 
-    for (const [groupName, groupConfig] of Object.entries(detectorsConfig)) {
+    // Index access throughout, because array destructuring and `for...of` both route through
+    // `Array.prototype[Symbol.iterator]`, which the page can replace.
+    const groups = objectEntries(detectorsConfig);
+    for (let i = 0; i < groups.length; i++) {
+        const groupName = groups[i][0];
+        const groupConfig = groups[i][1];
         if (!isValidName(groupName)) {
             continue;
         }
@@ -163,7 +174,10 @@ export function parseDetectors(detectorsConfig) {
         /** @type {Record<string, DetectorConfig>} */
         const groupDetectors = {};
 
-        for (const [detectorId, detectorConfig] of Object.entries(groupConfig)) {
+        const groupEntries = objectEntries(groupConfig);
+        for (let j = 0; j < groupEntries.length; j++) {
+            const detectorId = groupEntries[j][0];
+            const detectorConfig = groupEntries[j][1];
             if (!isValidName(detectorId)) {
                 continue;
             }

--- a/injected/unit-test/helpers/install-dom-globals.js
+++ b/injected/unit-test/helpers/install-dom-globals.js
@@ -1,0 +1,36 @@
+import { JSDOM } from 'jsdom';
+
+/**
+ * Installs one JSDOM window's globals before any spec module is imported.
+ *
+ * Jasmine loads helpers before spec files, so this runs before `captured-globals.js` is
+ * evaluated. That ordering is the point: it captures DOM query methods at module evaluation,
+ * which is `document_start` in production. Without a document in place first it would capture
+ * nothing, and every DOM-based test would exercise a path that does not exist in a browser.
+ *
+ * There is exactly one window for the whole run, and it has to stay that way - the captured
+ * methods are bound to this `document`. A spec that needs different markup should replace the
+ * contents of this document via `resetDom` rather than construct another JSDOM.
+ */
+const dom = new JSDOM('<!DOCTYPE html><html><body></body></html>');
+
+globalThis.document = dom.window.document;
+globalThis.Document = dom.window.Document;
+globalThis.DocumentFragment = dom.window.DocumentFragment;
+globalThis.Element = dom.window.Element;
+globalThis.HTMLElement = dom.window.HTMLElement;
+globalThis.Node = dom.window.Node;
+globalThis.NodeList = dom.window.NodeList;
+globalThis.DOMParser = dom.window.DOMParser;
+globalThis.XPathExpression = dom.window.XPathExpression;
+globalThis.XPathResult = dom.window.XPathResult;
+globalThis.getComputedStyle = dom.window.getComputedStyle.bind(dom.window);
+
+/**
+ * Replace the contents of the shared document.
+ *
+ * @param {string} [html] Markup for `<body>`.
+ */
+export function resetDom(html = '') {
+    document.body.innerHTML = html;
+}

--- a/injected/unit-test/helpers/install-dom-globals.js
+++ b/injected/unit-test/helpers/install-dom-globals.js
@@ -3,32 +3,83 @@ import { JSDOM } from 'jsdom';
 /**
  * Installs one JSDOM window's globals before any spec module is imported.
  *
- * Jasmine loads helpers before spec files, so this runs before `captured-globals.js` captures
- * the DOM query methods at module evaluation. A document must be in place by then for the
- * captures to resolve.
+ * Jasmine loads helpers before spec files, so this runs before `captured-globals.js` captures the
+ * DOM APIs at module evaluation. A document must be in place by then for the captures to resolve.
  *
- * There is one window for the whole run, and the captured methods are bound to its `document`.
- * A spec needing different markup replaces this document's contents via `resetDom`.
+ * There is one window for the whole run, and the captures are bound to its `document` and taken
+ * from its prototypes. A spec needing different markup or layout calls `resetDom`.
  */
-const dom = new JSDOM('<!DOCTYPE html><html><body></body></html>');
+/** Matches `polyfillProcessGlobals`' default, so `document.location` and `globalThis.location` agree. */
+const DEFAULT_URL = 'http://localhost:8080';
 
-globalThis.document = dom.window.document;
-globalThis.Document = dom.window.Document;
-globalThis.DocumentFragment = dom.window.DocumentFragment;
-globalThis.Element = dom.window.Element;
-globalThis.HTMLElement = dom.window.HTMLElement;
-globalThis.Node = dom.window.Node;
-globalThis.NodeList = dom.window.NodeList;
-globalThis.DOMParser = dom.window.DOMParser;
-globalThis.XPathExpression = dom.window.XPathExpression;
-globalThis.XPathResult = dom.window.XPathResult;
-globalThis.getComputedStyle = dom.window.getComputedStyle.bind(dom.window);
+const dom = new JSDOM('<!DOCTYPE html><html><head></head><body></body></html>', { url: DEFAULT_URL });
 
 /**
- * Replace the contents of the shared document.
+ * Selectors whose elements report 0x0. Read by the `getBoundingClientRect` shim below.
+ *
+ * @type {string[]}
+ */
+let zeroSizeSelectors = [];
+
+// JSDOM has no layout: every element measures 0x0, which `isVisible` reads as hidden. The shim
+// must be installed before the capture, so it lives here rather than in a spec.
+dom.window.Element.prototype.getBoundingClientRect = function () {
+    const isZeroSize = zeroSizeSelectors.some((selector) => this.matches(selector));
+    return new dom.window.DOMRect(0, 0, isZeroSize ? 0 : 100, isZeroSize ? 0 : 50);
+};
+
+// JSDOM computes "" for opacity where a browser computes "1". Property accessors such as
+// `style.opacity` route through `getPropertyValue`, so patching it covers both reads.
+const jsdomGetPropertyValue = dom.window.CSSStyleDeclaration.prototype.getPropertyValue;
+dom.window.CSSStyleDeclaration.prototype.getPropertyValue = function (property) {
+    const value = jsdomGetPropertyValue.call(this, property);
+    if (property === 'opacity' && value === '') return '1';
+    return value;
+};
+
+for (const name of [
+    'document',
+    'Document',
+    'DocumentFragment',
+    'Element',
+    'HTMLElement',
+    'HTMLIFrameElement',
+    'Node',
+    'NodeList',
+    'DOMParser',
+    'DOMRect',
+    'CSSStyleDeclaration',
+    'XPathExpression',
+    'XPathResult',
+]) {
+    // `Reflect.set` rather than assignment: `globalThis.x = …` in a JS file declares a global that
+    // TypeScript then resolves `typeof globalThis` types into, which typedoc reports as an
+    // undocumented export.
+    Reflect.set(globalThis, name, dom.window[name]);
+}
+Reflect.set(globalThis, 'getComputedStyle', dom.window.getComputedStyle.bind(dom.window));
+
+/**
+ * Set the URL the shared document reports through `document.location` and `document.URL`.
+ *
+ * JSDOM's `location` is non-configurable, so navigation is the only way to change it.
+ *
+ * @param {string} [url]
+ */
+export function setDocumentUrl(url = DEFAULT_URL) {
+    dom.reconfigure({ url });
+}
+
+/**
+ * Replace the contents of the shared document and the layout it reports.
+ *
+ * Resets `<head>` as well as `<body>`, so nothing a spec adds outlives it — specs run in random
+ * order against this one document.
  *
  * @param {string} [html] Markup for `<body>`.
+ * @param {string[]} [zeroSize] Selectors whose elements measure 0x0.
  */
-export function resetDom(html = '') {
-    document.body.innerHTML = html;
+export function resetDom(html = '', zeroSize = []) {
+    document.documentElement.innerHTML = `<head></head><body>${html}</body>`;
+    zeroSizeSelectors = zeroSize;
 }

--- a/injected/unit-test/helpers/install-dom-globals.js
+++ b/injected/unit-test/helpers/install-dom-globals.js
@@ -3,14 +3,12 @@ import { JSDOM } from 'jsdom';
 /**
  * Installs one JSDOM window's globals before any spec module is imported.
  *
- * Jasmine loads helpers before spec files, so this runs before `captured-globals.js` is
- * evaluated. That ordering is the point: it captures DOM query methods at module evaluation,
- * which is `document_start` in production. Without a document in place first it would capture
- * nothing, and every DOM-based test would exercise a path that does not exist in a browser.
+ * Jasmine loads helpers before spec files, so this runs before `captured-globals.js` captures
+ * the DOM query methods at module evaluation. A document must be in place by then for the
+ * captures to resolve.
  *
- * There is exactly one window for the whole run, and it has to stay that way - the captured
- * methods are bound to this `document`. A spec that needs different markup should replace the
- * contents of this document via `resetDom` rather than construct another JSDOM.
+ * There is one window for the whole run, and the captured methods are bound to its `document`.
+ * A spec needing different markup replaces this document's contents via `resetDom`.
  */
 const dom = new JSDOM('<!DOCTYPE html><html><body></body></html>');
 

--- a/injected/unit-test/helpers/polyfill-process-globals.js
+++ b/injected/unit-test/helpers/polyfill-process-globals.js
@@ -39,16 +39,14 @@ export function createDomStringList(list) {
 
 export function polyfillProcessGlobals(defaultLocation = 'http://localhost:8080', frameAncestorsList = [], topisNull = false) {
     // Store original values to restore later
-    const originalDocument = globalThis.document;
     const originalLocation = globalThis.location;
     const originalTop = globalThis.top;
 
-    // Apply the patch
-    // @ts-expect-error - document is not defined in the type definition
-    globalThis.document = {
-        referrer: defaultLocation,
-        location: createLocationObject(defaultLocation, frameAncestorsList),
-    };
+    // Adjust the shared document rather than replacing it. The DOM query methods in
+    // captured-globals.js are bound to that document at module evaluation, so swapping the global
+    // out breaks every DOM-based spec - and several callers here run at module scope, which would
+    // break them for the whole run.
+    Object.defineProperty(globalThis.document, 'referrer', { value: defaultLocation, configurable: true });
 
     globalThis.location = createLocationObject(defaultLocation, frameAncestorsList);
 
@@ -61,7 +59,8 @@ export function polyfillProcessGlobals(defaultLocation = 'http://localhost:8080'
 
     // Return a cleanup function
     return function cleanup() {
-        globalThis.document = originalDocument;
+        // Removing the own property reveals the document's real accessor again
+        Reflect.deleteProperty(globalThis.document, 'referrer');
         globalThis.location = originalLocation;
         globalThis.top = originalTop;
     };

--- a/injected/unit-test/helpers/polyfill-process-globals.js
+++ b/injected/unit-test/helpers/polyfill-process-globals.js
@@ -48,10 +48,8 @@ export function polyfillProcessGlobals(defaultLocation = 'http://localhost:8080'
     const hasDocument = Boolean(globalThis.document);
 
     if (hasDocument) {
-        // Adjust the shared document rather than replacing it. The DOM query methods in
-        // captured-globals.js are bound to that document at module evaluation, so swapping the global
-        // out breaks every DOM-based spec - and several callers here run at module scope, which would
-        // break them for the whole run.
+        // The DOM query methods in captured-globals.js are bound to this document, so it must be
+        // adjusted in place rather than replaced.
         Object.defineProperty(globalThis.document, 'referrer', { value: defaultLocation, configurable: true });
     } else {
         globalThis.document = /** @type {Document} */ (
@@ -74,7 +72,7 @@ export function polyfillProcessGlobals(defaultLocation = 'http://localhost:8080'
     // Return a cleanup function
     return function cleanup() {
         if (hasDocument) {
-            // Removing the own property reveals the document's real accessor again
+            // Removing the own property restores the document's own `referrer` accessor
             Reflect.deleteProperty(globalThis.document, 'referrer');
         } else {
             Reflect.deleteProperty(globalThis, 'document');

--- a/injected/unit-test/helpers/polyfill-process-globals.js
+++ b/injected/unit-test/helpers/polyfill-process-globals.js
@@ -48,8 +48,9 @@ export function polyfillProcessGlobals(defaultLocation = 'http://localhost:8080'
     const hasDocument = Boolean(globalThis.document);
 
     if (hasDocument) {
-        // The DOM query methods in captured-globals.js are bound to this document, so it must be
-        // adjusted in place rather than replaced.
+        // The DOM APIs in captured-globals.js are bound to this document, so it must be adjusted in
+        // place rather than replaced. `document.location` is non-configurable in JSDOM: it reports
+        // the shared window's URL, which a spec changes through `setDocumentUrl`.
         Object.defineProperty(globalThis.document, 'referrer', { value: defaultLocation, configurable: true });
     } else {
         globalThis.document = /** @type {Document} */ (
@@ -72,7 +73,7 @@ export function polyfillProcessGlobals(defaultLocation = 'http://localhost:8080'
     // Return a cleanup function
     return function cleanup() {
         if (hasDocument) {
-            // Removing the own property restores the document's own `referrer` accessor
+            // Removing the own properties restores the document's own accessors
             Reflect.deleteProperty(globalThis.document, 'referrer');
         } else {
             Reflect.deleteProperty(globalThis, 'document');

--- a/injected/unit-test/helpers/polyfill-process-globals.js
+++ b/injected/unit-test/helpers/polyfill-process-globals.js
@@ -42,11 +42,25 @@ export function polyfillProcessGlobals(defaultLocation = 'http://localhost:8080'
     const originalLocation = globalThis.location;
     const originalTop = globalThis.top;
 
-    // Adjust the shared document rather than replacing it. The DOM query methods in
-    // captured-globals.js are bound to that document at module evaluation, so swapping the global
-    // out breaks every DOM-based spec - and several callers here run at module scope, which would
-    // break them for the whole run.
-    Object.defineProperty(globalThis.document, 'referrer', { value: defaultLocation, configurable: true });
+    // The unit-test run installs a document (see install-dom-globals.js); the Playwright runner does
+    // not, yet its helpers call into src/utils.js, which reads `document.referrer` and
+    // `document.location`.
+    const hasDocument = Boolean(globalThis.document);
+
+    if (hasDocument) {
+        // Adjust the shared document rather than replacing it. The DOM query methods in
+        // captured-globals.js are bound to that document at module evaluation, so swapping the global
+        // out breaks every DOM-based spec - and several callers here run at module scope, which would
+        // break them for the whole run.
+        Object.defineProperty(globalThis.document, 'referrer', { value: defaultLocation, configurable: true });
+    } else {
+        globalThis.document = /** @type {Document} */ (
+            /** @type {unknown} */ ({
+                referrer: defaultLocation,
+                location: createLocationObject(defaultLocation, frameAncestorsList),
+            })
+        );
+    }
 
     globalThis.location = createLocationObject(defaultLocation, frameAncestorsList);
 
@@ -59,8 +73,12 @@ export function polyfillProcessGlobals(defaultLocation = 'http://localhost:8080'
 
     // Return a cleanup function
     return function cleanup() {
-        // Removing the own property reveals the document's real accessor again
-        Reflect.deleteProperty(globalThis.document, 'referrer');
+        if (hasDocument) {
+            // Removing the own property reveals the document's real accessor again
+            Reflect.deleteProperty(globalThis.document, 'referrer');
+        } else {
+            Reflect.deleteProperty(globalThis, 'document');
+        }
         globalThis.location = originalLocation;
         globalThis.top = originalTop;
     };

--- a/injected/unit-test/web-detection.js
+++ b/injected/unit-test/web-detection.js
@@ -651,15 +651,14 @@ describe('WebDetection', () => {
          */
         function matchInDOM(html, match, options = {}) {
             const { zeroSizeSelectors = [] } = options;
-            // The shared document is reused rather than replaced, because the query methods
-            // captured at module evaluation are bound to it (see helpers/install-dom-globals.js).
+            // The captured query methods are bound to the shared document, so its contents are
+            // replaced rather than the document itself (see helpers/install-dom-globals.js).
             resetDom(html);
             const originalGetComputedStyle = globalThis.getComputedStyle;
 
             // Wrap getComputedStyle to return browser-like defaults (JSDOM returns "" for opacity)
-            const jsdomGetComputedStyle = originalGetComputedStyle;
             globalThis.getComputedStyle = (el, pseudoElt) => {
-                const style = jsdomGetComputedStyle(el, pseudoElt);
+                const style = originalGetComputedStyle(el, pseudoElt);
                 return new Proxy(style, {
                     get(target, prop) {
                         const value = target[prop];
@@ -698,9 +697,8 @@ describe('WebDetection', () => {
 
         describe('query API capture', () => {
             /**
-             * Replace every query method the feature could reach, run `body`, and report what the
-             * replacements saw. The methods are captured at module evaluation, so a replacement
-             * installed here - as a Cloudflare challenge page installs one - must observe nothing.
+             * Replace every query method the feature could reach, run `run`, and return the
+             * selectors the replacements saw.
              *
              * @param {() => void} run
              * @returns {string[]}
@@ -730,7 +728,7 @@ describe('WebDetection', () => {
                 return observed;
             }
 
-            it('is effective, so an empty result below is meaningful', () => {
+            it('records selectors passed through a replaced query method', () => {
                 const observed = selectorsObservedDuring(() => document.querySelectorAll('.replacement-is-live'));
                 expect(observed).toEqual(['.replacement-is-live']);
             });
@@ -741,7 +739,6 @@ describe('WebDetection', () => {
                 const observed = selectorsObservedDuring(() => {
                     matched = matchInDOM('<div class="g-recaptcha"></div>', { element: { selector: '.g-recaptcha' } });
                 });
-                // The detector still matched, so the query happened - just not through the replacement
                 expect(matched).toBe(true);
                 expect(observed).toEqual([]);
             });

--- a/injected/unit-test/web-detection.js
+++ b/injected/unit-test/web-detection.js
@@ -660,74 +660,143 @@ describe('WebDetection', () => {
             }
         }
 
-        describe('query API capture', () => {
+        describe('captured API surface', () => {
             /**
-             * Replace every query method the feature could reach, run `run`, and return the
-             * selectors the replacements saw.
+             * Replace every page-reachable API the matcher could reach with one that records what
+             * it was given, evaluate `match` against `html`, and return the recorded strings that
+             * disclose a detector's configuration.
              *
-             * @param {() => void} run
-             * @returns {string[]}
+             * Elements are recorded as their markup, so an uncaptured call that merely receives a
+             * matched node still shows which selector found it.
+             *
+             * @param {object} options
+             * @param {string} options.html
+             * @param {import('../src/features/web-detection/parse.js').MatchCondition} options.match
+             * @param {string[]} options.secrets Strings a page must not be able to observe.
+             * @param {string[]} [options.zeroSizeSelectors]
+             * @param {() => void} [options.probe] Runs while the replacements are installed.
+             * @returns {{ matched: boolean, observed: string[] }}
              */
-            function selectorsObservedDuring(run) {
+            function evaluateUnderReplacedApis({ html, match, secrets, zeroSizeSelectors, probe }) {
+                // Markup is in place before the recording starts, so the parse work of building it
+                // is not mistaken for the matcher's own reads.
+                resetDom(html, zeroSizeSelectors);
+
                 /** @type {string[]} */
-                const observed = [];
+                const recorded = [];
                 /** @type {Array<() => void>} */
                 const restore = [];
-                for (const proto of [Document.prototype, Element.prototype]) {
-                    for (const name of ['querySelector', 'querySelectorAll']) {
-                        const original = proto[name];
-                        restore.push(() => {
-                            proto[name] = original;
-                        });
-                        proto[name] = function (/** @type {string} */ selectors) {
-                            observed.push(selectors);
-                            return original.call(this, selectors);
-                        };
-                    }
+
+                /**
+                 * @param {object} target
+                 * @param {string} name
+                 * @param {(this: any, result: any, ...args: any[]) => string} describe What the
+                 *   replacement discloses: the argument it was given or the node it returned.
+                 */
+                function replace(target, name, describe) {
+                    const original = target[name];
+                    restore.push(() => {
+                        target[name] = original;
+                    });
+                    target[name] = function (...args) {
+                        const result = original.apply(this, args);
+                        recorded.push(describe.call(this, result, ...args));
+                        return result;
+                    };
                 }
+
+                for (const proto of [Document.prototype, Element.prototype]) {
+                    replace(proto, 'querySelector', (_result, selectors) => selectors);
+                    replace(proto, 'querySelectorAll', (_result, selectors) => selectors);
+                }
+                replace(Document.prototype, 'createExpression', (_result, expression) => expression);
+                replace(XPathExpression.prototype, 'evaluate', (_result, contextNode) => String(contextNode));
+                replace(XPathResult.prototype, 'snapshotItem', (node) => String(node?.textContent));
+                replace(DOMParser.prototype, 'parseFromString', (_result, markup) => markup);
+                replace(NodeList.prototype, 'item', (node) => String(node?.outerHTML));
+                replace(RegExp.prototype, 'test', function () {
+                    return this.source;
+                });
+                replace(Element.prototype, 'remove', function () {
+                    return this.outerHTML;
+                });
+                replace(Element.prototype, 'getBoundingClientRect', function () {
+                    return this.outerHTML;
+                });
+                replace(globalThis, 'getComputedStyle', (_result, element) => element.outerHTML);
+
                 try {
-                    run();
+                    probe?.();
+                    const matched = evaluateMatch(match);
+                    return { matched, observed: recorded.filter((entry) => secrets.some((secret) => entry.includes(secret))) };
                 } finally {
                     for (const undo of restore) undo();
+                    resetDom();
                 }
-                return observed;
             }
 
-            it('records selectors passed through a replaced query method', () => {
-                const observed = selectorsObservedDuring(() => document.querySelectorAll('.replacement-is-live'));
-                expect(observed).toEqual(['.replacement-is-live']);
+            it('records configuration passed through a replaced API', () => {
+                // Control: the replacements are live for anything not routed through a captured
+                // reference, so the empty results below mean capture, not an inert test.
+                const { observed } = evaluateUnderReplacedApis({
+                    html: '<div class="g-recaptcha"></div>',
+                    match: {},
+                    secrets: ['leaked'],
+                    probe: () => {
+                        const source = 'leaked-pattern';
+                        document.querySelectorAll('.leaked-selector');
+                        new RegExp(source).test('nothing');
+                    },
+                });
+                expect(observed).toEqual(['.leaked-selector', 'leaked-pattern']);
             });
 
-            it('hides element condition selectors from a replaced query method', () => {
-                /** @type {boolean | undefined} */
-                let matched;
-                const observed = selectorsObservedDuring(() => {
-                    matched = matchInDOM('<div class="g-recaptcha"></div>', { element: { selector: '.g-recaptcha' } });
+            it('hides element condition selectors', () => {
+                const { matched, observed } = evaluateUnderReplacedApis({
+                    html: '<div class="g-recaptcha"></div>',
+                    match: { element: { selector: '.g-recaptcha' } },
+                    secrets: ['g-recaptcha'],
                 });
                 expect(matched).toBe(true);
                 expect(observed).toEqual([]);
             });
 
-            it('hides text condition selectors from a replaced query method', () => {
-                /** @type {boolean | undefined} */
-                let matched;
-                const observed = selectorsObservedDuring(() => {
-                    matched = matchInDOM('<p class="wall">adblocker detected</p>', {
-                        text: { pattern: 'adblocker detected', selector: '.wall' },
-                    });
+            it('hides text condition selectors and patterns', () => {
+                const { matched, observed } = evaluateUnderReplacedApis({
+                    html: '<p class="wall">adblocker detected</p>',
+                    match: { text: { pattern: 'adblocker detected', selector: '.wall' } },
+                    secrets: ['adblocker detected', '.wall'],
                 });
                 expect(matched).toBe(true);
                 expect(observed).toEqual([]);
             });
 
-            it('hides the selectors used when probing content of a matched element', () => {
+            it('hides xpath expressions and the patterns matched against them', () => {
+                const { matched, observed } = evaluateUnderReplacedApis({
+                    html: '<div class="wall">adblocker detected</div>',
+                    match: { text: { pattern: 'adblocker detected', xpath: '//div[@class="wall"]//text()' } },
+                    secrets: ['adblocker detected', '@class="wall"'],
+                });
+                expect(matched).toBe(true);
+                expect(observed).toEqual([]);
+            });
+
+            it('hides the markup and selectors used when probing content of a matched element', () => {
                 // `content` visibility inspects a detached DOMParser tree, which shares these prototypes
-                /** @type {boolean | undefined} */
-                let matched;
-                const observed = selectorsObservedDuring(() => {
-                    matched = matchInDOM('<div class="cf-turnstile"><iframe src="https://example.com/"></iframe></div>', {
-                        element: { selector: '.cf-turnstile', visibility: 'content' },
-                    });
+                const { matched, observed } = evaluateUnderReplacedApis({
+                    html: '<div class="cf-turnstile"><iframe src="https://example.com/"></iframe></div>',
+                    match: { element: { selector: '.cf-turnstile', visibility: 'content' } },
+                    secrets: ['cf-turnstile'],
+                });
+                expect(matched).toBe(true);
+                expect(observed).toEqual([]);
+            });
+
+            it('hides the elements measured for a visibility check', () => {
+                const { matched, observed } = evaluateUnderReplacedApis({
+                    html: '<div class="g-recaptcha">challenge</div>',
+                    match: { element: { selector: '.g-recaptcha', visibility: 'visible' } },
+                    secrets: ['g-recaptcha'],
                 });
                 expect(matched).toBe(true);
                 expect(observed).toEqual([]);

--- a/injected/unit-test/web-detection.js
+++ b/injected/unit-test/web-detection.js
@@ -650,48 +650,13 @@ describe('WebDetection', () => {
          * @returns {boolean}
          */
         function matchInDOM(html, match, options = {}) {
-            const { zeroSizeSelectors = [] } = options;
-            // The captured query methods are bound to the shared document, so its contents are
-            // replaced rather than the document itself (see helpers/install-dom-globals.js).
-            resetDom(html);
-            const originalGetComputedStyle = globalThis.getComputedStyle;
-
-            // Wrap getComputedStyle to return browser-like defaults (JSDOM returns "" for opacity)
-            globalThis.getComputedStyle = (el, pseudoElt) => {
-                const style = originalGetComputedStyle(el, pseudoElt);
-                return new Proxy(style, {
-                    get(target, prop) {
-                        const value = target[prop];
-                        // JSDOM returns "" for opacity, browsers return "1"
-                        if (prop === 'opacity' && value === '') return '1';
-                        return value;
-                    },
-                });
-            };
-
-            // Patch Element prototype to mock getBoundingClientRect based on selectors
-            const ElementProto = Element.prototype;
-            const originalGetBoundingClientRect = ElementProto.getBoundingClientRect;
-            ElementProto.getBoundingClientRect = function () {
-                const isZeroSize = zeroSizeSelectors.some((sel) => this.matches(sel));
-                return {
-                    width: isZeroSize ? 0 : 100,
-                    height: isZeroSize ? 0 : 50,
-                    top: 0,
-                    left: 0,
-                    right: isZeroSize ? 0 : 100,
-                    bottom: isZeroSize ? 0 : 50,
-                    x: 0,
-                    y: 0,
-                    toJSON: () => ({}),
-                };
-            };
-
+            // Captured DOM APIs are bound to the shared document and taken from its prototypes, so
+            // markup and layout are replaced in place (see helpers/install-dom-globals.js).
+            resetDom(html, options.zeroSizeSelectors);
             try {
                 return evaluateMatch(match);
             } finally {
-                globalThis.getComputedStyle = originalGetComputedStyle;
-                ElementProto.getBoundingClientRect = originalGetBoundingClientRect;
+                resetDom();
             }
         }
 

--- a/injected/unit-test/web-detection.js
+++ b/injected/unit-test/web-detection.js
@@ -1,4 +1,4 @@
-import { JSDOM } from 'jsdom';
+import { resetDom } from './helpers/install-dom-globals.js';
 import { parseDetectors } from '../src/features/web-detection/parse.js';
 import { evaluateMatch } from '../src/features/web-detection/matching.js';
 import WebDetection from '../src/features/web-detection.js';
@@ -651,16 +651,13 @@ describe('WebDetection', () => {
          */
         function matchInDOM(html, match, options = {}) {
             const { zeroSizeSelectors = [] } = options;
-            const dom = new JSDOM(`<!DOCTYPE html><html><body>${html}</body></html>`);
-            const originalDocument = globalThis.document;
+            // The shared document is reused rather than replaced, because the query methods
+            // captured at module evaluation are bound to it (see helpers/install-dom-globals.js).
+            resetDom(html);
             const originalGetComputedStyle = globalThis.getComputedStyle;
-            const originalDOMParser = globalThis.DOMParser;
-            globalThis.document = dom.window.document;
-            // `content` visibility mode uses DOMParser; provide JSDOM's implementation.
-            globalThis.DOMParser = dom.window.DOMParser;
 
             // Wrap getComputedStyle to return browser-like defaults (JSDOM returns "" for opacity)
-            const jsdomGetComputedStyle = dom.window.getComputedStyle;
+            const jsdomGetComputedStyle = originalGetComputedStyle;
             globalThis.getComputedStyle = (el, pseudoElt) => {
                 const style = jsdomGetComputedStyle(el, pseudoElt);
                 return new Proxy(style, {
@@ -674,7 +671,7 @@ describe('WebDetection', () => {
             };
 
             // Patch Element prototype to mock getBoundingClientRect based on selectors
-            const ElementProto = dom.window.Element.prototype;
+            const ElementProto = Element.prototype;
             const originalGetBoundingClientRect = ElementProto.getBoundingClientRect;
             ElementProto.getBoundingClientRect = function () {
                 const isZeroSize = zeroSizeSelectors.some((sel) => this.matches(sel));
@@ -694,12 +691,86 @@ describe('WebDetection', () => {
             try {
                 return evaluateMatch(match);
             } finally {
-                globalThis.document = originalDocument;
                 globalThis.getComputedStyle = originalGetComputedStyle;
-                globalThis.DOMParser = originalDOMParser;
                 ElementProto.getBoundingClientRect = originalGetBoundingClientRect;
             }
         }
+
+        describe('query API capture', () => {
+            /**
+             * Replace every query method the feature could reach, run `body`, and report what the
+             * replacements saw. The methods are captured at module evaluation, so a replacement
+             * installed here - as a Cloudflare challenge page installs one - must observe nothing.
+             *
+             * @param {() => void} run
+             * @returns {string[]}
+             */
+            function selectorsObservedDuring(run) {
+                /** @type {string[]} */
+                const observed = [];
+                /** @type {Array<() => void>} */
+                const restore = [];
+                for (const proto of [Document.prototype, Element.prototype]) {
+                    for (const name of ['querySelector', 'querySelectorAll']) {
+                        const original = proto[name];
+                        restore.push(() => {
+                            proto[name] = original;
+                        });
+                        proto[name] = function (/** @type {string} */ selectors) {
+                            observed.push(selectors);
+                            return original.call(this, selectors);
+                        };
+                    }
+                }
+                try {
+                    run();
+                } finally {
+                    for (const undo of restore) undo();
+                }
+                return observed;
+            }
+
+            it('is effective, so an empty result below is meaningful', () => {
+                const observed = selectorsObservedDuring(() => document.querySelectorAll('.replacement-is-live'));
+                expect(observed).toEqual(['.replacement-is-live']);
+            });
+
+            it('hides element condition selectors from a replaced query method', () => {
+                /** @type {boolean | undefined} */
+                let matched;
+                const observed = selectorsObservedDuring(() => {
+                    matched = matchInDOM('<div class="g-recaptcha"></div>', { element: { selector: '.g-recaptcha' } });
+                });
+                // The detector still matched, so the query happened - just not through the replacement
+                expect(matched).toBe(true);
+                expect(observed).toEqual([]);
+            });
+
+            it('hides text condition selectors from a replaced query method', () => {
+                /** @type {boolean | undefined} */
+                let matched;
+                const observed = selectorsObservedDuring(() => {
+                    matched = matchInDOM('<p class="wall">adblocker detected</p>', {
+                        text: { pattern: 'adblocker detected', selector: '.wall' },
+                    });
+                });
+                expect(matched).toBe(true);
+                expect(observed).toEqual([]);
+            });
+
+            it('hides the selectors used when probing content of a matched element', () => {
+                // `content` visibility inspects a detached DOMParser tree, which shares these prototypes
+                /** @type {boolean | undefined} */
+                let matched;
+                const observed = selectorsObservedDuring(() => {
+                    matched = matchInDOM('<div class="cf-turnstile"><iframe src="https://example.com/"></iframe></div>', {
+                        element: { selector: '.cf-turnstile', visibility: 'content' },
+                    });
+                });
+                expect(matched).toBe(true);
+                expect(observed).toEqual([]);
+            });
+        });
 
         describe('empty conditions', () => {
             it('should match with empty object (no conditions)', () => {
@@ -878,17 +949,11 @@ describe('WebDetection', () => {
 
             it('should see content added between evaluations', () => {
                 // Compiled expressions are reused across evaluations; the DOM they run against is not
-                const dom = new JSDOM('<!DOCTYPE html><html><body><p>Loading...</p></body></html>');
-                const originalDocument = globalThis.document;
-                globalThis.document = dom.window.document;
-                try {
-                    const match = { text: { pattern: 'adblocker detected', xpath: RENDERED_TEXT } };
-                    expect(evaluateMatch(match)).toBe(false);
-                    dom.window.document.body.insertAdjacentHTML('beforeend', '<div class="wall">adblocker detected</div>');
-                    expect(evaluateMatch(match)).toBe(true);
-                } finally {
-                    globalThis.document = originalDocument;
-                }
+                resetDom('<p>Loading...</p>');
+                const match = { text: { pattern: 'adblocker detected', xpath: RENDERED_TEXT } };
+                expect(evaluateMatch(match)).toBe(false);
+                document.body.insertAdjacentHTML('beforeend', '<div class="wall">adblocker detected</div>');
+                expect(evaluateMatch(match)).toBe(true);
             });
 
             it('should throw on an invalid expression, surfacing as a detector error', () => {

--- a/typedoc.js
+++ b/typedoc.js
@@ -46,6 +46,9 @@ const config = /** @type {Partial<import('typedoc').TypeDocOptions>} */ ({
     excludeInternal: true,
     readme: 'none',
     treatWarningsAsErrors: true,
+    // Documented `typeof globalThis` types resolve into test helpers that assign to `globalThis.*`,
+    // since in a `.js` file such an assignment declares a global.
+    intentionallyNotExported: ['globalThis'],
     searchInComments: true,
     blockTags: [...OptionDefaults.blockTags, '@maxItems'],
     modifierTags: [...OptionDefaults.modifierTags, '@implements'],

--- a/typedoc.js
+++ b/typedoc.js
@@ -46,9 +46,6 @@ const config = /** @type {Partial<import('typedoc').TypeDocOptions>} */ ({
     excludeInternal: true,
     readme: 'none',
     treatWarningsAsErrors: true,
-    // Test helpers assign to `globalThis.*`, which in a `.js` file declares a global, and
-    // documented `typeof globalThis` types resolve into those declarations.
-    intentionallyNotExported: ['globalThis'],
     searchInComments: true,
     blockTags: [...OptionDefaults.blockTags, '@maxItems'],
     modifierTags: [...OptionDefaults.modifierTags, '@implements'],

--- a/typedoc.js
+++ b/typedoc.js
@@ -46,8 +46,8 @@ const config = /** @type {Partial<import('typedoc').TypeDocOptions>} */ ({
     excludeInternal: true,
     readme: 'none',
     treatWarningsAsErrors: true,
-    // Documented `typeof globalThis` types resolve into test helpers that assign to `globalThis.*`,
-    // since in a `.js` file such an assignment declares a global.
+    // Test helpers assign to `globalThis.*`, which in a `.js` file declares a global, and
+    // documented `typeof globalThis` types resolve into those declarations.
     intentionallyNotExported: ['globalThis'],
     searchInComments: true,
     blockTags: [...OptionDefaults.blockTags, '@maxItems'],


### PR DESCRIPTION
**Asana Task/Github Issue:** https://app.asana.com/1/137249556945/project/1200811069326255/task/1217408393396344?focus=true
## Description

Capture more global values used by web detection inc. query selectors.

<!--
  Provide a terse summary of what the change is, detailed descriptions should belong in ship reviews or tech designs
-->

## Testing Steps

- <!-- Include simple steps on how to check this change is working. Write "N/A" if not applicable. -->

## Checklist

<!--
  These questions are a friendly reminder to shipping code, if you're uncertain ask the AoR owners.
  It's also totally appropriate to not check some of these boxes, if they don't apply to your change.
-->
*Please tick all that apply:*

- [ ] I have tested this change locally
- [ ] I have tested this change locally in all supported browsers
- [ ] This change will be visible to users
- [ ] I have added automated tests that cover this change
- [ ] I have ensured the change is gated by config
- [ ] This change was covered by a ship review
- [ ] This change was covered by a tech design
- [ ] Any dependent config has been merged


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large refactor of security-sensitive matcher logic on hostile pages; behavior should be equivalent but any missed uncaptured call would leak detector configuration.
> 
> **Overview**
> **Hardens web-detection matching** so remote-config selectors, XPath expressions, and regex patterns are not observable when a page replaces `querySelectorAll`, `RegExp.prototype.test`, `Array.prototype` methods, or similar slots after injection.
> 
> `captured-globals.js` now snapshots DOM and intrinsic APIs at module load (`document_start`) and exposes receiver-style helpers (`documentQuerySelectorAll`, `regExpTest`, `nodeTextContent`, etc.). `matching.js` and `parse.js` route all config-driven DOM, regex, and collection work through those captures, using **index loops** instead of `for...of`, spread, or `.some`/`join` on config arrays.
> 
> **Enforcement and docs:** ESLint blocks raw globals, risky prototype calls, and replaceable iteration in `injected/src/features/web-detection/**`. Coding guidelines and `BUGBOT.md` describe the disclosure model.
> 
> **Tests:** Shared JSDOM setup (`install-dom-globals.js`) so captures bind before specs load; unit tests that replace prototypes and assert secrets stay hidden; an integration test that proves live reCAPTCHA detection still fires while only a control selector is observed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 910a1f16dbb17396a62ae6d3d9ee549d200054ad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->