### PR TITLE
Use .nvmrc Node version in remaining workflow jobs

### DIFF
--- a/.github/workflows/auto-respond-pr.yml
+++ b/.github/workflows/auto-respond-pr.yml
@@ -25,6 +25,11 @@ jobs:
                   path: pr
                   fetch-depth: 0
 
+            - name: Use Node.js
+              uses: actions/setup-node@v6
+              with:
+                  node-version-file: 'pr/.nvmrc'
+
             - name: Run build script on base branch
               run: |
                   cd base

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -30,9 +30,16 @@ jobs:
               uses: actions/checkout@v7
               with:
                   ref: ${{ github.event.pull_request.base.ref }}
-                  sparse-checkout: .github/scripts
+                  sparse-checkout: |
+                      .github/scripts
+                      .nvmrc
                   sparse-checkout-cone-mode: false
                   persist-credentials: false
+
+            - name: Use Node.js
+              uses: actions/setup-node@v6
+              with:
+                  node-version-file: '.nvmrc'
 
             - name: Dependabot metadata
               id: metadata

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -97,6 +97,9 @@ jobs:
             version: ${{ steps.pw.outputs.version }}
         steps:
             - uses: actions/checkout@v7
+            - uses: actions/setup-node@v6
+              with:
+                  node-version-file: '.nvmrc'
             - id: pw
               run: |
                   VERSION=$(node -e "const l=require('./package-lock.json'); console.log((l.packages['node_modules/@playwright/test']||l.packages['node_modules/playwright']).version)")


### PR DESCRIPTION
**Asana Task/Github Issue:** N/A (follow-up to #3011)

## Description

Follow-up to the Node 24 upgrade (#3011): an audit of all workflows found three jobs still running `node`/`npm` on the runner's pre-installed Node instead of the version pinned in `.nvmrc`:

- `auto-respond-pr.yml` (`auto_respond`): runs `npm install && npm run build` on both the base and PR checkouts to produce the generated file diff comment. Now sets up Node from `pr/.nvmrc` before building.
- `dependabot-auto-merge.yml` (`dependabot`): runs the Anthropic gate script with `node`. `.nvmrc` is added to the sparse checkout so `setup-node` can read it.
- `tests.yml` (`get-playwright-version`): reads the Playwright version out of `package-lock.json` with `node`. Pinned for consistency.

Every other workflow without `setup-node` only uses actions such as `actions/github-script`, which run on the Actions runtime Node and cannot be pinned. All pre-existing `setup-node` steps already use `node-version-file: '.nvmrc'` (with `semver-label.yml` intentionally reading `base/.nvmrc`).

## Testing Steps

- Verified by parsing every workflow's YAML and flagging any job that runs `node`/`npm` in a `run:` step without a `setup-node` step: zero remaining.
- Prettier passes on the edited files.
- `tests.yml` change is exercised by CI on this PR; the other two workflows run on their usual triggers.

## Checklist

*Please tick all that apply:*

- [x] I have tested this change locally
- [ ] I have tested this change locally in all supported browsers
- [ ] This change will be visible to users
- [ ] I have added automated tests that cover this change
- [ ] I have ensured the change is gated by config
- [ ] This change was covered by a ship review
- [ ] This change was covered by a tech design
- [ ] Any dependent config has been merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Khk3AzAZQL2qK9Ss8rYdsD

---
_Generated by [Claude Code](https://claude.ai/code/session_01Khk3AzAZQL2qK9Ss8rYdsD)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes only affect CI workflow Node setup; no application runtime, auth, or data-handling logic is modified.
> 
> **Overview**
> Follow-up to the Node 24 upgrade: three GitHub Actions jobs that ran `node`/`npm` on the runner’s default Node now use **`actions/setup-node@v6`** with **`node-version-file`** pointing at the repo’s `.nvmrc`.
> 
> In **`auto-respond-pr.yml`**, Node is set up from `pr/.nvmrc` before the base/PR `npm install` and build steps used for the generated file-diff comment. **`dependabot-auto-merge.yml`** adds `.nvmrc` to the sparse checkout (with `.github/scripts`) and pins Node before the Dependabot Anthropic gate scripts. **`tests.yml`** pins Node in **`get-playwright-version`** before the one-liner that reads Playwright’s version from `package-lock.json`, matching the rest of the test workflow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f18ca3a3b9f3758c23b438da1df4c6d6f9c75868. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->