### PR TITLE
Fix iframe sandbox detection to require both allow-scripts and allow-same-origin

### DIFF
--- a/injected/src/features/page-context.js
+++ b/injected/src/features/page-context.js
@@ -41,6 +41,19 @@ function isHtmlElement(node) {
 }
 
 /**
+ * Parse the sandbox attribute of an iframe into its set of flags.
+ * Read from the attribute rather than `iframe.sandbox` so the check works in
+ * environments without a DOMTokenList for it (e.g. JSDOM in unit tests).
+ * Sandbox flags are ASCII case-insensitive, so normalise to lower case.
+ * @param {HTMLIFrameElement} iframe
+ * @returns {Set<string>}
+ */
+function getSandboxFlags(iframe) {
+    const value = iframe.getAttribute('sandbox') ?? '';
+    return new Set(value.toLowerCase().split(/\s+/).filter(Boolean));
+}
+
+/**
  * Check if an iframe is same-origin and return its content document
  * @param {HTMLIFrameElement} iframe
  * @returns {Document | null}
@@ -49,11 +62,19 @@ function getSameOriginIframeDocument(iframe) {
     // Pre-check conditions that would prevent access without triggering security errors
     const src = iframe.src;
 
-    // Skip sandboxed iframes unless they explicitly allow scripts
-    // Avoids: Blocked script execution in 'about:blank' because the document's frame is sandboxed and the 'allow-scripts' permission is not set.
-    // Note: iframe.sandbox always returns a DOMTokenList, so check hasAttribute instead
-    if (iframe.hasAttribute('sandbox') && !iframe.sandbox.contains('allow-scripts')) {
-        return null;
+    // Skip sandboxed iframes unless they explicitly allow both scripts and same-origin access.
+    // Without 'allow-same-origin' the frame has an opaque origin, so its document is inaccessible
+    // even when the src matches our origin. WebKit logs a console error rather than throwing:
+    //   Sandbox access violation: Blocked a frame at "..." from accessing a frame at "...".
+    //   The frame being accessed is sandboxed and lacks the "allow-same-origin" flag.
+    // Without 'allow-scripts' we get:
+    //   Blocked script execution in 'about:blank' because the document's frame is sandboxed and the 'allow-scripts' permission is not set.
+    // Note: an empty sandbox attribute is the most restrictive, so check hasAttribute rather than truthiness.
+    if (iframe.hasAttribute('sandbox')) {
+        const sandboxFlags = getSandboxFlags(iframe);
+        if (!sandboxFlags.has('allow-scripts') || !sandboxFlags.has('allow-same-origin')) {
+            return null;
+        }
     }
 
     // Check for cross-origin URLs (but allow about:blank and empty src as they inherit parent origin)

--- a/injected/src/features/page-context.js
+++ b/injected/src/features/page-context.js
@@ -50,7 +50,12 @@ function isHtmlElement(node) {
  */
 function getSandboxFlags(iframe) {
     const value = iframe.getAttribute('sandbox') ?? '';
-    return new Set(value.toLowerCase().split(/\s+/).filter(Boolean));
+    return new Set(
+        value
+            .toLowerCase()
+            .split(/\s+/)
+            .filter((flag) => flag.length > 0),
+    );
 }
 
 /**

--- a/injected/unit-test/page-context-dom.spec.js
+++ b/injected/unit-test/page-context-dom.spec.js
@@ -214,7 +214,11 @@ describe('page-context.js - domToMarkdown iframe handling', () => {
         global.Node = window.Node;
         try {
             const iframe = /** @type {HTMLIFrameElement} */ (window.document.querySelector('iframe'));
-            iframe.contentDocument.body.innerHTML = '<p>Inner text</p>';
+            const iframeDocument = iframe.contentDocument;
+            if (!iframeDocument) {
+                throw new Error('Expected JSDOM to provide a contentDocument for the test iframe');
+            }
+            iframeDocument.body.innerHTML = '<p>Inner text</p>';
             return domToMarkdown(window.document.body, iframeSettings, 0);
         } finally {
             global.window = originalWindow;

--- a/injected/unit-test/page-context-dom.spec.js
+++ b/injected/unit-test/page-context-dom.spec.js
@@ -195,3 +195,68 @@ describe('page-context.js - domToMarkdown', () => {
         });
     }
 });
+
+describe('page-context.js - domToMarkdown iframe handling', () => {
+    const iframeSettings = { maxLength: 10000, maxDepth: 100, excludeSelectors: null, includeIframes: true, trimBlankLinks: false };
+    const iframeMarker = '--- Iframe Content ---';
+
+    /**
+     * Render a page containing one iframe (with the given attributes) whose document holds "Inner text"
+     * @param {string} iframeAttributes
+     * @returns {string}
+     */
+    function renderWithIframe(iframeAttributes) {
+        const dom = new JSDOM(`<!DOCTYPE html><html><body><p>Outer</p><iframe ${iframeAttributes}></iframe></body></html>`);
+        const { window } = dom;
+        const originalWindow = global.window;
+        const originalNode = global.Node;
+        global.window = window;
+        global.Node = window.Node;
+        try {
+            const iframe = /** @type {HTMLIFrameElement} */ (window.document.querySelector('iframe'));
+            iframe.contentDocument.body.innerHTML = '<p>Inner text</p>';
+            return domToMarkdown(window.document.body, iframeSettings, 0);
+        } finally {
+            global.window = originalWindow;
+            global.Node = originalNode;
+        }
+    }
+
+    it('includes content from an unsandboxed same-origin iframe', () => {
+        const markdown = renderWithIframe('');
+        expect(markdown).toContain(iframeMarker);
+        expect(markdown).toContain('Inner text');
+    });
+
+    it('skips an iframe with an empty sandbox attribute', () => {
+        const markdown = renderWithIframe('sandbox');
+        expect(markdown).not.toContain(iframeMarker);
+        expect(markdown).not.toContain('Inner text');
+    });
+
+    it('skips a sandboxed iframe that lacks allow-same-origin', () => {
+        // Without allow-same-origin the frame has an opaque origin, so reading its document
+        // is a sandbox access violation even when the src is same-origin.
+        const markdown = renderWithIframe('sandbox="allow-scripts"');
+        expect(markdown).not.toContain(iframeMarker);
+        expect(markdown).not.toContain('Inner text');
+    });
+
+    it('skips a sandboxed iframe that lacks allow-scripts', () => {
+        const markdown = renderWithIframe('sandbox="allow-same-origin"');
+        expect(markdown).not.toContain(iframeMarker);
+        expect(markdown).not.toContain('Inner text');
+    });
+
+    it('includes content from a sandboxed iframe with allow-scripts and allow-same-origin', () => {
+        const markdown = renderWithIframe('sandbox="allow-scripts allow-same-origin"');
+        expect(markdown).toContain(iframeMarker);
+        expect(markdown).toContain('Inner text');
+    });
+
+    it('treats sandbox flags as case-insensitive', () => {
+        const markdown = renderWithIframe('sandbox="ALLOW-SCRIPTS Allow-Same-Origin"');
+        expect(markdown).toContain(iframeMarker);
+        expect(markdown).toContain('Inner text');
+    });
+});


### PR DESCRIPTION
**Description**

Improves iframe content extraction in `domToMarkdown` by fixing the sandbox attribute validation logic. Previously, the code only checked for the `allow-scripts` flag when deciding whether to access an iframe's document. This change now requires both `allow-scripts` and `allow-same-origin` flags to be present.

Without `allow-same-origin`, a sandboxed iframe has an opaque origin and its document is inaccessible regardless of whether the src matches the parent's origin. The fix prevents unnecessary access attempts that would trigger sandbox violation errors in WebKit and other browsers.

The implementation also:
- Extracts sandbox flag parsing into a dedicated `getSandboxFlags()` helper function
- Normalizes flags to lowercase for case-insensitive comparison (per HTML spec)
- Reads from the `sandbox` attribute directly rather than the `iframe.sandbox` DOMTokenList (for JSDOM compatibility in tests)
- Updates comments to document both error conditions

**Testing Steps**

- Run `npm run test-unit` to verify all iframe sandbox handling tests pass
- The new test suite covers:
  - Unsandboxed iframes (content included)
  - Empty sandbox attribute (content skipped)
  - Sandbox with only `allow-scripts` (content skipped)
  - Sandbox with only `allow-same-origin` (content skipped)
  - Sandbox with both flags (content included)
  - Case-insensitive flag matching

**Checklist**

- [x] I have tested this change locally
- [x] I have added automated tests that cover this change

https://claude.ai/code/session_013RvaTxYBzRagtcMDrJeef9

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized change to iframe pre-checks before document access; reduces console noise and skips inaccessible sandboxed frames without touching auth or network paths.
> 
> **Overview**
> **Tightens when `domToMarkdown` reads same-origin iframe bodies** so sandboxed frames are only accessed when both `allow-scripts` and `allow-same-origin` are set. Previously only `allow-scripts` was required, which could still hit opaque-origin sandbox frames and trigger WebKit sandbox console errors.
> 
> Adds **`getSandboxFlags()`** to parse the `sandbox` attribute (lowercased, token-split) instead of `iframe.sandbox`, so checks work under JSDOM and treat flags case-insensitively.
> 
> **Unit tests** cover unsandboxed inclusion, empty/restrictive sandbox skipping, each flag alone, both flags together, and mixed-case sandbox tokens.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2d57f37078a8dd1a20c0dfca3570cff076336e8e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->