### PR TITLE
Add Smartling translations for chromeWebstorePatching button copy

### DIFF
--- a/injected/src/locales/chrome-webstore-patching/es/chrome-store-strings.json
+++ b/injected/src/locales/chrome-webstore-patching/es/chrome-store-strings.json
@@ -10,19 +10,19 @@
     ]
   },
   "install": {
-    "title": "Zu DuckDuckGo hinzufügen",
+    "title": "Añadir a DuckDuckGo",
     "note": "Install button on a Chrome Web Store extension detail page, replacing 'Add to Chrome'."
   },
   "remove": {
-    "title": "Von DuckDuckGo entfernen",
+    "title": "Eliminar de DuckDuckGo",
     "note": "Uninstall button on a Chrome Web Store extension detail page, shown when the extension is already installed."
   },
   "unavailable": {
-    "title": "Nicht unterstützte Erweiterung",
+    "title": "Extensión no compatible",
     "note": "Label on a disabled button, shown on extensions the DuckDuckGo browser does not support."
   },
   "unavailableDescription": {
-    "title": "Diese Erweiterung wird nicht unterstützt.",
+    "title": "Esta extensión no es compatible.",
     "note": "Tooltip shown when hovering the disabled 'Unsupported extension' button."
   }
 }

--- a/injected/src/locales/chrome-webstore-patching/fr/chrome-store-strings.json
+++ b/injected/src/locales/chrome-webstore-patching/fr/chrome-store-strings.json
@@ -10,19 +10,19 @@
     ]
   },
   "install": {
-    "title": "Zu DuckDuckGo hinzufügen",
+    "title": "Ajouter à DuckDuckGo",
     "note": "Install button on a Chrome Web Store extension detail page, replacing 'Add to Chrome'."
   },
   "remove": {
-    "title": "Von DuckDuckGo entfernen",
+    "title": "Supprimer de DuckDuckGo",
     "note": "Uninstall button on a Chrome Web Store extension detail page, shown when the extension is already installed."
   },
   "unavailable": {
-    "title": "Nicht unterstützte Erweiterung",
+    "title": "Extension non prise en charge",
     "note": "Label on a disabled button, shown on extensions the DuckDuckGo browser does not support."
   },
   "unavailableDescription": {
-    "title": "Diese Erweiterung wird nicht unterstützt.",
+    "title": "Cette extension n’est pas prise en charge.",
     "note": "Tooltip shown when hovering the disabled 'Unsupported extension' button."
   }
 }

--- a/injected/src/locales/chrome-webstore-patching/it/chrome-store-strings.json
+++ b/injected/src/locales/chrome-webstore-patching/it/chrome-store-strings.json
@@ -10,19 +10,19 @@
     ]
   },
   "install": {
-    "title": "Zu DuckDuckGo hinzufügen",
+    "title": "Aggiungi a DuckDuckGo",
     "note": "Install button on a Chrome Web Store extension detail page, replacing 'Add to Chrome'."
   },
   "remove": {
-    "title": "Von DuckDuckGo entfernen",
+    "title": "Rimuovi da DuckDuckGo",
     "note": "Uninstall button on a Chrome Web Store extension detail page, shown when the extension is already installed."
   },
   "unavailable": {
-    "title": "Nicht unterstützte Erweiterung",
+    "title": "Estensione non supportata",
     "note": "Label on a disabled button, shown on extensions the DuckDuckGo browser does not support."
   },
   "unavailableDescription": {
-    "title": "Diese Erweiterung wird nicht unterstützt.",
+    "title": "Questa estensione non è supportata.",
     "note": "Tooltip shown when hovering the disabled 'Unsupported extension' button."
   }
 }

--- a/injected/src/locales/chrome-webstore-patching/nl/chrome-store-strings.json
+++ b/injected/src/locales/chrome-webstore-patching/nl/chrome-store-strings.json
@@ -10,19 +10,19 @@
     ]
   },
   "install": {
-    "title": "Zu DuckDuckGo hinzufügen",
+    "title": "Toevoegen aan DuckDuckGo",
     "note": "Install button on a Chrome Web Store extension detail page, replacing 'Add to Chrome'."
   },
   "remove": {
-    "title": "Von DuckDuckGo entfernen",
+    "title": "Verwijderen uit DuckDuckGo",
     "note": "Uninstall button on a Chrome Web Store extension detail page, shown when the extension is already installed."
   },
   "unavailable": {
-    "title": "Nicht unterstützte Erweiterung",
+    "title": "Niet-ondersteunde extensie",
     "note": "Label on a disabled button, shown on extensions the DuckDuckGo browser does not support."
   },
   "unavailableDescription": {
-    "title": "Diese Erweiterung wird nicht unterstützt.",
+    "title": "Deze extensie wordt niet ondersteund.",
     "note": "Tooltip shown when hovering the disabled 'Unsupported extension' button."
   }
 }

--- a/injected/src/locales/chrome-webstore-patching/pl/chrome-store-strings.json
+++ b/injected/src/locales/chrome-webstore-patching/pl/chrome-store-strings.json
@@ -10,19 +10,19 @@
     ]
   },
   "install": {
-    "title": "Zu DuckDuckGo hinzufügen",
+    "title": "Dodaj do DuckDuckGo",
     "note": "Install button on a Chrome Web Store extension detail page, replacing 'Add to Chrome'."
   },
   "remove": {
-    "title": "Von DuckDuckGo entfernen",
+    "title": "Usuń z DuckDuckGo",
     "note": "Uninstall button on a Chrome Web Store extension detail page, shown when the extension is already installed."
   },
   "unavailable": {
-    "title": "Nicht unterstützte Erweiterung",
+    "title": "Nieobsługiwane rozszerzenie",
     "note": "Label on a disabled button, shown on extensions the DuckDuckGo browser does not support."
   },
   "unavailableDescription": {
-    "title": "Diese Erweiterung wird nicht unterstützt.",
+    "title": "To rozszerzenie nie jest obsługiwane.",
     "note": "Tooltip shown when hovering the disabled 'Unsupported extension' button."
   }
 }

--- a/injected/src/locales/chrome-webstore-patching/pt/chrome-store-strings.json
+++ b/injected/src/locales/chrome-webstore-patching/pt/chrome-store-strings.json
@@ -10,19 +10,19 @@
     ]
   },
   "install": {
-    "title": "Zu DuckDuckGo hinzufügen",
+    "title": "Adicionar ao DuckDuckGo",
     "note": "Install button on a Chrome Web Store extension detail page, replacing 'Add to Chrome'."
   },
   "remove": {
-    "title": "Von DuckDuckGo entfernen",
+    "title": "Remover do DuckDuckGo",
     "note": "Uninstall button on a Chrome Web Store extension detail page, shown when the extension is already installed."
   },
   "unavailable": {
-    "title": "Nicht unterstützte Erweiterung",
+    "title": "Extensão não suportada",
     "note": "Label on a disabled button, shown on extensions the DuckDuckGo browser does not support."
   },
   "unavailableDescription": {
-    "title": "Diese Erweiterung wird nicht unterstützt.",
+    "title": "Esta extensão não é suportada.",
     "note": "Tooltip shown when hovering the disabled 'Unsupported extension' button."
   }
 }

--- a/injected/src/locales/chrome-webstore-patching/ru/chrome-store-strings.json
+++ b/injected/src/locales/chrome-webstore-patching/ru/chrome-store-strings.json
@@ -10,19 +10,19 @@
     ]
   },
   "install": {
-    "title": "Zu DuckDuckGo hinzufügen",
+    "title": "Добавить в DuckDuckGo",
     "note": "Install button on a Chrome Web Store extension detail page, replacing 'Add to Chrome'."
   },
   "remove": {
-    "title": "Von DuckDuckGo entfernen",
+    "title": "Удалить из DuckDuckGo",
     "note": "Uninstall button on a Chrome Web Store extension detail page, shown when the extension is already installed."
   },
   "unavailable": {
-    "title": "Nicht unterstützte Erweiterung",
+    "title": "Неподдерживаемое расширение браузера",
     "note": "Label on a disabled button, shown on extensions the DuckDuckGo browser does not support."
   },
   "unavailableDescription": {
-    "title": "Diese Erweiterung wird nicht unterstützt.",
+    "title": "Это расширение браузера не поддерживается.",
     "note": "Tooltip shown when hovering the disabled 'Unsupported extension' button."
   }
 }


### PR DESCRIPTION
**Asana Task/Github Issue:** [Translations for Chrome Web Store patching](https://app.asana.com/1/137249556945/task/1218284471093099?focus=true)

## Description

Follow-up to #2991. Adds the translated button copy returned by Smartling for the `chromeWebstorePatching` feature, covering the 8 desktop languages: `de`, `es`, `fr`, `it`, `nl`, `pl`, `pt`, `ru`.

Data only, no code changes. `buildLocales.js` bundles every directory under `src/locales/chrome-webstore-patching/`, so the strings are picked up by `npm run build` without any wiring.

Region suffixes are stripped on the way in (`pl_PL` -> `pl`) to match the bare language codes the feature resolves against, since it takes `args.locale` and drops the region subtag.

`de` was previously a hand-written placeholder used to prove the resolution path; it is replaced here by the real translation. The only difference is `remove`: "Aus DuckDuckGo entfernen" -> "Von DuckDuckGo entfernen".

## Testing Steps

- `npm run build`, then confirm `build/locales/chrome-webstore-patching-locales.js` contains 9 locales with 4 keys each
- `npm exec --workspace=injected playwright -- test --project=windows chrome-webstore-patching --reporter=list` (34 specs)
- Each file was checked before landing: valid JSON, all 4 keys present, no empty or non-string titles, no extra keys, and no title identical to English (which would indicate an untranslated string)

## Manual Proof (switching Debug->Localization in DDG browser to Russian)
<img width="2288" height="342" alt="image" src="https://github.com/user-attachments/assets/f3e8952d-327e-4de7-a404-e6327f72863a" />


Manual verification on a Windows internal build is limited to layout, since the resolution path is unchanged and already verified for `de`. Two locales are worth a look on an uncurated extension detail page, where the `unavailable` pill renders:

- **`ru`** - longest label in the set at 36 chars (`Неподдерживаемое расширение браузера`) vs 30 for `de`, and the only non-Latin script, so it exercises both overflow and font coverage
- **`nl`** - longest `remove` at 26 chars vs 24 for `de`

Every other string is at or below a length already exercised by `de`.

## Checklist

*Please tick all that apply:*

- [x] I have tested this change locally
- [ ] I have tested this change locally in all supported browsers
- [x] This change will be visible to users
- [x] I have added automated tests that cover this change
- [x] I have ensured the change is gated by config
- [ ] This change was covered by a ship review
- [ ] This change was covered by a tech design
- [x] Any dependent config has been merged

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localization-only JSON; user-visible copy changes with no logic, auth, or data-handling impact.
> 
> **Overview**
> Adds **Smartling-translated** copy for Chrome Web Store patching buttons and unsupported-extension labels in **`es`, `fr`, `it`, `nl`, `pl`, `pt`, and `ru`**, each with the same four keys as English (`install`, `remove`, `unavailable`, `unavailableDescription`).
> 
> **German** is updated from the prior placeholder: the uninstall label changes from *"Aus DuckDuckGo entfernen"* to *"Von DuckDuckGo entfernen"*. No application code changes—new files under `injected/src/locales/chrome-webstore-patching/` are picked up at build time like existing locales.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2972ccb4f7e6a73ab1ecc8552c18fbceb90453d7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->